### PR TITLE
feat(generators): detect non-deterministic generators by re-running

### DIFF
--- a/docs/plans/2026-05-03-e2e-testing-strategy-design.md
+++ b/docs/plans/2026-05-03-e2e-testing-strategy-design.md
@@ -1,0 +1,369 @@
+# E2E Testing Strategy — Design
+
+## Problem
+
+`rbx` has no broad, declarative e2e coverage. The existing e2e tests live in
+`tests/rbx/box/cli/problem_test.py` (CLI smoke tests against the default preset
+and an interactive problem) and `tests/rbx/box/packaging/e2e/test_boca_e2e.py`
+(docker-orchestrated BOCA upload). They are written as ad-hoc Python and only
+assert exit codes; adding a new e2e case means writing a new Python test by
+hand.
+
+We want a way to drop a barebones problem package into a directory tree, write
+a small YAML file next to it describing what `rbx` should do with it and what
+the expected outcomes are, and have pytest automatically pick it up.
+
+## Goals
+
+- Adding a new e2e test = create a directory + write `e2e.rbx.yml`.
+- Expressive enough to assert verdict matrices for `rbx run`, generated tests
+  for `rbx build`, statement artifacts for `rbx st b`, and packaging artifacts
+  for `rbx pkg <format>`.
+- Always opt-in (gated by `@pytest.mark.e2e`); never runs on `mise run test`.
+- Reuses the existing `TestingPackage` helper for tmpdir isolation.
+
+## Non-goals (v1)
+
+- `rbx stress` assertions — deferred. Needs a `--report` JSON flag added to
+  `stress`; design captured at the bottom under "Future work."
+- Migrating the docker-based BOCA upload test (`test_boca_e2e.py`). The DSL is
+  not a good fit for orchestrating an external service; it stays Python.
+- Multi-problem contest packages.
+
+## Layout
+
+A new tree, separate from the existing CLI/packaging e2e tests:
+
+```
+tests/e2e/
+  __init__.py
+  conftest.py            # collection hook + Pydantic schema
+  e2e_runner.py          # pytest Item + assertion classes
+  testdata/
+    simple-ac/
+      e2e.rbx.yml
+      problem.rbx.yml
+      sols/main.cpp
+      gens/gen.cpp
+      ...
+    mixed-solutions/
+      e2e.rbx.yml
+      ...
+    bad-validator/
+      e2e.rbx.yml
+      ...
+```
+
+Pytest collects every `e2e.rbx.yml` automatically; the directory tree itself is
+the test suite. Each `e2e.rbx.yml` describes one or more **scenarios**; pytest
+reports one node per scenario as `tests/e2e/testdata/<pkg>/e2e.rbx.yml::<scenario>`.
+
+## Execution model
+
+- Each scenario gets a fresh tmpdir copy of its package via the existing
+  `rbx.box.testing.testing_package.TestingPackage` helper. Scenarios are
+  independent.
+- Steps within a scenario share the tmpdir and run in order. The first failing
+  step fails the scenario; subsequent steps are skipped.
+- All scenarios are marked `@pytest.mark.e2e` so they are excluded from
+  `mise run test` and run only via the existing `mise run test-e2e`.
+- Commands are invoked with Typer's `CliRunner` against `rbx.box.cli.app`, the
+  same approach the current CLI tests use. Command strings are split with
+  `shlex.split`.
+
+## Schema
+
+Top-level `e2e.rbx.yml`:
+
+```yaml
+scenarios:
+  - name: <string, required, unique within file>
+    description: <string, optional>
+    steps: [<step>]
+```
+
+Step:
+
+```yaml
+cmd: <string, required>           # e.g. "build", "run", "pkg boca", "st b -l en"
+expect_exit: <int, default 0>
+expect:                           # all keys optional
+  stdout_contains: <string | list[string]>
+  stderr_contains: <string | list[string]>
+  stdout_matches: <regex>
+  files_exist: <list[glob]>       # paths relative to package root (tmpdir)
+  files_absent: <list[glob]>
+  file_contains:
+    <path>: <substring or /regex/>
+  zip_contains:
+    path: <glob to zip artifact>
+    entries: <list[glob within zip]>
+  zip_not_contains:
+    path: <glob>
+    entries: <list[glob]>
+  # Command-specific structured matchers (only valid for that cmd):
+  solutions: ...                  # only with cmd: run
+  tests: ...                      # only with cmd: build
+```
+
+The schema is a Pydantic model with `extra="forbid"` so typos surface at
+collection time, not run time.
+
+`expect_exit` defaults to `0`. Negative tests opt in by setting it. When
+`expect_exit != 0`, structured assertions (`solutions:`, `tests:`) may produce
+no data; it is the user's responsibility to write only assertions that make
+sense for the expected exit state.
+
+### Structured matcher: `solutions:` (cmd: `run`)
+
+Source of truth: `skeleton.yml` produced by `rbx run`, which already contains
+per-(solution, group) outcomes and per-(solution, test) verdicts.
+
+Per solution path, the value is either a bare verdict or a map:
+
+```yaml
+solutions:
+  # Bare: shorthand for {"*": ac}
+  sols/main.cpp: ac
+
+  # Map: '*' baseline + group/test overrides
+  sols/wa.cpp:
+    "*": wa                         # every group's outcome is WA
+    samples: ac                     # group 'samples' outcome is AC (overrides *)
+    main_tests/edge_case: ac        # specific test verdict is AC
+```
+
+**Verdict vocabulary:** values are parsed as `ExpectedOutcome`
+(`rbx/box/schema.py`), reusing the same matching grammar (and aliases:
+`ac`/`wa`/`tle`/`incorrect`/`any`/`ac+tle`/etc.) that `problem.rbx.yml`'s
+`outcome:` field already accepts. Each `ExpectedOutcome` exposes
+`match(outcome: Outcome) -> bool`, which the runner uses for assertions.
+
+**Resolution (per user-written entry):**
+
+1. If the key contains `/` it is interpreted as a **test path**; assert that
+   test's verdict matches the `ExpectedOutcome`.
+2. Else if the key matches a **group name** in the package; assert that
+   group's overall outcome matches.
+3. Else if the key is `*`; assert every group's overall outcome matches
+   (groups separately overridden by name take precedence).
+
+**Sparse coverage is valid.** Untouched groups and tests are simply not
+asserted. The user opts into whatever subset they care about.
+
+**Group vs. test verdicts** (important distinction):
+- `<group>: wa` asserts the **group's aggregated outcome** (the same notion
+  rbx already computes from `skeleton.yml` and uses for reporting and for
+  `expectedOutcomes` in `problem.rbx.yml`). It does **not** assert "every
+  test in the group is WA."
+- `<group>/<test>: wa` asserts the specific test's verdict.
+
+### Structured matcher: `tests:` (cmd: `build`)
+
+Source: enumerate generated test files in `build/tests/` after the build
+completes, plus the validation report (if a structured one is not currently
+persisted, the implementation will add one — same pattern as the
+`--report`-flag escape hatch we're considering for `stress`).
+
+```yaml
+tests:
+  count: <int>                    # optional total count
+  groups:                         # optional per-group counts
+    samples: 3
+    main_tests: 9
+  all_valid: <bool, default true> # all generated tests passed validation
+  exist: [<path>, ...]            # specific paths under build/tests/ that must exist
+```
+
+Anything more granular (asserting test file content) is expressed via the
+generic `file_contains:` matcher; no need to special-case it here.
+
+## Concrete examples
+
+### Vanilla AC pipeline
+
+```yaml
+# tests/e2e/testdata/simple-ac/e2e.rbx.yml
+scenarios:
+  - name: full-pipeline
+    steps:
+      - cmd: build
+        expect:
+          tests:
+            count: 5
+            all_valid: true
+
+      - cmd: run
+        expect:
+          solutions:
+            sols/main.cpp: ac
+
+      - cmd: st b
+        expect:
+          files_exist: [build/statements/statement.pdf]
+
+      - cmd: pkg boca
+        expect:
+          files_exist: ["build/boca/*.zip"]
+          zip_contains:
+            path: build/boca/*.zip
+            entries: [description.xml, "limits/*"]
+```
+
+### Mixed verdicts, sparse assertions
+
+```yaml
+# tests/e2e/testdata/mixed-solutions/e2e.rbx.yml
+scenarios:
+  - name: verdict-matrix
+    steps:
+      - cmd: run
+        expect:
+          solutions:
+            sols/main.cpp: ac
+            sols/wa_on_big.cpp:
+              "*": ac
+              main_tests: wa
+              main_tests/edge_case: ac
+            sols/tle.cpp:
+              "*": tle
+              samples: ac
+            sols/sometimes_wa.cpp:
+              samples/0: ac
+              main_tests/tricky: wa
+```
+
+### Negative test (broken validator)
+
+```yaml
+# tests/e2e/testdata/bad-validator/e2e.rbx.yml
+scenarios:
+  - name: build-should-fail
+    steps:
+      - cmd: build
+        expect_exit: 1
+        expect:
+          stderr_contains: "validator"
+```
+
+### Multiple scenarios per package
+
+```yaml
+# tests/e2e/testdata/full-coverage/e2e.rbx.yml
+scenarios:
+  - name: build-and-run
+    steps:
+      - cmd: build
+      - cmd: run
+        expect:
+          solutions:
+            sols/main.cpp: ac
+
+  - name: package-boca
+    steps:
+      - cmd: build
+      - cmd: pkg boca
+        expect:
+          files_exist: ["build/boca/*.zip"]
+
+  - name: package-polygon
+    steps:
+      - cmd: build
+      - cmd: pkg polygon
+        expect:
+          files_exist: ["build/polygon/*.zip"]
+```
+
+Each scenario starts from a fresh tmpdir copy, so `build` is repeated in
+scenarios 2 and 3.
+
+## Implementation sketch
+
+### Collection hook
+
+```python
+# tests/e2e/conftest.py
+def pytest_collect_file(parent, file_path):
+    if file_path.name == "e2e.rbx.yml":
+        return E2EYamlFile.from_parent(parent, path=file_path)
+```
+
+`E2EYamlFile.collect()` parses the YAML through a Pydantic `E2ESpec` model
+and yields one `E2EScenarioItem` per scenario. Schema errors fail at
+collection (clear pytest error) rather than runtime.
+
+### Scenario item
+
+```python
+class E2EScenarioItem(pytest.Item):
+    def runtest(self):
+        with TestingPackage(self.package_dir) as pkg:
+            for step in self.scenario.steps:
+                self._run_step(pkg, step)
+
+    def _run_step(self, pkg, step):
+        result = CliRunner().invoke(rbx_app, shlex.split(step.cmd))
+        assert result.exit_code == step.expect_exit, ...
+        for assertion in step.assertions:
+            assertion.check(pkg, result)
+```
+
+### Assertion classes
+
+Each assertion is a small Pydantic submodel with a `check(pkg, result)`
+method. One class per matcher: `StdoutContains`, `StderrContains`,
+`StdoutMatches`, `FilesExist`, `FilesAbsent`, `FileContains`, `ZipContains`,
+`ZipNotContains`, `SolutionsMatcher`, `TestsMatcher`.
+
+All assertion failures embed: package name, scenario name, step `cmd`,
+expected vs. found.
+
+### Marker
+
+`pytest_collection_modifyitems` adds `pytest.mark.e2e` to every collected
+`E2EScenarioItem` so `mise run test` keeps ignoring them. No new mise task is
+required — `mise run test-e2e` already runs everything tagged `e2e`.
+
+## Migration of existing e2e tests
+
+**Migrate to the new tree:**
+
+- `tests/rbx/box/cli/problem_test.py::test_default_preset_problem` →
+  one package + scenario invoking `run`, `unit`, `st b`, `pkg boca`,
+  `pkg polygon`. Strengthen the assertions beyond exit code where the
+  structured matchers can express something.
+- `tests/rbx/box/cli/problem_test.py::test_interactive_problem` →
+  same structure for an interactive problem package.
+- `tests/rbx/box/packaging/e2e/testdata/simple-problem/` → moves under
+  `tests/e2e/testdata/`.
+
+**Leave in Python:**
+
+- `tests/rbx/box/packaging/e2e/test_boca_e2e.py` — docker-compose
+  orchestration and HTTP uploads to a real BOCA service; not a fit for the
+  YAML DSL. Keep its existing markers.
+
+## Future work
+
+- **`rbx stress` support.** Add a `--report <path>` flag to `rbx stress` that
+  emits structured JSON (counterexamples found, seeds, finder verdicts).
+  Then add a `stress:` matcher with assertions like
+  `found_counterexample: true|false`, `count_at_least: <int>`. Determinism
+  via pinned `--seed` in `cmd:`.
+- **Multi-language statement assertions.** Trivial extension once the v1
+  `files_exist` matcher exists.
+- **Contest packages (`contest.rbx.yml`).** Same DSL with a top-level
+  contest scenario; deferred until needed.
+
+## Risks
+
+- **Schema drift.** Adding new `expect:` keys is cheap, but renaming or
+  changing the resolution algorithm later breaks existing YAML. Mitigation:
+  `extra="forbid"` plus this design doc as the schema's source of truth.
+- **`skeleton.yml` format dependency.** If `rbx run` ever changes that
+  file's shape, every e2e test breaks at once. Mitigation: a single
+  `SolutionsMatcher` reads it, isolating the parsing concern.
+- **`build` validation report not yet structured.** If `rbx build` does not
+  already persist a validation report, the `tests.all_valid` matcher needs
+  one added during implementation. The implementation plan should confirm
+  this on day one.

--- a/docs/plans/2026-05-03-e2e-testing-strategy.md
+++ b/docs/plans/2026-05-03-e2e-testing-strategy.md
@@ -1,0 +1,888 @@
+# E2E Testing Strategy Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a YAML-driven e2e test framework where dropping a barebones problem package + `e2e.rbx.yml` into `tests/e2e/testdata/` automatically becomes a pytest test that exercises `rbx run`/`build`/`st b`/`pkg <fmt>` with structured assertions.
+
+**Architecture:** Custom pytest collection hook discovers every `e2e.rbx.yml` under `tests/e2e/testdata/`, parses it into a Pydantic `E2ESpec`, and yields one `pytest.Item` per scenario. Each item copies the package to a tmpdir via the existing `TestingPackage` helper, runs each step's `cmd` through Typer's `CliRunner`, then evaluates assertion classes against the resulting stdout/stderr/exit-code/filesystem state. Verdict assertions read on-disk artifacts (`skeleton.yml` for `rbx run`) rather than parsing CLI output.
+
+**Tech Stack:** pytest (custom collection), Pydantic v2, Typer `CliRunner`, `shlex`, `zipfile`, `glob`/`pathlib`, existing `rbx.box.testing.testing_package.TestingPackage`.
+
+**Reference design doc:** `docs/plans/2026-05-03-e2e-testing-strategy-design.md`. Read it before starting any task.
+
+---
+
+## Task 0: Spike — confirm verdict data source on disk
+
+**Why first:** the design hinges on reading per-(solution, group, testcase) verdicts from disk. `skeleton.yml` is the *plan* (it does not contain verdicts — it lists solutions/groups/testcases/limits). Per-evaluation results are written elsewhere by the runner. We must locate the canonical on-disk verdict source before designing the `SolutionsMatcher`.
+
+**Files:**
+- Read: `rbx/box/solutions.py` (especially `_get_report_skeleton`, `_produce_solution_items`, `print_run_report`, `_evaluate_item`)
+- Read: `rbx/box/ui/utils/run_ui.py` (already reads skeleton + per-eval data)
+- Read: `rbx/grading/steps.py` (`Evaluation` dataclass, `Outcome` enum)
+
+**Step 1: Trace `rbx run`**
+
+Run a sample package end-to-end:
+
+```bash
+cd tests/rbx/box/packaging/e2e/testdata/simple-problem
+uv run rbx run
+ls .box/runs/                  # find skeleton.yml + per-solution dirs
+find .box/runs/ -type f | head -50
+```
+
+Expected: identify the directory containing per-(solution, group, testcase) outcome data and its on-disk format (YAML? individual files?).
+
+**Step 2: Document findings inline**
+
+Append a short "Verdict source" section to the design doc (`docs/plans/2026-05-03-e2e-testing-strategy-design.md`) describing the exact paths, file format, and Pydantic model used. If `Evaluation` is not currently persisted, this task expands to either (a) adding a `--report` flag to `rbx run` that writes a stable JSON/YAML report, or (b) making the runner persist per-eval files. Pick whichever is least invasive; document the choice.
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-05-03-e2e-testing-strategy-design.md
+git commit -m "docs(tests): document verdict on-disk source for e2e DSL"
+```
+
+---
+
+## Task 1: Scaffold `tests/e2e/` and one fixture package
+
+**Files:**
+- Create: `tests/e2e/__init__.py` (empty)
+- Create: `tests/e2e/conftest.py` (placeholder)
+- Create: `tests/e2e/testdata/simple-ac/problem.rbx.yml`
+- Create: `tests/e2e/testdata/simple-ac/sols/main.cpp`
+- Create: `tests/e2e/testdata/simple-ac/gens/gen.cpp`
+- Create: `tests/e2e/testdata/simple-ac/e2e.rbx.yml`
+
+**Step 1: Build a minimal AC package by hand**
+
+Use `tests/rbx/box/packaging/e2e/testdata/simple-problem/` as a reference. The new package must be small (≤ 5 testcases), have one AC solution, no statements (we add those later), and run `rbx build` cleanly when invoked manually.
+
+**Step 2: Write the smallest possible `e2e.rbx.yml`**
+
+```yaml
+scenarios:
+  - name: smoke
+    steps:
+      - cmd: build
+```
+
+No assertions yet — exit code 0 is the implicit assertion.
+
+**Step 3: Verify by hand**
+
+```bash
+cd tests/e2e/testdata/simple-ac && uv run rbx build && cd -
+```
+
+Expected: build succeeds, generated `build/tests/*.in` and `build/tests/*.out` files exist.
+
+**Step 4: Commit**
+
+```bash
+git add tests/e2e/
+git commit -m "test(e2e): scaffold tests/e2e tree with simple-ac fixture"
+```
+
+---
+
+## Task 2: Pydantic schema for `e2e.rbx.yml`
+
+**Files:**
+- Create: `tests/e2e/spec.py`
+- Test: `tests/e2e/test_spec.py`
+
+**Step 1: Write failing tests**
+
+Cover: valid minimal scenario; rejecting unknown keys; defaulting `expect_exit` to 0; rejecting duplicate scenario names; parsing solutions in all three forms (bare verdict, `*` baseline, with overrides); accepting `ExpectedOutcome` aliases (`ac`/`AC`/`accepted`/`wa`); rejecting unknown verdicts.
+
+```python
+# tests/e2e/test_spec.py
+import pytest
+from rbx.box.schema import ExpectedOutcome
+from tests.e2e.spec import E2ESpec, parse_spec
+
+def test_minimal():
+    spec = parse_spec({"scenarios": [{"name": "s", "steps": [{"cmd": "build"}]}]})
+    assert spec.scenarios[0].steps[0].expect_exit == 0
+
+def test_rejects_unknown_keys():
+    with pytest.raises(ValueError):
+        parse_spec({"scenarios": [{"name": "s", "steps": [{"cmd": "x", "typo": 1}]}]})
+
+def test_rejects_duplicate_scenario_names():
+    with pytest.raises(ValueError):
+        parse_spec({"scenarios": [
+            {"name": "s", "steps": []},
+            {"name": "s", "steps": []},
+        ]})
+
+def test_solutions_bare_verdict_parses_as_star_map():
+    spec = parse_spec({"scenarios": [{"name": "s", "steps": [
+        {"cmd": "run", "expect": {"solutions": {"sols/main.cpp": "ac"}}}
+    ]}]})
+    matcher = spec.scenarios[0].steps[0].expect.solutions
+    assert matcher["sols/main.cpp"].star == ExpectedOutcome.ACCEPTED
+
+def test_solutions_full_form():
+    spec = parse_spec({"scenarios": [{"name": "s", "steps": [
+        {"cmd": "run", "expect": {"solutions": {
+            "sols/wa.cpp": {"*": "wa", "samples": "ac", "main_tests/edge": "ac"}
+        }}}
+    ]}]})
+    m = spec.scenarios[0].steps[0].expect.solutions["sols/wa.cpp"]
+    assert m.star == ExpectedOutcome.WRONG_ANSWER
+    assert m.entries == {"samples": ExpectedOutcome.ACCEPTED,
+                          "main_tests/edge": ExpectedOutcome.ACCEPTED}
+
+def test_unknown_verdict():
+    with pytest.raises(ValueError):
+        parse_spec({"scenarios": [{"name": "s", "steps": [
+            {"cmd": "run", "expect": {"solutions": {"sols/x.cpp": "BOGUS"}}}
+        ]}]})
+```
+
+Run: `uv run pytest tests/e2e/test_spec.py -v`. Expected: all FAIL (module not found).
+
+**Step 2: Implement `tests/e2e/spec.py`**
+
+```python
+import pathlib
+from typing import Dict, List, Optional, Union
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from rbx.box.schema import ExpectedOutcome
+
+
+class _Forbid(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+
+class SolutionMatcher(_Forbid):
+    star: Optional[ExpectedOutcome] = None  # the "*" key
+    entries: Dict[str, ExpectedOutcome] = Field(default_factory=dict)
+
+
+class TestsMatcher(_Forbid):
+    count: Optional[int] = None
+    groups: Dict[str, int] = Field(default_factory=dict)
+    all_valid: bool = True
+    exist: List[str] = Field(default_factory=list)
+
+
+class ZipMatcher(_Forbid):
+    path: str
+    entries: List[str]
+
+
+class Expect(_Forbid):
+    stdout_contains: Union[str, List[str], None] = None
+    stderr_contains: Union[str, List[str], None] = None
+    stdout_matches: Optional[str] = None
+    files_exist: List[str] = Field(default_factory=list)
+    files_absent: List[str] = Field(default_factory=list)
+    file_contains: Dict[str, str] = Field(default_factory=dict)
+    zip_contains: Optional[ZipMatcher] = None
+    zip_not_contains: Optional[ZipMatcher] = None
+    solutions: Optional[Dict[str, SolutionMatcher]] = None
+    tests: Optional[TestsMatcher] = None
+
+
+class Step(_Forbid):
+    cmd: str
+    expect_exit: int = 0
+    expect: Expect = Field(default_factory=Expect)
+
+
+class Scenario(_Forbid):
+    name: str
+    description: Optional[str] = None
+    steps: List[Step] = Field(default_factory=list)
+
+
+class E2ESpec(_Forbid):
+    scenarios: List[Scenario]
+
+    @model_validator(mode='after')
+    def _unique_scenario_names(self):
+        names = [s.name for s in self.scenarios]
+        if len(set(names)) != len(names):
+            raise ValueError(f'duplicate scenario names: {names}')
+        return self
+
+
+def _parse_solution_matcher(value) -> SolutionMatcher:
+    if isinstance(value, str):
+        return SolutionMatcher(star=ExpectedOutcome(value), entries={})
+    if isinstance(value, dict):
+        star_raw = value.get('*')
+        star = ExpectedOutcome(star_raw) if star_raw is not None else None
+        entries = {
+            k: ExpectedOutcome(v) for k, v in value.items() if k != '*'
+        }
+        return SolutionMatcher(star=star, entries=entries)
+    raise ValueError(f'invalid solution matcher: {value!r}')
+
+
+def parse_spec(data: dict) -> E2ESpec:
+    # Pre-process solutions field: bare strings → SolutionMatcher
+    for sc in data.get('scenarios', []):
+        for step in sc.get('steps', []):
+            sols = step.get('expect', {}).get('solutions')
+            if sols:
+                step['expect']['solutions'] = {
+                    k: _parse_solution_matcher(v) for k, v in sols.items()
+                }
+    return E2ESpec.model_validate(data)
+
+
+def load_spec(path: pathlib.Path) -> E2ESpec:
+    return parse_spec(yaml.safe_load(path.read_text()))
+```
+
+Run: `uv run pytest tests/e2e/test_spec.py -v`. Expected: all PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/e2e/spec.py tests/e2e/test_spec.py
+git commit -m "test(e2e): add Pydantic schema for e2e.rbx.yml"
+```
+
+---
+
+## Task 3: Pytest collection hook
+
+**Files:**
+- Modify: `tests/e2e/conftest.py`
+- Create: `tests/e2e/runner.py` (skeleton — `runtest` is a no-op for now, just so collection succeeds)
+- Test: `tests/e2e/test_collection.py`
+
+**Step 1: Write failing collection test**
+
+```python
+# tests/e2e/test_collection.py
+def test_collects_scenarios(pytester):
+    pytester.makepyfile(conftest="""
+from tests.e2e.conftest import *
+""")
+    pytester.makefile(".rbx.yml", **{
+        "testdata/x/e2e": "scenarios:\n  - name: a\n    steps: []\n  - name: b\n    steps: []\n",
+    })
+    result = pytester.runpytest("--collect-only", "-q")
+    result.stdout.fnmatch_lines(["*x/e2e.rbx.yml::a*", "*x/e2e.rbx.yml::b*"])
+```
+
+(Use `pytester` plugin; enable via root `conftest.py` if not already.)
+
+Run: `uv run pytest tests/e2e/test_collection.py -v`. Expected: FAIL.
+
+**Step 2: Implement collection in `tests/e2e/conftest.py`**
+
+```python
+import pathlib
+import pytest
+from tests.e2e.spec import load_spec
+from tests.e2e.runner import E2EScenarioItem
+
+
+class E2EYamlFile(pytest.File):
+    def collect(self):
+        spec = load_spec(self.path)
+        for scenario in spec.scenarios:
+            yield E2EScenarioItem.from_parent(
+                self, name=scenario.name, scenario=scenario
+            )
+
+
+def pytest_collect_file(parent, file_path):
+    if file_path.name == 'e2e.rbx.yml':
+        return E2EYamlFile.from_parent(parent, path=file_path)
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if isinstance(item, E2EScenarioItem):
+            item.add_marker(pytest.mark.e2e)
+```
+
+`tests/e2e/runner.py` skeleton:
+
+```python
+import pytest
+from tests.e2e.spec import Scenario
+
+
+class E2EScenarioItem(pytest.Item):
+    def __init__(self, *, scenario: Scenario, **kwargs):
+        super().__init__(**kwargs)
+        self.scenario = scenario
+
+    def runtest(self):
+        # Implemented in Task 4
+        pass
+
+    def reportinfo(self):
+        return self.path, 0, f'scenario: {self.name}'
+```
+
+Run: `uv run pytest tests/e2e/test_collection.py -v`. Expected: PASS.
+Also run `uv run pytest --collect-only tests/e2e/testdata/simple-ac/`. Expected: collects `simple-ac/e2e.rbx.yml::smoke`.
+
+**Step 3: Commit**
+
+```bash
+git add tests/e2e/conftest.py tests/e2e/runner.py tests/e2e/test_collection.py
+git commit -m "test(e2e): add pytest collection hook for e2e.rbx.yml"
+```
+
+---
+
+## Task 4: Step runner + exit code assertion
+
+**Files:**
+- Modify: `tests/e2e/runner.py`
+- Test: extend `tests/e2e/testdata/simple-ac/e2e.rbx.yml`
+
+**Step 1: Make the smoke scenario pass end-to-end**
+
+Implement `runtest` to:
+1. Copy the package directory to a tmpdir (use `TestingPackage(self.path.parent)` — it does this).
+2. For each step, run `CliRunner().invoke(rbx_app, shlex.split(step.cmd))`.
+3. Assert `result.exit_code == step.expect_exit` with a clear failure message.
+
+```python
+import shlex
+from typer.testing import CliRunner
+from rbx.box.cli import app as rbx_app
+from rbx.box.testing.testing_package import TestingPackage
+
+
+class E2EScenarioItem(pytest.Item):
+    ...
+    def runtest(self):
+        with TestingPackage(self.path.parent) as pkg:
+            for step in self.scenario.steps:
+                self._run_step(pkg, step)
+
+    def _run_step(self, pkg, step):
+        result = CliRunner(mix_stderr=False).invoke(rbx_app, shlex.split(step.cmd))
+        if result.exit_code != step.expect_exit:
+            raise AssertionError(
+                f"[{self.path.parent.name}::{self.scenario.name}] "
+                f"step {step.cmd!r} exited {result.exit_code}, expected {step.expect_exit}\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+```
+
+**Step 2: Run the smoke test**
+
+```bash
+uv run pytest tests/e2e/testdata/simple-ac/e2e.rbx.yml -v
+```
+
+Expected: PASS. (The step runs `rbx build`, exit code 0, no assertions.)
+
+**Step 3: Add a negative-test fixture**
+
+Create `tests/e2e/testdata/bad-exit/e2e.rbx.yml`:
+
+```yaml
+scenarios:
+  - name: nonexistent-cmd
+    steps:
+      - cmd: this-is-not-a-command
+        expect_exit: 2
+```
+
+Run: `uv run pytest tests/e2e/testdata/bad-exit/ -v`. Expected: PASS (Typer returns 2 for unknown commands; verify by hand and adjust if Typer's exit code differs).
+
+**Step 4: Commit**
+
+```bash
+git add tests/e2e/runner.py tests/e2e/testdata/
+git commit -m "test(e2e): implement step runner with exit-code assertion"
+```
+
+---
+
+## Task 5: Generic assertions — stdout/stderr/files/file_contains
+
+**Files:**
+- Create: `tests/e2e/assertions.py`
+- Modify: `tests/e2e/runner.py`
+- Test: extend a fixture's `e2e.rbx.yml`
+
+**Step 1: Write failing tests at the assertion level**
+
+Unit-test each assertion class independently in `tests/e2e/test_assertions.py`. Each class takes a constructed input (a fake `result` for stdout matchers, a tmpdir for filesystem matchers), exercises the matcher, and asserts pass/fail.
+
+**Step 2: Implement each assertion class**
+
+```python
+# tests/e2e/assertions.py
+import glob
+import pathlib
+import re
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class AssertionContext:
+    package_root: pathlib.Path
+    stdout: str
+    stderr: str
+
+
+def _as_list(v):
+    if v is None:
+        return []
+    return [v] if isinstance(v, str) else list(v)
+
+
+def check_stdout_contains(ctx: AssertionContext, expected) -> None:
+    for needle in _as_list(expected):
+        if needle not in ctx.stdout:
+            raise AssertionError(f'stdout missing {needle!r}')
+
+
+def check_stderr_contains(ctx: AssertionContext, expected) -> None:
+    for needle in _as_list(expected):
+        if needle not in ctx.stderr:
+            raise AssertionError(f'stderr missing {needle!r}')
+
+
+def check_stdout_matches(ctx: AssertionContext, pattern: str) -> None:
+    if not re.search(pattern, ctx.stdout):
+        raise AssertionError(f'stdout did not match /{pattern}/')
+
+
+def check_files_exist(ctx: AssertionContext, patterns: List[str]) -> None:
+    for pat in patterns:
+        if not glob.glob(str(ctx.package_root / pat)):
+            raise AssertionError(f'no file matched {pat!r}')
+
+
+def check_files_absent(ctx: AssertionContext, patterns: List[str]) -> None:
+    for pat in patterns:
+        if glob.glob(str(ctx.package_root / pat)):
+            raise AssertionError(f'unexpected file matched {pat!r}')
+
+
+def check_file_contains(ctx: AssertionContext, mapping) -> None:
+    for path, needle in mapping.items():
+        text = (ctx.package_root / path).read_text()
+        if needle.startswith('/') and needle.endswith('/') and len(needle) > 2:
+            if not re.search(needle[1:-1], text):
+                raise AssertionError(f'{path}: regex {needle} no match')
+        elif needle not in text:
+            raise AssertionError(f'{path}: missing {needle!r}')
+```
+
+**Step 3: Wire into runner**
+
+In `_run_step`, after the exit-code check, dispatch each non-None field of `step.expect` to the corresponding `check_*` function. Keep a tight whitelist; one block per matcher.
+
+**Step 4: Extend `simple-ac/e2e.rbx.yml`**
+
+```yaml
+scenarios:
+  - name: smoke
+    steps:
+      - cmd: build
+        expect:
+          files_exist:
+            - "build/tests/*.in"
+```
+
+Run: `uv run pytest tests/e2e/testdata/simple-ac/ -v`. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/assertions.py tests/e2e/runner.py tests/e2e/test_assertions.py tests/e2e/testdata/simple-ac/e2e.rbx.yml
+git commit -m "test(e2e): add stdout/stderr/file assertions"
+```
+
+---
+
+## Task 6: Zip assertions
+
+**Files:**
+- Modify: `tests/e2e/assertions.py`
+- Modify: `tests/e2e/runner.py`
+- Test: `tests/e2e/test_assertions.py`
+
+**Step 1: Tests**
+
+In `test_assertions.py`, build a small `.zip` in a tmpdir with `zipfile.ZipFile`, exercise `check_zip_contains` with both literal entries and globs (`*.xml`, `limits/*`), and `check_zip_not_contains`.
+
+**Step 2: Implement**
+
+```python
+import fnmatch
+import zipfile
+
+def _glob_in_zip(zip_path: pathlib.Path, pattern: str) -> bool:
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+    return any(fnmatch.fnmatch(n, pattern) for n in names)
+
+
+def check_zip_contains(ctx, matcher) -> None:
+    zip_paths = glob.glob(str(ctx.package_root / matcher.path))
+    if not zip_paths:
+        raise AssertionError(f'no zip matched {matcher.path!r}')
+    zip_path = pathlib.Path(zip_paths[0])
+    for entry in matcher.entries:
+        if not _glob_in_zip(zip_path, entry):
+            raise AssertionError(f'{zip_path.name}: missing entry {entry!r}')
+
+
+def check_zip_not_contains(ctx, matcher) -> None:
+    zip_paths = glob.glob(str(ctx.package_root / matcher.path))
+    if not zip_paths:
+        return
+    zip_path = pathlib.Path(zip_paths[0])
+    for entry in matcher.entries:
+        if _glob_in_zip(zip_path, entry):
+            raise AssertionError(f'{zip_path.name}: unexpected entry {entry!r}')
+```
+
+Wire into runner.
+
+**Step 3: Add a fixture exercising it**
+
+Build a fixture (`tests/e2e/testdata/pkg-boca/`) — minimal package, scenario:
+
+```yaml
+scenarios:
+  - name: package-boca
+    steps:
+      - cmd: build
+      - cmd: pkg boca
+        expect:
+          files_exist: ["build/boca/*.zip"]
+          zip_contains:
+            path: build/boca/*.zip
+            entries: [description.xml]
+```
+
+Run: `uv run pytest tests/e2e/testdata/pkg-boca/ -v`. Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add tests/e2e/
+git commit -m "test(e2e): add zip_contains/zip_not_contains assertions"
+```
+
+---
+
+## Task 7: `solutions:` matcher (verdict matrix)
+
+**Files:**
+- Modify: `tests/e2e/assertions.py`
+- Test: `tests/e2e/test_solutions_matcher.py`
+
+**Prereq:** Task 0 must be done; the on-disk verdict source is now known. The implementation below assumes per-test `Evaluation` files exist; adjust file paths to match what Task 0 documents.
+
+**Step 1: Write failing tests**
+
+Construct fake on-disk evaluation data in a tmpdir mirroring the real layout. Cover:
+- Bare-verdict form passes when all groups match.
+- `*: wa` + `samples: ac` correctly resolves group-by-name override.
+- Per-test override (`group/test_id: ac`) takes precedence over group entry.
+- Sparse coverage: only specified entries are checked; other groups/tests can have any verdict.
+- Failure cases: clear message naming the (solution, group/test, expected, actual).
+- Solutions in the YAML that don't exist in the package → assertion error.
+
+**Step 2: Implement**
+
+Outline (concrete code depends on Task 0):
+
+```python
+def check_solutions(ctx, matchers):
+    # Load the verdict report (path determined by Task 0).
+    report = _load_verdict_report(ctx.package_root)
+
+    for sol_path, matcher in matchers.items():
+        if sol_path not in report.solutions:
+            raise AssertionError(f'solution {sol_path!r} not in run report')
+
+        # Per-test entries: keys containing "/"
+        # Per-group entries: identifier-like keys
+        per_test = {k: v for k, v in matcher.entries.items() if '/' in k}
+        per_group = {k: v for k, v in matcher.entries.items() if '/' not in k}
+
+        # 1. Per-test assertions.
+        for test_path, expected in per_test.items():
+            actual = report.test_verdict(sol_path, test_path)
+            if not expected.match(actual):
+                raise AssertionError(
+                    f'{sol_path} / {test_path}: expected {expected.name}, got {actual.name}'
+                )
+
+        # 2. Per-group assertions (explicit + '*' fallback).
+        for group_name in report.group_names(sol_path):
+            if group_name in per_group:
+                expected = per_group[group_name]
+            elif matcher.star is not None:
+                expected = matcher.star
+            else:
+                continue  # sparse: not asserted
+            actual = report.group_outcome(sol_path, group_name)
+            if not expected.match(actual):
+                raise AssertionError(
+                    f'{sol_path} / {group_name}: expected {expected.name}, got {actual.name}'
+                )
+```
+
+Use `ExpectedOutcome.match(outcome: Outcome)` from `rbx/box/schema.py` — the same matcher rbx already uses for `problem.rbx.yml`'s `outcome:` field. Do **not** reinvent verdict comparison.
+
+**Step 3: Add a multi-solution fixture**
+
+Build `tests/e2e/testdata/mixed-solutions/` with one AC solution, one WA solution, exercising the full matcher syntax. Run end-to-end:
+
+```bash
+uv run pytest tests/e2e/testdata/mixed-solutions/ -v
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add tests/e2e/
+git commit -m "test(e2e): add solutions verdict matcher"
+```
+
+---
+
+## Task 8: `tests:` matcher (build-time generation/validation report)
+
+**Files:**
+- Modify: `tests/e2e/assertions.py`
+- Test: `tests/e2e/test_tests_matcher.py`
+
+**Prereq:** confirm whether `rbx build` currently persists a structured generation/validation report. Inspect during the task; if not, the smallest acceptable change is to write `build/tests/_report.json` (or yaml) listing each generated test path, group, and validation status.
+
+**Step 1: Tests**
+
+Cover: total `count`, per-group `groups: {name: int}`, `all_valid: true` when all generated tests passed validation, `all_valid: false` allowed (don't enforce), `exist:` with literal paths under `build/tests/`.
+
+**Step 2: Implement**
+
+```python
+def check_tests(ctx, matcher):
+    report = _load_build_report(ctx.package_root)
+    if matcher.count is not None and report.count != matcher.count:
+        raise AssertionError(f'tests.count: expected {matcher.count}, got {report.count}')
+    for grp, n in matcher.groups.items():
+        actual = report.group_count(grp)
+        if actual != n:
+            raise AssertionError(f'tests.groups.{grp}: expected {n}, got {actual}')
+    if matcher.all_valid and not report.all_valid:
+        raise AssertionError('tests.all_valid: some tests failed validation')
+    for path in matcher.exist:
+        if not (ctx.package_root / 'build' / 'tests' / path).exists():
+            raise AssertionError(f'tests.exist: missing {path!r}')
+```
+
+**Step 3: Extend the simple-ac fixture**
+
+```yaml
+- cmd: build
+  expect:
+    tests:
+      count: 5
+      all_valid: true
+```
+
+Run: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add tests/e2e/
+git commit -m "test(e2e): add tests build-report matcher"
+```
+
+---
+
+## Task 9: Statement build assertions (`st b`)
+
+**Files:**
+- Test: `tests/e2e/testdata/with-statement/`
+
+**Step 1: Build a fixture with a minimal statement**
+
+Reuse `template.rbx.tex` and `statements/` layout from `simple-problem`. Add `mock_pdflatex` style mocking? **No** — the `e2e` mark already implies real LaTeX. If LaTeX is not on CI, mark this scenario `@pytest.mark.slow` via a YAML hint (see Task 11 — pytest-marker passthrough).
+
+Scenario:
+
+```yaml
+scenarios:
+  - name: statement
+    steps:
+      - cmd: build
+      - cmd: st b
+        expect:
+          files_exist: [build/statements/statement.pdf]
+```
+
+**Step 2: Run**
+
+```bash
+uv run pytest tests/e2e/testdata/with-statement/ -v -m e2e
+```
+
+Expected: PASS (or SKIP if LaTeX missing locally — fine).
+
+**Step 3: Commit**
+
+```bash
+git add tests/e2e/testdata/with-statement/
+git commit -m "test(e2e): add statement-build fixture"
+```
+
+---
+
+## Task 10: Migrate existing CLI e2e tests
+
+**Files:**
+- Move/recreate: `tests/rbx/box/cli/problem_test.py` content as YAML scenarios under `tests/e2e/testdata/`.
+- Delete: `tests/rbx/box/cli/problem_test.py` (after parity).
+- Optionally relocate: `tests/rbx/box/packaging/e2e/testdata/simple-problem/` → `tests/e2e/testdata/simple-problem/` (only if no other test references it).
+
+**Step 1: Mirror `test_default_preset_problem`**
+
+Create `tests/e2e/testdata/default-preset/e2e.rbx.yml`:
+
+```yaml
+scenarios:
+  - name: full-pipeline
+    steps:
+      - cmd: run
+      - cmd: unit
+      - cmd: st b
+      - cmd: pkg boca
+      - cmd: pkg polygon
+```
+
+The original test relies on the default preset being copied in. Reuse the preset-copy logic from the existing `pkg_from_resources` fixture by adding a small per-package opt-in: a top-level `setup:` key in `e2e.rbx.yml` referencing a preset name. Add this to the schema (Task 2 extension), not as a separate concept.
+
+If preset-copy is too invasive, alternative: the `default-preset` fixture directory directly contains the materialized preset files (committed). Choose whichever produces less ongoing maintenance.
+
+**Step 2: Mirror `test_interactive_problem`**
+
+Same approach for the interactive package. The original used `tests/rbx/box/cli/testdata/problems/interactive` — copy its files under `tests/e2e/testdata/interactive/`.
+
+**Step 3: Delete the old Python tests**
+
+```bash
+git rm tests/rbx/box/cli/problem_test.py
+```
+
+Verify: `uv run pytest tests/rbx/box/cli/` runs cleanly (or is empty).
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "test(e2e): migrate CLI e2e tests to YAML DSL"
+```
+
+---
+
+## Task 11: Slow/docker passthrough
+
+**Files:**
+- Modify: `tests/e2e/spec.py` (add `markers: List[str]` to `Scenario`).
+- Modify: `tests/e2e/conftest.py` (apply markers in `pytest_collection_modifyitems`).
+
+**Step 1: Schema**
+
+```yaml
+scenarios:
+  - name: heavy
+    markers: [slow]
+    steps: [...]
+```
+
+**Step 2: Implementation**
+
+In `pytest_collection_modifyitems`, after adding `e2e`, also apply each marker name from `scenario.markers` (whitelisted to `slow`, `docker` — reject unknown to avoid typo bugs).
+
+**Step 3: Commit**
+
+```bash
+git commit -am "test(e2e): support slow/docker markers per scenario"
+```
+
+---
+
+## Task 12: README + docs
+
+**Files:**
+- Create: `tests/e2e/README.md` (how to add a new e2e package, schema reference, examples).
+- Update: `tests/rbx/box/packaging/e2e/README.md` to point at the new tree.
+- Update top-level `CLAUDE.md` testing section to mention `mise run test-e2e` and the YAML DSL.
+
+**Step 1: Write the README**
+
+Cover: directory layout, how to add a new package, full schema with one example per matcher, how to run a single scenario, how to debug a failing assertion (`-v`, look at stdout/stderr in the failure message), the marker passthrough.
+
+**Step 2: Commit**
+
+```bash
+git add tests/e2e/README.md tests/rbx/box/packaging/e2e/README.md CLAUDE.md
+git commit -m "docs(e2e): document YAML-driven e2e test framework"
+```
+
+---
+
+## Task 13: CI verification
+
+**Files:** none (verification only).
+
+**Step 1: Run the new e2e suite locally**
+
+```bash
+mise run test-e2e
+```
+
+Expected: all e2e tests pass. Runtime: capture and document in the README.
+
+**Step 2: Run the unit suite to confirm exclusion**
+
+```bash
+mise run test
+```
+
+Expected: zero `tests/e2e/...` entries collected. (The `e2e` mark filter excludes them.)
+
+**Step 3: Inspect CI workflow**
+
+Read `.github/workflows/tests.yml` (already open in the IDE). Confirm `mise run test-e2e` is invoked in CI; if not, add it as a separate job (matching existing patterns).
+
+**Step 4: If CI changes were needed, commit**
+
+```bash
+git add .github/workflows/tests.yml
+git commit -m "ci: run e2e suite via mise run test-e2e"
+```
+
+---
+
+## Out of scope (documented in design doc)
+
+- `rbx stress` matchers — needs structured `--report` flag added to `stress` first.
+- Migrating `tests/rbx/box/packaging/e2e/test_boca_e2e.py` — stays Python.
+- Multi-language statement assertions — trivial extension once v1 lands.
+- Contest-level packages — same DSL would extend; deferred.

--- a/docs/plans/2026-05-03-generator-determinism-check-design.md
+++ b/docs/plans/2026-05-03-generator-determinism-check-design.md
@@ -1,0 +1,110 @@
+# Generator Determinism Check — Design
+
+## Problem
+
+Generators in rbx are expected to produce identical output whenever called
+with the same `argv`. A generator that seeds itself from a non-`argv` source
+(`time(NULL)`, `/dev/urandom`, an unseeded `rand()`, etc.) will silently
+produce different testcases on different builds, breaking reproducibility and
+masking subtle bugs in problem packages.
+
+We want a cheap, opportunistic check that catches the obvious cases: run each
+generator twice and compare digests. A non-deterministic generator may still
+slip through if both runs happen to coincide, but the check raises the cost
+of being undetected.
+
+## Trigger
+
+The check runs whenever `VerificationLevel >= VALIDATE` (i.e. anytime
+validation is on). At `VerificationLevel.NONE` the check is skipped, keeping
+plain `rbx build -v0` cheap.
+
+## Behavior on mismatch
+
+Hard error: raise `GenerationError` with a message naming the generator and
+the offending args, and noting the likely cause (generator not seeded from
+`argv`). The build aborts.
+
+Mirrors the strictness of validator failures rather than the warning-only
+hash-duplicate detection, because non-determinism breaks reproducibility
+across builds, which is worse than a duplicate test.
+
+## Scope
+
+Only generator-call testcases get the second run. `copied_from` and inline
+`content` testcases are deterministic by construction — skipped.
+
+## Where the change lives
+
+`rbx/box/generators.py`, inside `BuildTestcaseVisitor._visit` (the existing
+build-pipeline call site that already digests outputs for hash-duplicate
+detection). `generate_standalone` is left untouched — it has other callers
+(stress testing) where doubling generator cost is unwanted.
+
+## Mechanism
+
+Inside `_visit`, when the entry is a generator call, run two coroutines
+concurrently with `asyncio.gather`:
+
+1. The existing `generate_standalone(...)` call, which writes the test to
+   `spec.copied_to.inputPath` on disk.
+2. A new helper `_run_generator_to_digest(call, generator_digest, holder)`
+   that wraps `run_item` with `stdout=DigestOrDest.create(holder)`. The
+   stdout streams straight into the file cacher; no temp file is
+   materialized on disk.
+
+The two runs write to disjoint sinks (disk path vs. `DigestHolder`), so they
+are safe to run in parallel.
+
+After `gather` returns:
+
+- Compute the disk digest with `digest_file(...)` (this is already what
+  `_visit` does today).
+- If the determinism check is enabled, compare against `holder.value`. On
+  mismatch raise `GenerationError`.
+- Return the disk digest as before so the existing duplicate-detection logic
+  is unchanged.
+
+## Plumbing the trigger
+
+`generate_testcases` currently takes no verification parameter. Three small
+changes:
+
+1. **`generators.generate_testcases`** — add
+   `verification: VerificationLevel = VerificationLevel.NONE`. Default to
+   `NONE` so other callers stay opt-out.
+2. **`BuildTestcaseVisitor`** — store a single boolean
+   `check_determinism: bool`. The visitor stays decoupled from
+   `VerificationLevel`; translation happens in `generate_testcases`:
+   `check_determinism = verification.value >= VerificationLevel.VALIDATE.value`.
+3. **`builder.build()`** — pass it through:
+   `await generate_testcases(s, groups=groups, verification=VerificationLevel(verification))`.
+
+`VerificationLevel` is already imported in `builder.py`; `generators.py`
+gains an import from `rbx.box.environment`.
+
+## Performance
+
+Doubles generator wall time when validation is on. Acceptable: generator
+runs are already parallelized via the visitor, the second run streams
+straight into the cacher (no extra disk I/O), and validation-enabled builds
+are not the hot inner loop.
+
+## Testing
+
+Unit tests in `tests/rbx/box/`. New testdata package containing two tiny
+C++ generators:
+
+- A deterministic generator that echoes its `argv`.
+- A non-deterministic generator that prints a value derived from
+  `time(NULL)` or `/dev/urandom` so the two runs reliably diverge.
+
+Cases:
+
+1. Deterministic generator at `VerificationLevel.VALIDATE` — `build` succeeds.
+2. Non-deterministic generator at `VerificationLevel.VALIDATE` — `build`
+   raises `GenerationError`; message references the generator name and args.
+3. Non-deterministic generator at `VerificationLevel.NONE` — `build`
+   succeeds (proves the gate is wired correctly).
+
+Reuse existing fixtures (`cleandir_with_testdata`, `pkg_from_testdata`).

--- a/docs/plans/2026-05-03-generator-determinism-check.md
+++ b/docs/plans/2026-05-03-generator-determinism-check.md
@@ -1,0 +1,410 @@
+# Generator Determinism Check Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Detect non-deterministic generators (those not seeded by `argv`) by running each generator twice and comparing output digests; raise a hard error on mismatch when `VerificationLevel >= VALIDATE`.
+
+**Architecture:** Inside `BuildTestcaseVisitor._visit` in `rbx/box/generators.py`, run the existing `generate_standalone` call concurrently with a second `run_item` invocation that streams stdout into a `DigestHolder`. After both finish, compare the disk-file digest with the holder's digest and raise `GenerationError` on mismatch. Gating is plumbed through `generate_testcases(..., verification: VerificationLevel)` from `builder.build()`; the visitor itself only sees a `check_determinism: bool`.
+
+**Tech Stack:** Python 3, asyncio, Pydantic v2, pytest, Typer (rbx CLI), C++ generators using testlib.
+
+**Design doc:** `docs/plans/2026-05-03-generator-determinism-check-design.md`
+
+---
+
+## Task 1: Add a non-deterministic test generator fixture
+
+**Files:**
+- Create: `rbx/testdata/generators/gen-nondet.cpp`
+
+**Step 1: Create the C++ generator**
+
+Mirror `rbx/testdata/generators/gen-id.cpp` but emit a value derived from a non-`argv` source so two runs reliably differ. Use `time(NULL)` plus the process PID and a tight loop nonce — the loop nonce guarantees divergence even if the two runs land in the same second.
+
+```cpp
+#include "testlib.h"
+#include <ctime>
+#include <unistd.h>
+
+using namespace std;
+
+int main(int argc, char *argv[]) {
+  registerGen(argc, argv, 1);
+  // Intentionally NOT seeded from argv: this generator is used in tests to
+  // verify the determinism check. It must produce different output on
+  // back-to-back runs.
+  static int nonce = 0;
+  unsigned long long v =
+      (unsigned long long)time(NULL) ^
+      (unsigned long long)getpid() ^
+      (unsigned long long)(++nonce);
+  cout << v << endl;
+  return 0;
+}
+```
+
+**Step 2: Verify the file compiles standalone (sanity check)**
+
+Run: `ls rbx/testdata/generators/gen-nondet.cpp`
+Expected: file listed.
+
+The generator gets compiled inside the rbx sandbox during the actual tests; no separate compile step needed here.
+
+**Step 3: Commit**
+
+```bash
+git add rbx/testdata/generators/gen-nondet.cpp
+git commit -m "test(generators): add non-deterministic generator fixture"
+```
+
+---
+
+## Task 2: Write failing test — non-determinism is detected at VerificationLevel.VALIDATE
+
+**Files:**
+- Modify: `tests/rbx/box/generators_test.py` (append a new test)
+
+**Step 1: Add the failing test**
+
+At the bottom of `tests/rbx/box/generators_test.py`, append:
+
+```python
+async def test_generator_determinism_check_detects_nondeterministic_generator(
+    testing_pkg: testing_package.TestingPackage,
+):
+    from rbx.box.environment import VerificationLevel
+    from rbx.box.generators import GenerationError
+
+    testing_pkg.add_generator('gens/gen.cpp', src='generators/gen-nondet.cpp')
+    testing_pkg.add_testgroup_from_plan('main', 'gens/gen.cpp 123\n')
+
+    with pytest.raises(GenerationError):
+        await generate_testcases(verification=VerificationLevel.VALIDATE)
+```
+
+**Step 2: Run the test, confirm it fails**
+
+Run: `uv run pytest tests/rbx/box/generators_test.py::test_generator_determinism_check_detects_nondeterministic_generator -v`
+Expected: FAIL — likely `TypeError: generate_testcases() got an unexpected keyword argument 'verification'` (no `verification` param yet).
+
+**Step 3: Commit the failing test**
+
+```bash
+git add tests/rbx/box/generators_test.py
+git commit -m "test(generators): add failing test for determinism check"
+```
+
+---
+
+## Task 3: Plumb `verification` param through `generate_testcases`
+
+**Files:**
+- Modify: `rbx/box/generators.py` (signature of `generate_testcases` near line 421; visitor instantiation near line 467)
+- Modify: `rbx/box/builder.py:45`
+
+**Step 1: Add the import and parameter in `generators.py`**
+
+At the top of `rbx/box/generators.py`, add to the existing `from rbx.box import (...)` block: ensure `environment` is importable. Add a dedicated import line:
+
+```python
+from rbx.box.environment import VerificationLevel
+```
+
+Change the `generate_testcases` signature from:
+
+```python
+async def generate_testcases(
+    progress: Optional[StatusProgress] = None, groups: Optional[Set[str]] = None
+):
+```
+
+to:
+
+```python
+async def generate_testcases(
+    progress: Optional[StatusProgress] = None,
+    groups: Optional[Set[str]] = None,
+    verification: VerificationLevel = VerificationLevel.NONE,
+):
+```
+
+Just before the visitor instantiation (currently `visitor = BuildTestcaseVisitor(groups)` near line 467), compute the boolean:
+
+```python
+check_determinism = verification.value >= VerificationLevel.VALIDATE.value
+```
+
+(The visitor is updated in Task 4 to accept this parameter.)
+
+**Step 2: Pass the value from `builder.build()`**
+
+In `rbx/box/builder.py`, change line 45 from:
+
+```python
+await generate_testcases(s, groups=groups)
+```
+
+to:
+
+```python
+await generate_testcases(
+    s, groups=groups, verification=VerificationLevel(verification)
+)
+```
+
+`VerificationLevel` is already imported at line 5.
+
+**Step 3: Run the (still-failing) test, confirm the failure mode changed**
+
+Run: `uv run pytest tests/rbx/box/generators_test.py::test_generator_determinism_check_detects_nondeterministic_generator -v`
+Expected: still FAIL, but no longer with `unexpected keyword argument`. It now fails because `GenerationError` is not raised — the determinism check is not yet implemented.
+
+**Step 4: Commit**
+
+```bash
+git add rbx/box/generators.py rbx/box/builder.py
+git commit -m "feat(generators): plumb VerificationLevel into generate_testcases"
+```
+
+---
+
+## Task 4: Teach `BuildTestcaseVisitor` to take a `check_determinism` flag
+
+**Files:**
+- Modify: `rbx/box/generators.py` (around lines 437–468)
+
+**Step 1: Update the visitor**
+
+`BuildTestcaseVisitor` currently inherits its `__init__` from `TestcaseGroupVisitor` (instantiated as `BuildTestcaseVisitor(groups)`). Add an explicit `__init__` that captures the boolean and forwards `groups` to the parent:
+
+```python
+class BuildTestcaseVisitor(TestcaseGroupVisitor):
+    def __init__(
+        self,
+        groups: Optional[Set[str]],
+        *,
+        check_determinism: bool = False,
+    ):
+        super().__init__(groups)
+        self.check_determinism = check_determinism
+
+    async def visit(self, entry: GenerationTestcaseEntry):
+        ...
+```
+
+Update the visitor instantiation a few lines below to:
+
+```python
+visitor = BuildTestcaseVisitor(groups, check_determinism=check_determinism)
+```
+
+`_visit` is unchanged in this task; the flag is wired but not yet consumed.
+
+**Step 2: Run the existing generator tests to confirm no regression**
+
+Run: `uv run pytest tests/rbx/box/generators_test.py -v -k 'not nondeterministic'`
+Expected: all existing tests PASS.
+
+**Step 3: Commit**
+
+```bash
+git add rbx/box/generators.py
+git commit -m "refactor(generators): add check_determinism flag to BuildTestcaseVisitor"
+```
+
+---
+
+## Task 5: Implement the determinism check inside `_visit`
+
+**Files:**
+- Modify: `rbx/box/generators.py` (the `_visit` method around lines 442–465; add a new helper above it)
+
+**Step 1: Add the helper that runs a generator into a `DigestHolder`**
+
+Add this helper at module scope, somewhere above `generate_testcases` (e.g. just after `_compile_generator` near line 60):
+
+```python
+async def _run_generator_to_digest(
+    generator: CodeItem,
+    generator_digest: str,
+    args: Optional[str],
+) -> str:
+    """Run a generator with stdout captured into a DigestHolder and return the digest.
+
+    Used by the determinism check: re-runs a generator with the same args as a
+    prior invocation and returns the digest of its stdout, without touching the
+    on-disk testcase file.
+    """
+    holder = DigestHolder()
+    log = await run_item(
+        generator,
+        DigestOrSource.create(generator_digest),
+        stdout=DigestOrDest.create(holder),
+        extra_args=args or None,
+    )
+    if not log or log.exitcode != 0 or holder.value is None:
+        raise GenerationError(
+            f'Determinism re-run of generator {generator.path} failed '
+            f'(exit={None if log is None else log.exitcode}).'
+        )
+    return holder.value
+```
+
+**Step 2: Update `_visit` to run both invocations in parallel and compare**
+
+Replace the `elif entry.metadata.generator_call is not None:` branch (currently lines 453–461) with:
+
+```python
+elif entry.metadata.generator_call is not None:
+    call = entry.metadata.generator_call
+    generator_digest = compiled_generators[call.name]
+    primary = generate_standalone(
+        entry.metadata,
+        group_entry=entry.group_entry,
+        validate=False,
+        generator_digest=generator_digest,
+    )
+    if self.check_determinism:
+        verify = _run_generator_to_digest(
+            package.get_generator(call.name),
+            generator_digest,
+            call.args,
+        )
+        _, verify_digest = await asyncio.gather(primary, verify)
+    else:
+        await primary
+        verify_digest = None
+```
+
+Then, after the existing `assert entry.metadata.copied_to.inputPath.is_file()` line, before the `return digest_file(...)`:
+
+```python
+first_digest = digest_file(entry.metadata.copied_to.inputPath)
+if verify_digest is not None and verify_digest != first_digest:
+    raise GenerationError(
+        f'Generator [item]{call.name}[/item] with args [item]{call.args}[/item] '
+        f'is non-deterministic: two runs produced different output. '
+        f'This usually means the generator is not seeded from its argv.'
+    )
+return first_digest
+```
+
+(Remove the previous `return digest_file(entry.metadata.copied_to.inputPath)` line — it is replaced by the block above.)
+
+Note: `verify_digest` must be defined on every code path through `_visit` before the comparison. For the `copied_from` and `content` branches, set `verify_digest = None` at the start of those branches, or hoist `verify_digest = None` to the top of `_visit`.
+
+**Step 3: Run the failing test, confirm it now passes**
+
+Run: `uv run pytest tests/rbx/box/generators_test.py::test_generator_determinism_check_detects_nondeterministic_generator -v`
+Expected: PASS.
+
+**Step 4: Run the full generators test file to confirm no regressions**
+
+Run: `uv run pytest tests/rbx/box/generators_test.py -v`
+Expected: all tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/generators.py
+git commit -m "feat(generators): check determinism by re-running generators"
+```
+
+---
+
+## Task 6: Add the positive-path test (deterministic generator passes)
+
+**Files:**
+- Modify: `tests/rbx/box/generators_test.py`
+
+**Step 1: Append the test**
+
+```python
+async def test_generator_determinism_check_passes_for_deterministic_generator(
+    testing_pkg: testing_package.TestingPackage,
+):
+    from rbx.box.environment import VerificationLevel
+
+    testing_pkg.add_generator('gens/gen.cpp', src='generators/gen-id.cpp')
+    testing_pkg.add_testgroup_from_plan('main', 'gens/gen.cpp 123\n')
+
+    # Should not raise.
+    await generate_testcases(verification=VerificationLevel.VALIDATE)
+
+    assert (
+        testing_pkg.get_build_testgroup_path('main') / '000.in'
+    ).read_text() == '123\n'
+```
+
+**Step 2: Run the test**
+
+Run: `uv run pytest tests/rbx/box/generators_test.py::test_generator_determinism_check_passes_for_deterministic_generator -v`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/box/generators_test.py
+git commit -m "test(generators): cover deterministic generator passes the check"
+```
+
+---
+
+## Task 7: Add the gating test (no check at VerificationLevel.NONE)
+
+**Files:**
+- Modify: `tests/rbx/box/generators_test.py`
+
+**Step 1: Append the test**
+
+```python
+async def test_generator_determinism_check_skipped_at_verification_none(
+    testing_pkg: testing_package.TestingPackage,
+):
+    from rbx.box.environment import VerificationLevel
+
+    testing_pkg.add_generator('gens/gen.cpp', src='generators/gen-nondet.cpp')
+    testing_pkg.add_testgroup_from_plan('main', 'gens/gen.cpp 123\n')
+
+    # No verification → no determinism check → no error even though the
+    # generator is non-deterministic.
+    await generate_testcases(verification=VerificationLevel.NONE)
+```
+
+**Step 2: Run the test**
+
+Run: `uv run pytest tests/rbx/box/generators_test.py::test_generator_determinism_check_skipped_at_verification_none -v`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/box/generators_test.py
+git commit -m "test(generators): cover that determinism check is gated by verification"
+```
+
+---
+
+## Task 8: Final verification
+
+**Step 1: Run the full generators test file**
+
+Run: `uv run pytest tests/rbx/box/generators_test.py -v`
+Expected: all tests PASS.
+
+**Step 2: Run the broader fast test suite**
+
+Run: `uv run pytest --ignore=tests/rbx/box/cli -n auto`
+Expected: all tests PASS (or pre-existing failures unrelated to this change).
+
+**Step 3: Lint and format**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: no errors. If formatting differs, run `uv run ruff format .` and amend.
+
+**Step 4: Final commit (only if Step 3 produced reformatting)**
+
+```bash
+git add -u
+git commit -m "style: apply ruff format"
+```

--- a/rbx/box/builder.py
+++ b/rbx/box/builder.py
@@ -42,7 +42,9 @@ async def build(
         'Built [item]{processed}[/item] testcases...',
         keep=True,
     ) as s:
-        await generate_testcases(s, groups=groups)
+        await generate_testcases(
+            s, groups=groups, verification=VerificationLevel(verification)
+        )
 
     if verification > 0 and validate:
         with utils.StatusProgress(

--- a/rbx/box/fields.py
+++ b/rbx/box/fields.py
@@ -84,7 +84,7 @@ def expand_vars(recvars: RecVars) -> Vars:
             else:
                 try:
                     new_ctx[k] = expand_var(v, ctx)
-                except (safeeval.NameNotDefined, safeeval.AttributeDoesNotExist):
+                except safeeval.NameNotDefined, safeeval.AttributeDoesNotExist:
                     if should_raise:
                         raise
 

--- a/rbx/box/generators.py
+++ b/rbx/box/generators.py
@@ -433,12 +433,21 @@ async def generate_testcases(
     )
 
     testcase_utils.clear_built_testcases()
-    check_determinism = verification.value >= VerificationLevel.VALIDATE.value  # noqa: F841
+    check_determinism = verification.value >= VerificationLevel.VALIDATE.value
 
     executor = setter_config.get_async_executor(detach=True)
     futures: List[asyncio.Future[IdentifiedResult[GenerationTestcaseEntry, str]]] = []
 
     class BuildTestcaseVisitor(TestcaseGroupVisitor):
+        def __init__(
+            self,
+            groups: Optional[Set[str]],
+            *,
+            check_determinism: bool = False,
+        ):
+            super().__init__(groups)
+            self.check_determinism = check_determinism
+
         async def visit(self, entry: GenerationTestcaseEntry):
             _, completed = executor.submit_with_identity(entry, self._visit, entry)
             futures.append(completed)
@@ -468,7 +477,7 @@ async def generate_testcases(
             assert entry.metadata.copied_to.inputPath.is_file()
             return digest_file(entry.metadata.copied_to.inputPath)
 
-    visitor = BuildTestcaseVisitor(groups)
+    visitor = BuildTestcaseVisitor(groups, check_determinism=check_determinism)
     await run_testcase_visitor(visitor)
 
     # Wait for all testcases to be generated (in original order), and process exceptions and duplicates.

--- a/rbx/box/generators.py
+++ b/rbx/box/generators.py
@@ -61,6 +61,33 @@ async def _compile_generator(generator: CodeItem) -> str:
     return await compile_item(generator, sanitized=SanitizationLevel.PREFER)
 
 
+async def _run_generator_to_digest(
+    generator: CodeItem,
+    generator_digest: str,
+    args: Optional[str],
+) -> str:
+    """Run a generator with stdout captured into a DigestHolder and return the digest.
+
+    Used by the determinism check: re-runs a generator with the same args as a
+    prior invocation and returns the digest of its stdout, without touching the
+    on-disk testcase file.
+    """
+    holder = DigestHolder()
+    log = await run_item(
+        generator,
+        DigestOrSource.create(generator_digest),
+        stdout=DigestOrDest.create(holder),
+        extra_args=args or None,
+    )
+    if not log or log.exitcode != 0 or holder.value is None:
+        with GenerationError() as err:
+            err.print(
+                f'[error]Determinism re-run of generator [item]{generator.path}[/item] '
+                f'failed (exit={None if log is None else log.exitcode}).[/error]'
+            )
+    return holder.value
+
+
 @functools.cache
 def _warn_once_about_crlf():
     console.console.print(
@@ -453,6 +480,7 @@ async def generate_testcases(
             futures.append(completed)
 
         async def _visit(self, entry: GenerationTestcaseEntry) -> str:
+            verify_digest = None
             if entry.metadata.copied_from is not None:
                 _copy_testcase_over(
                     entry.metadata.copied_from,
@@ -464,18 +492,37 @@ async def generate_testcases(
                 )
                 entry.metadata.copied_to.inputPath.write_text(entry.metadata.content)
             elif entry.metadata.generator_call is not None:
-                await generate_standalone(
+                call = entry.metadata.generator_call
+                generator_digest = compiled_generators[call.name]
+                primary = generate_standalone(
                     entry.metadata,
                     group_entry=entry.group_entry,
                     validate=False,
-                    generator_digest=compiled_generators[
-                        entry.metadata.generator_call.name
-                    ],
+                    generator_digest=generator_digest,
                 )
+                if self.check_determinism:
+                    verify = _run_generator_to_digest(
+                        package.get_generator(call.name),
+                        generator_digest,
+                        call.args,
+                    )
+                    _, verify_digest = await asyncio.gather(primary, verify)
+                else:
+                    await primary
             else:
                 raise ValueError(f'Invalid generation metadata: {entry.metadata}')
             assert entry.metadata.copied_to.inputPath.is_file()
-            return digest_file(entry.metadata.copied_to.inputPath)
+            first_digest = digest_file(entry.metadata.copied_to.inputPath)
+            if verify_digest is not None and verify_digest != first_digest:
+                call = entry.metadata.generator_call
+                with GenerationError() as err:
+                    err.print(
+                        f'[error]Generator [item]{call.name}[/item] with args '
+                        f'[item]{call.args}[/item] is non-deterministic: two runs '
+                        f'produced different output. This usually means the generator '
+                        f'is not seeded from its argv.[/error]'
+                    )
+            return first_digest
 
     visitor = BuildTestcaseVisitor(groups, check_determinism=check_determinism)
     await run_testcase_visitor(visitor)

--- a/rbx/box/generators.py
+++ b/rbx/box/generators.py
@@ -17,6 +17,7 @@ from rbx.box import (
     validators,
 )
 from rbx.box.code import SanitizationLevel, compile_item, run_item
+from rbx.box.environment import VerificationLevel
 from rbx.box.exception import RbxException
 from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
 from rbx.box.parallel import live_tasks
@@ -419,7 +420,9 @@ async def generate_standalone(
 
 
 async def generate_testcases(
-    progress: Optional[StatusProgress] = None, groups: Optional[Set[str]] = None
+    progress: Optional[StatusProgress] = None,
+    groups: Optional[Set[str]] = None,
+    verification: VerificationLevel = VerificationLevel.NONE,
 ):
     def step():
         if progress is not None:
@@ -430,6 +433,7 @@ async def generate_testcases(
     )
 
     testcase_utils.clear_built_testcases()
+    check_determinism = verification.value >= VerificationLevel.VALIDATE.value  # noqa: F841
 
     executor = setter_config.get_async_executor(detach=True)
     futures: List[asyncio.Future[IdentifiedResult[GenerationTestcaseEntry, str]]] = []

--- a/rbx/box/main.py
+++ b/rbx/box/main.py
@@ -99,7 +99,7 @@ def app():
         nest_asyncio.apply()
 
         run_app_cli()
-    except (KeyboardInterrupt, typer.Abort):
+    except KeyboardInterrupt, typer.Abort:
         _abort()
     except SystemExit as e:
         if e.code == 130:

--- a/rbx/box/statements/demacro_utils.py
+++ b/rbx/box/statements/demacro_utils.py
@@ -221,7 +221,7 @@ def _collect_recursive(
 
     try:
         content = tex_path.read_text(encoding='utf-8')
-    except (OSError, UnicodeDecodeError):
+    except OSError, UnicodeDecodeError:
         return MacroDefinitions()
 
     defs = extract_definitions(content, source_file=str(resolved))

--- a/rbx/box/tooling/boca/debug_utils.py
+++ b/rbx/box/tooling/boca/debug_utils.py
@@ -60,7 +60,7 @@ def pretty_print_request_data(req: Any) -> None:
                                                 console.console.print(
                                                     f'  [green]{field_name}[/green]: [white]{field_value}[/white]'
                                                 )
-                                    except (ValueError, IndexError):
+                                    except ValueError, IndexError:
                                         console.console.print(
                                             f'  [green]{field_name}[/green]: [dim](could not parse value)[/dim]'
                                         )

--- a/rbx/testdata/generators/gen-nondet.cpp
+++ b/rbx/testdata/generators/gen-nondet.cpp
@@ -1,0 +1,19 @@
+#include "testlib.h"
+#include <ctime>
+#include <unistd.h>
+
+using namespace std;
+
+int main(int argc, char *argv[]) {
+  registerGen(argc, argv, 1);
+  // Intentionally NOT seeded from argv: this generator is used in tests to
+  // verify the determinism check. It must produce different output on
+  // back-to-back runs.
+  static int nonce = 0;
+  unsigned long long v =
+      (unsigned long long)time(NULL) ^
+      (unsigned long long)getpid() ^
+      (unsigned long long)(++nonce);
+  cout << v << endl;
+  return 0;
+}

--- a/rbx/testing_utils.py
+++ b/rbx/testing_utils.py
@@ -67,7 +67,7 @@ def walk_directory(
                     resolved = path.resolve()
                     text_filename.append(' → ', 'cyan')
                     text_filename.append(str(resolved), 'cyan italic')
-                except (OSError, RuntimeError):
+                except OSError, RuntimeError:
                     text_filename.append(' → ', 'red')
                     text_filename.append(f'{os.readlink(path)}', 'red italic')
 

--- a/tests/rbx/box/generators_test.py
+++ b/tests/rbx/box/generators_test.py
@@ -564,3 +564,16 @@ async def test_generator_determinism_check_passes_for_deterministic_generator(
     assert (
         testing_pkg.get_build_testgroup_path('main') / '000.in'
     ).read_text() == '123\n'
+
+
+async def test_generator_determinism_check_skipped_at_verification_none(
+    testing_pkg: testing_package.TestingPackage,
+):
+    from rbx.box.environment import VerificationLevel
+
+    testing_pkg.add_generator('gens/gen.cpp', src='generators/gen-nondet.cpp')
+    testing_pkg.add_testgroup_from_plan('main', 'gens/gen.cpp 123\n')
+
+    # No verification → no determinism check → no error even though the
+    # generator is non-deterministic.
+    await generate_testcases(verification=VerificationLevel.NONE)

--- a/tests/rbx/box/generators_test.py
+++ b/tests/rbx/box/generators_test.py
@@ -535,3 +535,16 @@ gens/gen.cpp 2
 
     out = capsys.readouterr().out
     assert 'is a hash duplicate of' not in out
+
+
+async def test_generator_determinism_check_detects_nondeterministic_generator(
+    testing_pkg: testing_package.TestingPackage,
+):
+    from rbx.box.environment import VerificationLevel
+    from rbx.box.generators import GenerationError
+
+    testing_pkg.add_generator('gens/gen.cpp', src='generators/gen-nondet.cpp')
+    testing_pkg.add_testgroup_from_plan('main', 'gens/gen.cpp 123\n')
+
+    with pytest.raises(GenerationError):
+        await generate_testcases(verification=VerificationLevel.VALIDATE)

--- a/tests/rbx/box/generators_test.py
+++ b/tests/rbx/box/generators_test.py
@@ -548,3 +548,19 @@ async def test_generator_determinism_check_detects_nondeterministic_generator(
 
     with pytest.raises(GenerationError):
         await generate_testcases(verification=VerificationLevel.VALIDATE)
+
+
+async def test_generator_determinism_check_passes_for_deterministic_generator(
+    testing_pkg: testing_package.TestingPackage,
+):
+    from rbx.box.environment import VerificationLevel
+
+    testing_pkg.add_generator('gens/gen.cpp', src='generators/gen-id.cpp')
+    testing_pkg.add_testgroup_from_plan('main', 'gens/gen.cpp 123\n')
+
+    # Should not raise.
+    await generate_testcases(verification=VerificationLevel.VALIDATE)
+
+    assert (
+        testing_pkg.get_build_testgroup_path('main') / '000.in'
+    ).read_text() == '123\n'

--- a/tests/rbx/box/packaging/e2e/test_boca_e2e.py
+++ b/tests/rbx/box/packaging/e2e/test_boca_e2e.py
@@ -73,7 +73,7 @@ def boca_environment(
     try:
         subprocess.run(['docker', '--version'], check=True, capture_output=True)
         subprocess.run(['docker-compose', '--version'], check=True, capture_output=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except subprocess.CalledProcessError, FileNotFoundError:
         pytest.skip('Docker or docker-compose not available')
 
     # Start the BOCA environment


### PR DESCRIPTION
## Summary

- Run each generator-call testcase twice in parallel (via `asyncio.gather`) when `VerificationLevel >= VALIDATE` and compare output digests; mismatch raises `GenerationError`.
- The verification re-run streams stdout into a `DigestHolder` (no extra disk I/O); the original run continues writing to the on-disk testcase file.
- `verification` is plumbed through `generate_testcases` from `builder.build`. `BuildTestcaseVisitor` stays decoupled from rbx specifics — it only sees a `check_determinism: bool` flag.
- Catches generators that aren't seeded from `argv` (e.g. `time(NULL)`, `/dev/urandom`, unseeded `rand()`). Truly non-deterministic generators may still slip through if both runs coincide, but this raises the cost of being undetected.

Design: `docs/plans/2026-05-03-generator-determinism-check-design.md`
Plan: `docs/plans/2026-05-03-generator-determinism-check.md`

## Test plan

- [x] Non-deterministic generator at `VerificationLevel.VALIDATE` raises `GenerationError`
- [x] Deterministic generator at `VerificationLevel.VALIDATE` passes
- [x] Non-deterministic generator at `VerificationLevel.NONE` does **not** raise (gating works)
- [x] Pre-existing `tests/rbx/box/generators_test.py` still passes (25/25)
- [x] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)