### PR TITLE
fix(grading): make AsyncFileLock acquire/release atomic on the event loop

### DIFF
--- a/rbx/box/package.py
+++ b/rbx/box/package.py
@@ -14,7 +14,7 @@ from typing import (
 import async_lru
 import ruyaml
 import typer
-from filelock import AsyncFileLock, BaseAsyncFileLock
+from filelock import BaseAsyncFileLock
 
 from rbx import console, utils
 from rbx.box import cd, environment, global_package, path_resolution
@@ -44,6 +44,7 @@ from rbx.box.yaml_validation import load_yaml_model
 from rbx.config import get_builtin_checker
 from rbx.grading.caching import DependencyCache
 from rbx.grading.judge.cacher import FileCacher
+from rbx.grading.judge.lock import make_async_file_lock
 from rbx.grading.judge.sandbox import SandboxBase
 from rbx.grading.judge.storage import FilesystemStorage, Storage
 
@@ -210,10 +211,7 @@ def get_problem_preprocessed_path(
 def get_preprocessed_file_lock(
     root: pathlib.Path = pathlib.Path(),
 ) -> BaseAsyncFileLock:
-    return AsyncFileLock(
-        get_problem_cache_dir(root) / '.preprocessed' / '.lock',
-        run_in_executor=False,
-    )
+    return make_async_file_lock(get_problem_cache_dir(root) / '.preprocessed' / '.lock')
 
 
 async def write_preprocessed_file(

--- a/rbx/box/package.py
+++ b/rbx/box/package.py
@@ -210,7 +210,10 @@ def get_problem_preprocessed_path(
 def get_preprocessed_file_lock(
     root: pathlib.Path = pathlib.Path(),
 ) -> BaseAsyncFileLock:
-    return AsyncFileLock(get_problem_cache_dir(root) / '.preprocessed' / '.lock')
+    return AsyncFileLock(
+        get_problem_cache_dir(root) / '.preprocessed' / '.lock',
+        run_in_executor=False,
+    )
 
 
 async def write_preprocessed_file(

--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 from typing import Any, Dict, List, Optional
 
-from filelock import AsyncFileLock, BaseAsyncFileLock
+from filelock import BaseAsyncFileLock
 from pydantic import BaseModel
 from sqlitedict import SqliteDict
 
@@ -15,6 +15,7 @@ from rbx import console
 from rbx.grading import grading_context
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.judge.digester import digest_cooperatively
+from rbx.grading.judge.lock import make_async_file_lock
 from rbx.grading.judge.storage import copyfileobj
 from rbx.grading.profiling import Profiler
 from rbx.grading.steps import (
@@ -375,11 +376,7 @@ class DependencyCache:
         self.db = SqliteDict(self._cache_name(), autocommit=True)
         tmp_dir = pathlib.Path(tempfile.mkdtemp())
         self.transient_db = SqliteDict(str(tmp_dir / '.cache_db'), autocommit=True)
-        self.lock = AsyncFileLock(
-            self.root / 'cache.lock',
-            thread_local=False,
-            run_in_executor=False,
-        )
+        self.lock = make_async_file_lock(self.root / 'cache.lock')
         atexit.register(lambda: self.db.close())
         atexit.register(lambda: self.transient_db.close())
         atexit.register(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))

--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -375,7 +375,11 @@ class DependencyCache:
         self.db = SqliteDict(self._cache_name(), autocommit=True)
         tmp_dir = pathlib.Path(tempfile.mkdtemp())
         self.transient_db = SqliteDict(str(tmp_dir / '.cache_db'), autocommit=True)
-        self.lock = AsyncFileLock(self.root / 'cache.lock', thread_local=False)
+        self.lock = AsyncFileLock(
+            self.root / 'cache.lock',
+            thread_local=False,
+            run_in_executor=False,
+        )
         atexit.register(lambda: self.db.close())
         atexit.register(lambda: self.transient_db.close())
         atexit.register(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))

--- a/rbx/grading/judge/cacher.py
+++ b/rbx/grading/judge/cacher.py
@@ -9,11 +9,12 @@ import tempfile
 import typing
 from typing import IO, Dict, List, Optional, Type
 
-from filelock import AsyncFileLock, BaseAsyncFileLock
+from filelock import BaseAsyncFileLock
 from pydantic import BaseModel
 
 from rbx.grading import grading_context
 from rbx.grading.judge import digester, storage
+from rbx.grading.judge.lock import make_async_file_lock
 
 logger = logging.getLogger(__name__)
 
@@ -89,11 +90,7 @@ class FileCacher:
             tempfile.mkdtemp(dir=self.file_dir, prefix='_temp')
         )
         atexit.register(lambda: shutil.rmtree(str(self.temp_dir), ignore_errors=True))
-        self.lock = AsyncFileLock(
-            self.file_dir / 'cache.lock',
-            thread_local=False,
-            run_in_executor=False,
-        )
+        self.lock = make_async_file_lock(self.file_dir / 'cache.lock')
         # Just to make sure it was created.
 
     def is_shared(self) -> bool:

--- a/rbx/grading/judge/cacher.py
+++ b/rbx/grading/judge/cacher.py
@@ -89,7 +89,11 @@ class FileCacher:
             tempfile.mkdtemp(dir=self.file_dir, prefix='_temp')
         )
         atexit.register(lambda: shutil.rmtree(str(self.temp_dir), ignore_errors=True))
-        self.lock = AsyncFileLock(self.file_dir / 'cache.lock', thread_local=False)
+        self.lock = AsyncFileLock(
+            self.file_dir / 'cache.lock',
+            thread_local=False,
+            run_in_executor=False,
+        )
         # Just to make sure it was created.
 
     def is_shared(self) -> bool:

--- a/rbx/grading/judge/lock.py
+++ b/rbx/grading/judge/lock.py
@@ -1,0 +1,16 @@
+import os
+
+from filelock import AsyncFileLock, BaseAsyncFileLock
+
+
+def make_async_file_lock(path: 'os.PathLike[str]') -> BaseAsyncFileLock:
+    """Construct an ``AsyncFileLock`` with the parameters this codebase relies on.
+
+    ``thread_local=False`` keeps the lock state shared across coroutines, and
+    ``run_in_executor=False`` runs the underlying ``fcntl.flock`` call directly
+    on the event loop. Both are required: with the executor variant, mutations
+    to the internal counter and ``lock_file_fd`` happen on the loop while the
+    syscall runs in a thread, which races between concurrent acquire/release
+    pairs and surfaces as ``fcntl.flock(None, ...)`` raising ``TypeError``.
+    """
+    return AsyncFileLock(path, thread_local=False, run_in_executor=False)

--- a/rbx/grading/judge/storage.py
+++ b/rbx/grading/judge/storage.py
@@ -252,7 +252,11 @@ class FilesystemStorage(Storage):
         (path / '.metadata').mkdir(parents=True, exist_ok=True)
         # Place the lock in the parent directory so it doesn't appear in list().
         path.parent.mkdir(parents=True, exist_ok=True)
-        self.lock = AsyncFileLock(path.parent / f'{path.name}.lock', thread_local=False)
+        self.lock = AsyncFileLock(
+            path.parent / f'{path.name}.lock',
+            thread_local=False,
+            run_in_executor=False,
+        )
 
     async def get_file(self, filename: str) -> IO[bytes]:
         """See FileCacherBackend.get_file()."""

--- a/rbx/grading/judge/storage.py
+++ b/rbx/grading/judge/storage.py
@@ -8,11 +8,12 @@ from abc import ABC, abstractmethod
 from typing import IO, AnyStr, Dict, List, Optional, Type, TypeVar
 
 import lz4.frame
-from filelock import AsyncFileLock, BaseAsyncFileLock
+from filelock import BaseAsyncFileLock
 from pydantic import BaseModel
 
 from rbx import utils
 from rbx.grading import grading_context
+from rbx.grading.judge.lock import make_async_file_lock
 
 logger = logging.getLogger(__name__)
 
@@ -252,11 +253,7 @@ class FilesystemStorage(Storage):
         (path / '.metadata').mkdir(parents=True, exist_ok=True)
         # Place the lock in the parent directory so it doesn't appear in list().
         path.parent.mkdir(parents=True, exist_ok=True)
-        self.lock = AsyncFileLock(
-            path.parent / f'{path.name}.lock',
-            thread_local=False,
-            run_in_executor=False,
-        )
+        self.lock = make_async_file_lock(path.parent / f'{path.name}.lock')
 
     async def get_file(self, filename: str) -> IO[bytes]:
         """See FileCacherBackend.get_file()."""


### PR DESCRIPTION
## Summary

- After #420 migrated to `AsyncFileLock`, `tests/rbx/box/solutions_test.py::test_get_solution_outcome_report` started failing on `main` with `TypeError: argument must be an int, or have a fileno() method.` from `fcntl.flock` inside `filelock`'s `_release`.
- Root cause: with `run_in_executor=True` (filelock's default), `lock_counter` and `lock_file_fd` are mutated on the event loop while the actual fcntl syscalls run in an executor thread. With `thread_local=False` (which we need for cross-coroutine reentrance), two coroutines sharing the same lock can interleave: one decrements the counter and awaits `run_in_executor(_release)`; before that finishes another coroutine sees `lock_file_fd` still set, re-enters `acquire`, and later schedules a second `_release`. The second one reads `lock_file_fd=None` and calls `fcntl.flock(None, LOCK_UN)` → `TypeError`.
- Fix: pass `run_in_executor=False` to every `AsyncFileLock` we construct. `fcntl.flock` with `LOCK_EX|LOCK_NB` is non-blocking, so doing it directly on the event loop is fine and makes the counter/fd state mutations atomic w.r.t. other tasks (no yield between check and syscall). Polling between failed acquires still yields via `asyncio.sleep`, so contention behavior is unchanged.

## Test plan

- [x] `uv run pytest tests/rbx/box/solutions_test.py::test_get_solution_outcome_report` — fails on `main`, passes with this change.
- [x] `uv run pytest tests/rbx/grading tests/rbx/box/solutions_test.py tests/rbx/box/code_run_test.py -n auto` — 419 passed, 1 skipped.
- [x] `uv run ruff check` / `ruff format --check` on the four touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)