### PR TITLE
fix(ui): resolve .eval paths via the actual on-disk stem

### DIFF
--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -106,8 +106,12 @@ class GroupSkeleton(BaseModel):
 class SolutionSkeleton(Solution):
     runs_dir: pathlib.Path
 
-    def get_entry_prefix(self, entry: TestcaseEntry) -> pathlib.Path:
-        return self.runs_dir / entry.group / f'{entry.index:03d}'
+    def get_entry_prefix(
+        self, entry: TestcaseEntry, stem: Optional[str] = None
+    ) -> pathlib.Path:
+        if stem is None:
+            stem = f'{entry.index:03d}'
+        return self.runs_dir / entry.group / stem
 
     def runs_dir_href(self) -> str:
         relpath = self.runs_dir.relative_to(package.find_problem())
@@ -147,6 +151,23 @@ class SolutionReportSkeleton(BaseModel):
         return [
             entry for entry in self.entries if entry.group_entry.group == group_name
         ]
+
+    def get_entry_stem(self, entry: TestcaseEntry) -> str:
+        # The on-disk .eval/.out/.log filename stem comes from
+        # ``Testcase.inputPath.stem`` (see ``rbx/box/tasks.py``), which for
+        # subgroup-generated tests is e.g. ``1-gen-000`` rather than the
+        # zero-padded group index. Resolve the actual stem via the matching
+        # GenerationTestcaseEntry; fall back to ``{idx:03d}`` for legacy
+        # packages that emit flat numeric filenames.
+        for e in self.entries:
+            if e.group_entry == entry:
+                return e.metadata.copied_to.inputPath.stem
+        return f'{entry.index:03d}'
+
+    def get_solution_entry_prefix(
+        self, solution: 'SolutionSkeleton', entry: TestcaseEntry
+    ) -> pathlib.Path:
+        return solution.get_entry_prefix(entry, stem=self.get_entry_stem(entry))
 
     def find_solution_skeleton(self, solution: Solution) -> Optional[SolutionSkeleton]:
         for sol in self.solutions:

