### PR TITLE
test: stop relying on cross-test cwd pollution (#424)

### DIFF
--- a/tests/rbx/box/test_testcase_sample_utils.py
+++ b/tests/rbx/box/test_testcase_sample_utils.py
@@ -8,6 +8,7 @@ from rbx.box import testcase_sample_utils
 from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
 from rbx.box.schema import Testcase
 from rbx.box.testcase_schema import TestcaseEntry
+from rbx.box.testing import testing_package
 
 
 @pytest.fixture
@@ -323,7 +324,9 @@ async def test_get_statement_samples_out_statement_vs_out(
 
 @pytest.mark.asyncio
 async def test_get_statement_samples_interaction_generated(
-    tmp_path, mock_extract_generation_testcases_from_groups
+    tmp_path,
+    mock_extract_generation_testcases_from_groups,
+    testing_pkg: testing_package.TestingPackage,
 ):
     """Test 14: Interaction (Generated)."""
     dest_input = tmp_path / 'dest.in'

--- a/tests/rbx/box/testcase_utils_test.py
+++ b/tests/rbx/box/testcase_utils_test.py
@@ -217,7 +217,9 @@ class TestClearBuiltTestcases:
 
         assert not tests_path.exists()
 
-    def test_clear_built_testcases_nonexistent(self):
+    def test_clear_built_testcases_nonexistent(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
         """Test clearing when directory doesn't exist doesn't raise error."""
         # This should not raise an error
         clear_built_testcases()


### PR DESCRIPTION
## Summary
- Adds the `testing_pkg` fixture to two tests that were silently relying on a prior test having `chdir`-ed into a problem package.
- After #423 restored cwd between tests, both tests called `package.find_problem()` from the repo root and exited. With the fixture, each test runs inside its own clean problem dir.

Closes #424

## Test plan
- [x] `uv run pytest tests/rbx/box/testcase_utils_test.py::TestClearBuiltTestcases::test_clear_built_testcases_nonexistent tests/rbx/box/test_testcase_sample_utils.py::test_get_statement_samples_interaction_generated` — both pass
- [x] `uv run pytest tests/rbx/box/testcase_utils_test.py tests/rbx/box/test_testcase_sample_utils.py` — 80 passed
- [x] `uv run ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)