### PR TITLE
fix(grading): migrate FileLock to AsyncFileLock for asyncio safety (#394)

### DIFF
--- a/docs/plans/2026-05-03-async-filelock-design.md
+++ b/docs/plans/2026-05-03-async-filelock-design.md
@@ -1,0 +1,71 @@
+# Async FileLock migration
+
+Issue: rsalesc/rbx#394.
+
+## Problem
+
+`FileCacher`, `FileCacheStorage`, `DependencyCache`, and `box.package.get_preprocessed_file_lock` all use synchronous `filelock.FileLock` to guard their critical sections. Callers run as multiple asyncio tasks on a single event loop. Today no locked operation yields, so the bug is latent — but a future change that introduces an `await` inside a lock would deadlock the loop: a yielding task would let another task take over, and that other task would then block on the same `FileLock` while still on the loop thread.
+
+The fix is to switch the locks to `filelock.AsyncFileLock`, which suspends via `asyncio.sleep` instead of blocking the thread.
+
+## Approach
+
+Approach **B** from brainstorming: async-primary API with thin sync wrappers where legitimately needed.
+
+- Locked methods on the three lock-owning classes become `async def` and use `async with self.lock` against an `AsyncFileLock`.
+- Callers that already live inside `async def` (the vast majority) gain `await`.
+- For the small set of methods that have legitimate sync callers, keep a sibling sync method that uses a sync `FileLock` on the same lockfile path (filelock interoperates fine — both async and sync variants coordinate via the OS file lock, so cross-process and cross-context exclusion still hold).
+- We do NOT add `asyncio.run` / `syncer` shims at random call sites; we only keep sync versions where a sync caller actually exists.
+
+This keeps the cascade narrow: only methods that hold a lock get colored async, and only their async callers gain `await`.
+
+## Scope
+
+In scope:
+- `rbx/grading/judge/storage.py`: `FileCacheStorage` (12 lock sites).
+- `rbx/grading/judge/cacher.py`: `FileCacher` (14 lock sites).
+- `rbx/grading/caching.py`: `DependencyCache` (2 lock sites).
+- `rbx/box/package.py`: `get_preprocessed_file_lock` (1 site, used by `mark_problem_as_preprocessed`).
+- All callers of the above whose paths reach a locked method, transitively. Most are already `async def`; a handful (`is_executable_sanitized`, `warning_stack` consumers, validators) need either conversion or sync wrappers.
+
+Out of scope:
+- Reorganizing the cacher / storage interfaces beyond what async forces.
+- Replacing the `FileLock` used in test fixtures or unrelated tools.
+- Behavioural changes (timeouts, retries, granularity).
+
+## API decisions
+
+For each class, the policy is:
+
+1. **Lock-holding method becomes `async def`** by default.
+2. **Sync sibling is added only when an existing sync caller cannot reasonably be made async.** Naming convention: append `_sync` (e.g. `FileCacher.exists_sync`).
+3. The sync sibling reuses a `FileLock` constructed against the same path; the async sibling uses `AsyncFileLock` against the same path. Both are stored as instance attributes (`self.lock` async, `self.sync_lock` sync) only when a sync sibling actually exists.
+
+Concretely we expect sync siblings on, at most:
+- `FileCacher.exists` (called from sync `is_executable_sanitized`, possibly Pydantic-side helpers).
+- `FileCacher.path_for_symlink` / `transient_path_for_symlink` if any sync site uses them.
+- `get_preprocessed_file_lock` keeps a sync entry for current sync callers; we add an async variant.
+
+We will only add a sync sibling after confirming a real sync caller — not preemptively.
+
+## Cascade plan
+
+The cascade is mechanical:
+
+1. Convert leaf methods (those that only use `with self.lock`) to async first.
+2. For each caller, pick: (a) it's already `async def` → add `await`; (b) it can become `async def` cheaply → make it async; (c) it's a sync entry point → add a sync sibling on the callee.
+3. Repeat outward until callers no longer call a converted method.
+
+Order: storage.py → cacher.py → caching.py → package.py, since cacher depends on storage and caching depends on cacher.
+
+## Testing
+
+- Unit tests for cacher / storage / caching that exercise the async path. Reuse existing fixtures where possible.
+- Add a regression test asserting that two concurrent asyncio tasks that both acquire a `FileCacher` lock do not deadlock — i.e. each task includes an `await asyncio.sleep(0)` between its operations, simulating future code paths that yield. Without `AsyncFileLock` this would deadlock today (well — it wouldn't, because nothing yields under the lock; the test exists to lock in the new invariant).
+- Run `uv run pytest --ignore=tests/rbx/box/cli` to catch regressions.
+
+## Risks
+
+- **Hidden sync callers** in test fixtures or rarely-exercised CLI paths. Mitigation: run the test suite end-to-end, including CLI tests once the bulk of changes land.
+- **Pydantic validators** that touch the cacher synchronously. Mitigation: handle case-by-case with sync siblings.
+- **Lock semantics drift**: `AsyncFileLock` and `FileLock` are interoperable for the same file path, but `thread_local=False` on the sync lock matters. We preserve this on sync siblings.

--- a/docs/plans/2026-05-03-async-filelock.md
+++ b/docs/plans/2026-05-03-async-filelock.md
@@ -1,0 +1,331 @@
+# Async FileLock migration — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `filelock.FileLock` with `filelock.AsyncFileLock` in the four lock-owning sites so locked critical sections cannot deadlock the asyncio event loop if a future change introduces an `await` under the lock. Closes #394.
+
+**Architecture:** Locked methods on `FileCacheStorage`, `FileCacher`, `DependencyCache`, and `get_preprocessed_file_lock` become `async def` and use `async with self.lock` against an `AsyncFileLock`. The cascade adds `await` to every caller; callers that are already `async def` (the majority) are unchanged in shape. Where a sync caller cannot reasonably be made async, we add a `_sync` sibling on the callee that uses a sync `FileLock` against the same lockfile path (the OS file-lock interoperates between sync and async usages, so cross-task and cross-process exclusion are preserved).
+
+**Tech Stack:** Python 3, `filelock` (≥3.14, already pinned), `asyncio`, `pytest-asyncio` (already used).
+
+**Reference:** Design doc at `docs/plans/2026-05-03-async-filelock-design.md`.
+
+---
+
+## Cascade order
+
+storage → cacher → caching → package. Each task migrates its target class plus all of its callers in the same commit, so the tree always builds and the test suite always runs.
+
+---
+
+### Task 1: Concurrency regression test
+
+**Goal:** Lock in the new invariant — two asyncio tasks contending for a `FileCacher` lock can interleave `await`s without deadlocking. This test must FAIL on `main` (it deadlocks because `FileLock.acquire()` blocks the loop thread) and PASS after the migration.
+
+**Files:**
+- Create: `tests/rbx/grading/judge/test_cacher_concurrency.py`
+
+**Step 1: Write the failing test**
+
+```python
+import asyncio
+import pathlib
+
+import pytest
+
+from rbx.grading.judge.cacher import FileCacher
+from rbx.grading.judge.storage import FilesystemStorage
+
+
+@pytest.mark.asyncio
+async def test_cacher_two_tasks_yield_under_lock(tmp_path: pathlib.Path):
+    """Two asyncio tasks alternating cacher ops with explicit yields must
+    both make progress under AsyncFileLock — they would deadlock under a
+    plain FileLock if either yielded while holding the lock."""
+    storage = FilesystemStorage(tmp_path / 'storage')
+    cacher = FileCacher(storage)
+
+    async def worker(name: bytes, n: int) -> list[str]:
+        digests: list[str] = []
+        for i in range(n):
+            digest = await cacher.put_file_content(
+                name + str(i).encode(), f'desc-{name!r}-{i}'
+            )
+            digests.append(digest)
+            # Yield to give the other task a chance to run.
+            await asyncio.sleep(0)
+            assert await cacher.exists(digest)
+        return digests
+
+    a, b = await asyncio.wait_for(
+        asyncio.gather(worker(b'a', 5), worker(b'b', 5)),
+        timeout=5.0,
+    )
+    assert len(a) == 5 and len(b) == 5
+```
+
+**Step 2: Confirm it fails today**
+
+Run: `uv run pytest tests/rbx/grading/judge/test_cacher_concurrency.py -v`
+Expected: FAIL — `put_file_content` is sync (no `await`), `AttributeError`/`TypeError`. This is fine: it documents the contract we're moving toward.
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/grading/judge/test_cacher_concurrency.py
+git commit -m "test(grading): add concurrency regression for async cacher locks"
+```
+
+---
+
+### Task 2: Migrate `FileCacheStorage` to `AsyncFileLock`
+
+**Files:**
+- Modify: `rbx/grading/judge/storage.py`
+- Modify: `rbx/grading/judge/storage.py` ABCs (`Storage`, `NullStorage`) — match the new async signatures.
+
+**Step 1: Replace the lock construction**
+
+`storage.py:11`:
+```python
+from filelock import AsyncFileLock, BaseAsyncFileLock
+```
+
+`storage.py:243`:
+```python
+    lock: BaseAsyncFileLock
+```
+
+`storage.py:251`:
+```python
+        self.lock = AsyncFileLock(path / 'storage.lock', thread_local=False)
+```
+
+**Step 2: Convert lock-holding methods to `async def`**
+
+In `FileCacheStorage`, each method that contains `with self.lock:` becomes `async def` and uses `async with self.lock:`. The methods are: `get_file`, `create_file`, `commit_file`, `set_metadata`, `get_metadata`, `list_metadata`, `exists`, `get_size`, `delete`, `list`, `path_for_symlink`, `filename_from_symlink`.
+
+`_set_metadata` and `_get_metadata_path` are private helpers that don't take the lock; leave sync.
+
+Note: `commit_file` uses `pending.fd.close()` and shutil-style ops inside the lock. Those are blocking but *don't yield*, so converting just changes the lock idiom; the body stays the same.
+
+**Step 3: Update the abstract `Storage` and `NullStorage` to match**
+
+Make all corresponding methods `async def` in the ABC and `NullStorage`. `NullStorage` returns immediately (no I/O).
+
+**Step 4: No callers to fix yet — `FileCacheStorage` is only consumed by `FileCacher`, which Task 3 covers**
+
+But the test suite likely imports `FilesystemStorage` directly. After Task 2, those will fail until Task 3 + Task 6 update them. We accept that and don't commit until tasks 2+3 land together — see Step 6 below.
+
+**Step 5: Defer commit**
+
+Tasks 2 and 3 ship in one commit because `FileCacher` calls into `FileCacheStorage` everywhere; splitting them would leave `FileCacher` uncompilable.
+
+---
+
+### Task 3: Migrate `FileCacher` to `AsyncFileLock`
+
+**Files:**
+- Modify: `rbx/grading/judge/cacher.py`
+- Modify: every caller of `FileCacher` methods (search below).
+- Modify: `tests/rbx/grading/judge/test_cacher.py` and any direct tests.
+
+**Step 1: Replace the lock**
+
+`cacher.py:12`, `cacher.py:55`, `cacher.py:92` — analogous to Task 2 (`AsyncFileLock`, `BaseAsyncFileLock`).
+
+**Step 2: Convert lock-holding methods to `async def`**
+
+Methods with `with self.lock:` (per grep): `_load`, `exists`, `path_for_symlink`, `transient_path_for_symlink`, `get_file`, `get_file_content`, `get_file_to_fobj`, `get_file_to_path`, `put_file_from_fobj`, `put_file_content`, `put_file_from_path`, `delete`, `purge_cache`, `list`, `destroy_cache` (verify exact list — there are 14 sites).
+
+Each `with self.lock:` → `async with self.lock:`. Each `storage.X(...)` call becomes `await self.storage.X(...)`. Each in-method call to a sibling that's now async becomes `await`.
+
+**Step 3: Identify sync callers**
+
+Run:
+```bash
+grep -rn "cacher\.\|FileCacher" --include="*.py" rbx tests | grep -v "^rbx/grading/judge/" > /tmp/cacher-callers.txt
+```
+
+For each callsite, determine the enclosing function. If it's `async def`, prepend `await`. If it's plain `def`:
+- Check if the function can be made `async def` cheaply (its callers are async or few). Prefer this.
+- Only if that's truly disruptive, add a `_sync` sibling on `FileCacher` (and on `FileCacheStorage`, see below) that constructs a parallel `FileLock(...)` against the same `cache.lock` / `storage.lock` path and uses sync I/O.
+
+Known sync sites to handle:
+- `rbx/box/code.py:102` — `is_executable_sanitized`. Convert to `async def`; its callers (search `is_executable_sanitized`) are likely already async or trivially convertible.
+- `rbx/box/sanitizers/warning_stack.py` — uses `cacher.get_file_to_path`. Check enclosing async-ness; convert callers as needed.
+- Any test fixtures in `tests/rbx/conftest.py` etc.
+
+**Step 4: Sync siblings (only if Step 3 forces them)**
+
+If a sync sibling is unavoidable, add it as a separate method:
+
+```python
+def exists_sync(self, digest: str, cache_only: bool = False) -> bool:
+    with FileLock(self.file_dir / 'cache.lock', thread_local=False):
+        ...  # body identical to async version, no awaits
+```
+
+Keep the async version as the canonical one; document `_sync` as "for use from sync entry points only."
+
+**Step 5: Run the regression test**
+
+Run: `uv run pytest tests/rbx/grading/judge/test_cacher_concurrency.py -v`
+Expected: PASS.
+
+**Step 6: Run cacher unit tests**
+
+Run: `uv run pytest tests/rbx/grading/judge/ -v`
+Expected: all pass after fixing test files (they likely call cacher methods directly — add `await` and `@pytest.mark.asyncio` where needed).
+
+**Step 7: Commit (tasks 2 + 3 together)**
+
+```bash
+git add rbx/grading/judge/storage.py rbx/grading/judge/cacher.py \
+        rbx/box/code.py rbx/box/sanitizers/warning_stack.py \
+        tests/rbx/grading/judge/
+# Plus any other caller files modified.
+git commit -m "refactor(grading): make FileCacher and FileCacheStorage locks async (#394)"
+```
+
+---
+
+### Task 4: Migrate `DependencyCache` to `AsyncFileLock`
+
+**Files:**
+- Modify: `rbx/grading/caching.py`
+- Modify: callers — primarily `rbx/grading/steps_with_caching.py`, `rbx/box/code.py`.
+
+**Step 1: Replace the lock**
+
+`caching.py:10`, `caching.py:366`, `caching.py:374` — `AsyncFileLock`, `BaseAsyncFileLock`.
+
+**Step 2: Convert lock-holding methods**
+
+Two sites at `caching.py:414` and `caching.py:489`. Identify which methods they live in (likely `get_compilation` / `put_compilation` or similar) and make those `async def` with `async with self.lock:`. Internal calls to `FileCacher` (now async) become `await`s.
+
+**Step 3: Update callers**
+
+Grep:
+```bash
+grep -rn "dependency_cache\.\|DependencyCache\b" --include="*.py" rbx tests | grep -v "^rbx/grading/caching.py:"
+```
+
+Top hits:
+- `rbx/grading/steps_with_caching.py` — already async per its function signatures.
+- `rbx/box/code.py` — most callers are inside `async def`.
+Add `await`s.
+
+**Step 4: Run targeted tests**
+
+Run: `uv run pytest tests/rbx/grading/ -v`
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/grading/caching.py rbx/grading/steps_with_caching.py rbx/box/code.py tests/
+git commit -m "refactor(grading): make DependencyCache lock async (#394)"
+```
+
+---
+
+### Task 5: Migrate `get_preprocessed_file_lock`
+
+**Files:**
+- Modify: `rbx/box/package.py`
+- Modify: callers of `get_preprocessed_file_lock` and `mark_problem_as_preprocessed` (or whichever function uses it at line 216).
+
+**Step 1: Replace**
+
+`package.py:16`:
+```python
+from filelock import AsyncFileLock, BaseAsyncFileLock
+```
+
+`package.py:209-216`:
+```python
+def get_preprocessed_file_lock(root: pathlib.Path = pathlib.Path()) -> BaseAsyncFileLock:
+    return AsyncFileLock(get_problem_cache_dir(root) / '.preprocessed' / '.lock')
+```
+
+The function at line 216 that does `with get_preprocessed_file_lock(root):` becomes `async def` with `async with`.
+
+**Step 2: Update callers**
+
+```bash
+grep -rn "mark_problem_as_preprocessed\|get_preprocessed_file_lock" --include="*.py" rbx tests
+```
+
+Add `await` or convert to `async def` as needed. If a sync caller exists and conversion is awkward, add `mark_problem_as_preprocessed_sync` that uses a sync `FileLock` against the same path.
+
+**Step 3: Run tests**
+
+Run: `uv run pytest --ignore=tests/rbx/box/cli -x -q`
+Expected: pass.
+
+**Step 4: Commit**
+
+```bash
+git add rbx/box/package.py [callers]
+git commit -m "refactor(box): make preprocessed-file lock async (#394)"
+```
+
+---
+
+### Task 6: Full sweep — fix any remaining callers
+
+**Step 1: Run the whole suite**
+
+```bash
+uv run pytest --ignore=tests/rbx/box/cli -n auto
+```
+
+Triage failures: most will be missing `await`s or test functions that need `@pytest.mark.asyncio`.
+
+**Step 2: Run CLI tests too (slower, but catches the long tail)**
+
+```bash
+uv run pytest tests/rbx/box/cli -n auto
+```
+
+**Step 3: Lint**
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+```
+
+Fix any issues.
+
+**Step 4: Commit fixes (if any)**
+
+```bash
+git commit -m "fix(grading): trailing async cacher caller fixes (#394)"
+```
+
+---
+
+### Task 7: Final verification
+
+**Step 1:** Re-run the regression test under load:
+```bash
+uv run pytest tests/rbx/grading/judge/test_cacher_concurrency.py -v --count=20
+```
+(or run it 20 times via `pytest-repeat` if installed; otherwise loop in shell). Must be deterministic.
+
+**Step 2:** `git log` review — confirm commits are coherent and the diff matches the design doc.
+
+**Step 3:** Open PR referencing #394.
+
+---
+
+## DRY / YAGNI / TDD reminders
+
+- **DRY:** the sync `_sync` siblings are mechanical duplication. Only add them when a real sync caller exists; do not add them speculatively.
+- **YAGNI:** don't redesign cacher / storage interfaces. Don't add timeouts / retries / new metrics. Just swap the lock and propagate `await`.
+- **TDD:** Task 1's regression test is the single TDD anchor. Beyond that, existing unit tests provide coverage; add new tests only if a class of behaviour becomes uncovered.
+
+## Risks & escape hatches
+
+- If the cascade balloons unexpectedly (e.g. forces a Pydantic model validator into asyncland), pause and add a `_sync` sibling instead — that's exactly the safety valve.
+- If `AsyncFileLock` interop with `FileLock` on the same lockfile turns out to be flaky on a target platform, document and fall back to async-only with `asyncio.run` shims for the sync entry points (worse ergonomics, same correctness).

--- a/docs/plans/2026-05-03-async-filelock.md
+++ b/docs/plans/2026-05-03-async-filelock.md
@@ -10,6 +10,13 @@
 
 **Reference:** Design doc at `docs/plans/2026-05-03-async-filelock-design.md`.
 
+**Resolved friction points** (from sync-caller audit, decided 2026-05-03):
+
+- `DependencyCacheBlock` (`rbx/grading/caching.py`) is currently a sync CM whose `__enter__`/`__exit__` call `DependencyCache.find_in_cache` / `.store_in_cache`. **Convert it to an async CM** (`__aenter__` / `__aexit__`); update the 3 `with dependency_cache(...)` callsites in `rbx/grading/steps_with_caching.py:33, 84, 144` to `async with`. All 3 enclosing functions are already `async def`. Do NOT add `_sync` siblings on `DependencyCache`.
+- `get_digest_as_string` (`rbx/box/package.py:238-248`) is `@functools.cache`-decorated and called only from async contexts. **Convert to `async def`** and replace `@functools.cache` with **`@async_lru.alru_cache(maxsize=None)`** — `async_lru` is already a dependency (used in `rbx/box/visualizers.py:125`, `rbx/box/stresses.py:405,453`). Do NOT add `_sync` siblings on `FileCacher`.
+
+**Net `_sync` siblings expected: ZERO.** If new sync callers surface during cascade, prefer making them async over adding `_sync`.
+
 ---
 
 ## Cascade order

--- a/rbx/box/checkers.py
+++ b/rbx/box/checkers.py
@@ -310,7 +310,7 @@ async def _check(
             extra_args=checker_mode.get_args('input.txt', 'output.txt', 'expected.txt'),
         )
     )
-    message = package.get_digest_as_string(error.value) or ''
+    message = await package.get_digest_as_string(error.value) or ''
 
     processed_checker_result = process_checker_run_log(checker_run_log, message)
     if processed_checker_result.outcome == Outcome.INTERNAL_ERROR:

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -192,10 +192,10 @@ def _add_warning_pragmas_around(code: str) -> str:
     )
 
 
-def _ignore_warning_in_cxx_input(input: GradingFileInput):
+async def _ignore_warning_in_cxx_input(input: GradingFileInput):
     if input.src is None or input.src.suffix not in ('.h', '.hpp'):
         return
-    preprocessed_path = package.write_preprocessed_file(
+    preprocessed_path = await package.write_preprocessed_file(
         input.src, _add_warning_pragmas_around(input.src.read_text())
     )
     input.src = preprocessed_path
@@ -221,7 +221,7 @@ def _get_code_variables(code: CodeItem, language: str) -> dict[str, Any]:
     return res
 
 
-def maybe_rename_java_class(
+async def maybe_rename_java_class(
     compilable_path: pathlib.Path,
     file_mapping: FileMapping,
 ) -> pathlib.Path:
@@ -251,7 +251,7 @@ def maybe_rename_java_class(
     if new_content == java_content:
         return compilable_path
 
-    return package.write_preprocessed_file(compilable_path, new_content)
+    return await package.write_preprocessed_file(compilable_path, new_content)
 
 
 def _format_stack_limit(limit: int) -> str:
@@ -619,7 +619,7 @@ async def compile_item(
         download.maybe_add_testlib(code, artifacts)
         download.maybe_add_jngen(code, artifacts)
         download.maybe_add_rbx_header(code, artifacts)
-        compilable_path = maybe_rename_java_class(compilable_path, file_mapping)
+        compilable_path = await maybe_rename_java_class(compilable_path, file_mapping)
         artifacts.inputs.append(
             GradingFileInput(
                 src=compilable_path, dest=PosixPath(file_mapping.compilable)
@@ -637,7 +637,7 @@ async def compile_item(
         )
 
         for input in artifacts.inputs:
-            _ignore_warning_in_cxx_input(input)
+            await _ignore_warning_in_cxx_input(input)
 
         # Add system bits/stdc++.h to the compilation.
         bits_artifact = maybe_get_bits_stdcpp_for_commands(commands)

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -94,13 +94,13 @@ def find_language_name(code: CodeItem) -> str:
     return find_language(code).name
 
 
-def is_executable_sanitized(executable: DigestOrSource) -> bool:
+async def is_executable_sanitized(executable: DigestOrSource) -> bool:
     if executable.digest is None:
         return False
     if executable.digest.value is None:
         return False
     cacher = package.get_file_cacher()
-    desc = cacher.get_metadata(
+    desc = await cacher.get_metadata(
         executable.digest.value, 'compilation', CompilationMetadata
     )
     if desc is None:
@@ -320,7 +320,7 @@ class PreparedRun:
     metadata: RunLogMetadata
 
 
-def _prepare_run(
+async def _prepare_run(
     code: CodeItem,
     executable: DigestOrSource,
     stdin: Optional[DigestOrSource] = None,
@@ -345,7 +345,7 @@ def _prepare_run(
 
     # Sanitization parameters.
     sanitized = False
-    if is_executable_sanitized(executable):
+    if await is_executable_sanitized(executable):
         # Remove any memory constraints for a sanitized executable.
         # Sanitizers are known to be memory-hungry.
         sandbox_params.address_space = None
@@ -528,18 +528,22 @@ async def _precompile_header(
 
         assert precompiled_digest.value is not None
 
-        digest_path = dependency_cache.cacher.path_for_symlink(precompiled_digest.value)
+        digest_path = await dependency_cache.cacher.path_for_symlink(
+            precompiled_digest.value
+        )
         if digest_path is not None and digest_path.is_file():
             # If storage backend supports symlinks, use it as the grading input.
             input = DigestOrSource.create(digest_path)
         else:
             # Otherwise, copy the file to the local cache, transiently.
             local_cacher = package.get_file_cacher()
-            with dependency_cache.cacher.get_file(precompiled_digest.value) as f:
+            with await dependency_cache.cacher.get_file(precompiled_digest.value) as f:
                 with grading_context.cache_level(
                     grading_context.CacheLevel.CACHE_TRANSIENTLY
                 ):
-                    input = DigestOrSource.create(local_cacher.put_file_from_fobj(f))
+                    input = DigestOrSource.create(
+                        await local_cacher.put_file_from_fobj(f)
+                    )
 
         res = GradingFileInput(
             **input.expand(),
@@ -582,7 +586,7 @@ async def compile_item(
 
         if not compilation_options.commands:
             # Language is not compiled.
-            return sandbox.file_cacher.put_file_from_path(compilable_path)
+            return await sandbox.file_cacher.put_file_from_path(compilable_path)
 
         commands = get_mapped_commands(
             compilation_options.commands,
@@ -721,13 +725,13 @@ async def compile_item(
             when=lambda: is_path_remote(code.path),
         ):
             if sanitized.should_sanitize():
-                cacher.set_metadata(
+                await cacher.set_metadata(
                     compiled_digest.value,
                     'compilation',
                     CompilationMetadata(is_sanitized=True),
                 )
             else:
-                cacher.set_metadata(compiled_digest.value, 'compilation', None)
+                await cacher.set_metadata(compiled_digest.value, 'compilation', None)
 
         return compiled_digest.value
 
@@ -749,7 +753,7 @@ async def run_item(
 
         dependency_cache = package.get_dependency_cache()
 
-        prepared = _prepare_run(
+        prepared = await _prepare_run(
             code,
             executable,
             stdin,
@@ -784,7 +788,7 @@ async def run_item(
                 prepared.sandbox_params.stderr_file
             )
             if stderr_output is not None:
-                warning_stack.get_warning_stack().add_sanitizer_warning(
+                await warning_stack.get_warning_stack().add_sanitizer_warning(
                     package.get_file_cacher(), code, stderr_output
                 )
         return run_log
@@ -802,8 +806,8 @@ class CommunicationItem:
     extra_config: Optional[ExecutionConfig] = None
     capture: Optional[DigestOrDest] = None
 
-    def prepare(self) -> PreparedRun:
-        return _prepare_run(
+    async def prepare(self) -> PreparedRun:
+        return await _prepare_run(
             self.code,
             self.executable,
             stdout=self.capture,
@@ -824,8 +828,8 @@ async def run_communication(
     retry_index: Optional[int] = None,
 ) -> Tuple[Optional[RunLog], Optional[RunLog]]:
     with package.get_new_sandbox() as sandbox:
-        interactor_prepared = interactor.prepare()
-        solution_prepared = solution.prepare()
+        interactor_prepared = await interactor.prepare()
+        solution_prepared = await solution.prepare()
 
         # Prepare retry index.
         interactor_prepared.metadata.retryIndex = retry_index

--- a/rbx/box/compile.py
+++ b/rbx/box/compile.py
@@ -23,7 +23,7 @@ async def _compile(item: CodeItem, sanitized: SanitizationLevel, warnings: bool)
     )
     cacher = package.get_file_cacher()
     out_path = _compile_out()
-    cacher.get_file_to_path(digest, out_path)
+    await cacher.get_file_to_path(digest, out_path)
     out_path.chmod(0o755)
 
     # Clear the warning stack as we don't really worry about it when running

--- a/rbx/box/generators.py
+++ b/rbx/box/generators.py
@@ -400,7 +400,8 @@ async def generate_standalone(
                 if generation_stderr.value is not None:
                     err.print('[error]Stderr:[/error]')
                     err.print(
-                        package.get_digest_as_string(generation_stderr.value) or '',
+                        await package.get_digest_as_string(generation_stderr.value)
+                        or '',
                     )
     elif spec.content is not None:
         spec.copied_to.inputPath.parent.mkdir(parents=True, exist_ok=True)

--- a/rbx/box/package.py
+++ b/rbx/box/package.py
@@ -11,6 +11,7 @@ from typing import (
     TypeVar,
 )
 
+import async_lru
 import ruyaml
 import typer
 from filelock import BaseFileLock, FileLock
@@ -234,15 +235,15 @@ def get_file_cacher(root: pathlib.Path = pathlib.Path()) -> FileCacher:
     return FileCacher(get_cache_storage(root))
 
 
-@functools.cache
-def get_digest_as_string(
+@async_lru.alru_cache(maxsize=None)
+async def get_digest_as_string(
     digest: Optional[str], root: pathlib.Path = pathlib.Path()
 ) -> Optional[str]:
     if not digest:
         return None
     cacher = get_file_cacher(root)
     try:
-        content = cacher.get_file_content(digest)
+        content = await cacher.get_file_content(digest)
         return content.decode()
     except KeyError:
         return None

--- a/rbx/box/package.py
+++ b/rbx/box/package.py
@@ -14,7 +14,7 @@ from typing import (
 import async_lru
 import ruyaml
 import typer
-from filelock import BaseFileLock, FileLock
+from filelock import AsyncFileLock, BaseAsyncFileLock
 
 from rbx import console, utils
 from rbx.box import cd, environment, global_package, path_resolution
@@ -207,14 +207,16 @@ def get_problem_preprocessed_path(
 
 
 @functools.cache
-def get_preprocessed_file_lock(root: pathlib.Path = pathlib.Path()) -> BaseFileLock:
-    return FileLock(get_problem_cache_dir(root) / '.preprocessed' / '.lock')
+def get_preprocessed_file_lock(
+    root: pathlib.Path = pathlib.Path(),
+) -> BaseAsyncFileLock:
+    return AsyncFileLock(get_problem_cache_dir(root) / '.preprocessed' / '.lock')
 
 
-def write_preprocessed_file(
+async def write_preprocessed_file(
     path: pathlib.Path, content: str, root: pathlib.Path = pathlib.Path()
 ) -> pathlib.Path:
-    with get_preprocessed_file_lock(root):
+    async with get_preprocessed_file_lock(root):
         path = get_problem_preprocessed_path(path, root)
         path.write_text(content)
         return path

--- a/rbx/box/sanitizers/warning_stack.py
+++ b/rbx/box/sanitizers/warning_stack.py
@@ -18,7 +18,7 @@ class WarningStack:
     def add_warning(self, code: CodeItem):
         self.warnings.add(code.path)
 
-    def add_sanitizer_warning(
+    async def add_sanitizer_warning(
         self, cacher: FileCacher, code: CodeItem, reference: GradingFileOutput
     ):
         if code.path in self.sanitizer_warnings:
@@ -27,7 +27,7 @@ class WarningStack:
             code.path.with_suffix(code.path.suffix + '.log')
         )
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        f = reference.get_file(cacher)
+        f = await reference.get_file(cacher)
         if f is None:
             return
         with f:

--- a/rbx/box/testcase_extractors.py
+++ b/rbx/box/testcase_extractors.py
@@ -60,7 +60,9 @@ async def run_generator_script(testcase: TestcaseSubgroup) -> str:
 
     script_digest = DigestHolder()
     if testcase.generatorScript.path.suffix == '.txt':
-        script_digest.value = cacher.put_file_from_path(testcase.generatorScript.path)
+        script_digest.value = await cacher.put_file_from_path(
+            testcase.generatorScript.path
+        )
     else:
         try:
             compiled_digest = await compile_item(testcase.generatorScript)
@@ -89,12 +91,12 @@ async def run_generator_script(testcase: TestcaseSubgroup) -> str:
             if run_stderr.value is not None:
                 console.console.print('[error]Stderr:[/error]')
                 console.console.print(
-                    package.get_digest_as_string(run_stderr.value) or ''
+                    await package.get_digest_as_string(run_stderr.value) or ''
                 )
             raise typer.Exit(1)
 
     assert script_digest.value
-    script = cacher.get_file_content(script_digest.value).decode()
+    script = (await cacher.get_file_content(script_digest.value)).decode()
     return script
 
 

--- a/rbx/box/validators.py
+++ b/rbx/box/validators.py
@@ -128,7 +128,7 @@ async def _validate_testcase(
         extra_args=shlex.join(var_args) if var_args else None,
     )
 
-    message = package.get_digest_as_string(message_digest.value or '')
+    message = await package.get_digest_as_string(message_digest.value or '')
     if (
         run_log is not None
         and run_log.exitcode != 0
@@ -144,7 +144,7 @@ async def _validate_testcase(
 
     log_overview = ''
     if log_digest.value is not None:
-        log_overview = package.get_digest_as_string(log_digest.value or '')
+        log_overview = await package.get_digest_as_string(log_digest.value or '')
     return (
         run_log is not None and run_log.exitcode == 0,
         message,

--- a/rbx/box/visualizers.py
+++ b/rbx/box/visualizers.py
@@ -352,7 +352,7 @@ async def run_visualizer(
             if run_log is not None:
                 e.print(f'[error]Summary:[/error] {run_log.get_summary()}')
                 e.print(
-                    f'[error]Stderr:[/error] {package.get_digest_as_string(stderr_holder.value or "")}'
+                    f'[error]Stderr:[/error] {await package.get_digest_as_string(stderr_holder.value or "")}'
                 )
 
     return visualization_path

--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 from typing import Any, Dict, List, Optional
 
-from filelock import BaseFileLock, FileLock
+from filelock import AsyncFileLock, BaseAsyncFileLock
 from pydantic import BaseModel
 from sqlitedict import SqliteDict
 
@@ -367,7 +367,7 @@ class DependencyCacheBlock:
 class DependencyCache:
     root: pathlib.Path
     cacher: FileCacher
-    lock: BaseFileLock
+    lock: BaseAsyncFileLock
 
     def __init__(self, root: pathlib.Path, cacher: FileCacher):
         self.root = root
@@ -375,7 +375,7 @@ class DependencyCache:
         self.db = SqliteDict(self._cache_name(), autocommit=True)
         tmp_dir = pathlib.Path(tempfile.mkdtemp())
         self.transient_db = SqliteDict(str(tmp_dir / '.cache_db'), autocommit=True)
-        self.lock = FileLock(self.root / 'cache.lock', thread_local=False)
+        self.lock = AsyncFileLock(self.root / 'cache.lock', thread_local=False)
         atexit.register(lambda: self.db.close())
         atexit.register(lambda: self.transient_db.close())
         atexit.register(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
@@ -415,8 +415,7 @@ class DependencyCache:
         extra_params: Dict[str, Any],
         key: Optional[str] = None,
     ) -> bool:
-        # TODO(#394 task 4): swap to AsyncFileLock
-        with self.lock:
+        async with self.lock:
             input = await _build_cache_input(
                 commands=commands,
                 artifact_list=artifact_list,
@@ -491,8 +490,7 @@ class DependencyCache:
         extra_params: Dict[str, Any],
         key: Optional[str] = None,
     ):
-        # TODO(#394 task 4): swap to AsyncFileLock
-        with self.lock:
+        async with self.lock:
             input = await _build_cache_input(
                 commands=commands,
                 artifact_list=artifact_list,

--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -112,7 +112,7 @@ def _build_digest_list(artifacts_list: List[GradingArtifacts]) -> List[DigestHol
     return digests
 
 
-def _build_fingerprint_list(
+async def _build_fingerprint_list(
     artifacts_list: List[GradingArtifacts], cacher: FileCacher
 ) -> List[str]:
     fingerprints = []
@@ -120,7 +120,7 @@ def _build_fingerprint_list(
         for input in artifacts.inputs:
             if input.src is None or not input.hash:
                 continue
-            if cacher.digest_from_symlink(input.src) is not None:
+            if await cacher.digest_from_symlink(input.src) is not None:
                 continue
             with input.src.open('rb') as f:
                 fingerprints.append(digest_cooperatively(f))
@@ -183,12 +183,12 @@ def _build_logs_list(artifacts_list: List[GradingArtifacts]) -> List[GradingLogs
     return logs
 
 
-def _build_cache_fingerprint(
+async def _build_cache_fingerprint(
     artifacts_list: List[GradingArtifacts],
     cacher: FileCacher,
 ) -> CacheFingerprint:
     digests = [digest.value for digest in _build_digest_list(artifacts_list)]
-    fingerprints = _build_fingerprint_list(artifacts_list, cacher)
+    fingerprints = await _build_fingerprint_list(artifacts_list, cacher)
     output_fingerprints = _build_output_fingerprint_list(
         artifacts_list,
     )
@@ -216,7 +216,7 @@ def _output_fingerprints_match(
     return tuple(lhs) == tuple(rhs)
 
 
-def _build_cache_input(
+async def _build_cache_input(
     commands: List[str],
     artifact_list: List[GradingArtifacts],
     extra_params: Dict[str, Any],
@@ -233,7 +233,7 @@ def _build_cache_input(
         for input in artifacts.inputs:
             if input.src is None:
                 continue
-            inferred_digest = cacher.digest_from_symlink(input.src)
+            inferred_digest = await cacher.digest_from_symlink(input.src)
             if inferred_digest is not None:
                 # Consume cache from digest instead of file.
                 input.digest = DigestHolder(value=inferred_digest)
@@ -260,7 +260,7 @@ def _build_cache_key(input: CacheInput) -> str:
         return digest_cooperatively(fobj)
 
 
-def _copy_hashed_files(artifact_list: List[GradingArtifacts], cacher: FileCacher):
+async def _copy_hashed_files(artifact_list: List[GradingArtifacts], cacher: FileCacher):
     for artifact in artifact_list:
         for output in artifact.outputs:
             if not output.hash or output.dest is None:
@@ -270,7 +270,7 @@ def _copy_hashed_files(artifact_list: List[GradingArtifacts], cacher: FileCacher
                 continue
             assert output.digest.value is not None
             if (
-                path_to_symlink := cacher.path_for_symlink(output.digest.value)
+                path_to_symlink := await cacher.path_for_symlink(output.digest.value)
             ) is not None:
                 # Use a symlink to the file in the persistent cache, if available.
                 output.dest.unlink(missing_ok=True)
@@ -278,19 +278,21 @@ def _copy_hashed_files(artifact_list: List[GradingArtifacts], cacher: FileCacher
                 output.dest.symlink_to(path_to_symlink)
             else:
                 # Otherwise, copy it.
-                with cacher.get_file(output.digest.value) as fobj:
+                with await cacher.get_file(output.digest.value) as fobj:
                     with output.dest.open('wb') as f:
                         copyfileobj(fobj, f, maxlen=output.maxlen)
             if output.executable:
                 output.dest.chmod(0o755)
 
 
-def is_artifact_ok(artifact: GradingArtifacts, cacher: FileCacher) -> bool:
+async def is_artifact_ok(artifact: GradingArtifacts, cacher: FileCacher) -> bool:
     for output in artifact.outputs:
         if output.optional or output.intermediate:
             continue
         if output.digest is not None:
-            if output.digest.value is None or not cacher.exists(output.digest.value):
+            if output.digest.value is None or not await cacher.exists(
+                output.digest.value
+            ):
                 return False
             return True
         assert output.dest is not None
@@ -303,9 +305,11 @@ def is_artifact_ok(artifact: GradingArtifacts, cacher: FileCacher) -> bool:
     return True
 
 
-def are_artifacts_ok(artifacts: List[GradingArtifacts], cacher: FileCacher) -> bool:
+async def are_artifacts_ok(
+    artifacts: List[GradingArtifacts], cacher: FileCacher
+) -> bool:
     for artifact in artifacts:
-        if not is_artifact_ok(artifact, cacher):
+        if not await is_artifact_ok(artifact, cacher):
             return False
     return True
 
@@ -327,11 +331,11 @@ class DependencyCacheBlock:
         self.extra_params = extra_params
         self._key = None
 
-    def __enter__(self):
+    async def __aenter__(self):
         with Profiler('enter_in_cache'):
             if grading_context.is_no_cache():
                 return False
-            input = _build_cache_input(
+            input = await _build_cache_input(
                 commands=self.commands,
                 artifact_list=self.artifact_list,
                 extra_params=self.extra_params,
@@ -342,17 +346,17 @@ class DependencyCacheBlock:
             self._key = _build_cache_key(input)
             if VERBOSE:
                 console.console.log(f'Cache key is: {self._key}')
-            found = self.cache.find_in_cache(
+            found = await self.cache.find_in_cache(
                 self.commands, self.artifact_list, self.extra_params, key=self._key
             )
             return found
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
         with Profiler('exit_in_cache'):
             if grading_context.is_no_cache():
                 return True if exc_type is NoCacheException else None
             if exc_type is None:
-                self.cache.store_in_cache(
+                await self.cache.store_in_cache(
                     self.commands, self.artifact_list, self.extra_params, key=self._key
                 )
             if exc_type is NoCacheException:
@@ -404,15 +408,16 @@ class DependencyCache:
         _check_digests(artifact_list)
         return DependencyCacheBlock(self, commands, artifact_list, extra_params or {})
 
-    def find_in_cache(
+    async def find_in_cache(
         self,
         commands: List[str],
         artifact_list: List[GradingArtifacts],
         extra_params: Dict[str, Any],
         key: Optional[str] = None,
     ) -> bool:
+        # TODO(#394 task 4): swap to AsyncFileLock
         with self.lock:
-            input = _build_cache_input(
+            input = await _build_cache_input(
                 commands=commands,
                 artifact_list=artifact_list,
                 extra_params=extra_params,
@@ -424,7 +429,7 @@ class DependencyCache:
             if fingerprint is None:
                 return False
 
-            reference_fingerprint = _build_cache_fingerprint(
+            reference_fingerprint = await _build_cache_fingerprint(
                 artifact_list,
                 self.cacher,
             )
@@ -449,7 +454,7 @@ class DependencyCache:
             for digest, reference_digest in zip(fingerprint.digests, reference_digests):
                 reference_digest.value = digest
 
-            if not are_artifacts_ok(artifact_list, self.cacher):
+            if not await are_artifacts_ok(artifact_list, self.cacher):
                 # Rollback digest changes.
                 for old_digest_value, reference_digest in zip(
                     old_digest_values, reference_digests
@@ -459,7 +464,7 @@ class DependencyCache:
                 return False
 
             # Copy hashed files to file system.
-            _copy_hashed_files(artifact_list, self.cacher)
+            await _copy_hashed_files(artifact_list, self.cacher)
 
             # Apply logs changes.
             for logs, reference_logs in zip(
@@ -479,15 +484,16 @@ class DependencyCache:
 
             return True
 
-    def store_in_cache(
+    async def store_in_cache(
         self,
         commands: List[str],
         artifact_list: List[GradingArtifacts],
         extra_params: Dict[str, Any],
         key: Optional[str] = None,
     ):
+        # TODO(#394 task 4): swap to AsyncFileLock
         with self.lock:
-            input = _build_cache_input(
+            input = await _build_cache_input(
                 commands=commands,
                 artifact_list=artifact_list,
                 extra_params=extra_params,
@@ -495,10 +501,10 @@ class DependencyCache:
             )
             key = key or _build_cache_key(input)
 
-            if not are_artifacts_ok(artifact_list, self.cacher):
+            if not await are_artifacts_ok(artifact_list, self.cacher):
                 return
 
-            reference_fingerprint = _build_cache_fingerprint(
+            reference_fingerprint = await _build_cache_fingerprint(
                 artifact_list,
                 self.cacher,
             )

--- a/rbx/grading/judge/cacher.py
+++ b/rbx/grading/judge/cacher.py
@@ -9,7 +9,7 @@ import tempfile
 import typing
 from typing import IO, Dict, List, Optional, Type
 
-from filelock import BaseFileLock, FileLock
+from filelock import AsyncFileLock, BaseAsyncFileLock
 from pydantic import BaseModel
 
 from rbx.grading import grading_context
@@ -52,7 +52,7 @@ class FileCacher:
     file_dir: pathlib.Path
     temp_dir: pathlib.Path
     folder: Optional[pathlib.Path]
-    lock: BaseFileLock
+    lock: BaseAsyncFileLock
 
     def __init__(
         self,
@@ -89,7 +89,7 @@ class FileCacher:
             tempfile.mkdtemp(dir=self.file_dir, prefix='_temp')
         )
         atexit.register(lambda: shutil.rmtree(str(self.temp_dir), ignore_errors=True))
-        self.lock = FileLock(self.file_dir / 'cache.lock', thread_local=False)
+        self.lock = AsyncFileLock(self.file_dir / 'cache.lock', thread_local=False)
         # Just to make sure it was created.
 
     def is_shared(self) -> bool:
@@ -131,7 +131,7 @@ class FileCacher:
             if not returned:
                 fobj.close()
 
-    def _load(self, digest: str, cache_only: bool) -> Optional[IO[bytes]]:
+    async def _load(self, digest: str, cache_only: bool) -> Optional[IO[bytes]]:
         """Load a file into the cache and open it for reading.
 
         cache_only (bool): don't open the file for reading.
@@ -142,7 +142,7 @@ class FileCacher:
         raise (KeyError): if the file cannot be found.
 
         """
-        with self.lock:
+        async with self.lock:
             cache_file_path = self.file_dir / digest
 
             if cache_only:
@@ -156,7 +156,7 @@ class FileCacher:
 
             logger.debug('File %s not in cache, downloading from database.', digest)
 
-            if (symlink := self.backend.path_for_symlink(digest)) is not None:
+            if (symlink := await self.backend.path_for_symlink(digest)) is not None:
                 cache_file_path.unlink(missing_ok=True)
                 cache_file_path.symlink_to(symlink)
                 return cache_file_path.open('rb') if not cache_only else None
@@ -165,7 +165,10 @@ class FileCacher:
                 dir=self.temp_dir, text=False
             )
             temp_file_path = pathlib.Path(temp_file_path)
-            with open(ftmp_handle, 'wb') as ftmp, self.backend.get_file(digest) as fobj:
+            with (
+                open(ftmp_handle, 'wb') as ftmp,
+                await self.backend.get_file(digest) as fobj,
+            ):
                 storage.copyfileobj(fobj, ftmp, self.CHUNK_SIZE)
 
             if not cache_only:
@@ -185,24 +188,24 @@ class FileCacher:
             if not cache_only:
                 return fd
 
-    def exists(self, digest: str, cache_only: bool = False) -> bool:
+    async def exists(self, digest: str, cache_only: bool = False) -> bool:
         """Check if a file exists in the cacher.
 
         cache_only (bool): don't check the backend.
 
         """
-        with self.lock:
+        async with self.lock:
             cache_file_path = self.file_dir / digest
             if cache_file_path.exists() or digest in self.existing:
                 return True
             if cache_only:
                 return False
-            exists = self.backend.exists(digest)
+            exists = await self.backend.exists(digest)
             if exists:
                 self.existing.add(digest)
             return exists
 
-    def cache_file(self, digest: str):
+    async def cache_file(self, digest: str):
         """Load a file into the cache.
 
         Ask the backend to provide the file and store it in the cache for the
@@ -220,9 +223,9 @@ class FileCacher:
         if digest == storage.TOMBSTONE:
             raise TombstoneError()
 
-        self._load(digest, True)
+        await self._load(digest, True)
 
-    def get_file(self, digest: str) -> IO[bytes]:
+    async def get_file(self, digest: str) -> IO[bytes]:
         """Retrieve a file from the storage.
 
         If it's available in the cache use that copy, without querying
@@ -247,9 +250,9 @@ class FileCacher:
 
         logger.debug('Getting file %s.', digest)
 
-        return typing.cast(IO[bytes], self._load(digest, False))
+        return typing.cast(IO[bytes], await self._load(digest, False))
 
-    def path_for_symlink(self, digest: str) -> Optional[pathlib.Path]:
+    async def path_for_symlink(self, digest: str) -> Optional[pathlib.Path]:
         """Retrieve the symlink path that points to the backend file.
 
         If the file is not in the cache, or it is stored in a transformed
@@ -263,9 +266,9 @@ class FileCacher:
             return None
 
         logger.debug('Getting symlink file path %s.', digest)
-        return self.backend.path_for_symlink(digest)
+        return await self.backend.path_for_symlink(digest)
 
-    def transient_path_for_symlink(self, digest: str):
+    async def transient_path_for_symlink(self, digest: str):
         """Retrieve a file from the storage and return a path to it.
 
         Notice that this is different than `path_for_symlink', which
@@ -282,15 +285,15 @@ class FileCacher:
         """
         if digest == storage.TOMBSTONE:
             raise TombstoneError()
-        with self.lock:
-            self._load(digest, cache_only=True)
+        async with self.lock:
+            await self._load(digest, cache_only=True)
 
             cache_file_path = self.file_dir / digest
             if not cache_file_path.exists():
                 raise FileNotFoundError(f'File {digest} not found in cache.')
             return cache_file_path
 
-    def digest_from_symlink(self, link: pathlib.Path) -> Optional[str]:
+    async def digest_from_symlink(self, link: pathlib.Path) -> Optional[str]:
         """Retrieve the digest of the file that the symlink points to.
 
         This is supposed to be used as a counterpart to `path_for_symlink'.
@@ -300,9 +303,9 @@ class FileCacher:
         if grading_context.is_transient():
             return None
 
-        return self.backend.filename_from_symlink(link)
+        return await self.backend.filename_from_symlink(link)
 
-    def get_file_content(self, digest: str) -> bytes:
+    async def get_file_content(self, digest: str) -> bytes:
         """Retrieve a file from the storage.
 
         See `get_file'. This method returns the content of the file, as
@@ -316,13 +319,13 @@ class FileCacher:
         raise (TombstoneError): if the digest is the tombstone
 
         """
-        with self.lock:
+        async with self.lock:
             if digest == storage.TOMBSTONE:
                 raise TombstoneError()
-            with self.get_file(digest) as src:
+            with await self.get_file(digest) as src:
                 return src.read()
 
-    def get_file_to_fobj(self, digest: str, dst: IO[bytes]):
+    async def get_file_to_fobj(self, digest: str, dst: IO[bytes]):
         """Retrieve a file from the storage.
 
         See `get_file'. This method will write the content of the file
@@ -336,13 +339,13 @@ class FileCacher:
         raise (TombstoneError): if the digest is the tombstone
 
         """
-        with self.lock:
+        async with self.lock:
             if digest == storage.TOMBSTONE:
                 raise TombstoneError()
-            with self.get_file(digest) as src:
+            with await self.get_file(digest) as src:
                 storage.copyfileobj(src, dst, self.CHUNK_SIZE)
 
-    def get_file_to_path(self, digest: str, dst_path: pathlib.Path):
+    async def get_file_to_path(self, digest: str, dst_path: pathlib.Path):
         """Retrieve a file from the storage.
 
         See `get_file'. This method will write the content of a file
@@ -355,15 +358,15 @@ class FileCacher:
         raise (KeyError): if the file cannot be found.
 
         """
-        with self.lock:
+        async with self.lock:
             if digest == storage.TOMBSTONE:
                 raise TombstoneError()
-            with self.get_file(digest) as src:
+            with await self.get_file(digest) as src:
                 dst_path.parent.mkdir(parents=True, exist_ok=True)
                 with dst_path.open('wb') as dst:
                     storage.copyfileobj(src, dst, self.CHUNK_SIZE)
 
-    def put_file_from_fobj(
+    async def put_file_from_fobj(
         self, src: IO[bytes], metadata: Optional[Dict[str, BaseModel]] = None
     ) -> str:
         """Store a file in the storage.
@@ -384,7 +387,7 @@ class FileCacher:
 
         """
         logger.debug('Reading input file to store on the database.')
-        with self.lock:
+        async with self.lock:
             # Unfortunately, we have to read the whole file-obj to compute
             # the digest but we take that chance to save it to a temporary
             # path so that we then just need to move it. Hoping that both
@@ -423,16 +426,16 @@ class FileCacher:
                 # Only store file when not in transient mode.
                 if not grading_context.is_transient():
                     with open(dst.name, 'rb') as src:
-                        pending_file = self.backend.create_file(digest)
+                        pending_file = await self.backend.create_file(digest)
                         if pending_file is not None:
                             storage.copyfileobj(src, pending_file.fd, self.CHUNK_SIZE)
-                            self.backend.commit_file(pending_file, metadata)
+                            await self.backend.commit_file(pending_file, metadata)
 
                 os.rename(dst.name, cache_file_path)
 
             return digest
 
-    def put_file_content(
+    async def put_file_content(
         self, content: bytes, metadata: Optional[Dict[str, BaseModel]] = None
     ) -> str:
         """Store a file in the storage.
@@ -447,17 +450,17 @@ class FileCacher:
         return (unicode): the digest of the stored file.
 
         """
-        with self.lock:
+        async with self.lock:
             with io.BytesIO(content) as src:
-                return self.put_file_from_fobj(src, metadata)
+                return await self.put_file_from_fobj(src, metadata)
 
-    def put_file_text(
+    async def put_file_text(
         self, text: str, metadata: Optional[Dict[str, BaseModel]] = None
     ) -> str:
-        with self.lock:
-            return self.put_file_content(text.encode('utf-8'), metadata)
+        async with self.lock:
+            return await self.put_file_content(text.encode('utf-8'), metadata)
 
-    def put_file_from_path(
+    async def put_file_from_path(
         self, src_path: pathlib.Path, metadata: Optional[Dict[str, BaseModel]] = None
     ) -> str:
         """Store a file in the storage.
@@ -473,11 +476,11 @@ class FileCacher:
         return (unicode): the digest of the stored file.
 
         """
-        with self.lock:
+        async with self.lock:
             with src_path.open('rb') as src:
-                return self.put_file_from_fobj(src, metadata)
+                return await self.put_file_from_fobj(src, metadata)
 
-    def set_metadata(self, digest: str, key: str, value: Optional[BaseModel]):
+    async def set_metadata(self, digest: str, key: str, value: Optional[BaseModel]):
         """Set the description of a file given its digest.
 
         digest (unicode): the digest of the file to add the description.
@@ -486,9 +489,9 @@ class FileCacher:
         """
         if grading_context.is_transient():
             return
-        self.backend.set_metadata(digest, key, value)
+        await self.backend.set_metadata(digest, key, value)
 
-    def get_metadata(
+    async def get_metadata(
         self, digest: str, key: str, model_cls: Type[storage.BaseModelT]
     ) -> Optional[storage.BaseModelT]:
         """Return the description of a file given its digest.
@@ -505,18 +508,18 @@ class FileCacher:
             raise TombstoneError()
         return typing.cast(
             Optional[storage.BaseModelT],
-            self.backend.get_metadata(digest, key, model_cls),
+            await self.backend.get_metadata(digest, key, model_cls),
         )
 
-    def list_metadata(self, filename: str) -> List[str]:
+    async def list_metadata(self, filename: str) -> List[str]:
         """List the metadata of a file given its filename.
 
         filename (str): the filename of the file to list the metadata.
         return (List[str]): the list of metadata keys.
         """
-        return self.backend.list_metadata(filename)
+        return await self.backend.list_metadata(filename)
 
-    def get_size(self, digest: str) -> int:
+    async def get_size(self, digest: str) -> int:
         """Return the size of a file given its digest.
 
         digest (unicode): the digest of the file to calculate the size
@@ -530,40 +533,40 @@ class FileCacher:
         """
         if digest == storage.TOMBSTONE:
             raise TombstoneError()
-        return self.backend.get_size(digest)
+        return await self.backend.get_size(digest)
 
-    def delete(self, digest: str):
+    async def delete(self, digest: str):
         """Delete a file from the backend and the local cache.
 
         digest (unicode): the digest of the file to delete.
 
         """
-        with self.lock:
+        async with self.lock:
             if digest == storage.TOMBSTONE:
                 return
-            self.drop(digest)
-            self.backend.delete(digest)
+            await self.drop(digest)
+            await self.backend.delete(digest)
 
-    def drop(self, digest):
+    async def drop(self, digest):
         """Delete a file only from the local cache.
 
         digest (unicode): the file to delete.
 
         """
-        with self.lock:
+        async with self.lock:
             if digest == storage.TOMBSTONE:
                 return
             cache_file_path: pathlib.Path = self.file_dir / digest
             cache_file_path.unlink(missing_ok=True)
             self.existing.discard(digest)
 
-    def purge_cache(self):
+    async def purge_cache(self):
         """Empty the local cache.
 
         This function must not be called if the cache directory is shared.
 
         """
-        with self.lock:
+        async with self.lock:
             self.destroy_cache()
             self.file_dir.mkdir(parents=True, exist_ok=True)
             if self.folder is not None:
@@ -583,16 +586,16 @@ class FileCacher:
             raise Exception('You may not destroy a shared cache.')
         shutil.rmtree(str(self.file_dir), ignore_errors=True)
 
-    def list(self) -> List[storage.FileWithMetadata]:
+    async def list(self) -> List[storage.FileWithMetadata]:
         """List the files available in the storage.
 
         return ([(unicode, unicode)]): a list of pairs, each
             representing a file in the form (digest, description).
 
         """
-        return self.backend.list()
+        return await self.backend.list()
 
-    def check_backend_integrity(self, delete: bool = False) -> bool:
+    async def check_backend_integrity(self, delete: bool = False) -> bool:
         """Check the integrity of the backend.
 
         Request all the files from the backend. For each of them the
@@ -606,12 +609,12 @@ class FileCacher:
         delete (bool): if True, files with wrong digest are deleted.
 
         """
-        with self.lock:
+        async with self.lock:
             clean = True
-            for fwd in self.list():
+            for fwd in await self.list():
                 digest = fwd.filename
                 d = digester.Digester()
-                with self.backend.get_file(digest) as fobj:
+                with await self.backend.get_file(digest) as fobj:
                     buf = fobj.read(self.CHUNK_SIZE)
                     while len(buf) > 0:
                         d.update(buf)
@@ -624,7 +627,7 @@ class FileCacher:
                         computed_digest,
                     )
                     if delete:
-                        self.delete(digest)
+                        await self.delete(digest)
                     clean = False
 
             return clean

--- a/rbx/grading/judge/sandbox.py
+++ b/rbx/grading/judge/sandbox.py
@@ -353,7 +353,7 @@ class SandboxBase(abc.ABC):
         os.mkfifo(str(real_path))
         return real_path
 
-    def create_file_from_storage(
+    async def create_file_from_storage(
         self,
         path: pathlib.Path,
         digest: str,
@@ -369,7 +369,7 @@ class SandboxBase(abc.ABC):
 
         """
         if try_symlink and executable:
-            symlink_path = self.file_cacher.transient_path_for_symlink(digest)
+            symlink_path = await self.file_cacher.transient_path_for_symlink(digest)
             if symlink_path is not None:
                 created = self.create_symlink(
                     path,
@@ -380,7 +380,7 @@ class SandboxBase(abc.ABC):
                     created.chmod(0o755)
                     return
         with self.create_file(path, executable, override=override) as dest_fobj:
-            self.file_cacher.get_file_to_fobj(digest, dest_fobj)
+            await self.file_cacher.get_file_to_fobj(digest, dest_fobj)
 
     def create_file_from_bytes(
         self,
@@ -399,7 +399,7 @@ class SandboxBase(abc.ABC):
         with self.create_file(path, executable, override=override) as dest_fobj:
             dest_fobj.write(content)
 
-    def create_file_from_other_file(
+    async def create_file_from_other_file(
         self,
         path: pathlib.Path,
         from_path: pathlib.Path,
@@ -519,7 +519,7 @@ class SandboxBase(abc.ABC):
         """
         return self.get_file_to_bytes(path, maxlen).decode('utf-8')
 
-    def get_file_to_storage(
+    async def get_file_to_storage(
         self,
         path: pathlib.Path,
         metadata: Optional[Dict[str, pydantic.BaseModel]] = None,
@@ -536,7 +536,7 @@ class SandboxBase(abc.ABC):
 
         """
         with self.get_file(path, trunc_len=trunc_len) as file_:
-            return self.file_cacher.put_file_from_fobj(file_, metadata)
+            return await self.file_cacher.put_file_from_fobj(file_, metadata)
 
     def stat_file(self, path: pathlib.Path) -> os.stat_result:
         """Return the stats of a file in the sandbox.

--- a/rbx/grading/judge/storage.py
+++ b/rbx/grading/judge/storage.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import IO, AnyStr, Dict, List, Optional, Type, TypeVar
 
 import lz4.frame
-from filelock import BaseFileLock, FileLock
+from filelock import AsyncFileLock, BaseAsyncFileLock
 from pydantic import BaseModel
 
 from rbx import utils
@@ -77,7 +77,7 @@ class Storage(ABC):
     """Abstract base class for all concrete storages."""
 
     @abstractmethod
-    def get_file(self, filename: str) -> IO[bytes]:
+    async def get_file(self, filename: str) -> IO[bytes]:
         """Retrieve a file from the storage.
         filename (unicode): the path of the file to retrieve.
         return (fileobj): a readable binary file-like object from which
@@ -87,7 +87,7 @@ class Storage(ABC):
         pass
 
     @abstractmethod
-    def create_file(self, filename: str) -> Optional[PendingFile]:
+    async def create_file(self, filename: str) -> Optional[PendingFile]:
         """Create an empty file that will live in the storage.
         Once the caller has written the contents to the file, the commit_file()
         method must be called to commit it into the store.
@@ -99,7 +99,7 @@ class Storage(ABC):
         pass
 
     @abstractmethod
-    def commit_file(
+    async def commit_file(
         self, file: PendingFile, metadata: Optional[Dict[str, BaseModel]] = None
     ) -> bool:
         """Commit a file created by create_file() to be stored.
@@ -116,7 +116,7 @@ class Storage(ABC):
         pass
 
     @abstractmethod
-    def set_metadata(self, filename: str, key: str, value: Optional[BaseModel]):
+    async def set_metadata(self, filename: str, key: str, value: Optional[BaseModel]):
         """Set the metadata of a file given its filename.
         filename (unicode): the filename of the file to set the metadata.
         key (unicode): the key of the metadata to set.
@@ -125,7 +125,7 @@ class Storage(ABC):
         pass
 
     @abstractmethod
-    def get_metadata(
+    async def get_metadata(
         self, filename: str, key: str, model_cls: Type[BaseModel]
     ) -> Optional[BaseModel]:
         """Get the metadata of a file given its filename and key.
@@ -138,7 +138,7 @@ class Storage(ABC):
         pass
 
     @abstractmethod
-    def list_metadata(self, filename: str) -> List[str]:
+    async def list_metadata(self, filename: str) -> List[str]:
         """List the metadata of a file given its filename.
         filename (unicode): the filename of the file to list the metadata.
         return (List[str]): the list of metadata keys.
@@ -146,12 +146,12 @@ class Storage(ABC):
         pass
 
     @abstractmethod
-    def exists(self, filename: str) -> bool:
+    async def exists(self, filename: str) -> bool:
         """Check if a file exists in the storage."""
         pass
 
     @abstractmethod
-    def get_size(self, filename: str) -> int:
+    async def get_size(self, filename: str) -> int:
         """Return the size of a file given its filename.
         filename (unicode): the filename of the file to calculate the size
             of.
@@ -161,14 +161,14 @@ class Storage(ABC):
         pass
 
     @abstractmethod
-    def delete(self, filename: str):
+    async def delete(self, filename: str):
         """Delete a file from the storage.
         filename (unicode): the filename of the file to delete.
         """
         pass
 
     @abstractmethod
-    def list(self) -> List[FileWithMetadata]:
+    async def list(self) -> List[FileWithMetadata]:
         """List the files available in the storage.
         return ([(unicode, unicode)]): a list of pairs, each
             representing a file in the form (filename, description).
@@ -176,11 +176,11 @@ class Storage(ABC):
         pass
 
     @abstractmethod
-    def path_for_symlink(self, filename: str) -> Optional[pathlib.Path]:
+    async def path_for_symlink(self, filename: str) -> Optional[pathlib.Path]:
         pass
 
     @abstractmethod
-    def filename_from_symlink(self, link: pathlib.Path) -> Optional[str]:
+    async def filename_from_symlink(self, link: pathlib.Path) -> Optional[str]:
         pass
 
 
@@ -192,44 +192,44 @@ class NullStorage(Storage):
 
     """
 
-    def get_file(self, digest: str) -> IO[bytes]:
+    async def get_file(self, digest: str) -> IO[bytes]:
         raise KeyError('File not found.')
 
-    def create_file(self, digest: str) -> Optional[PendingFile]:
+    async def create_file(self, digest: str) -> Optional[PendingFile]:
         return None
 
-    def commit_file(
+    async def commit_file(
         self, file: PendingFile, metadata: Optional[Dict[str, BaseModel]] = None
     ) -> bool:
         return False
 
-    def set_metadata(self, filename: str, key: str, value: Optional[BaseModel]):
+    async def set_metadata(self, filename: str, key: str, value: Optional[BaseModel]):
         pass
 
-    def get_metadata(
+    async def get_metadata(
         self, filename: str, key: str, model_cls: Type[BaseModel]
     ) -> Optional[BaseModel]:
         raise KeyError('File not found.')
 
-    def list_metadata(self, filename: str) -> List[str]:
+    async def list_metadata(self, filename: str) -> List[str]:
         return []
 
-    def exists(self, filename: str) -> bool:
+    async def exists(self, filename: str) -> bool:
         return False
 
-    def get_size(self, digest: str) -> int:
+    async def get_size(self, digest: str) -> int:
         raise KeyError('File not found.')
 
-    def delete(self, digest: str):
+    async def delete(self, digest: str):
         pass
 
-    def list(self) -> List[FileWithMetadata]:
+    async def list(self) -> List[FileWithMetadata]:
         return list()
 
-    def path_for_symlink(self, digest: str) -> Optional[pathlib.Path]:
+    async def path_for_symlink(self, digest: str) -> Optional[pathlib.Path]:
         return None
 
-    def filename_from_symlink(self, link: pathlib.Path) -> Optional[str]:
+    async def filename_from_symlink(self, link: pathlib.Path) -> Optional[str]:
         return None
 
 
@@ -240,7 +240,7 @@ class FilesystemStorage(Storage):
 
     path: pathlib.Path
     compress: bool
-    lock: BaseFileLock
+    lock: BaseAsyncFileLock
 
     def __init__(self, path: pathlib.Path, compress: bool = False):
         """Initialize the backend.
@@ -252,17 +252,17 @@ class FilesystemStorage(Storage):
         (path / '.metadata').mkdir(parents=True, exist_ok=True)
         # Place the lock in the parent directory so it doesn't appear in list().
         path.parent.mkdir(parents=True, exist_ok=True)
-        self.lock = FileLock(path.parent / f'{path.name}.lock', thread_local=False)
+        self.lock = AsyncFileLock(path.parent / f'{path.name}.lock', thread_local=False)
 
-    def get_file(self, filename: str) -> IO[bytes]:
+    async def get_file(self, filename: str) -> IO[bytes]:
         """See FileCacherBackend.get_file()."""
-        with self.lock:
+        async with self.lock:
             file_path = self.path / filename
 
             if not file_path.is_file():
                 raise KeyError('File not found.')
 
-            compression_metadata = self.get_metadata(
+            compression_metadata = await self.get_metadata(
                 filename, 'compression', CompressionMetadata
             )
             if compression_metadata is not None:
@@ -276,11 +276,11 @@ class FilesystemStorage(Storage):
                 )
             return file_path.open('rb')
 
-    def create_file(self, filename: str) -> Optional[PendingFile]:
+    async def create_file(self, filename: str) -> Optional[PendingFile]:
         """See FileCacherBackend.create_file()."""
         # Check if the file already exists. Return None if so, to inform the
         # caller they don't need to store the file.
-        with self.lock:
+        async with self.lock:
             file_path = self.path / filename
 
             if file_path.is_file():
@@ -313,11 +313,11 @@ class FilesystemStorage(Storage):
 
             return PendingFile(fd=temp_file, filename=filename, metadata=metadata)
 
-    def commit_file(
+    async def commit_file(
         self, file: PendingFile, metadata: Optional[Dict[str, BaseModel]] = None
     ) -> bool:
         """See FileCacherBackend.commit_file()."""
-        with self.lock:
+        async with self.lock:
             file.fd.close()
 
             file_path: pathlib.Path = self.path / file.filename
@@ -354,24 +354,24 @@ class FilesystemStorage(Storage):
             metadata_path.parent.mkdir(parents=True, exist_ok=True)
             metadata_path.write_text(value.model_dump_json())
 
-    def set_metadata(self, filename: str, key: str, value: Optional[BaseModel]):
-        with self.lock:
-            if not self.exists(filename):
+    async def set_metadata(self, filename: str, key: str, value: Optional[BaseModel]):
+        async with self.lock:
+            if not await self.exists(filename):
                 raise KeyError('File not found.')
 
             self._set_metadata(filename, key, value)
 
-    def get_metadata(
+    async def get_metadata(
         self, filename: str, key: str, model_cls: Type[BaseModelT]
     ) -> Optional[BaseModelT]:
-        with self.lock:
+        async with self.lock:
             path = self._get_metadata_path(filename, key)
             if not path.is_file():
                 return None
             return model_cls.model_validate_json(path.read_text())
 
-    def list_metadata(self, filename: str) -> List[str]:
-        with self.lock:
+    async def list_metadata(self, filename: str) -> List[str]:
+        async with self.lock:
             return [
                 path.stem.split('__')[1]
                 for path in sorted(
@@ -379,16 +379,16 @@ class FilesystemStorage(Storage):
                 )
             ]
 
-    def exists(self, filename: str) -> bool:
+    async def exists(self, filename: str) -> bool:
         """See FileCacherBackend.exists()."""
-        with self.lock:
+        async with self.lock:
             file_path: pathlib.Path = self.path / filename
 
             return file_path.is_file()
 
-    def get_size(self, filename: str) -> int:
+    async def get_size(self, filename: str) -> int:
         """See FileCacherBackend.get_size()."""
-        with self.lock:
+        async with self.lock:
             file_path: pathlib.Path = self.path / filename
 
             if not file_path.is_file():
@@ -396,45 +396,46 @@ class FilesystemStorage(Storage):
 
             return file_path.stat().st_size
 
-    def delete(self, filename: str):
+    async def delete(self, filename: str):
         """See FileCacherBackend.delete()."""
-        with self.lock:
+        async with self.lock:
             file_path: pathlib.Path = self.path / filename
 
             file_path.unlink(missing_ok=True)
-            for key in self.list_metadata(filename):
+            for key in await self.list_metadata(filename):
                 self._get_metadata_path(filename, key).unlink(missing_ok=True)
 
-    def list(self) -> List[FileWithMetadata]:
+    async def list(self) -> List[FileWithMetadata]:
         """See FileCacherBackend.list()."""
-        with self.lock:
+        async with self.lock:
             res = []
             for path in self.path.glob('*'):
-                if path.is_file():
-                    filename = str(path.relative_to(self.path))
-                    res.append(
-                        FileWithMetadata(
-                            filename=filename,
-                            metadata=self.list_metadata(filename),
-                        )
+                if not path.is_file():
+                    continue
+                filename = str(path.relative_to(self.path))
+                res.append(
+                    FileWithMetadata(
+                        filename=filename,
+                        metadata=await self.list_metadata(filename),
                     )
+                )
             return res
 
-    def path_for_symlink(self, filename: str) -> Optional[pathlib.Path]:
-        with self.lock:
+    async def path_for_symlink(self, filename: str) -> Optional[pathlib.Path]:
+        async with self.lock:
             file_path = self.path / filename
             if not file_path.is_file():
                 raise KeyError('File not found.')
 
-            compression_metadata = self.get_metadata(
+            compression_metadata = await self.get_metadata(
                 filename, 'compression', CompressionMetadata
             )
             if compression_metadata is not None:
                 return None
             return file_path
 
-    def filename_from_symlink(self, link: pathlib.Path) -> Optional[str]:
-        with self.lock:
+    async def filename_from_symlink(self, link: pathlib.Path) -> Optional[str]:
+        async with self.lock:
             if not link.is_symlink():
                 return None
 

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -181,15 +181,15 @@ class GradingFileOutput(BaseModel):
     # Whether to touch the file before the command runs.
     touch: bool = False
 
-    def get_file(self, cacher: FileCacher) -> Optional[IO[bytes]]:
+    async def get_file(self, cacher: FileCacher) -> Optional[IO[bytes]]:
         if self.dest is not None:
             if self.optional and not self.dest.exists():
                 return None
             return self.dest.open('rb')
         if self.digest is not None and self.digest.value is not None:
-            if self.optional and not cacher.exists(self.digest.value):
+            if self.optional and not await cacher.exists(self.digest.value):
                 return None
-            return cacher.get_file(self.digest.value)
+            return await cacher.get_file(self.digest.value)
         raise ValueError('No file to get')
 
 
@@ -299,11 +299,11 @@ class Evaluation(BaseModel):
     log: TestcaseLog
 
 
-def _process_input_artifacts(artifacts: GradingArtifacts, sandbox: SandboxBase):
+async def _process_input_artifacts(artifacts: GradingArtifacts, sandbox: SandboxBase):
     for input_artifact in artifacts.inputs:
         if input_artifact.digest is not None:
             assert input_artifact.digest.value is not None
-            sandbox.create_file_from_storage(
+            await sandbox.create_file_from_storage(
                 input_artifact.dest,
                 input_artifact.digest.value,
                 override=True,
@@ -312,7 +312,7 @@ def _process_input_artifacts(artifacts: GradingArtifacts, sandbox: SandboxBase):
             )
             continue
         assert input_artifact.src is not None
-        sandbox.create_file_from_other_file(
+        await sandbox.create_file_from_other_file(
             input_artifact.dest,
             artifacts.root / input_artifact.src,
             executable=input_artifact.executable,
@@ -329,7 +329,7 @@ def _process_input_artifacts(artifacts: GradingArtifacts, sandbox: SandboxBase):
             )
 
 
-def _process_output_artifacts(
+async def _process_output_artifacts(
     artifacts: GradingArtifacts,
     sandbox: SandboxBase,
 ) -> bool:
@@ -352,7 +352,7 @@ def _process_output_artifacts(
                 use_compression=True,
                 when=output_artifact.executable,
             ):
-                output_artifact.digest.value = sandbox.get_file_to_storage(
+                output_artifact.digest.value = await sandbox.get_file_to_storage(
                     output_artifact.src, trunc_len=output_artifact.maxlen
                 )
         if output_artifact.dest is None:
@@ -366,7 +366,7 @@ def _process_output_artifacts(
             output_artifact.digest is not None
             and output_artifact.digest.value is not None
             and (
-                path_to_symlink := sandbox.file_cacher.path_for_symlink(
+                path_to_symlink := await sandbox.file_cacher.path_for_symlink(
                     output_artifact.digest.value
                 )
             )
@@ -724,7 +724,7 @@ async def compile(
     sandbox.reset()
 
     commands = _try_following_alias_for_commands(commands)
-    _process_input_artifacts(artifacts, sandbox)
+    await _process_input_artifacts(artifacts, sandbox)
 
     if not commands:
         # Code does not need preprocessing of any kind.
@@ -792,7 +792,7 @@ async def compile(
             err.print(Text.from_ansi(logs[-1].log), style='default')
 
     # testing_utils.print_directory_tree(sandbox.get_root_path())
-    if not _process_output_artifacts(artifacts, sandbox):
+    if not await _process_output_artifacts(artifacts, sandbox):
         raise CompilationError()
 
 
@@ -805,7 +805,7 @@ async def run(
 ) -> Optional[RunLog]:
     sandbox.reset()
 
-    _process_input_artifacts(artifacts, sandbox)
+    await _process_input_artifacts(artifacts, sandbox)
     _process_fifos(artifacts, sandbox)
     cmd = _split_and_expand(command, sandbox, params)
     params = params.model_copy(deep=True)  # Copy to allow further modification.
@@ -817,7 +817,7 @@ async def run(
     try:
         sandbox_log = await asyncio.to_thread(sandbox.run, cmd, params)
 
-        if not _process_output_artifacts(artifacts, sandbox):
+        if not await _process_output_artifacts(artifacts, sandbox):
             return None
 
         run_log = _build_run_log(sandbox_log, sandbox, params, metadata)
@@ -846,7 +846,7 @@ async def run_coordinated(
 ) -> Tuple[Optional[RunLog], Optional[RunLog]]:
     sandbox.reset()
 
-    _process_input_artifacts(artifacts, sandbox)
+    await _process_input_artifacts(artifacts, sandbox)
     _process_fifos(artifacts, sandbox)
 
     interactor_cmd = _split_and_expand(interactor.command, sandbox, interactor.params)
@@ -871,7 +871,7 @@ async def run_coordinated(
             ),
         )
 
-        if not _process_output_artifacts(artifacts, sandbox):
+        if not await _process_output_artifacts(artifacts, sandbox):
             return None, None
 
         solution_log = _build_run_log(

--- a/rbx/grading/steps_with_caching.py
+++ b/rbx/grading/steps_with_caching.py
@@ -30,7 +30,7 @@ async def compile(
     cached_profile = profiling.Profiler('steps.compile[cached]', start=True)
     err: Optional[steps.CompilationError] = None
 
-    with dependency_cache(
+    async with dependency_cache(
         commands, [artifacts], params.get_cacheable_params()
     ) as is_cached:
         if not is_cached:
@@ -81,7 +81,9 @@ async def run(
         when=grading_context.is_compilation_only,
     ):
         cached_profile = profiling.Profiler('steps.run[cached]', start=True)
-        with dependency_cache([command], [artifacts], cacheable_params) as is_cached:
+        async with dependency_cache(
+            [command], [artifacts], cacheable_params
+        ) as is_cached:
             if not is_cached:
                 with profiling.Profiler('steps.run'):
                     profiling.add_to_counter('steps.run')
@@ -141,7 +143,7 @@ async def run_coordinated(
         when=grading_context.is_compilation_only,
     ):
         cached_profile = profiling.Profiler('steps.run_coordinated[cached]', start=True)
-        with dependency_cache(
+        async with dependency_cache(
             [interactor.command, solution.command],
             [artifacts],
             cacheable_params,

--- a/tests/rbx/box/code_compile_test.py
+++ b/tests/rbx/box/code_compile_test.py
@@ -19,7 +19,7 @@ class TestCompileItem:
     def mock_steps_with_caching(self, testing_pkg: testing_package.TestingPackage):
         """Mock steps_with_caching.compile to avoid heavy operations."""
 
-        def mock_compile_side_effect(
+        async def mock_compile_side_effect(
             commands, params, artifacts, sandbox, dependency_cache
         ):
             # Simulate setting digest values for output artifacts
@@ -28,7 +28,7 @@ class TestCompileItem:
                     cacher = package.get_file_cacher()
                     # Add the file to the actual file cacher to avoid KeyError
                     # Use the digest returned by put_file_content
-                    actual_digest = cacher.put_file_content(b'mock file content')
+                    actual_digest = await cacher.put_file_content(b'mock file content')
                     output.digest.value = actual_digest
             return True
 
@@ -505,7 +505,9 @@ int custom_function();
         code_item = CodeItem(path=cpp_file, language='cpp')
 
         with mock.patch('rbx.box.code.package.get_file_cacher') as mock_get_cacher:
-            mock_cacher = mock.Mock()
+            mock_cacher = mock.MagicMock()
+            mock_cacher.set_metadata = mock.AsyncMock()
+            mock_cacher.put_file_content = mock.AsyncMock(return_value='mock_digest')
             mock_get_cacher.return_value = mock_cacher
 
             await code.compile_item(code_item, sanitized=code.SanitizationLevel.FORCE)
@@ -524,7 +526,9 @@ int custom_function();
         code_item = CodeItem(path=cpp_file, language='cpp')
 
         with mock.patch('rbx.box.code.package.get_file_cacher') as mock_get_cacher:
-            mock_cacher = mock.Mock()
+            mock_cacher = mock.MagicMock()
+            mock_cacher.set_metadata = mock.AsyncMock()
+            mock_cacher.put_file_content = mock.AsyncMock(return_value='mock_digest')
             mock_get_cacher.return_value = mock_cacher
 
             await code.compile_item(code_item, sanitized=code.SanitizationLevel.NONE)

--- a/tests/rbx/box/code_java_rename_test.py
+++ b/tests/rbx/box/code_java_rename_test.py
@@ -6,7 +6,7 @@ from rbx.box.environment import FileMapping
 
 
 class TestMaybeRenameJavaClass:
-    def test_basic_class_renaming(self, testing_pkg):
+    async def test_basic_class_renaming(self, testing_pkg):
         """Test basic class renaming from Solution to Main"""
         java_file = testing_pkg.add_file('Solution.java')
         java_file.write_text("""public class Solution {
@@ -16,7 +16,7 @@ class TestMaybeRenameJavaClass:
 }""")
 
         file_mapping = FileMapping(compilable='Main.java', executable='Main')
-        result_path = maybe_rename_java_class(java_file, file_mapping)
+        result_path = await maybe_rename_java_class(java_file, file_mapping)
 
         expected_content = """public class Main {
     public static void main(String[] args) {
@@ -27,7 +27,7 @@ class TestMaybeRenameJavaClass:
         assert result_path.read_text() == expected_content
         assert result_path != java_file  # Should create new file
 
-    def test_no_change_needed(self, testing_pkg):
+    async def test_no_change_needed(self, testing_pkg):
         """Test when class is already named correctly"""
         java_file = testing_pkg.add_file('Main.java')
         original_content = """public class Main {
@@ -38,12 +38,12 @@ class TestMaybeRenameJavaClass:
         java_file.write_text(original_content)
 
         file_mapping = FileMapping(compilable='Main.java', executable='Main')
-        result_path = maybe_rename_java_class(java_file, file_mapping)
+        result_path = await maybe_rename_java_class(java_file, file_mapping)
 
         assert result_path.read_text() == original_content
         assert result_path == java_file  # Should return original file
 
-    def test_whitespace_variations(self, testing_pkg):
+    async def test_whitespace_variations(self, testing_pkg):
         """Test handling of various whitespace patterns"""
         java_file = testing_pkg.add_file('MyClass.java')
         java_file.write_text("""public   class    MyClass   {
@@ -53,7 +53,7 @@ class TestMaybeRenameJavaClass:
 }""")
 
         file_mapping = FileMapping(compilable='Main.java', executable='Main')
-        result_path = maybe_rename_java_class(java_file, file_mapping)
+        result_path = await maybe_rename_java_class(java_file, file_mapping)
 
         expected_content = """public class Main   {
     public static void main(String[] args) {
@@ -63,7 +63,7 @@ class TestMaybeRenameJavaClass:
 
         assert result_path.read_text() == expected_content
 
-    def test_complex_class_name(self, testing_pkg):
+    async def test_complex_class_name(self, testing_pkg):
         """Test renaming with complex class names containing underscores, numbers, and dollar signs"""
         java_file = testing_pkg.add_file('Complex_Class_123$.java')
         java_file.write_text("""public class Complex_Class_123$ {
@@ -73,7 +73,7 @@ class TestMaybeRenameJavaClass:
 }""")
 
         file_mapping = FileMapping(compilable='Main.java', executable='Main')
-        result_path = maybe_rename_java_class(java_file, file_mapping)
+        result_path = await maybe_rename_java_class(java_file, file_mapping)
 
         expected_content = """public class Main {
     public static void main(String[] args) {
@@ -83,7 +83,7 @@ class TestMaybeRenameJavaClass:
 
         assert result_path.read_text() == expected_content
 
-    def test_no_public_class_raises_error(self, testing_pkg):
+    async def test_no_public_class_raises_error(self, testing_pkg):
         """Test that missing public class raises typer.Exit"""
         java_file = testing_pkg.add_file('NoPublic.java')
         java_file.write_text("""class NoPublic {
@@ -95,9 +95,9 @@ class TestMaybeRenameJavaClass:
         file_mapping = FileMapping(compilable='Main.java', executable='Main')
 
         with pytest.raises(typer.Exit):
-            maybe_rename_java_class(java_file, file_mapping)
+            await maybe_rename_java_class(java_file, file_mapping)
 
-    def test_multiple_classes_only_renames_public(self, testing_pkg):
+    async def test_multiple_classes_only_renames_public(self, testing_pkg):
         """Test that only the public class gets renamed when multiple classes exist"""
         java_file = testing_pkg.add_file('MultiClass.java')
         java_file.write_text("""class Helper {
@@ -120,7 +120,7 @@ class AnotherHelper {
 }""")
 
         file_mapping = FileMapping(compilable='Main.java', executable='Main')
-        result_path = maybe_rename_java_class(java_file, file_mapping)
+        result_path = await maybe_rename_java_class(java_file, file_mapping)
 
         expected_content = """class Helper {
     public void help() {
@@ -143,7 +143,7 @@ class AnotherHelper {
 
         assert result_path.read_text() == expected_content
 
-    def test_preserves_comments_and_imports(self, testing_pkg):
+    async def test_preserves_comments_and_imports(self, testing_pkg):
         """Test that comments and imports are preserved during renaming"""
         java_file = testing_pkg.add_file('Solution.java')
         java_file.write_text("""// This is a comment
@@ -160,7 +160,7 @@ public class Solution {
 }""")
 
         file_mapping = FileMapping(compilable='Main.java', executable='Main')
-        result_path = maybe_rename_java_class(java_file, file_mapping)
+        result_path = await maybe_rename_java_class(java_file, file_mapping)
 
         expected_content = """// This is a comment
 import java.util.*;
@@ -177,7 +177,7 @@ public class Main {
 
         assert result_path.read_text() == expected_content
 
-    def test_non_java_files_unaffected(self, testing_pkg):
+    async def test_non_java_files_unaffected(self, testing_pkg):
         """Test that non-Java files are returned unchanged"""
         cpp_file = testing_pkg.add_file('solution.cpp')
         original_content = """#include <iostream>
@@ -190,7 +190,7 @@ int main() {
         cpp_file.write_text(original_content)
 
         file_mapping = FileMapping(compilable='solution.cpp', executable='solution')
-        result_path = maybe_rename_java_class(cpp_file, file_mapping)
+        result_path = await maybe_rename_java_class(cpp_file, file_mapping)
 
         assert result_path.read_text() == original_content
         assert result_path == cpp_file  # Should return original file unchanged

--- a/tests/rbx/box/code_run_test.py
+++ b/tests/rbx/box/code_run_test.py
@@ -1023,7 +1023,8 @@ int main() {
         with mock.patch(
             'rbx.box.code.warning_stack.get_warning_stack'
         ) as mock_warning_stack:
-            mock_stack = mock.Mock()
+            mock_stack = mock.MagicMock()
+            mock_stack.add_sanitizer_warning = mock.AsyncMock()
             mock_warning_stack.return_value = mock_stack
 
             # Run the program

--- a/tests/rbx/grading/judge/storage_test.py
+++ b/tests/rbx/grading/judge/storage_test.py
@@ -32,7 +32,7 @@ class ExtraMetadata(BaseModel):
 class TestCopyFileObj:
     """Test the copyfileobj utility function."""
 
-    def test_copy_full_content(self):
+    async def test_copy_full_content(self):
         """Test copying full content from source to destination."""
         source_data = b'Hello, world! This is test data.'
         source = io.BytesIO(source_data)
@@ -42,7 +42,7 @@ class TestCopyFileObj:
 
         assert destination.getvalue() == source_data
 
-    def test_copy_with_buffer_size(self):
+    async def test_copy_with_buffer_size(self):
         """Test copying with custom buffer size."""
         source_data = b'A' * 1000  # 1000 bytes
         source = io.BytesIO(source_data)
@@ -52,7 +52,7 @@ class TestCopyFileObj:
 
         assert destination.getvalue() == source_data
 
-    def test_copy_with_maxlen_smaller_than_source(self):
+    async def test_copy_with_maxlen_smaller_than_source(self):
         """Test copying with maxlen smaller than source data."""
         source_data = b'Hello, world!'
         source = io.BytesIO(source_data)
@@ -62,7 +62,7 @@ class TestCopyFileObj:
 
         assert destination.getvalue() == b'Hello'
 
-    def test_copy_with_maxlen_larger_than_source(self):
+    async def test_copy_with_maxlen_larger_than_source(self):
         """Test copying with maxlen larger than source data."""
         source_data = b'Hello'
         source = io.BytesIO(source_data)
@@ -72,7 +72,7 @@ class TestCopyFileObj:
 
         assert destination.getvalue() == source_data
 
-    def test_copy_empty_source(self):
+    async def test_copy_empty_source(self):
         """Test copying from empty source."""
         source = io.BytesIO(b'')
         destination = io.BytesIO()
@@ -81,7 +81,7 @@ class TestCopyFileObj:
 
         assert destination.getvalue() == b''
 
-    def test_copy_with_zero_maxlen(self):
+    async def test_copy_with_zero_maxlen(self):
         """Test copying with zero maxlen."""
         source_data = b'Hello, world!'
         source = io.BytesIO(source_data)
@@ -91,7 +91,7 @@ class TestCopyFileObj:
 
         assert destination.getvalue() == b''
 
-    def test_copy_text_mode(self):
+    async def test_copy_text_mode(self):
         """Test copying in text mode."""
         source_data = 'Hello, world! This is text data.'
         source = io.StringIO(source_data)
@@ -109,78 +109,78 @@ class TestNullStorage:
         """Set up test fixtures."""
         self.storage = NullStorage()
 
-    def test_get_file_raises_key_error(self):
+    async def test_get_file_raises_key_error(self):
         """Test that get_file always raises KeyError."""
         with pytest.raises(KeyError, match='File not found'):
-            self.storage.get_file('any_filename')
+            await self.storage.get_file('any_filename')
 
-    def test_create_file_returns_none(self):
+    async def test_create_file_returns_none(self):
         """Test that create_file always returns None."""
-        result = self.storage.create_file('any_filename')
+        result = await self.storage.create_file('any_filename')
         assert result is None
 
-    def test_commit_file_returns_false(self):
+    async def test_commit_file_returns_false(self):
         """Test that commit_file always returns False."""
         mock_pending_file = Mock(spec=PendingFile)
-        result = self.storage.commit_file(mock_pending_file)
+        result = await self.storage.commit_file(mock_pending_file)
         assert result is False
 
-    def test_commit_file_with_metadata_returns_false(self):
+    async def test_commit_file_with_metadata_returns_false(self):
         """Test that commit_file with metadata always returns False."""
         mock_pending_file = Mock(spec=PendingFile)
         metadata = cast(Dict[str, BaseModel], {'test': SampleMetadata(value='test')})
-        result = self.storage.commit_file(mock_pending_file, metadata)
+        result = await self.storage.commit_file(mock_pending_file, metadata)
         assert result is False
 
-    def test_set_metadata_does_nothing(self):
+    async def test_set_metadata_does_nothing(self):
         """Test that set_metadata does nothing (no exception)."""
         test_metadata = SampleMetadata(value='test')
-        self.storage.set_metadata('filename', 'key', test_metadata)
+        await self.storage.set_metadata('filename', 'key', test_metadata)
         # No assertion needed - just ensure no exception is raised
 
-    def test_set_metadata_with_none_does_nothing(self):
+    async def test_set_metadata_with_none_does_nothing(self):
         """Test that set_metadata with None value does nothing."""
-        self.storage.set_metadata('filename', 'key', None)
+        await self.storage.set_metadata('filename', 'key', None)
         # No assertion needed - just ensure no exception is raised
 
-    def test_get_metadata_raises_key_error(self):
+    async def test_get_metadata_raises_key_error(self):
         """Test that get_metadata always raises KeyError."""
         with pytest.raises(KeyError, match='File not found'):
-            self.storage.get_metadata('filename', 'key', SampleMetadata)
+            await self.storage.get_metadata('filename', 'key', SampleMetadata)
 
-    def test_list_metadata_returns_empty_list(self):
+    async def test_list_metadata_returns_empty_list(self):
         """Test that list_metadata always returns empty list."""
-        result = self.storage.list_metadata('any_filename')
+        result = await self.storage.list_metadata('any_filename')
         assert result == []
 
-    def test_exists_returns_false(self):
+    async def test_exists_returns_false(self):
         """Test that exists always returns False."""
-        assert self.storage.exists('any_filename') is False
+        assert await self.storage.exists('any_filename') is False
 
-    def test_get_size_raises_key_error(self):
+    async def test_get_size_raises_key_error(self):
         """Test that get_size always raises KeyError."""
         with pytest.raises(KeyError, match='File not found'):
-            self.storage.get_size('any_filename')
+            await self.storage.get_size('any_filename')
 
-    def test_delete_does_nothing(self):
+    async def test_delete_does_nothing(self):
         """Test that delete does nothing (no exception)."""
-        self.storage.delete('any_filename')
+        await self.storage.delete('any_filename')
         # No assertion needed - just ensure no exception is raised
 
-    def test_list_returns_empty_list(self):
+    async def test_list_returns_empty_list(self):
         """Test that list always returns empty list."""
-        result = self.storage.list()
+        result = await self.storage.list()
         assert result == []
 
-    def test_path_for_symlink_returns_none(self):
+    async def test_path_for_symlink_returns_none(self):
         """Test that path_for_symlink always returns None."""
-        result = self.storage.path_for_symlink('any_filename')
+        result = await self.storage.path_for_symlink('any_filename')
         assert result is None
 
-    def test_filename_from_symlink_returns_none(self):
+    async def test_filename_from_symlink_returns_none(self):
         """Test that filename_from_symlink always returns None."""
         mock_path = Mock(spec=pathlib.Path)
-        result = self.storage.filename_from_symlink(mock_path)
+        result = await self.storage.filename_from_symlink(mock_path)
         assert result is None
 
 
@@ -203,25 +203,25 @@ class TestFilesystemStorage:
         """Create a compressed FilesystemStorage instance for testing."""
         return FilesystemStorage(temp_dir, compress=True)
 
-    def test_init_creates_metadata_directory(self, temp_dir):
+    async def test_init_creates_metadata_directory(self, temp_dir):
         """Test that __init__ creates the metadata directory."""
         FilesystemStorage(temp_dir)
         metadata_dir = temp_dir / '.metadata'
         assert metadata_dir.exists()
         assert metadata_dir.is_dir()
 
-    def test_get_file_nonexistent_raises_key_error(self, storage):
+    async def test_get_file_nonexistent_raises_key_error(self, storage):
         """Test that get_file raises KeyError for nonexistent files."""
         with pytest.raises(KeyError, match='File not found'):
-            storage.get_file('nonexistent.txt')
+            await storage.get_file('nonexistent.txt')
 
-    def test_create_and_commit_file_basic(self, storage):
+    async def test_create_and_commit_file_basic(self, storage):
         """Test basic file creation and commit workflow."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         assert pending_file is not None
         assert pending_file.filename == filename
         assert pending_file.fd is not None
@@ -230,32 +230,32 @@ class TestFilesystemStorage:
         pending_file.fd.write(test_data)
 
         # Commit file
-        result = storage.commit_file(pending_file)
+        result = await storage.commit_file(pending_file)
         assert result is True
 
         # Verify file exists
-        assert storage.exists(filename)
+        assert await storage.exists(filename)
 
         # Read file back
-        with storage.get_file(filename) as f:
+        with await storage.get_file(filename) as f:
             content = f.read()
         assert content == test_data
 
-    def test_create_file_already_exists_returns_none(self, storage):
+    async def test_create_file_already_exists_returns_none(self, storage):
         """Test that create_file returns None if file already exists."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit first file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Try to create again
-        pending_file2 = storage.create_file(filename)
+        pending_file2 = await storage.create_file(filename)
         assert pending_file2 is None
 
-    def test_commit_file_already_exists_returns_false(self, storage, temp_dir):
+    async def test_commit_file_already_exists_returns_false(self, storage, temp_dir):
         """Test that commit_file returns False if file already exists."""
         filename = 'test.txt'
 
@@ -264,176 +264,182 @@ class TestFilesystemStorage:
         file_path.write_bytes(b'existing content')
 
         # Create pending file
-        pending_file = storage.create_file('other.txt')
+        pending_file = await storage.create_file('other.txt')
         pending_file.fd.write(b'new content')
         # Manually set filename to conflict
         pending_file.filename = filename
 
-        result = storage.commit_file(pending_file)
+        result = await storage.commit_file(pending_file)
         assert result is False
 
-    def test_metadata_operations(self, storage):
+    async def test_metadata_operations(self, storage):
         """Test metadata setting, getting, and listing."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Set metadata
         test_metadata = SampleMetadata(value='test_value', number=123)
-        storage.set_metadata(filename, 'test_key', test_metadata)
+        await storage.set_metadata(filename, 'test_key', test_metadata)
 
         # Get metadata
-        retrieved_metadata = storage.get_metadata(filename, 'test_key', SampleMetadata)
+        retrieved_metadata = await storage.get_metadata(
+            filename, 'test_key', SampleMetadata
+        )
         assert retrieved_metadata.value == 'test_value'
         assert retrieved_metadata.number == 123
 
         # List metadata
-        metadata_keys = storage.list_metadata(filename)
+        metadata_keys = await storage.list_metadata(filename)
         assert 'test_key' in metadata_keys
 
-    def test_metadata_operations_multiple_keys(self, storage):
+    async def test_metadata_operations_multiple_keys(self, storage):
         """Test metadata operations with multiple keys."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Set multiple metadata
         test_metadata1 = SampleMetadata(value='value1', number=1)
         test_metadata2 = ExtraMetadata(flag=False)
 
-        storage.set_metadata(filename, 'key1', test_metadata1)
-        storage.set_metadata(filename, 'key2', test_metadata2)
+        await storage.set_metadata(filename, 'key1', test_metadata1)
+        await storage.set_metadata(filename, 'key2', test_metadata2)
 
         # List metadata
-        metadata_keys = storage.list_metadata(filename)
+        metadata_keys = await storage.list_metadata(filename)
         assert set(metadata_keys) == {'key1', 'key2'}
 
         # Get both metadata
-        retrieved1 = storage.get_metadata(filename, 'key1', SampleMetadata)
-        retrieved2 = storage.get_metadata(filename, 'key2', ExtraMetadata)
+        retrieved1 = await storage.get_metadata(filename, 'key1', SampleMetadata)
+        retrieved2 = await storage.get_metadata(filename, 'key2', ExtraMetadata)
 
         assert retrieved1.value == 'value1'
         assert retrieved2.flag is False
 
-    def test_set_metadata_nonexistent_file_raises_key_error(self, storage):
+    async def test_set_metadata_nonexistent_file_raises_key_error(self, storage):
         """Test that set_metadata raises KeyError for nonexistent files."""
         test_metadata = SampleMetadata(value='test')
         with pytest.raises(KeyError, match='File not found'):
-            storage.set_metadata('nonexistent.txt', 'key', test_metadata)
+            await storage.set_metadata('nonexistent.txt', 'key', test_metadata)
 
-    def test_get_metadata_nonexistent_key_returns_none(self, storage):
+    async def test_get_metadata_nonexistent_key_returns_none(self, storage):
         """Test that get_metadata returns None for nonexistent keys."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Try to get nonexistent metadata
-        result = storage.get_metadata(filename, 'nonexistent_key', SampleMetadata)
+        result = await storage.get_metadata(filename, 'nonexistent_key', SampleMetadata)
         assert result is None
 
-    def test_set_metadata_none_removes_metadata(self, storage):
+    async def test_set_metadata_none_removes_metadata(self, storage):
         """Test that setting metadata to None removes it."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Set metadata
         test_metadata = SampleMetadata(value='test')
-        storage.set_metadata(filename, 'test_key', test_metadata)
+        await storage.set_metadata(filename, 'test_key', test_metadata)
 
         # Verify it exists
-        assert storage.get_metadata(filename, 'test_key', SampleMetadata) is not None
-        assert 'test_key' in storage.list_metadata(filename)
+        assert (
+            await storage.get_metadata(filename, 'test_key', SampleMetadata) is not None
+        )
+        assert 'test_key' in await storage.list_metadata(filename)
 
         # Remove metadata
-        storage.set_metadata(filename, 'test_key', None)
+        await storage.set_metadata(filename, 'test_key', None)
 
         # Verify it's gone
-        assert storage.get_metadata(filename, 'test_key', SampleMetadata) is None
-        assert 'test_key' not in storage.list_metadata(filename)
+        assert await storage.get_metadata(filename, 'test_key', SampleMetadata) is None
+        assert 'test_key' not in await storage.list_metadata(filename)
 
-    def test_get_size(self, storage):
+    async def test_get_size(self, storage):
         """Test get_size method."""
         filename = 'test.txt'
         test_data = b'Hello, world! This is a test.'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
-        size = storage.get_size(filename)
+        size = await storage.get_size(filename)
         assert size == len(test_data)
 
-    def test_get_size_nonexistent_raises_key_error(self, storage):
+    async def test_get_size_nonexistent_raises_key_error(self, storage):
         """Test that get_size raises KeyError for nonexistent files."""
         with pytest.raises(KeyError, match='File not found'):
-            storage.get_size('nonexistent.txt')
+            await storage.get_size('nonexistent.txt')
 
-    def test_delete_file(self, storage):
+    async def test_delete_file(self, storage):
         """Test file deletion."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit file with metadata
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         test_metadata = SampleMetadata(value='test')
-        storage.set_metadata(filename, 'test_key', test_metadata)
+        await storage.set_metadata(filename, 'test_key', test_metadata)
 
         # Verify file and metadata exist
-        assert storage.exists(filename)
-        assert storage.get_metadata(filename, 'test_key', SampleMetadata) is not None
+        assert await storage.exists(filename)
+        assert (
+            await storage.get_metadata(filename, 'test_key', SampleMetadata) is not None
+        )
 
         # Delete file
-        storage.delete(filename)
+        await storage.delete(filename)
 
         # Verify file and metadata are gone
-        assert not storage.exists(filename)
-        assert storage.get_metadata(filename, 'test_key', SampleMetadata) is None
+        assert not await storage.exists(filename)
+        assert await storage.get_metadata(filename, 'test_key', SampleMetadata) is None
 
-    def test_delete_nonexistent_file_no_error(self, storage):
+    async def test_delete_nonexistent_file_no_error(self, storage):
         """Test that deleting nonexistent file doesn't raise error."""
-        storage.delete('nonexistent.txt')  # Should not raise
+        await storage.delete('nonexistent.txt')  # Should not raise
 
-    def test_list_files(self, storage):
+    async def test_list_files(self, storage):
         """Test listing files in storage."""
         # Initially empty
-        files = storage.list()
+        files = await storage.list()
         assert files == []
 
         # Create some files
         for i in range(3):
             filename = f'test{i}.txt'
-            pending_file = storage.create_file(filename)
+            pending_file = await storage.create_file(filename)
             pending_file.fd.write(f'content{i}'.encode())
-            storage.commit_file(pending_file)
+            await storage.commit_file(pending_file)
 
             # Add metadata to some files
             if i < 2:
                 test_metadata = SampleMetadata(value=f'value{i}')
-                storage.set_metadata(filename, f'key{i}', test_metadata)
+                await storage.set_metadata(filename, f'key{i}', test_metadata)
 
         # List files
-        files = storage.list()
+        files = await storage.list()
         assert len(files) == 3
 
         filenames = [f.filename for f in files]
@@ -450,7 +456,7 @@ class TestFilesystemStorage:
 
     @patch('rbx.grading.grading_context.should_compress')
     @patch('rbx.grading.grading_context.get_compression_level')
-    def test_compression_with_context(
+    async def test_compression_with_context(
         self, mock_get_level, mock_should_compress, storage
     ):
         """Test compression when grading context indicates compression should be used."""
@@ -461,30 +467,30 @@ class TestFilesystemStorage:
         test_data = b'Hello, world! This should be compressed.'
 
         # Create file (should be compressed due to context)
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         assert pending_file is not None
         assert pending_file.metadata['compression'] is not None
         assert pending_file.metadata['compression'].compression_level == 3
 
         # Write and commit
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Verify compression metadata was stored
-        compression_meta = storage.get_metadata(
+        compression_meta = await storage.get_metadata(
             filename, 'compression', CompressionMetadata
         )
         assert compression_meta is not None
         assert compression_meta.compression_level == 3
 
-    def test_compression_with_flag(self, compressed_storage):
+    async def test_compression_with_flag(self, compressed_storage):
         """Test compression when storage is created with compress=True."""
         filename = 'test.txt'
         test_data = b'Hello, world! This should be compressed.'
 
         # Create file (should be compressed due to flag)
         with patch('rbx.grading.grading_context.get_compression_level', return_value=5):
-            pending_file = compressed_storage.create_file(filename)
+            pending_file = await compressed_storage.create_file(filename)
 
         assert pending_file is not None
         assert pending_file.metadata['compression'] is not None
@@ -492,10 +498,10 @@ class TestFilesystemStorage:
 
         # Write and commit
         pending_file.fd.write(test_data)
-        compressed_storage.commit_file(pending_file)
+        await compressed_storage.commit_file(pending_file)
 
         # Verify compression metadata was stored
-        compression_meta = compressed_storage.get_metadata(
+        compression_meta = await compressed_storage.get_metadata(
             filename, 'compression', CompressionMetadata
         )
         assert compression_meta is not None
@@ -503,7 +509,7 @@ class TestFilesystemStorage:
 
     @patch('rbx.grading.grading_context.should_compress')
     @patch('rbx.grading.grading_context.get_compression_level')
-    def test_compression_round_trip_data_integrity(
+    async def test_compression_round_trip_data_integrity(
         self, mock_get_level, mock_should_compress, storage
     ):
         """Test that compressed files can be read back and match original data."""
@@ -528,29 +534,29 @@ class TestFilesystemStorage:
         )
 
         # Create, write, and commit compressed file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         assert pending_file is not None
         assert pending_file.metadata['compression'] is not None
         assert pending_file.metadata['compression'].compression_level == 7
 
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Read the file back and verify it matches exactly
-        with storage.get_file(filename) as file_handle:
+        with await storage.get_file(filename) as file_handle:
             read_data = file_handle.read()
 
         assert read_data == test_data
         assert len(read_data) == len(test_data)
 
         # Verify it's actually compressed by checking metadata
-        compression_meta = storage.get_metadata(
+        compression_meta = await storage.get_metadata(
             filename, 'compression', CompressionMetadata
         )
         assert compression_meta is not None
         assert compression_meta.compression_level == 7
 
-    def test_compression_round_trip_with_flag(self, compressed_storage):
+    async def test_compression_round_trip_with_flag(self, compressed_storage):
         """Test round-trip data integrity when compression is enabled via flag."""
         filename = 'test_flag_roundtrip.bin'
         # Test with binary data including null bytes and various patterns
@@ -558,34 +564,34 @@ class TestFilesystemStorage:
 
         # Create file with compression flag
         with patch('rbx.grading.grading_context.get_compression_level', return_value=3):
-            pending_file = compressed_storage.create_file(filename)
+            pending_file = await compressed_storage.create_file(filename)
 
         assert pending_file is not None
         assert pending_file.metadata['compression'] is not None
 
         # Write and commit
         pending_file.fd.write(test_data)
-        compressed_storage.commit_file(pending_file)
+        await compressed_storage.commit_file(pending_file)
 
         # Read back and verify exact match
-        with compressed_storage.get_file(filename) as file_handle:
+        with await compressed_storage.get_file(filename) as file_handle:
             read_data = file_handle.read()
 
         assert read_data == test_data
         assert len(read_data) == len(test_data)
 
         # Verify the file exists and has correct size
-        assert compressed_storage.exists(filename)
+        assert await compressed_storage.exists(filename)
         # Note: get_size() returns compressed size, not original size
-        assert compressed_storage.get_size(filename) > 0
+        assert await compressed_storage.get_size(filename) > 0
 
-    def test_commit_file_with_additional_metadata(self, storage):
+    async def test_commit_file_with_additional_metadata(self, storage):
         """Test commit_file with additional metadata parameter."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
 
         # Commit with additional metadata
@@ -596,80 +602,80 @@ class TestFilesystemStorage:
                 'another': ExtraMetadata(flag=True),
             },
         )
-        storage.commit_file(pending_file, additional_metadata)
+        await storage.commit_file(pending_file, additional_metadata)
 
         # Verify all metadata was stored
-        custom_meta = storage.get_metadata(filename, 'custom', SampleMetadata)
-        another_meta = storage.get_metadata(filename, 'another', ExtraMetadata)
+        custom_meta = await storage.get_metadata(filename, 'custom', SampleMetadata)
+        another_meta = await storage.get_metadata(filename, 'another', ExtraMetadata)
 
         assert custom_meta.value == 'custom_value'
         assert another_meta.flag is True
 
-    def test_commit_file_creates_parent_directories(self, storage, temp_dir):
+    async def test_commit_file_creates_parent_directories(self, storage, temp_dir):
         """Test that commit_file creates parent directories as needed."""
         filename = 'subdir/nested/test.txt'
         test_data = b'Hello, world!'
 
         # Create file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
 
         # Commit file
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Verify file exists with proper directory structure
         file_path = temp_dir / filename
         assert file_path.exists()
         assert file_path.read_bytes() == test_data
 
-    def test_path_for_symlink_uncompressed(self, storage):
+    async def test_path_for_symlink_uncompressed(self, storage):
         """Test path_for_symlink for uncompressed files."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit uncompressed file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Get symlink path
-        symlink_path = storage.path_for_symlink(filename)
+        symlink_path = await storage.path_for_symlink(filename)
         assert symlink_path is not None
         assert symlink_path.exists()
         assert symlink_path.read_bytes() == test_data
 
-    def test_path_for_symlink_compressed_returns_none(self, storage):
+    async def test_path_for_symlink_compressed_returns_none(self, storage):
         """Test that path_for_symlink returns None for compressed files."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Manually set compression metadata
         compression_meta = CompressionMetadata(compression_level=5)
-        storage.set_metadata(filename, 'compression', compression_meta)
+        await storage.set_metadata(filename, 'compression', compression_meta)
 
         # Should return None for compressed files
-        symlink_path = storage.path_for_symlink(filename)
+        symlink_path = await storage.path_for_symlink(filename)
         assert symlink_path is None
 
-    def test_path_for_symlink_nonexistent_raises_key_error(self, storage):
+    async def test_path_for_symlink_nonexistent_raises_key_error(self, storage):
         """Test that path_for_symlink raises KeyError for nonexistent files."""
         with pytest.raises(KeyError, match='File not found'):
-            storage.path_for_symlink('nonexistent.txt')
+            await storage.path_for_symlink('nonexistent.txt')
 
-    def test_filename_from_symlink_valid(self, storage, temp_dir):
+    async def test_filename_from_symlink_valid(self, storage, temp_dir):
         """Test filename_from_symlink with valid symlink."""
         filename = 'test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Create a symlink
         target_path = temp_dir / filename
@@ -677,84 +683,88 @@ class TestFilesystemStorage:
         symlink_path.symlink_to(target_path)
 
         # Test filename extraction
-        result_filename = storage.filename_from_symlink(symlink_path)
+        result_filename = await storage.filename_from_symlink(symlink_path)
         assert result_filename == filename
 
-    def test_filename_from_symlink_not_symlink_returns_none(self, storage, temp_dir):
+    async def test_filename_from_symlink_not_symlink_returns_none(
+        self, storage, temp_dir
+    ):
         """Test that filename_from_symlink returns None for non-symlinks."""
         # Create regular file
         regular_file = temp_dir / 'regular.txt'
         regular_file.write_text('content')
 
-        result = storage.filename_from_symlink(regular_file)
+        result = await storage.filename_from_symlink(regular_file)
         assert result is None
 
-    def test_filename_from_symlink_broken_link_returns_none(self, storage, temp_dir):
+    async def test_filename_from_symlink_broken_link_returns_none(
+        self, storage, temp_dir
+    ):
         """Test that filename_from_symlink returns None for broken symlinks."""
         # Create symlink to nonexistent file
         symlink_path = temp_dir / 'broken_symlink.txt'
         symlink_path.symlink_to(temp_dir / 'nonexistent.txt')
 
-        result = storage.filename_from_symlink(symlink_path)
+        result = await storage.filename_from_symlink(symlink_path)
         assert result is None
 
-    def test_large_file_operations(self, storage):
+    async def test_large_file_operations(self, storage):
         """Test operations with larger files."""
         filename = 'large_test.txt'
         # Create 1MB of test data
         test_data = b'A' * (1024 * 1024)
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Verify size
-        assert storage.get_size(filename) == len(test_data)
+        assert await storage.get_size(filename) == len(test_data)
 
         # Read back and verify
-        with storage.get_file(filename) as f:
+        with await storage.get_file(filename) as f:
             content = f.read()
         assert content == test_data
 
-    def test_empty_file_operations(self, storage):
+    async def test_empty_file_operations(self, storage):
         """Test operations with empty files."""
         filename = 'empty.txt'
 
         # Create and commit empty file
-        pending_file = storage.create_file(filename)
-        storage.commit_file(pending_file)
+        pending_file = await storage.create_file(filename)
+        await storage.commit_file(pending_file)
 
         # Verify size
-        assert storage.get_size(filename) == 0
+        assert await storage.get_size(filename) == 0
 
         # Verify exists
-        assert storage.exists(filename)
+        assert await storage.exists(filename)
 
         # Read back
-        with storage.get_file(filename) as f:
+        with await storage.get_file(filename) as f:
             content = f.read()
         assert content == b''
 
-    def test_unicode_filename_handling(self, storage):
+    async def test_unicode_filename_handling(self, storage):
         """Test handling of unicode filenames."""
         filename = 'test_ñáéíóú_中文_🚀.txt'
         test_data = b'Unicode filename test'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Verify operations work with unicode filename
-        assert storage.exists(filename)
-        assert storage.get_size(filename) == len(test_data)
+        assert await storage.exists(filename)
+        assert await storage.get_size(filename) == len(test_data)
 
-        with storage.get_file(filename) as f:
+        with await storage.get_file(filename) as f:
             content = f.read()
         assert content == test_data
 
-    def test_concurrent_file_creation_race_condition(self, storage, temp_dir):
+    async def test_concurrent_file_creation_race_condition(self, storage, temp_dir):
         """Test handling of race condition in file creation."""
         filename = 'race_test.txt'
 
@@ -763,22 +773,22 @@ class TestFilesystemStorage:
         file_path.write_bytes(b'existing content')
 
         # Now try to create through storage
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         assert pending_file is None  # Should return None since file exists
 
-    def test_metadata_directory_structure(self, storage, temp_dir):
+    async def test_metadata_directory_structure(self, storage, temp_dir):
         """Test that metadata files are stored in correct directory structure."""
         filename = 'subdir/test.txt'
         test_data = b'Hello, world!'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Set metadata
         test_metadata = SampleMetadata(value='test')
-        storage.set_metadata(filename, 'test_key', test_metadata)
+        await storage.set_metadata(filename, 'test_key', test_metadata)
 
         # Verify metadata file exists in correct location
         metadata_file = temp_dir / '.metadata' / f'{filename}__test_key.json'
@@ -791,15 +801,15 @@ class TestFilesystemStorage:
         assert metadata_content['value'] == 'test'
         assert metadata_content['number'] == 42
 
-    def test_filename_from_symlink_chain_resolution(self, storage, temp_dir):
+    async def test_filename_from_symlink_chain_resolution(self, storage, temp_dir):
         """Test filename_from_symlink with a chain of symlinks."""
         filename = 'target.txt'
         test_data = b'Target file content'
 
         # Create and commit target file in storage
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Create a chain of symlinks: symlink1 -> symlink2 -> target
         target_path = temp_dir / filename
@@ -810,10 +820,10 @@ class TestFilesystemStorage:
         symlink1_path.symlink_to(symlink2_path)
 
         # Test that the chain is resolved correctly
-        result_filename = storage.filename_from_symlink(symlink1_path)
+        result_filename = await storage.filename_from_symlink(symlink1_path)
         assert result_filename == filename
 
-    def test_filename_from_symlink_outside_storage_returns_none(
+    async def test_filename_from_symlink_outside_storage_returns_none(
         self, storage, temp_dir
     ):
         """Test that filename_from_symlink returns None when target is outside storage path."""
@@ -827,10 +837,10 @@ class TestFilesystemStorage:
         symlink_path = temp_dir / 'external_symlink.txt'
         symlink_path.symlink_to(external_file)
 
-        result = storage.filename_from_symlink(symlink_path)
+        result = await storage.filename_from_symlink(symlink_path)
         assert result is None
 
-    def test_filename_from_symlink_points_to_directory_returns_none(
+    async def test_filename_from_symlink_points_to_directory_returns_none(
         self, storage, temp_dir
     ):
         """Test that filename_from_symlink returns None when symlink points to directory."""
@@ -842,10 +852,12 @@ class TestFilesystemStorage:
         symlink_path = temp_dir / 'dir_symlink'
         symlink_path.symlink_to(target_dir)
 
-        result = storage.filename_from_symlink(symlink_path)
+        result = await storage.filename_from_symlink(symlink_path)
         assert result is None
 
-    def test_filename_from_symlink_broken_chain_returns_none(self, storage, temp_dir):
+    async def test_filename_from_symlink_broken_chain_returns_none(
+        self, storage, temp_dir
+    ):
         """Test that filename_from_symlink returns None when symlink chain has broken link."""
         # Create symlink chain with a broken link in the middle
         broken_target = temp_dir / 'nonexistent.txt'
@@ -855,10 +867,12 @@ class TestFilesystemStorage:
         symlink2_path.symlink_to(broken_target)  # Points to nonexistent file
         symlink1_path.symlink_to(symlink2_path)
 
-        result = storage.filename_from_symlink(symlink1_path)
+        result = await storage.filename_from_symlink(symlink1_path)
         assert result is None
 
-    def test_filename_from_symlink_circular_reference_handling(self, storage, temp_dir):
+    async def test_filename_from_symlink_circular_reference_handling(
+        self, storage, temp_dir
+    ):
         """Test filename_from_symlink behavior with circular symlink references."""
         symlink1_path = temp_dir / 'symlink1.txt'
         symlink2_path = temp_dir / 'symlink2.txt'
@@ -868,10 +882,10 @@ class TestFilesystemStorage:
         symlink2_path.symlink_to(symlink1_path)
 
         # The implementation should detect circular references and return None
-        result = storage.filename_from_symlink(symlink1_path)
+        result = await storage.filename_from_symlink(symlink1_path)
         assert result is None
 
-    def test_filename_from_symlink_subdirectory_file(self, storage, temp_dir):
+    async def test_filename_from_symlink_subdirectory_file(self, storage, temp_dir):
         """Test filename_from_symlink with files in subdirectories."""
         filename = 'subdir/nested.txt'
         test_data = b'Nested file content'
@@ -880,87 +894,91 @@ class TestFilesystemStorage:
         subdir = temp_dir / 'subdir'
         subdir.mkdir()
 
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Create symlink to nested file
         target_path = temp_dir / filename
         symlink_path = temp_dir / 'nested_symlink.txt'
         symlink_path.symlink_to(target_path)
 
-        result_filename = storage.filename_from_symlink(symlink_path)
+        result_filename = await storage.filename_from_symlink(symlink_path)
         assert result_filename == filename
 
-    def test_filename_from_symlink_relative_vs_absolute_paths(self, storage, temp_dir):
+    async def test_filename_from_symlink_relative_vs_absolute_paths(
+        self, storage, temp_dir
+    ):
         """Test filename_from_symlink with both relative and absolute symlink targets."""
         filename = 'relative_test.txt'
         test_data = b'Relative path test'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         target_path = temp_dir / filename
 
         # Test with relative symlink
         rel_symlink_path = temp_dir / 'rel_symlink.txt'
         rel_symlink_path.symlink_to(filename)  # Relative path
-        result = storage.filename_from_symlink(rel_symlink_path)
+        result = await storage.filename_from_symlink(rel_symlink_path)
         assert result == filename
 
         # Test with absolute symlink
         abs_symlink_path = temp_dir / 'abs_symlink.txt'
         abs_symlink_path.symlink_to(target_path.absolute())  # Absolute path
-        result = storage.filename_from_symlink(abs_symlink_path)
+        result = await storage.filename_from_symlink(abs_symlink_path)
         assert result == filename
 
-    def test_filename_from_symlink_special_characters_in_path(self, storage, temp_dir):
+    async def test_filename_from_symlink_special_characters_in_path(
+        self, storage, temp_dir
+    ):
         """Test filename_from_symlink with special characters in file paths."""
         filename = 'special-chars_file!@#$%^&()_test.txt'
         test_data = b'Special characters test'
 
         # Create and commit file with special characters
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Create symlink
         target_path = temp_dir / filename
         symlink_path = temp_dir / 'special_symlink.txt'
         symlink_path.symlink_to(target_path)
 
-        result_filename = storage.filename_from_symlink(symlink_path)
+        result_filename = await storage.filename_from_symlink(symlink_path)
         assert result_filename == filename
 
-    def test_filename_from_symlink_with_spaces_in_path(self, storage, temp_dir):
+    async def test_filename_from_symlink_with_spaces_in_path(self, storage, temp_dir):
         """Test filename_from_symlink with spaces in file paths."""
         filename = 'file with spaces.txt'
         test_data = b'Spaces in filename test'
 
         # Create and commit file with spaces
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Create symlink
         target_path = temp_dir / filename
         symlink_path = temp_dir / 'spaces_symlink.txt'
         symlink_path.symlink_to(target_path)
 
-        result_filename = storage.filename_from_symlink(symlink_path)
+        result_filename = await storage.filename_from_symlink(symlink_path)
         assert result_filename == filename
 
-    def test_filename_from_symlink_mixed_chain_types(self, storage, temp_dir):
+    async def test_filename_from_symlink_mixed_chain_types(self, storage, temp_dir):
         """Test filename_from_symlink with a chain mixing relative and absolute symlinks."""
         filename = 'mixed_chain_target.txt'
         test_data = b'Mixed chain test'
 
         # Create and commit target file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Create chain: symlink1 (absolute) -> symlink2 (relative) -> target
         symlink2_path = temp_dir / 'symlink2.txt'
@@ -969,10 +987,10 @@ class TestFilesystemStorage:
         symlink2_path.symlink_to(filename)  # Relative
         symlink1_path.symlink_to(symlink2_path.absolute())  # Absolute
 
-        result_filename = storage.filename_from_symlink(symlink1_path)
+        result_filename = await storage.filename_from_symlink(symlink1_path)
         assert result_filename == filename
 
-    def test_filename_from_symlink_edge_case_empty_storage(self, temp_dir):
+    async def test_filename_from_symlink_edge_case_empty_storage(self, temp_dir):
         """Test filename_from_symlink with empty storage directory."""
         # Create storage with empty directory
         empty_storage = FilesystemStorage(temp_dir)
@@ -981,38 +999,38 @@ class TestFilesystemStorage:
         symlink_path = temp_dir / 'empty_symlink.txt'
         symlink_path.symlink_to(temp_dir / 'nonexistent.txt')
 
-        result = empty_storage.filename_from_symlink(symlink_path)
+        result = await empty_storage.filename_from_symlink(symlink_path)
         assert result is None
 
-    def test_filename_from_symlink_case_sensitivity(self, storage, temp_dir):
+    async def test_filename_from_symlink_case_sensitivity(self, storage, temp_dir):
         """Test filename_from_symlink case sensitivity behavior."""
         filename = 'CaseTest.txt'
         test_data = b'Case sensitivity test'
 
         # Create and commit file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Create symlink
         target_path = temp_dir / filename
         symlink_path = temp_dir / 'case_symlink.txt'
         symlink_path.symlink_to(target_path)
 
-        result_filename = storage.filename_from_symlink(symlink_path)
+        result_filename = await storage.filename_from_symlink(symlink_path)
         assert result_filename == filename
         # Verify exact case is preserved
         assert result_filename == 'CaseTest.txt'
 
-    def test_filename_from_symlink_max_depth_protection(self, storage, temp_dir):
+    async def test_filename_from_symlink_max_depth_protection(self, storage, temp_dir):
         """Test filename_from_symlink respects maximum depth limit."""
         filename = 'deep_target.txt'
         test_data = b'Deep chain target'
 
         # Create and commit target file
-        pending_file = storage.create_file(filename)
+        pending_file = await storage.create_file(filename)
         pending_file.fd.write(test_data)
-        storage.commit_file(pending_file)
+        await storage.commit_file(pending_file)
 
         # Create a very deep chain of symlinks (more than the max_depth limit)
         current_path = temp_dir / filename
@@ -1022,5 +1040,5 @@ class TestFilesystemStorage:
             current_path = next_path
 
         # The function should return None due to depth limit
-        result = storage.filename_from_symlink(current_path)
+        result = await storage.filename_from_symlink(current_path)
         assert result is None

--- a/tests/rbx/grading/judge/test_cacher.py
+++ b/tests/rbx/grading/judge/test_cacher.py
@@ -62,7 +62,7 @@ class TestFileCacher:
         """Create a shared FileCacher."""
         return FileCacher(filesystem_storage, shared=True, folder=temp_dir)
 
-    def test_init_non_shared_creates_temp_directory(self, mock_storage):
+    async def test_init_non_shared_creates_temp_directory(self, mock_storage):
         """Test that non-shared cacher creates temporary directories."""
         cacher = FileCacher(mock_storage, shared=False)
 
@@ -71,7 +71,7 @@ class TestFileCacher:
         assert cacher.temp_dir.exists()
         assert cacher.temp_dir.parent == cacher.file_dir
 
-    def test_init_shared_uses_provided_folder(self, mock_storage, temp_dir):
+    async def test_init_shared_uses_provided_folder(self, mock_storage, temp_dir):
         """Test that shared cacher uses provided folder."""
         cacher = FileCacher(mock_storage, shared=True, folder=temp_dir)
 
@@ -80,7 +80,7 @@ class TestFileCacher:
         assert cacher.file_dir.exists()
         assert cacher.temp_dir.exists()
 
-    def test_init_shared_creates_folder_if_provided(self, mock_storage, temp_dir):
+    async def test_init_shared_creates_folder_if_provided(self, mock_storage, temp_dir):
         """Test that shared cacher creates folder if it doesn't exist."""
         folder = temp_dir / 'new_folder'
         cacher = FileCacher(mock_storage, shared=True, folder=folder)
@@ -88,7 +88,7 @@ class TestFileCacher:
         assert cacher.is_shared()
         assert folder.exists()
 
-    def test_precache_lock_exclusive(self, shared_cacher):
+    async def test_precache_lock_exclusive(self, shared_cacher):
         """Test precache lock functionality."""
         # First lock should succeed
         lock1 = shared_cacher.precache_lock()
@@ -104,58 +104,60 @@ class TestFileCacher:
         assert lock3 is not None
         lock3.close()
 
-    def test_exists_cache_only_true_when_cached(self, cacher_with_mock):
+    async def test_exists_cache_only_true_when_cached(self, cacher_with_mock):
         """Test exists with cache_only=True returns True when file is cached."""
         digest = 'test_digest'
         cache_file = cacher_with_mock.file_dir / digest
         cache_file.write_bytes(b'test content')
 
-        assert cacher_with_mock.exists(digest, cache_only=True) is True
+        assert await cacher_with_mock.exists(digest, cache_only=True) is True
 
-    def test_exists_cache_only_false_when_not_cached(self, cacher_with_mock):
+    async def test_exists_cache_only_false_when_not_cached(self, cacher_with_mock):
         """Test exists with cache_only=True returns False when file is not cached."""
         digest = 'nonexistent_digest'
 
-        assert cacher_with_mock.exists(digest, cache_only=True) is False
+        assert await cacher_with_mock.exists(digest, cache_only=True) is False
 
-    def test_exists_checks_backend_when_not_cache_only(self, cacher_with_mock):
+    async def test_exists_checks_backend_when_not_cache_only(self, cacher_with_mock):
         """Test exists checks backend when cache_only=False."""
         digest = 'test_digest'
         cacher_with_mock.backend.exists.return_value = True
 
-        result = cacher_with_mock.exists(digest, cache_only=False)
+        result = await cacher_with_mock.exists(digest, cache_only=False)
 
         assert result is True
         cacher_with_mock.backend.exists.assert_called_once_with(digest)
         assert digest in cacher_with_mock.existing
 
-    def test_exists_remembers_existing_files(self, cacher_with_mock):
+    async def test_exists_remembers_existing_files(self, cacher_with_mock):
         """Test that exists remembers files that exist in backend."""
         digest = 'test_digest'
         cacher_with_mock.existing.add(digest)
 
-        result = cacher_with_mock.exists(digest, cache_only=True)
+        result = await cacher_with_mock.exists(digest, cache_only=True)
 
         assert result is True
 
-    def test_cache_file_tombstone_raises_error(self, cacher_with_mock):
+    async def test_cache_file_tombstone_raises_error(self, cacher_with_mock):
         """Test that cache_file raises TombstoneError for tombstone digest."""
         with pytest.raises(TombstoneError):
-            cacher_with_mock.cache_file(storage.TOMBSTONE)
+            await cacher_with_mock.cache_file(storage.TOMBSTONE)
 
-    def test_cache_file_with_cache_only_behavior(self, cacher_with_mock):
+    async def test_cache_file_with_cache_only_behavior(self, cacher_with_mock):
         """Test cache_file method behavior when file already exists in cache."""
         digest = 'test_digest'
         cache_file = cacher_with_mock.file_dir / digest
         cache_file.write_bytes(b'cached content')
 
         # This should not raise an error and should not call backend
-        cacher_with_mock.cache_file(digest)
+        await cacher_with_mock.cache_file(digest)
 
         # Verify backend wasn't called since file was already cached
         cacher_with_mock.backend.get_file.assert_not_called()
 
-    def test_cache_file_loads_from_backend_when_not_cached(self, cacher_with_mock):
+    async def test_cache_file_loads_from_backend_when_not_cached(
+        self, cacher_with_mock
+    ):
         """Test cache_file loads from backend when file not in cache."""
         digest = 'test_digest'
         test_content = b'backend content'
@@ -163,7 +165,7 @@ class TestFileCacher:
         cacher_with_mock.backend.path_for_symlink.return_value = None
         cacher_with_mock.backend.get_file.return_value = io.BytesIO(test_content)
 
-        cacher_with_mock.cache_file(digest)
+        await cacher_with_mock.cache_file(digest)
 
         # Verify file was loaded from backend and cached
         cache_file = cacher_with_mock.file_dir / digest
@@ -171,12 +173,12 @@ class TestFileCacher:
         assert cache_file.read_bytes() == test_content
         cacher_with_mock.backend.get_file.assert_called_once_with(digest)
 
-    def test_get_file_tombstone_raises_error(self, cacher_with_mock):
+    async def test_get_file_tombstone_raises_error(self, cacher_with_mock):
         """Test that get_file raises TombstoneError for tombstone digest."""
         with pytest.raises(TombstoneError):
-            cacher_with_mock.get_file(storage.TOMBSTONE)
+            await cacher_with_mock.get_file(storage.TOMBSTONE)
 
-    def test_get_file_from_cache_when_available(self, cacher_with_mock):
+    async def test_get_file_from_cache_when_available(self, cacher_with_mock):
         """Test get_file returns cached file when available."""
         digest = 'test_digest'
         test_content = b'cached content'
@@ -184,12 +186,12 @@ class TestFileCacher:
         cache_file = cacher_with_mock.file_dir / digest
         cache_file.write_bytes(test_content)
 
-        with cacher_with_mock.get_file(digest) as f:
+        with await cacher_with_mock.get_file(digest) as f:
             content = f.read()
 
         assert content == test_content
 
-    def test_get_file_loads_from_backend_when_not_cached(self, cacher_with_mock):
+    async def test_get_file_loads_from_backend_when_not_cached(self, cacher_with_mock):
         """Test get_file loads from backend when not cached."""
         digest = 'test_digest'
         test_content = b'backend content'
@@ -197,7 +199,7 @@ class TestFileCacher:
         cacher_with_mock.backend.path_for_symlink.return_value = None
         cacher_with_mock.backend.get_file.return_value = io.BytesIO(test_content)
 
-        with cacher_with_mock.get_file(digest) as f:
+        with await cacher_with_mock.get_file(digest) as f:
             content = f.read()
 
         assert content == test_content
@@ -206,7 +208,9 @@ class TestFileCacher:
         assert cache_file.exists()
         assert cache_file.read_bytes() == test_content
 
-    def test_get_file_uses_symlink_when_available(self, cacher_with_mock, temp_dir):
+    async def test_get_file_uses_symlink_when_available(
+        self, cacher_with_mock, temp_dir
+    ):
         """Test get_file creates symlink when backend provides path."""
         digest = 'test_digest'
         test_content = b'symlink content'
@@ -217,7 +221,7 @@ class TestFileCacher:
 
         cacher_with_mock.backend.path_for_symlink.return_value = source_file
 
-        with cacher_with_mock.get_file(digest) as f:
+        with await cacher_with_mock.get_file(digest) as f:
             content = f.read()
 
         assert content == test_content
@@ -227,7 +231,7 @@ class TestFileCacher:
         # Use resolve() to handle macOS /private symlink differences
         assert cache_file.resolve().samefile(source_file)
 
-    def test_get_file_content_returns_bytes(self, cacher_with_mock):
+    async def test_get_file_content_returns_bytes(self, cacher_with_mock):
         """Test get_file_content returns file content as bytes."""
         digest = 'test_digest'
         test_content = b'test content'
@@ -235,11 +239,11 @@ class TestFileCacher:
         cache_file = cacher_with_mock.file_dir / digest
         cache_file.write_bytes(test_content)
 
-        content = cacher_with_mock.get_file_content(digest)
+        content = await cacher_with_mock.get_file_content(digest)
 
         assert content == test_content
 
-    def test_get_file_to_fobj_writes_to_file_object(self, cacher_with_mock):
+    async def test_get_file_to_fobj_writes_to_file_object(self, cacher_with_mock):
         """Test get_file_to_fobj writes content to file object."""
         digest = 'test_digest'
         test_content = b'test content'
@@ -248,11 +252,11 @@ class TestFileCacher:
         cache_file.write_bytes(test_content)
 
         output = io.BytesIO()
-        cacher_with_mock.get_file_to_fobj(digest, output)
+        await cacher_with_mock.get_file_to_fobj(digest, output)
 
         assert output.getvalue() == test_content
 
-    def test_get_file_to_path_writes_to_path(self, cacher_with_mock, temp_dir):
+    async def test_get_file_to_path_writes_to_path(self, cacher_with_mock, temp_dir):
         """Test get_file_to_path writes content to specified path."""
         digest = 'test_digest'
         test_content = b'test content'
@@ -261,12 +265,12 @@ class TestFileCacher:
         cache_file = cacher_with_mock.file_dir / digest
         cache_file.write_bytes(test_content)
 
-        cacher_with_mock.get_file_to_path(digest, dest_path)
+        await cacher_with_mock.get_file_to_path(digest, dest_path)
 
         assert dest_path.exists()
         assert dest_path.read_bytes() == test_content
 
-    def test_get_file_to_path_creates_parent_directories(
+    async def test_get_file_to_path_creates_parent_directories(
         self, cacher_with_mock, temp_dir
     ):
         """Test get_file_to_path creates parent directories."""
@@ -277,25 +281,25 @@ class TestFileCacher:
         cache_file = cacher_with_mock.file_dir / digest
         cache_file.write_bytes(test_content)
 
-        cacher_with_mock.get_file_to_path(digest, dest_path)
+        await cacher_with_mock.get_file_to_path(digest, dest_path)
 
         assert dest_path.exists()
         assert dest_path.read_bytes() == test_content
 
-    def test_put_file_from_fobj_stores_content(self, cacher_with_mock):
+    async def test_put_file_from_fobj_stores_content(self, cacher_with_mock):
         """Test put_file_from_fobj stores file content and returns digest."""
         test_content = b'test content for storage'
 
         cacher_with_mock.backend.create_file.return_value = None
 
         with patch('rbx.grading.grading_context.is_transient', return_value=True):
-            cacher_with_mock.put_file_from_fobj(io.BytesIO(test_content))
+            await cacher_with_mock.put_file_from_fobj(io.BytesIO(test_content))
 
         # Verify content is cached
         # Note: digest is computed and used for caching verification
         assert len([f for f in cacher_with_mock.file_dir.iterdir() if f.is_file()]) > 0
 
-    def test_put_file_from_fobj_stores_in_backend_when_not_transient(
+    async def test_put_file_from_fobj_stores_in_backend_when_not_transient(
         self, cacher_with_mock
     ):
         """Test put_file_from_fobj stores in backend when not in transient mode."""
@@ -306,12 +310,12 @@ class TestFileCacher:
         cacher_with_mock.backend.create_file.return_value = mock_pending
 
         with patch('rbx.grading.grading_context.is_transient', return_value=False):
-            digest = cacher_with_mock.put_file_from_fobj(io.BytesIO(test_content))
+            digest = await cacher_with_mock.put_file_from_fobj(io.BytesIO(test_content))
 
         cacher_with_mock.backend.create_file.assert_called_once_with(digest)
         cacher_with_mock.backend.commit_file.assert_called_once_with(mock_pending, None)
 
-    def test_put_file_from_fobj_with_metadata(self, cacher_with_mock):
+    async def test_put_file_from_fobj_with_metadata(self, cacher_with_mock):
         """Test put_file_from_fobj stores metadata."""
         test_content = b'test content'
         metadata = {'test': CacherTestMetadata(value='test', number=123)}
@@ -321,19 +325,21 @@ class TestFileCacher:
         cacher_with_mock.backend.create_file.return_value = mock_pending
 
         with patch('rbx.grading.grading_context.is_transient', return_value=False):
-            cacher_with_mock.put_file_from_fobj(io.BytesIO(test_content), metadata)
+            await cacher_with_mock.put_file_from_fobj(
+                io.BytesIO(test_content), metadata
+            )
 
         cacher_with_mock.backend.commit_file.assert_called_once_with(
             mock_pending, metadata
         )
 
-    def test_put_file_content_calls_put_file_from_fobj(self, cacher_with_mock):
+    async def test_put_file_content_calls_put_file_from_fobj(self, cacher_with_mock):
         """Test put_file_content calls put_file_from_fobj with BytesIO."""
         test_content = b'test bytes content'
 
         with patch.object(cacher_with_mock, 'put_file_from_fobj') as mock_put:
             mock_put.return_value = 'test_digest'
-            result = cacher_with_mock.put_file_content(test_content)
+            result = await cacher_with_mock.put_file_content(test_content)
 
         assert result == 'test_digest'
         mock_put.assert_called_once()
@@ -342,19 +348,19 @@ class TestFileCacher:
         fobj = args[0]
         assert isinstance(fobj, io.BytesIO)
 
-    def test_put_file_text_encodes_to_utf8(self, cacher_with_mock):
+    async def test_put_file_text_encodes_to_utf8(self, cacher_with_mock):
         """Test put_file_text encodes text to UTF-8."""
         test_text = 'Hello, 世界!'
         expected_bytes = test_text.encode('utf-8')
 
         with patch.object(cacher_with_mock, 'put_file_content') as mock_put:
             mock_put.return_value = 'test_digest'
-            result = cacher_with_mock.put_file_text(test_text)
+            result = await cacher_with_mock.put_file_text(test_text)
 
         assert result == 'test_digest'
         mock_put.assert_called_once_with(expected_bytes, None)
 
-    def test_put_file_from_path_reads_file(self, cacher_with_mock, temp_dir):
+    async def test_put_file_from_path_reads_file(self, cacher_with_mock, temp_dir):
         """Test put_file_from_path reads file from filesystem."""
         test_content = b'file system content'
         source_file = temp_dir / 'source.txt'
@@ -362,24 +368,26 @@ class TestFileCacher:
 
         with patch.object(cacher_with_mock, 'put_file_from_fobj') as mock_put:
             mock_put.return_value = 'test_digest'
-            result = cacher_with_mock.put_file_from_path(source_file)
+            result = await cacher_with_mock.put_file_from_path(source_file)
 
         assert result == 'test_digest'
         mock_put.assert_called_once()
 
-    def test_path_for_symlink_tombstone_raises_error(self, cacher_with_mock):
+    async def test_path_for_symlink_tombstone_raises_error(self, cacher_with_mock):
         """Test path_for_symlink raises TombstoneError for tombstone."""
         with pytest.raises(TombstoneError):
-            cacher_with_mock.path_for_symlink(storage.TOMBSTONE)
+            await cacher_with_mock.path_for_symlink(storage.TOMBSTONE)
 
-    def test_path_for_symlink_returns_none_when_transient(self, cacher_with_mock):
+    async def test_path_for_symlink_returns_none_when_transient(self, cacher_with_mock):
         """Test path_for_symlink returns None when in transient mode."""
         with patch('rbx.grading.grading_context.is_transient', return_value=True):
-            result = cacher_with_mock.path_for_symlink('test_digest')
+            result = await cacher_with_mock.path_for_symlink('test_digest')
 
         assert result is None
 
-    def test_path_for_symlink_delegates_to_backend(self, cacher_with_mock, temp_dir):
+    async def test_path_for_symlink_delegates_to_backend(
+        self, cacher_with_mock, temp_dir
+    ):
         """Test path_for_symlink delegates to backend when not transient."""
         digest = 'test_digest'
         expected_path = temp_dir / 'symlink_target'
@@ -387,23 +395,25 @@ class TestFileCacher:
         cacher_with_mock.backend.path_for_symlink.return_value = expected_path
 
         with patch('rbx.grading.grading_context.is_transient', return_value=False):
-            result = cacher_with_mock.path_for_symlink(digest)
+            result = await cacher_with_mock.path_for_symlink(digest)
 
         assert result == expected_path
         cacher_with_mock.backend.path_for_symlink.assert_called_once_with(digest)
 
-    def test_digest_from_symlink_returns_none_when_transient(
+    async def test_digest_from_symlink_returns_none_when_transient(
         self, cacher_with_mock, temp_dir
     ):
         """Test digest_from_symlink returns None when in transient mode."""
         link_path = temp_dir / 'link'
 
         with patch('rbx.grading.grading_context.is_transient', return_value=True):
-            result = cacher_with_mock.digest_from_symlink(link_path)
+            result = await cacher_with_mock.digest_from_symlink(link_path)
 
         assert result is None
 
-    def test_digest_from_symlink_delegates_to_backend(self, cacher_with_mock, temp_dir):
+    async def test_digest_from_symlink_delegates_to_backend(
+        self, cacher_with_mock, temp_dir
+    ):
         """Test digest_from_symlink delegates to backend when not transient."""
         link_path = temp_dir / 'link'
         expected_digest = 'test_digest'
@@ -411,41 +421,43 @@ class TestFileCacher:
         cacher_with_mock.backend.filename_from_symlink.return_value = expected_digest
 
         with patch('rbx.grading.grading_context.is_transient', return_value=False):
-            result = cacher_with_mock.digest_from_symlink(link_path)
+            result = await cacher_with_mock.digest_from_symlink(link_path)
 
         assert result == expected_digest
         cacher_with_mock.backend.filename_from_symlink.assert_called_once_with(
             link_path
         )
 
-    def test_set_metadata_skips_when_transient(self, cacher_with_mock):
+    async def test_set_metadata_skips_when_transient(self, cacher_with_mock):
         """Test set_metadata does nothing when in transient mode."""
         with patch('rbx.grading.grading_context.is_transient', return_value=True):
-            cacher_with_mock.set_metadata(
+            await cacher_with_mock.set_metadata(
                 'digest', 'key', CacherTestMetadata(value='test')
             )
 
         cacher_with_mock.backend.set_metadata.assert_not_called()
 
-    def test_set_metadata_delegates_to_backend(self, cacher_with_mock):
+    async def test_set_metadata_delegates_to_backend(self, cacher_with_mock):
         """Test set_metadata delegates to backend when not transient."""
         digest = 'test_digest'
         key = 'test_key'
         value = CacherTestMetadata(value='test')
 
         with patch('rbx.grading.grading_context.is_transient', return_value=False):
-            cacher_with_mock.set_metadata(digest, key, value)
+            await cacher_with_mock.set_metadata(digest, key, value)
 
         cacher_with_mock.backend.set_metadata.assert_called_once_with(
             digest, key, value
         )
 
-    def test_get_metadata_tombstone_raises_error(self, cacher_with_mock):
+    async def test_get_metadata_tombstone_raises_error(self, cacher_with_mock):
         """Test get_metadata raises TombstoneError for tombstone."""
         with pytest.raises(TombstoneError):
-            cacher_with_mock.get_metadata(storage.TOMBSTONE, 'key', CacherTestMetadata)
+            await cacher_with_mock.get_metadata(
+                storage.TOMBSTONE, 'key', CacherTestMetadata
+            )
 
-    def test_get_metadata_delegates_to_backend(self, cacher_with_mock):
+    async def test_get_metadata_delegates_to_backend(self, cacher_with_mock):
         """Test get_metadata delegates to backend."""
         digest = 'test_digest'
         key = 'test_key'
@@ -453,43 +465,43 @@ class TestFileCacher:
 
         cacher_with_mock.backend.get_metadata.return_value = expected_metadata
 
-        result = cacher_with_mock.get_metadata(digest, key, CacherTestMetadata)
+        result = await cacher_with_mock.get_metadata(digest, key, CacherTestMetadata)
 
         assert result == expected_metadata
         cacher_with_mock.backend.get_metadata.assert_called_once_with(
             digest, key, CacherTestMetadata
         )
 
-    def test_list_metadata_delegates_to_backend(self, cacher_with_mock):
+    async def test_list_metadata_delegates_to_backend(self, cacher_with_mock):
         """Test list_metadata delegates to backend."""
         filename = 'test_file'
         expected_keys = ['key1', 'key2', 'key3']
 
         cacher_with_mock.backend.list_metadata.return_value = expected_keys
 
-        result = cacher_with_mock.list_metadata(filename)
+        result = await cacher_with_mock.list_metadata(filename)
 
         assert result == expected_keys
         cacher_with_mock.backend.list_metadata.assert_called_once_with(filename)
 
-    def test_get_size_tombstone_raises_error(self, cacher_with_mock):
+    async def test_get_size_tombstone_raises_error(self, cacher_with_mock):
         """Test get_size raises TombstoneError for tombstone."""
         with pytest.raises(TombstoneError):
-            cacher_with_mock.get_size(storage.TOMBSTONE)
+            await cacher_with_mock.get_size(storage.TOMBSTONE)
 
-    def test_get_size_delegates_to_backend(self, cacher_with_mock):
+    async def test_get_size_delegates_to_backend(self, cacher_with_mock):
         """Test get_size delegates to backend."""
         digest = 'test_digest'
         expected_size = 1024
 
         cacher_with_mock.backend.get_size.return_value = expected_size
 
-        result = cacher_with_mock.get_size(digest)
+        result = await cacher_with_mock.get_size(digest)
 
         assert result == expected_size
         cacher_with_mock.backend.get_size.assert_called_once_with(digest)
 
-    def test_delete_removes_from_cache_and_backend(self, cacher_with_mock):
+    async def test_delete_removes_from_cache_and_backend(self, cacher_with_mock):
         """Test delete removes file from both cache and backend."""
         digest = 'test_digest'
 
@@ -498,7 +510,7 @@ class TestFileCacher:
         cache_file.write_bytes(b'test content')
         cacher_with_mock.existing.add(digest)
 
-        cacher_with_mock.delete(digest)
+        await cacher_with_mock.delete(digest)
 
         # Verify file removed from cache
         assert not cache_file.exists()
@@ -507,13 +519,13 @@ class TestFileCacher:
         # Verify backend delete called
         cacher_with_mock.backend.delete.assert_called_once_with(digest)
 
-    def test_delete_tombstone_does_nothing(self, cacher_with_mock):
+    async def test_delete_tombstone_does_nothing(self, cacher_with_mock):
         """Test delete does nothing for tombstone."""
-        cacher_with_mock.delete(storage.TOMBSTONE)
+        await cacher_with_mock.delete(storage.TOMBSTONE)
 
         cacher_with_mock.backend.delete.assert_not_called()
 
-    def test_drop_removes_only_from_cache(self, cacher_with_mock):
+    async def test_drop_removes_only_from_cache(self, cacher_with_mock):
         """Test drop removes file only from cache."""
         digest = 'test_digest'
 
@@ -522,7 +534,7 @@ class TestFileCacher:
         cache_file.write_bytes(b'test content')
         cacher_with_mock.existing.add(digest)
 
-        cacher_with_mock.drop(digest)
+        await cacher_with_mock.drop(digest)
 
         # Verify file removed from cache
         assert not cache_file.exists()
@@ -531,13 +543,13 @@ class TestFileCacher:
         # Verify backend not touched
         cacher_with_mock.backend.delete.assert_not_called()
 
-    def test_drop_tombstone_does_nothing(self, cacher_with_mock):
+    async def test_drop_tombstone_does_nothing(self, cacher_with_mock):
         """Test drop does nothing for tombstone."""
-        cacher_with_mock.drop(storage.TOMBSTONE)
+        await cacher_with_mock.drop(storage.TOMBSTONE)
 
         # Should not raise any error
 
-    def test_purge_cache_clears_cache_directory(self, cacher_with_mock):
+    async def test_purge_cache_clears_cache_directory(self, cacher_with_mock):
         """Test purge_cache clears cache directory and recreates it."""
         # Add some files to cache
         (cacher_with_mock.file_dir / 'file1').write_bytes(b'content1')
@@ -545,7 +557,7 @@ class TestFileCacher:
         cacher_with_mock.existing.add('file1')
         cacher_with_mock.existing.add('file2')
 
-        cacher_with_mock.purge_cache()
+        await cacher_with_mock.purge_cache()
 
         # Verify directory is recreated and existing set is cleared
         assert cacher_with_mock.file_dir.exists()
@@ -558,7 +570,7 @@ class TestFileCacher:
         ]
         assert len(cache_files) == 0
 
-    def test_destroy_cache_removes_cache_directory(self, cacher_with_mock):
+    async def test_destroy_cache_removes_cache_directory(self, cacher_with_mock):
         """Test destroy_cache removes cache directory completely."""
         cache_dir = cacher_with_mock.file_dir
 
@@ -566,12 +578,12 @@ class TestFileCacher:
 
         assert not cache_dir.exists()
 
-    def test_destroy_cache_raises_for_shared_cache(self, shared_cacher):
+    async def test_destroy_cache_raises_for_shared_cache(self, shared_cacher):
         """Test destroy_cache raises exception for shared cache."""
         with pytest.raises(Exception, match='You may not destroy a shared cache'):
             shared_cacher.destroy_cache()
 
-    def test_list_delegates_to_backend(self, cacher_with_mock):
+    async def test_list_delegates_to_backend(self, cacher_with_mock):
         """Test list delegates to backend."""
         expected_files = [
             storage.FileWithMetadata(filename='file1', metadata=['key1']),
@@ -580,96 +592,96 @@ class TestFileCacher:
 
         cacher_with_mock.backend.list.return_value = expected_files
 
-        result = cacher_with_mock.list()
+        result = await cacher_with_mock.list()
 
         assert result == expected_files
         cacher_with_mock.backend.list.assert_called_once()
 
-    def test_check_backend_integrity_valid_files(self, cacher_with_filesystem):
+    async def test_check_backend_integrity_valid_files(self, cacher_with_filesystem):
         """Test check_backend_integrity with valid files."""
         # Store a file with known content
         test_content = b'integrity test content'
-        cacher_with_filesystem.put_file_content(test_content)
+        await cacher_with_filesystem.put_file_content(test_content)
 
         # Check integrity
-        result = cacher_with_filesystem.check_backend_integrity()
+        result = await cacher_with_filesystem.check_backend_integrity()
 
         assert result
 
-    def test_check_backend_integrity_invalid_file_reports_error(
+    async def test_check_backend_integrity_invalid_file_reports_error(
         self, cacher_with_filesystem, caplog
     ):
         """Test check_backend_integrity reports error for corrupted file."""
         # Store a file
         test_content = b'original content'
-        digest = cacher_with_filesystem.put_file_content(test_content)
+        digest = await cacher_with_filesystem.put_file_content(test_content)
 
         # Corrupt the backend file directly
         backend_file = cacher_with_filesystem.backend.path / digest
         backend_file.write_bytes(b'corrupted content')
 
         # Check integrity
-        result = cacher_with_filesystem.check_backend_integrity()
+        result = await cacher_with_filesystem.check_backend_integrity()
 
         assert not result
         assert 'actually has hash' in caplog.text
 
-    def test_check_backend_integrity_delete_corrupted_files(
+    async def test_check_backend_integrity_delete_corrupted_files(
         self, cacher_with_filesystem
     ):
         """Test check_backend_integrity deletes corrupted files when delete=True."""
         # Store a file
         test_content = b'original content'
-        digest = cacher_with_filesystem.put_file_content(test_content)
+        digest = await cacher_with_filesystem.put_file_content(test_content)
 
         # Corrupt the backend file
         backend_file = cacher_with_filesystem.backend.path / digest
         backend_file.write_bytes(b'corrupted content')
 
         # Check integrity with delete=True
-        result = cacher_with_filesystem.check_backend_integrity(delete=True)
+        result = await cacher_with_filesystem.check_backend_integrity(delete=True)
 
         assert not result
         # File should be deleted from backend
-        assert not cacher_with_filesystem.backend.exists(digest)
+        assert not await cacher_with_filesystem.backend.exists(digest)
 
-    def test_integration_put_and_get_file(self, cacher_with_filesystem):
+    async def test_integration_put_and_get_file(self, cacher_with_filesystem):
         """Integration test: put file and retrieve it."""
         test_content = b'integration test content'
 
         # Store file
-        digest = cacher_with_filesystem.put_file_content(test_content)
+        digest = await cacher_with_filesystem.put_file_content(test_content)
 
         # Retrieve file
-        retrieved_content = cacher_with_filesystem.get_file_content(digest)
+        retrieved_content = await cacher_with_filesystem.get_file_content(digest)
 
         assert retrieved_content == test_content
 
-    def test_integration_cache_persistence(self, cacher_with_filesystem):
+    async def test_integration_cache_persistence(self, cacher_with_filesystem):
         """Integration test: verify cache persists across operations."""
         test_content = b'persistent content'
 
         # Store and cache file
-        digest = cacher_with_filesystem.put_file_content(test_content)
+        digest = await cacher_with_filesystem.put_file_content(test_content)
 
         # Remove from backend to test cache
-        cacher_with_filesystem.backend.delete(digest)
+        await cacher_with_filesystem.backend.delete(digest)
 
         # Should still be accessible from cache
         cache_file = cacher_with_filesystem.file_dir / digest
         assert cache_file.exists()
         assert cache_file.read_bytes() == test_content
 
-    def test_integration_with_metadata(self, cacher_with_filesystem):
+    async def test_integration_with_metadata(self, cacher_with_filesystem):
         """Integration test: store and retrieve file with metadata."""
         test_content = b'content with metadata'
         metadata = {'test': CacherTestMetadata(value='integration', number=999)}
 
         # Store with metadata
-        digest = cacher_with_filesystem.put_file_content(test_content, metadata)
+        digest = await cacher_with_filesystem.put_file_content(test_content, metadata)
 
         # Retrieve metadata
-        retrieved_metadata = cacher_with_filesystem.get_metadata(
+        retrieved_metadata = await cacher_with_filesystem.get_metadata(
             digest, 'test', CacherTestMetadata
         )
 
@@ -677,26 +689,26 @@ class TestFileCacher:
         assert retrieved_metadata.value == 'integration'
         assert retrieved_metadata.number == 999
 
-    def test_large_file_handling(self, cacher_with_filesystem):
+    async def test_large_file_handling(self, cacher_with_filesystem):
         """Test handling of files larger than chunk size."""
         # Create content larger than CHUNK_SIZE (1MB)
         chunk_size = FileCacher.CHUNK_SIZE
         large_content = b'x' * (chunk_size + 1000)
 
         # Store and retrieve large file
-        digest = cacher_with_filesystem.put_file_content(large_content)
-        retrieved_content = cacher_with_filesystem.get_file_content(digest)
+        digest = await cacher_with_filesystem.put_file_content(large_content)
+        retrieved_content = await cacher_with_filesystem.get_file_content(digest)
 
         assert retrieved_content == large_content
 
-    def test_concurrent_cache_operations(self, shared_cacher):
+    async def test_concurrent_cache_operations(self, shared_cacher):
         """Test concurrent cache operations with locking."""
         # This test verifies that the locking mechanism works
         # Multiple cachers using same shared directory
         test_content = b'concurrent test'
 
         # Store file in first cacher
-        digest = shared_cacher.put_file_content(test_content)
+        digest = await shared_cacher.put_file_content(test_content)
 
         # Create second cacher with same backend and folder
         second_cacher = FileCacher(
@@ -704,13 +716,13 @@ class TestFileCacher:
         )
 
         # Both should be able to access the file
-        content1 = shared_cacher.get_file_content(digest)
-        content2 = second_cacher.get_file_content(digest)
+        content1 = await shared_cacher.get_file_content(digest)
+        content2 = await second_cacher.get_file_content(digest)
 
         assert content1 == test_content
         assert content2 == test_content
 
-    def test_error_handling_missing_file(self, cacher_with_mock):
+    async def test_error_handling_missing_file(self, cacher_with_mock):
         """Test error handling when backend file is missing."""
         digest = 'nonexistent_digest'
 
@@ -718,14 +730,16 @@ class TestFileCacher:
         cacher_with_mock.backend.get_file.side_effect = KeyError('File not found')
 
         with pytest.raises(KeyError):
-            cacher_with_mock.get_file(digest)
+            await cacher_with_mock.get_file(digest)
 
-    def test_transient_path_for_symlink_tombstone_raises_error(self, cacher_with_mock):
+    async def test_transient_path_for_symlink_tombstone_raises_error(
+        self, cacher_with_mock
+    ):
         """Test transient_path_for_symlink raises TombstoneError for tombstone."""
         with pytest.raises(TombstoneError):
-            cacher_with_mock.transient_path_for_symlink(storage.TOMBSTONE)
+            await cacher_with_mock.transient_path_for_symlink(storage.TOMBSTONE)
 
-    def test_transient_path_for_symlink_returns_cached_file_path(
+    async def test_transient_path_for_symlink_returns_cached_file_path(
         self, cacher_with_mock
     ):
         """Test transient_path_for_symlink returns path when file is already cached."""
@@ -736,13 +750,13 @@ class TestFileCacher:
         cache_file = cacher_with_mock.file_dir / digest
         cache_file.write_bytes(test_content)
 
-        result = cacher_with_mock.transient_path_for_symlink(digest)
+        result = await cacher_with_mock.transient_path_for_symlink(digest)
 
         assert result == cache_file
         assert result.exists()
         assert result.read_bytes() == test_content
 
-    def test_transient_path_for_symlink_loads_from_backend_when_not_cached(
+    async def test_transient_path_for_symlink_loads_from_backend_when_not_cached(
         self, cacher_with_mock
     ):
         """Test transient_path_for_symlink loads file from backend when not cached."""
@@ -753,7 +767,7 @@ class TestFileCacher:
         cacher_with_mock.backend.path_for_symlink.return_value = None
         cacher_with_mock.backend.get_file.return_value = io.BytesIO(test_content)
 
-        result = cacher_with_mock.transient_path_for_symlink(digest)
+        result = await cacher_with_mock.transient_path_for_symlink(digest)
 
         # Verify file was loaded from backend and cached
         cache_file = cacher_with_mock.file_dir / digest
@@ -762,7 +776,7 @@ class TestFileCacher:
         assert cache_file.read_bytes() == test_content
         cacher_with_mock.backend.get_file.assert_called_once_with(digest)
 
-    def test_transient_path_for_symlink_uses_symlink_when_available(
+    async def test_transient_path_for_symlink_uses_symlink_when_available(
         self, cacher_with_mock, temp_dir
     ):
         """Test transient_path_for_symlink creates symlink when backend provides path."""
@@ -775,7 +789,7 @@ class TestFileCacher:
 
         cacher_with_mock.backend.path_for_symlink.return_value = source_file
 
-        result = cacher_with_mock.transient_path_for_symlink(digest)
+        result = await cacher_with_mock.transient_path_for_symlink(digest)
 
         cache_file = cacher_with_mock.file_dir / digest
         assert result == cache_file
@@ -783,7 +797,7 @@ class TestFileCacher:
         # Use resolve() to handle macOS /private symlink differences
         assert cache_file.resolve().samefile(source_file)
 
-    def test_transient_path_for_symlink_backend_keyerror_propagates(
+    async def test_transient_path_for_symlink_backend_keyerror_propagates(
         self, cacher_with_mock
     ):
         """Test transient_path_for_symlink propagates KeyError when backend file doesn't exist."""
@@ -794,9 +808,9 @@ class TestFileCacher:
         cacher_with_mock.backend.get_file.side_effect = KeyError('File not found')
 
         with pytest.raises(KeyError, match='File not found'):
-            cacher_with_mock.transient_path_for_symlink(digest)
+            await cacher_with_mock.transient_path_for_symlink(digest)
 
-    def test_transient_path_for_symlink_cache_file_disappears_after_load(
+    async def test_transient_path_for_symlink_cache_file_disappears_after_load(
         self, cacher_with_mock
     ):
         """Test transient_path_for_symlink raises FileNotFoundError when cache file disappears after _load."""
@@ -809,11 +823,11 @@ class TestFileCacher:
             with pytest.raises(
                 FileNotFoundError, match=f'File {digest} not found in cache'
             ):
-                cacher_with_mock.transient_path_for_symlink(digest)
+                await cacher_with_mock.transient_path_for_symlink(digest)
 
             mock_load.assert_called_once_with(digest, cache_only=True)
 
-    def test_transient_path_for_symlink_multiple_calls_same_digest(
+    async def test_transient_path_for_symlink_multiple_calls_same_digest(
         self, cacher_with_mock
     ):
         """Test transient_path_for_symlink handles multiple calls for same digest efficiently."""
@@ -825,13 +839,13 @@ class TestFileCacher:
         cacher_with_mock.backend.get_file.return_value = io.BytesIO(test_content)
 
         # First call should load from backend
-        result1 = cacher_with_mock.transient_path_for_symlink(digest)
+        result1 = await cacher_with_mock.transient_path_for_symlink(digest)
 
         # Reset mock to verify second call doesn't hit backend
         cacher_with_mock.backend.get_file.reset_mock()
 
         # Second call should use cached file
-        result2 = cacher_with_mock.transient_path_for_symlink(digest)
+        result2 = await cacher_with_mock.transient_path_for_symlink(digest)
 
         assert result1 == result2
         cache_file = cacher_with_mock.file_dir / digest

--- a/tests/rbx/grading/judge/test_cacher_concurrency.py
+++ b/tests/rbx/grading/judge/test_cacher_concurrency.py
@@ -1,0 +1,37 @@
+import asyncio
+import pathlib
+
+import pytest
+
+from rbx.grading.judge.cacher import FileCacher
+from rbx.grading.judge.storage import FilesystemStorage
+
+
+@pytest.mark.asyncio
+async def test_cacher_two_tasks_yield_under_lock(tmp_path: pathlib.Path):
+    """Two asyncio tasks alternating cacher ops with explicit yields must
+    both make progress. Under AsyncFileLock they will; under a plain
+    FileLock they would deadlock if either yielded while holding the lock.
+    """
+    storage = FilesystemStorage(tmp_path / 'storage')
+    cacher = FileCacher(storage)
+
+    async def worker(name: bytes, n: int) -> list[str]:
+        digests: list[str] = []
+        for i in range(n):
+            digest = await cacher.put_file_content(name + str(i).encode())
+            digests.append(digest)
+            # Yield to give the other task a chance to run mid-critical-section
+            # of a future code path. Today nothing yields under the lock; this
+            # asserts the future-proofed behaviour.
+            await asyncio.sleep(0)
+            assert await cacher.exists(digest)
+        return digests
+
+    a, b = await asyncio.wait_for(
+        asyncio.gather(worker(b'a', 5), worker(b'b', 5)),
+        timeout=5.0,
+    )
+    assert len(a) == 5
+    assert len(b) == 5
+    assert set(a).isdisjoint(set(b))

--- a/tests/rbx/grading/judge/test_sandbox.py
+++ b/tests/rbx/grading/judge/test_sandbox.py
@@ -259,7 +259,7 @@ class TestSandboxBase:
         content = sandbox.get_file_to_string(file_path)
         assert content == test_string_content
 
-    def test_create_file_from_other_file(self, sandbox, tmp_path):
+    async def test_create_file_from_other_file(self, sandbox, tmp_path):
         """Test creating a file from another file."""
         # Create source file
         source_file = tmp_path / 'source.txt'
@@ -268,13 +268,13 @@ class TestSandboxBase:
 
         dest_path = pathlib.Path('test_from_file.txt')
 
-        sandbox.create_file_from_other_file(dest_path, source_file)
+        await sandbox.create_file_from_other_file(dest_path, source_file)
 
         # Verify content
         content = sandbox.get_file_to_bytes(dest_path)
         assert content == source_content
 
-    def test_create_file_from_storage(self, sandbox):
+    async def test_create_file_from_storage(self, sandbox):
         """Test creating a file from storage."""
         file_path = pathlib.Path('test_from_storage.txt')
         test_content = b'Storage file content'
@@ -283,10 +283,12 @@ class TestSandboxBase:
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(test_content)
             tmp.flush()
-            digest = sandbox.file_cacher.put_file_from_path(pathlib.Path(tmp.name))
+            digest = await sandbox.file_cacher.put_file_from_path(
+                pathlib.Path(tmp.name)
+            )
 
         # Create file from storage
-        sandbox.create_file_from_storage(file_path, digest)
+        await sandbox.create_file_from_storage(file_path, digest)
 
         # Verify content
         content = sandbox.get_file_to_bytes(file_path)
@@ -350,16 +352,16 @@ class TestSandboxBase:
         content = sandbox.get_file_to_string(file_path)
         assert content == test_string_content
 
-    def test_get_file_to_storage(self, sandbox, test_file_content):
+    async def test_get_file_to_storage(self, sandbox, test_file_content):
         """Test putting a file into storage."""
         file_path = pathlib.Path('test_to_storage.txt')
         sandbox.create_file_from_bytes(file_path, test_file_content)
 
-        digest = sandbox.get_file_to_storage(file_path)
+        digest = await sandbox.get_file_to_storage(file_path)
 
         # Verify we can retrieve the same content
         with tempfile.NamedTemporaryFile() as tmp:
-            sandbox.file_cacher.get_file_to_path(digest, pathlib.Path(tmp.name))
+            await sandbox.file_cacher.get_file_to_path(digest, pathlib.Path(tmp.name))
             retrieved_content = pathlib.Path(tmp.name).read_bytes()
 
         assert retrieved_content == test_file_content
@@ -557,19 +559,19 @@ class TestTruncator:
 class TestSandboxEdgeCases:
     """Test edge cases and error conditions."""
 
-    def test_get_file_to_storage_with_truncation(self, sandbox, tmp_path_factory):
+    async def test_get_file_to_storage_with_truncation(self, sandbox, tmp_path_factory):
         """Test putting truncated file to storage."""
         file_path = pathlib.Path('test_trunc_storage.txt')
         long_content = b'A' * 1000
         sandbox.create_file_from_bytes(file_path, long_content)
 
         # Put truncated version to storage
-        digest = sandbox.get_file_to_storage(file_path, trunc_len=100)
+        digest = await sandbox.get_file_to_storage(file_path, trunc_len=100)
 
         # Verify truncated content in storage
         tmp_path = tmp_path_factory.mktemp('test_trunc')
         tmp_file = tmp_path / 'truncated.txt'
-        sandbox.file_cacher.get_file_to_path(digest, tmp_file)
+        await sandbox.file_cacher.get_file_to_path(digest, tmp_file)
         retrieved_content = tmp_file.read_bytes()
 
         assert len(retrieved_content) == 100

--- a/tests/rbx/grading/steps_with_caching_run_test.py
+++ b/tests/rbx/grading/steps_with_caching_run_test.py
@@ -25,7 +25,7 @@ async def test_run_from_digest(
     sandbox: SandboxBase,
     file_cacher: FileCacher,
 ):
-    executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+    executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
     artifacts = GradingArtifacts()
     artifacts.inputs.append(
         GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -85,7 +85,7 @@ async def test_run_reruns_if_cache_disabled(
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -123,7 +123,7 @@ async def test_run_reruns_if_first_run_cache_disabled(
     async def configure_and_run_with_dest(
         dest: pathlib.Path, cache: bool = True
     ) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -163,7 +163,7 @@ async def test_run_reruns_if_second_run_cache_disabled(
     async def configure_and_run_with_dest(
         dest: pathlib.Path, cache: bool = True
     ) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -203,7 +203,7 @@ async def test_run_caches_intermediate_digest_if_dest_changes(
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -240,7 +240,7 @@ async def test_run_caches_intermediate_digest_if_dest_changes_and_cache_transien
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -279,7 +279,7 @@ async def test_run_overwrites_changed_file_when_storage_value_is_changed_and_cac
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -317,7 +317,7 @@ async def test_run_overwrites_changed_file_when_file_deleted_and_cache_transient
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -355,7 +355,7 @@ async def test_run_fails_when_storage_value_is_changed_and_integrity_check_is_en
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -392,7 +392,7 @@ async def test_run_evicts_and_recreates_deleted_file_with_storage_value(
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -429,7 +429,7 @@ async def test_run_evicts_when_storage_value_deleted(
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -454,7 +454,7 @@ async def test_run_evicts_when_storage_value_deleted(
     # Delete the file from the cache
     with pathlib.Path('out.txt').open('rb') as f:
         digest = digest_cooperatively(f)
-    file_cacher.delete(digest)
+    await file_cacher.delete(digest)
 
     another_artifacts = await configure_and_run_with_dest(pathlib.Path('out.txt'))
     assert (cleandir / 'out.txt').read_text().strip() == '5'
@@ -469,7 +469,7 @@ async def test_run_overwrite_exec_bit_when_changed(
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(
@@ -513,7 +513,7 @@ async def test_run_evicts_when_changed_file_and_no_hash(
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -550,7 +550,7 @@ async def test_run_evicts_when_exec_bit_different_and_no_hash(
     file_cacher: FileCacher,
 ):
     async def configure_and_run_with_dest(dest: pathlib.Path) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -673,7 +673,7 @@ async def test_run_misses_when_input_file_changes(
 ):
     async def configure_and_run(number: int) -> GradingArtifacts:
         executable = DigestOrSource.create(
-            file_cacher.put_file_text(f'print({number})')
+            await file_cacher.put_file_text(f'print({number})')
         )
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
@@ -715,10 +715,10 @@ async def test_run_coordinated_from_digest(
     file_cacher: FileCacher,
 ):
     interactor_executable = DigestOrSource.create(
-        file_cacher.put_file_text('print("hello"); input()')
+        await file_cacher.put_file_text('print("hello"); input()')
     )
     solution_executable = DigestOrSource.create(
-        file_cacher.put_file_text('print("world")')
+        await file_cacher.put_file_text('print("world")')
     )
 
     artifacts = GradingArtifacts()
@@ -784,10 +784,10 @@ async def test_run_coordinated_caches_intermediate_digest_if_dest_changes(
         int_dest: pathlib.Path, sol_dest: pathlib.Path
     ) -> GradingArtifacts:
         interactor_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("hello"); input()')
+            await file_cacher.put_file_text('print("hello"); input()')
         )
         solution_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("world")')
+            await file_cacher.put_file_text('print("world")')
         )
 
         artifacts = GradingArtifacts()
@@ -855,10 +855,10 @@ async def test_run_coordinated_evicts_when_retry_index_changes(
         interactor_retry: Optional[int], solution_retry: Optional[int]
     ) -> GradingArtifacts:
         interactor_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("hello"); input()')
+            await file_cacher.put_file_text('print("hello"); input()')
         )
         solution_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("world")')
+            await file_cacher.put_file_text('print("world")')
         )
 
         artifacts = GradingArtifacts()
@@ -944,7 +944,7 @@ async def test_run_transient_fallback_when_sanitized(
     async def configure_and_run_with_metadata(
         metadata: Optional[RunLogMetadata],
     ) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -991,7 +991,7 @@ async def test_run_no_transient_fallback_when_not_sanitized(
     async def configure_and_run_with_metadata(
         metadata: Optional[RunLogMetadata],
     ) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -1038,7 +1038,7 @@ async def test_run_no_transient_fallback_when_no_metadata(
     """Test that run() does not use transient cache when metadata is None during compilation-only mode."""
 
     async def configure_and_run() -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -1084,7 +1084,7 @@ async def test_run_stress_mode_disables_transient_fallback(
     async def configure_and_run_with_metadata(
         metadata: Optional[RunLogMetadata],
     ) -> GradingArtifacts:
-        executable = DigestOrSource.create(file_cacher.put_file_text('print(5)'))
+        executable = DigestOrSource.create(await file_cacher.put_file_text('print(5)'))
         artifacts = GradingArtifacts()
         artifacts.inputs.append(
             GradingFileInput(**executable.expand(), dest=pathlib.Path('executable.py'))
@@ -1139,10 +1139,10 @@ async def test_run_coordinated_transient_fallback_when_interactor_sanitized(
         solution_metadata: Optional[RunLogMetadata],
     ) -> GradingArtifacts:
         interactor_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("hello"); input()')
+            await file_cacher.put_file_text('print("hello"); input()')
         )
         solution_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("world")')
+            await file_cacher.put_file_text('print("world")')
         )
 
         artifacts = GradingArtifacts()
@@ -1222,10 +1222,10 @@ async def test_run_coordinated_transient_fallback_when_solution_sanitized(
         solution_metadata: Optional[RunLogMetadata],
     ) -> GradingArtifacts:
         interactor_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("hello"); input()')
+            await file_cacher.put_file_text('print("hello"); input()')
         )
         solution_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("world")')
+            await file_cacher.put_file_text('print("world")')
         )
 
         artifacts = GradingArtifacts()
@@ -1305,10 +1305,10 @@ async def test_run_coordinated_no_transient_fallback_when_not_sanitized(
         solution_metadata: Optional[RunLogMetadata],
     ) -> GradingArtifacts:
         interactor_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("hello"); input()')
+            await file_cacher.put_file_text('print("hello"); input()')
         )
         solution_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("world")')
+            await file_cacher.put_file_text('print("world")')
         )
 
         artifacts = GradingArtifacts()
@@ -1390,10 +1390,10 @@ async def test_run_coordinated_stress_mode_disables_transient_fallback(
         solution_metadata: Optional[RunLogMetadata],
     ) -> GradingArtifacts:
         interactor_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("hello"); input()')
+            await file_cacher.put_file_text('print("hello"); input()')
         )
         solution_executable = DigestOrSource.create(
-            file_cacher.put_file_text('print("world")')
+            await file_cacher.put_file_text('print("world")')
         )
 
         artifacts = GradingArtifacts()


### PR DESCRIPTION
## Summary

Closes #394.

`FileCacher`, `FileCacheStorage`, `DependencyCache`, and `get_preprocessed_file_lock` previously used `filelock.FileLock` to guard their critical sections. Callers run as multiple asyncio tasks on a single event loop; if a future change introduced an `await` under the lock, two tasks would deadlock — the yielding task would let another take over, which would then block the whole loop thread on the same `FileLock`. This PR replaces those locks with `filelock.AsyncFileLock`, which suspends via `asyncio.sleep` instead of blocking the thread, and propagates `await` through every caller.

- All locked methods on the four lock-owning sites are now `async def` using `async with self.lock`.
- `DependencyCacheBlock` was a sync context manager whose `__enter__`/`__exit__` called now-async methods; converted to `__aenter__`/`__aexit__` with the 3 callsites in `steps_with_caching.py` switching to `async with`.
- `get_digest_as_string` was `@functools.cache`-decorated; switched to `@async_lru.alru_cache(maxsize=None)` (already a project dep) since `functools.cache` cannot cache coroutine results.
- Sync-caller audit found **no Category B/C cases** (no Pydantic validators, dunders, threadpool workers, or other framework-sync boundaries calling locked methods), so **zero `_sync` siblings** were added. The cascade is wide but mechanical.
- `FilesystemStorage.list()` now skips the lockfile sentinel — `AsyncFileLock` creates it more eagerly than `FileLock` did, which would otherwise leak `storage.lock` into directory listings and break `check_backend_integrity`.

Design doc: [`docs/plans/2026-05-03-async-filelock-design.md`](docs/plans/2026-05-03-async-filelock-design.md). Implementation plan: [`docs/plans/2026-05-03-async-filelock.md`](docs/plans/2026-05-03-async-filelock.md).

## Test plan

- [x] New regression test `tests/rbx/grading/judge/test_cacher_concurrency.py::test_cacher_two_tasks_yield_under_lock` — two asyncio tasks alternating cacher ops with explicit `await asyncio.sleep(0)` mid-iteration both make progress (would deadlock under sync `FileLock` with future code paths that yield).
- [x] `uv run pytest tests/rbx/grading/` — 375 passed, 0 failed.
- [x] `uv run pytest --ignore=tests/rbx/box/cli` — 1366 passed; failures match pre-existing Python 3.14 / `syncer.sync()` event-loop issues observed on `main` (1364 passed there). No new regressions introduced.
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)