--- a/rbx/box/ui/screens/run_test_explorer.py
+++ b/rbx/box/ui/screens/run_test_explorer.py
@@ -103,7 +103,7 @@ class RunTestExplorerScreen(Screen):
         self, solution: SolutionSkeleton, entry: GenerationTestcaseEntry
     ) -> TestcaseRenderingData:
         rendering_data = TestcaseRenderingData.from_one_path(
-            solution.get_entry_prefix(entry.group_entry)
+            self.skeleton.get_solution_entry_prefix(solution, entry.group_entry)
         )
         rendering_data.rich_content = get_run_testcase_metadata_markup(
             self.skeleton, solution, entry.group_entry

--- a/rbx/box/ui/utils/run_ui.py
+++ b/rbx/box/ui/utils/run_ui.py
@@ -31,9 +31,11 @@ def get_skeleton() -> SolutionReportSkeleton:
 
 
 def get_solution_eval(
-    solution: SolutionSkeleton, entry: TestcaseEntry
+    skeleton: SolutionReportSkeleton,
+    solution: SolutionSkeleton,
+    entry: TestcaseEntry,
 ) -> Optional[Evaluation]:
-    path = solution.get_entry_prefix(entry).with_suffix('.eval')
+    path = skeleton.get_solution_entry_prefix(solution, entry).with_suffix('.eval')
     if not path.is_file():
         return None
     return utils.model_from_yaml(Evaluation, path.read_text())
@@ -43,7 +45,8 @@ def get_solution_evals(
     skeleton: SolutionReportSkeleton, solution: SolutionSkeleton
 ) -> List[Optional[Evaluation]]:
     return [
-        get_solution_eval(solution, entry.group_entry) for entry in skeleton.entries
+        get_solution_eval(skeleton, solution, entry.group_entry)
+        for entry in skeleton.entries
     ]
 
 
@@ -109,9 +112,11 @@ def get_entries_options(
             Option(console.expand_markup(f'[b]{group}[/b] {score_str}'), disabled=True)
         )
         for entry in entries:
-            if solution is not None:
+            if solution is not None and skeleton is not None:
                 _add(
-                    console.expand_markup(get_run_testcase_markup(solution, entry)),
+                    console.expand_markup(
+                        get_run_testcase_markup(skeleton, solution, entry)
+                    ),
                     entry,
                 )
             else:
@@ -160,9 +165,11 @@ def get_solution_markup(
 
 
 def get_run_testcase_markup(
-    solution: SolutionSkeleton, entry: GenerationTestcaseEntry
+    skeleton: SolutionReportSkeleton,
+    solution: SolutionSkeleton,
+    entry: GenerationTestcaseEntry,
 ) -> str:
-    eval = get_solution_eval(solution, entry.group_entry)
+    eval = get_solution_eval(skeleton, solution, entry.group_entry)
     if eval is None:
         return f'{entry}'
     testcase_markup = solutions.get_testcase_markup_verdict(eval)
@@ -178,7 +185,7 @@ def _get_checker_msg_last_line(eval: Evaluation) -> Optional[str]:
 def get_run_testcase_metadata_markup(
     skeleton: SolutionReportSkeleton, solution: SolutionSkeleton, entry: TestcaseEntry
 ) -> Optional[str]:
-    eval = get_solution_eval(solution, entry)
+    eval = get_solution_eval(skeleton, solution, entry)
     if eval is None:
         return None
     limits = skeleton.get_solution_limits(solution)

--- a/tests/e2e/assertions.py
+++ b/tests/e2e/assertions.py
@@ -22,6 +22,7 @@ from rbx.box.solutions import (
     SolutionSkeleton,
     get_worst_outcome,
 )
+from rbx.box.testcase_schema import TestcaseEntry
 from rbx.grading.steps import Evaluation
 from tests.e2e.spec import SolutionMatcher, TestsMatcher, ZipMatcher
 
@@ -166,21 +167,9 @@ def _resolve_eval_path(
     group: str,
     idx: int,
 ) -> pathlib.Path:
-    """Compute the on-disk ``.eval`` path for a (solution, group, index) cell.
-
-    The eval filename stem is taken from ``Testcase.inputPath.stem``, which
-    for generated tests reflects the subgroup naming
-    (e.g. ``1-gen-000``), not a flat ``{idx:03d}``. We recover it by looking
-    up the matching ``GenerationTestcaseEntry`` in ``skeleton.entries``.
-    """
-    for entry in skeleton.entries:
-        ge = entry.group_entry
-        if ge.group == group and ge.index == idx:
-            stem = entry.metadata.copied_to.inputPath.stem
-            return sol.runs_dir / group / f'{stem}.eval'
-    # Fallback to the historical ``{idx:03d}`` convention so cleanly-laid-out
-    # packages still resolve even if entries metadata is sparse.
-    return sol.runs_dir / group / f'{idx:03d}.eval'
+    return skeleton.get_solution_entry_prefix(
+        sol, TestcaseEntry(group=group, index=idx)
+    ).with_suffix('.eval')
 
 
 def _read_eval(

--- a/tests/rbx/box/ui/test_run_ui.py
+++ b/tests/rbx/box/ui/test_run_ui.py
@@ -1,0 +1,135 @@
+"""Tests for path resolution in `rbx.box.ui.utils.run_ui`.
+
+Regression coverage for the bug where ``get_solution_eval`` recomputed the
+on-disk filename from the zero-padded testcase index, missing ``.eval`` files
+written under the actual stem (e.g. ``1-gen-000.eval``) for tests generated
+through subgroups.
+"""
+
+import pathlib
+
+from rbx import utils
+from rbx.box.environment import VerificationLevel
+from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
+from rbx.box.schema import ExpectedOutcome, Solution, Testcase
+from rbx.box.solutions import (
+    SolutionReportSkeleton,
+    SolutionSkeleton,
+)
+from rbx.box.testcase_schema import TestcaseEntry
+from rbx.box.ui.utils.run_ui import get_solution_eval, get_solution_evals
+from rbx.grading.limits import Limits
+from rbx.grading.steps import (
+    CheckerResult,
+    Evaluation,
+    Outcome,
+    TestcaseIO,
+    TestcaseLog,
+)
+
+
+def _make_skeleton(
+    runs_dir: pathlib.Path,
+    inputs_dir: pathlib.Path,
+    stems: list[str],
+    group: str = 'main',
+) -> SolutionReportSkeleton:
+    inputs_dir.mkdir(parents=True, exist_ok=True)
+    entries = []
+    for idx, stem in enumerate(stems):
+        input_path = inputs_dir / f'{stem}.in'
+        input_path.write_text('')
+        entry = TestcaseEntry(group=group, index=idx)
+        entries.append(
+            GenerationTestcaseEntry(
+                group_entry=entry,
+                subgroup_entry=entry,
+                metadata=GenerationMetadata(copied_to=Testcase(inputPath=input_path)),
+            )
+        )
+    solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED)
+    return SolutionReportSkeleton(
+        solutions=[SolutionSkeleton(**solution.model_dump(), runs_dir=runs_dir)],
+        entries=entries,
+        groups=[],
+        limits={'cpp': Limits(time=1000, memory=256, profile=None, isDoubleTL=False)},
+        compiled_solutions={'sol.cpp': 'digest'},
+        verification=VerificationLevel.FULL,
+    )
+
+
+def _write_eval(prefix: pathlib.Path, outcome: Outcome) -> None:
+    prefix.parent.mkdir(parents=True, exist_ok=True)
+    eval = Evaluation(
+        result=CheckerResult(outcome=outcome),
+        log=TestcaseLog(),
+        testcase=TestcaseIO(index=0),
+    )
+    prefix.with_suffix('.eval').write_text(utils.model_to_yaml(eval))
+
+
+def test_get_entry_stem_uses_actual_input_stem(tmp_path):
+    skeleton = _make_skeleton(
+        tmp_path / 'runs',
+        tmp_path / 'tests',
+        stems=['1-gen-000', '1-gen-001'],
+    )
+    entry = TestcaseEntry(group='main', index=0)
+    assert skeleton.get_entry_stem(entry) == '1-gen-000'
+
+
+def test_get_entry_stem_falls_back_to_zero_padded_index(tmp_path):
+    skeleton = _make_skeleton(
+        tmp_path / 'runs',
+        tmp_path / 'tests',
+        stems=['1-gen-000'],
+    )
+    # Entry not present in skeleton.entries -> legacy fallback.
+    missing = TestcaseEntry(group='other', index=7)
+    assert skeleton.get_entry_stem(missing) == '007'
+
+
+def test_get_solution_eval_reads_subgroup_stem(tmp_path):
+    skeleton = _make_skeleton(
+        tmp_path / 'runs',
+        tmp_path / 'tests',
+        stems=['1-gen-000'],
+    )
+    sol = skeleton.solutions[0]
+    _write_eval(sol.runs_dir / 'main' / '1-gen-000', Outcome.WRONG_ANSWER)
+
+    eval = get_solution_eval(skeleton, sol, TestcaseEntry(group='main', index=0))
+    assert eval is not None
+    assert eval.result.outcome == Outcome.WRONG_ANSWER
+
+
+def test_get_solution_eval_reads_legacy_numeric_stem(tmp_path):
+    skeleton = _make_skeleton(
+        tmp_path / 'runs',
+        tmp_path / 'tests',
+        stems=['000', '001'],
+    )
+    sol = skeleton.solutions[0]
+    _write_eval(sol.runs_dir / 'main' / '001', Outcome.ACCEPTED)
+
+    eval = get_solution_eval(skeleton, sol, TestcaseEntry(group='main', index=1))
+    assert eval is not None
+    assert eval.result.outcome == Outcome.ACCEPTED
+
+
+def test_get_solution_evals_finds_all_for_subgroup_stems(tmp_path):
+    skeleton = _make_skeleton(
+        tmp_path / 'runs',
+        tmp_path / 'tests',
+        stems=['1-gen-000', '1-gen-001'],
+    )
+    sol = skeleton.solutions[0]
+    _write_eval(sol.runs_dir / 'main' / '1-gen-000', Outcome.ACCEPTED)
+    _write_eval(sol.runs_dir / 'main' / '1-gen-001', Outcome.WRONG_ANSWER)
+
+    evals = get_solution_evals(skeleton, sol)
+    assert [e.result.outcome for e in evals if e is not None] == [
+        Outcome.ACCEPTED,
+        Outcome.WRONG_ANSWER,
+    ]
+    assert all(e is not None for e in evals)


### PR DESCRIPTION
## Summary

Fixes #418.

`get_solution_eval` recomputed the `.eval` path from the zero-padded testcase index (`{idx:03d}.eval`), but the runner writes those files using `Testcase.inputPath.stem` -- which for subgroup-generated tests is e.g. `1-gen-000.eval`. The lookup then returned `None` and the TUI silently treated real verdicts as "not yet evaluated."

The fix:

- `SolutionSkeleton.get_entry_prefix(entry, stem=None)` -- accepts an optional override; defaults to the legacy `{idx:03d}` form.
- `SolutionReportSkeleton.get_entry_stem(entry)` / `.get_solution_entry_prefix(sol, entry)` -- resolve the actual stem from the matching `GenerationTestcaseEntry` in the skeleton, with a fallback to `{idx:03d}` for legacy packages.
- `rbx/box/ui/utils/run_ui.py` -- `get_solution_eval` / `get_run_testcase_markup` / `get_run_testcase_metadata_markup` now thread the skeleton through and use the helper.
- `rbx/box/ui/screens/run_test_explorer.py` -- uses `skeleton.get_solution_entry_prefix(...)` for rendering.
- `tests/e2e/assertions.py` -- drops its local workaround in favor of the new helper.

## Test plan

- [x] Added `tests/rbx/box/ui/test_run_ui.py` with regression coverage: subgroup stems are resolved (`1-gen-000`), legacy `{idx:03d}` stems still work, missing entries fall back to the legacy form, and `get_solution_evals` finds all evaluations for a subgroup-generated group.
- [x] `uv run pytest tests/rbx/box/solutions_test.py tests/rbx/box/ui/ tests/e2e/test_solutions_matcher.py` -- 60 passed.
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)