### PR TITLE
feat(contest): multi-contest dispatcher mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Low-level sandboxed execution layer:
 ### Configuration Files (user-facing, not project config)
 
 - `problem.rbx.yml`: Problem structure, test cases, solutions, validators
-- `contest.rbx.yml`: Contest-level settings
+- `contest.rbx.yml`: Contest-level settings. May be a single contest or a dispatcher (`use_variants: true`); when dispatcher, contests live in sibling `contest.<id>.rbx.yml` files. Selected via `-C <id>` or `RBX_CONTEST=<id>`. See `docs/plans/2026-05-06-multi-contest-design.md`.
 - `env.rbx.yml`: Language settings, compilation flags, sandbox configuration
 
 ### Submodules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Low-level sandboxed execution layer:
 ### Configuration Files (user-facing, not project config)
 
 - `problem.rbx.yml`: Problem structure, test cases, solutions, validators
-- `contest.rbx.yml`: Contest-level settings. May be a single contest or a dispatcher (`use_variants: true`); when dispatcher, contests live in sibling `contest.<id>.rbx.yml` files. Selected via `-C <id>` or `RBX_CONTEST=<id>`. See `docs/plans/2026-05-06-multi-contest-design.md`.
+- `contest.rbx.yml`: Contest-level settings. May be a single contest, a dispatcher (`use_variants: true`) with all contests in sibling `contest.<id>.rbx.yml` files, or a real contest WITH sibling variants (canonical is the default, siblings are extra variants). Selected via `-C <id>` or `RBX_CONTEST=<id>`. See `docs/plans/2026-05-06-multi-contest-design.md`.
 - `env.rbx.yml`: Language settings, compilation flags, sandbox configuration
 
 ### Submodules

--- a/docs/plans/2026-05-06-multi-contest-design.md
+++ b/docs/plans/2026-05-06-multi-contest-design.md
@@ -35,21 +35,21 @@ Out (deferred):
 `contest.rbx.yml` is **always required** to mark a directory as a contest dir.
 It has two modes:
 
-1. **Single-contest mode** (today's behavior). The file is a normal `Contest`.
-   It is the default contest. No variants exist.
+1. **Real-contest mode** (today's behavior). The file is a normal `Contest`.
+   It is the default contest. Sibling `contest.<id>.rbx.yml` files MAY also
+   exist; they are additional selectable variants. The canonical is the
+   default selection (used when no `-C`/`RBX_CONTEST` is set).
 2. **Dispatcher mode**. The file is a sentinel:
    ```yaml
    use_variants: true
    ```
    No other fields are validated. There is no default contest. All variants
-   live in sibling files matching `contest.<id>.rbx.yml`.
+   live in sibling files matching `contest.<id>.rbx.yml`. `use_variants` is
+   purely a permission flag that allows the canonical to be empty.
 
 Variant id rules: `^[A-Za-z][A-Za-z0-9_-]*$`. Variant discovery is purely
 filesystem-driven (`glob('contest.*.rbx.yml')`); the dispatcher does not list
 variants.
-
-It is an error for `contest.rbx.yml` to be a real contest *and* to have
-`contest.<id>.rbx.yml` siblings.
 
 ## Schema changes
 
@@ -98,13 +98,14 @@ Updated signature. Algorithm:
    - Real contest → mode = `single`.
    - `use_variants: true` → mode = `dispatcher`.
 3. Resolve effective `contest_id`: parameter > contextvar > `None`.
-4. Decide:
-   - `single` mode, no `contest_id` → return `contest_root/contest.rbx.yml`.
-   - `single` mode, `contest_id` set → error: this directory is not a
-     dispatcher.
-   - `dispatcher` mode, `contest_id` set → return
-     `contest_root/contest.<contest_id>.rbx.yml` if exists, else error.
-   - `dispatcher` mode, no `contest_id` → return `None` (caller decides).
+4. Discover variants. Real-contest mode yields `{None: canonical, **siblings}`;
+   dispatcher mode yields `{**siblings}` only.
+5. Decide:
+   - No `contest_id` → return `variants.get(None)`. That is the canonical
+     in real-contest mode (default selection), or `None` in dispatcher mode.
+   - `contest_id` set and present in `variants` → return that path. (Real
+     contests with siblings can resolve `-C <sibling>` to the sibling path.)
+   - `contest_id` set but unknown → error with picker (`Available: [...]`).
 
 `find_contest_package(root)` then loads the path returned, or returns `None`
 when the resolver returned `None`. Both functions remain `@functools.cache`d,

--- a/docs/plans/2026-05-06-multi-contest-design.md
+++ b/docs/plans/2026-05-06-multi-contest-design.md
@@ -1,0 +1,197 @@
+# Multi-contest packages
+
+**Issue:** [#431](https://github.com/rsalesc/rbx/issues/431) — Allow for multiple contests in a single contest directory.
+
+## Problem
+
+A single physical directory often hosts several logical contests: divisions of an
+informatics olympiad, ICPC variants with overlapping problems, warmup vs. main
+contests sharing a tree. Today, each contest needs its own folder, which forces
+duplication of statement templates, common configuration, and sometimes problem
+packages themselves.
+
+We want one directory to back many `contest.rbx.yml` configurations sharing the
+underlying filesystem (statement templates, assets, problem packages).
+
+## Scope
+
+In:
+
+- Multiple contest definitions co-located in one directory.
+- A way to select one of them (`-C`/`--contest`/env var) for any contest-scoped
+  command.
+- Sentinel mode where no contest is the default; consumers that need contest
+  context error out clearly.
+- Auto-selection when a problem belongs to exactly one variant.
+
+Out (deferred):
+
+- YAML inheritance / `extends:` between variants. Variants share files on disk;
+  YAML duplication is accepted for now (re-evaluate when it becomes painful).
+- `rbx contest add_variant` scaffolding command. Tracked as a follow-up issue.
+
+## File layout
+
+`contest.rbx.yml` is **always required** to mark a directory as a contest dir.
+It has two modes:
+
+1. **Single-contest mode** (today's behavior). The file is a normal `Contest`.
+   It is the default contest. No variants exist.
+2. **Dispatcher mode**. The file is a sentinel:
+   ```yaml
+   use_variants: true
+   ```
+   No other fields are validated. There is no default contest. All variants
+   live in sibling files matching `contest.<id>.rbx.yml`.
+
+Variant id rules: `^[A-Za-z][A-Za-z0-9_-]*$`. Variant discovery is purely
+filesystem-driven (`glob('contest.*.rbx.yml')`); the dispatcher does not list
+variants.
+
+It is an error for `contest.rbx.yml` to be a real contest *and* to have
+`contest.<id>.rbx.yml` siblings.
+
+## Schema changes
+
+`rbx/box/contest/schema.py`:
+
+- Add an optional `use_variants: bool = False` field on `Contest`. When
+  `use_variants` is `true`, validation of the rest of the model is relaxed
+  (probably via a `model_validator(mode='before')` that fills in safe defaults
+  for `name`, `problems`, `statements`).
+- Helper `Contest.is_dispatcher` property.
+
+A separate `ContestDispatcher` model was considered and rejected to keep
+discovery code from branching on which model loaded.
+
+## Selection mechanism
+
+### Flag
+
+- Long: `--contest <id>`.
+- Short: `-C` (capital). `-c` stays `--cache`.
+- Env var fallback: `RBX_CONTEST=<id>`.
+
+The flag is registered on **two** Typer callbacks:
+
+- Root `rbx/box/cli.py:main` — for problem-level commands that implicitly
+  consult contest context (`rbx package build`, `rbx statements build`, BOCA
+  tooling).
+- Contest sub-app `rbx/box/contest/main.py` — for `rbx contest *` commands.
+
+### Resolver
+
+A new `rbx/box/contest/contest_state.py` exposes a `ContextVar[Optional[str]]`
+holding the explicit selection. Set by each callback in the order:
+
+1. CLI flag value, if provided.
+2. `os.environ['RBX_CONTEST']`, if set.
+3. `None` (no explicit selection).
+
+### `find_contest_yaml(root, contest_id=None)`
+
+Updated signature. Algorithm:
+
+1. Walk up from `root` until a directory containing `contest.rbx.yml` is found,
+   or root reaches `/`. (Same as today.) Save this as `contest_root`.
+2. Load `contest.rbx.yml`. Determine mode:
+   - Real contest → mode = `single`.
+   - `use_variants: true` → mode = `dispatcher`.
+3. Resolve effective `contest_id`: parameter > contextvar > `None`.
+4. Decide:
+   - `single` mode, no `contest_id` → return `contest_root/contest.rbx.yml`.
+   - `single` mode, `contest_id` set → error: this directory is not a
+     dispatcher.
+   - `dispatcher` mode, `contest_id` set → return
+     `contest_root/contest.<contest_id>.rbx.yml` if exists, else error.
+   - `dispatcher` mode, no `contest_id` → return `None` (caller decides).
+
+`find_contest_package(root)` then loads the path returned, or returns `None`
+when the resolver returned `None`. Both functions remain `@functools.cache`d,
+keyed on `(root, contest_id)`. Both stay registered in
+`rbx.testing_utils.clear_all_functools_cache` per the test isolation rule.
+
+### `find_contest_package_or_die`
+
+Errors with a picker message when called in dispatcher mode without a
+selection:
+
+```
+Multiple contests are defined in this directory. Pass -C <id> or set
+RBX_CONTEST=<id>. Available contests: div1, div2.
+```
+
+## Implicit consumers and their behavior
+
+The following sites resolve "the contest" implicitly today; each gets a
+defined behavior under dispatcher mode.
+
+| Consumer | Dispatcher, no selection |
+|---|---|
+| `naming.get_problem_entry_in_contest` | Walk **all** variants. If problem appears in exactly one, return that entry. If in zero, return `None` (today's standalone path). If in ≥2, return `None`; consumers requiring `short_name` then fail. |
+| `naming.get_problem_shortname` / `get_problem_index` | Defer to above. Return `None` when ambiguous. |
+| `naming.get_contest_title` | Same: pick the single containing variant; otherwise `None`. |
+| `statement_overriding.get_inheritance_overrides` | Hard error in ambiguous mode: "Statement `<name>` extends contest, but multiple contests are defined. Pass `-C <id>`." |
+| `statement_overriding.get_statement_builder_contest_for_problem` | Returns `None` when ambiguous (problem statement builds without contest context). |
+| `packaging/*/packager.py` | Each call site that uses `get_problem_shortname` switches to a new helper `naming.require_problem_in_contest()` that errors with the picker message when ambiguous. Packaging *requires* a letter; refusing is correct. |
+| `packaging/contest_main.py` | Errors via `find_contest_package_or_die` (already resolves through the chain). |
+| `tooling/boca/*` | Same as packaging — uses `require_problem_in_contest`. |
+| `cli.py:751` (`rbx ui` from problem) | Show variant picker before launching contest UI when ambiguous. |
+| `stats.py` | Iterates all reachable contests; in dispatcher mode iterates all variants. |
+
+`within_contest` decorator: resolves the selection and `cd`s into the contest
+directory (still shared across variants). The decorator records the resolved
+id on the contextvar for downstream calls.
+
+## CLI surface
+
+Existing `rbx contest` commands keep working:
+
+- `rbx contest each|on|summary|edit|add|remove|package|statements`: all use
+  `within_contest`, so they pick up `-C` automatically. In dispatcher mode
+  without `-C`, they error.
+- `rbx contest add` writes to the selected variant file. `rbx contest remove`
+  same.
+
+New:
+
+- `rbx contest list` — prints every variant id (or "default" for single mode),
+  marks the active selection.
+
+Deferred (separate follow-up issue):
+
+- `rbx contest add_variant <id>` — scaffolds `contest.<id>.rbx.yml` from a
+  template.
+
+## Testing
+
+- Unit tests for `find_contest_yaml` covering: single mode, dispatcher mode +
+  `-C`, dispatcher mode + env var, dispatcher mode + no selection (returns
+  `None`), invalid id (`-C bogus`).
+- Unit tests for `naming.get_problem_entry_in_contest` covering: problem in
+  zero/one/many variants under dispatcher mode.
+- E2E (`tests/e2e/`) fixture: a directory with `contest.rbx.yml` (sentinel) +
+  `contest.div1.rbx.yml` + `contest.div2.rbx.yml`, sharing a problem and a
+  statement template. Cases:
+  - `rbx contest each rbx run` errors without `-C`.
+  - `rbx -C div1 contest each rbx run` succeeds.
+  - `rbx -C div1 package build` produces a div1-letter-named package.
+  - `rbx -C div2 package build` produces a div2-letter-named package for the
+    same problem (different letter).
+  - Building a problem statement that `extends:` contest works under each
+    variant; errors without `-C` when problem is in both variants.
+
+## Migration
+
+None. All existing single-contest packages keep working without changes —
+their `contest.rbx.yml` continues to be a real contest, no `use_variants` flag,
+no variant siblings. The dispatcher pattern is purely opt-in.
+
+## Follow-ups
+
+- YAML inheritance between variants (`extends:`) — defer until duplication is
+  reported as painful.
+- `rbx contest add_variant <id>` — scaffolds variant yaml from a template.
+- Consider whether a problem appearing in multiple variants should produce
+  multiple packages on a single `rbx package build` invocation (one per
+  membership). Currently we error and require `-C`.

--- a/docs/plans/2026-05-06-multi-contest.md
+++ b/docs/plans/2026-05-06-multi-contest.md
@@ -1,0 +1,1028 @@
+# Multi-Contest Packages Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow a single contest directory to host multiple `Contest` configurations (variants), selectable via `-C <id>` / `RBX_CONTEST`, sharing the same filesystem (statements, problems, assets).
+
+**Architecture:** `contest.rbx.yml` is always required and either (a) is itself the single contest (today's behavior, default) or (b) sets `use_variants: true` and acts as a sentinel — variants live in sibling `contest.<id>.rbx.yml` files. A contextvar holds the current selection set by Typer callbacks. `find_contest_yaml` is variant-aware. Implicit consumers (naming, packaging, BOCA, statement-extends) auto-pick when a problem belongs to exactly one variant; otherwise they error with a picker message.
+
+**Tech Stack:** Pydantic v2, Typer, contextvars, `@functools.cache`, ruyaml.
+
+**Reference:** [`docs/plans/2026-05-06-multi-contest-design.md`](2026-05-06-multi-contest-design.md).
+
+---
+
+## Pre-flight
+
+- Worktree: `.worktrees/multi-contest`, branch `feature/multi-contest`.
+- Use `/commit` skill conventions (`feat`, `fix`, `docs`, `test`, `refactor`).
+- Run `uv run pytest --ignore=tests/rbx/box/cli -n auto` after each task; commit only when green.
+- After every task that adds a `@functools.cache`, register it in `rbx/testing_utils.py:clear_all_functools_cache`.
+
+---
+
+## Task 1: Add `use_variants` to `Contest` schema
+
+**Files:**
+- Modify: `rbx/box/contest/schema.py:258-309`
+- Test: `tests/rbx/box/contest/test_contest_schema.py`
+
+**Step 1: Write the failing tests**
+
+Add to `tests/rbx/box/contest/test_contest_schema.py`:
+
+```python
+def test_contest_default_is_not_dispatcher():
+    contest = Contest(name='c')
+    assert contest.use_variants is False
+    assert contest.is_dispatcher is False
+
+
+def test_contest_dispatcher_skips_required_validation():
+    contest = Contest.model_validate({'use_variants': True})
+    assert contest.is_dispatcher is True
+    assert contest.problems == []
+    assert contest.statements == []
+
+
+def test_contest_dispatcher_rejects_problems_field():
+    import pydantic
+    with pytest.raises(pydantic.ValidationError):
+        Contest.model_validate({
+            'use_variants': True,
+            'problems': [{'short_name': 'A'}],
+        })
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_schema.py -v -k 'dispatcher or default_is_not'`
+Expected: FAIL (no `use_variants`/`is_dispatcher` attribute).
+
+**Step 3: Implementation**
+
+In `rbx/box/contest/schema.py`, modify `Contest`:
+
+```python
+class Contest(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    use_variants: bool = Field(
+        default=False,
+        description=(
+            'When true, this file is a sentinel marking the directory as a '
+            'multi-contest dispatcher. The actual contests live in sibling '
+            'files matching contest.<id>.rbx.yml. When set, no other Contest '
+            'fields may be specified.'
+        ),
+    )
+
+    name: str = Field(
+        default='', description='Name of this contest.'
+    )  # Was NameField; relaxed to allow empty for dispatcher mode.
+
+    # ... rest of fields stay (titles, problems, statements, vars), all already have defaults ...
+
+    @model_validator(mode='after')
+    def _validate_dispatcher_or_real(self):
+        if self.use_variants:
+            for field in ('name', 'titles', 'problems', 'statements', 'vars'):
+                value = getattr(self, field)
+                if value:
+                    raise ValueError(
+                        f'Field {field!r} cannot be set when use_variants is true.'
+                    )
+        else:
+            if not self.name:
+                raise ValueError('Field "name" is required for a contest.')
+        return self
+
+    @property
+    def is_dispatcher(self) -> bool:
+        return self.use_variants
+```
+
+Keep `check_problem_identifiers_unique` as-is. Note: `name` field constraints from `NameField` are moved into the conditional validator so dispatcher mode can omit it. If `NameField` provides a regex, port that check into `_validate_dispatcher_or_real` for the non-dispatcher branch (keep the regex tight; reuse the same one).
+
+**Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_schema.py -v`
+Expected: All pass. Existing schema tests must still pass.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/schema.py tests/rbx/box/contest/test_contest_schema.py
+git commit -m "feat(contest): add use_variants dispatcher mode to Contest schema"
+```
+
+---
+
+## Task 2: Variant id constants and selection state module
+
+**Files:**
+- Create: `rbx/box/contest/contest_state.py`
+- Test: `tests/rbx/box/contest/test_contest_state.py`
+
+**Step 1: Write the failing tests**
+
+```python
+import re
+import pytest
+
+from rbx.box.contest import contest_state
+
+
+def test_variant_id_pattern_accepts_typical_ids():
+    assert contest_state.is_valid_variant_id('div1')
+    assert contest_state.is_valid_variant_id('warmup')
+    assert contest_state.is_valid_variant_id('A1')
+    assert contest_state.is_valid_variant_id('ioi-2024_main')
+
+
+def test_variant_id_pattern_rejects_invalid():
+    assert not contest_state.is_valid_variant_id('')
+    assert not contest_state.is_valid_variant_id('1div')
+    assert not contest_state.is_valid_variant_id('div 1')
+    assert not contest_state.is_valid_variant_id('div.1')
+
+
+def test_selection_default_is_none():
+    assert contest_state.get_selected_variant_id() is None
+
+
+def test_set_selected_variant_id_round_trip():
+    token = contest_state.selected_variant_id_var.set('div1')
+    try:
+        assert contest_state.get_selected_variant_id() == 'div1'
+    finally:
+        contest_state.selected_variant_id_var.reset(token)
+    assert contest_state.get_selected_variant_id() is None
+
+
+def test_resolve_from_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('RBX_CONTEST', 'envdiv')
+    assert contest_state.resolve_explicit_selection() == 'envdiv'
+
+
+def test_resolve_prefers_var_over_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('RBX_CONTEST', 'envdiv')
+    token = contest_state.selected_variant_id_var.set('flagdiv')
+    try:
+        assert contest_state.resolve_explicit_selection() == 'flagdiv'
+    finally:
+        contest_state.selected_variant_id_var.reset(token)
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_state.py -v`
+Expected: FAIL (module doesn't exist).
+
+**Step 3: Implementation**
+
+Create `rbx/box/contest/contest_state.py`:
+
+```python
+import contextvars
+import os
+import re
+from typing import Optional
+
+VARIANT_ID_PATTERN = re.compile(r'^[A-Za-z][A-Za-z0-9_-]*$')
+ENV_VAR = 'RBX_CONTEST'
+
+selected_variant_id_var: contextvars.ContextVar[Optional[str]] = (
+    contextvars.ContextVar('rbx_selected_variant_id', default=None)
+)
+
+
+def is_valid_variant_id(value: str) -> bool:
+    return bool(VARIANT_ID_PATTERN.match(value))
+
+
+def get_selected_variant_id() -> Optional[str]:
+    return selected_variant_id_var.get()
+
+
+def resolve_explicit_selection() -> Optional[str]:
+    """Returns the selected variant id, preferring contextvar over env var."""
+    explicit = selected_variant_id_var.get()
+    if explicit is not None:
+        return explicit
+    env_value = os.environ.get(ENV_VAR)
+    if env_value:
+        return env_value
+    return None
+```
+
+**Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_state.py -v`
+Expected: All pass.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/contest_state.py tests/rbx/box/contest/test_contest_state.py
+git commit -m "feat(contest): add variant id selection state and helpers"
+```
+
+---
+
+## Task 3: Variant discovery helper
+
+**Files:**
+- Modify: `rbx/box/contest/contest_package.py` (top of file)
+- Test: `tests/rbx/box/contest/test_contest_package.py` (new test class)
+
+**Step 1: Write the failing tests**
+
+Add `class TestDiscoverVariants` to the existing test file:
+
+```python
+def test_discover_variants_single_mode_returns_default(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text('name: c\n')
+    variants = cp_module.discover_contest_variants(tmp_path)
+    assert variants == {None: tmp_path / 'contest.rbx.yml'}
+
+
+def test_discover_variants_dispatcher_mode_lists_siblings(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+    (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1\n')
+    (tmp_path / 'contest.div2.rbx.yml').write_text('name: div2\n')
+    variants = cp_module.discover_contest_variants(tmp_path)
+    assert set(variants.keys()) == {'div1', 'div2'}
+    assert variants['div1'].name == 'contest.div1.rbx.yml'
+
+
+def test_discover_variants_dispatcher_with_invalid_id(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+    (tmp_path / 'contest.bad name.rbx.yml').write_text('name: bad\n')
+    variants = cp_module.discover_contest_variants(tmp_path)
+    # Files with invalid ids are silently skipped (logged elsewhere).
+    assert variants == {}
+
+
+def test_discover_variants_no_yaml_returns_empty(tmp_path):
+    assert cp_module.discover_contest_variants(tmp_path) == {}
+
+
+def test_discover_variants_real_contest_with_siblings_errors(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text('name: c\n')
+    (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1\n')
+    with pytest.raises(typer.Exit):
+        cp_module.discover_contest_variants(tmp_path)
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_package.py::TestDiscoverVariants -v`
+Expected: FAIL (function doesn't exist).
+
+**Step 3: Implementation**
+
+In `rbx/box/contest/contest_package.py`, add (after existing imports, before `find_contest_yaml`):
+
+```python
+from typing import Dict
+from rbx.box.contest.contest_state import is_valid_variant_id
+
+VARIANT_GLOB = 'contest.*.rbx.yml'
+
+
+def discover_contest_variants(
+    contest_root: pathlib.Path,
+) -> Dict[Optional[str], pathlib.Path]:
+    """Returns variant_id -> yaml path. Single-contest mode uses key None.
+
+    Errors via typer.Exit if contest.rbx.yml is a real contest AND there are
+    sibling contest.<id>.rbx.yml files (ambiguous).
+    """
+    canonical = contest_root / YAML_NAME
+    if not canonical.is_file():
+        return {}
+
+    canonical_contest = load_yaml_model(canonical, Contest)
+    sibling_paths = sorted(contest_root.glob(VARIANT_GLOB))
+    siblings: Dict[str, pathlib.Path] = {}
+    for path in sibling_paths:
+        # path.name is e.g. 'contest.div1.rbx.yml' -> id 'div1'
+        # Strip leading 'contest.' and trailing '.rbx.yml'.
+        name = path.name[len('contest.'):-len('.rbx.yml')]
+        if not is_valid_variant_id(name):
+            continue
+        siblings[name] = path
+
+    if canonical_contest.is_dispatcher:
+        return {vid: p for vid, p in siblings.items()}
+
+    if siblings:
+        console.console.print(
+            f'[error]{canonical} is a real contest but sibling variant files '
+            f'exist: {[p.name for p in siblings.values()]}. Set '
+            f'use_variants: true on contest.rbx.yml to enable dispatcher '
+            f'mode.[/error]'
+        )
+        raise typer.Exit(1)
+
+    return {None: canonical}
+```
+
+**Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_package.py::TestDiscoverVariants -v`
+Expected: All pass.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/contest_package.py tests/rbx/box/contest/test_contest_package.py
+git commit -m "feat(contest): add discover_contest_variants helper"
+```
+
+---
+
+## Task 4: Variant-aware `find_contest_yaml` / `find_contest_package`
+
+**Files:**
+- Modify: `rbx/box/contest/contest_package.py:66-96`
+- Modify: `rbx/testing_utils.py` (no change expected — already covers `contest_package`).
+- Test: `tests/rbx/box/contest/test_contest_package.py` (new test class).
+
+**Step 1: Write the failing tests**
+
+```python
+class TestFindContestYamlVariantAware:
+    def test_single_mode_returns_canonical(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: c\n')
+        cp_module.find_contest_yaml.cache_clear()
+        assert cp_module.find_contest_yaml(tmp_path) == tmp_path / 'contest.rbx.yml'
+
+    def test_dispatcher_with_explicit_selection(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1\n')
+        cp_module.find_contest_yaml.cache_clear()
+        assert (
+            cp_module.find_contest_yaml(tmp_path, contest_id='div1')
+            == tmp_path / 'contest.div1.rbx.yml'
+        )
+
+    def test_dispatcher_unknown_id_errors(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        cp_module.find_contest_yaml.cache_clear()
+        with pytest.raises(typer.Exit):
+            cp_module.find_contest_yaml(tmp_path, contest_id='ghost')
+
+    def test_dispatcher_no_selection_returns_none(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1\n')
+        cp_module.find_contest_yaml.cache_clear()
+        assert cp_module.find_contest_yaml(tmp_path) is None
+
+    def test_single_mode_with_id_errors(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: c\n')
+        cp_module.find_contest_yaml.cache_clear()
+        with pytest.raises(typer.Exit):
+            cp_module.find_contest_yaml(tmp_path, contest_id='div1')
+
+    def test_uses_contextvar_when_no_arg(self, tmp_path):
+        from rbx.box.contest.contest_state import selected_variant_id_var
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.div2.rbx.yml').write_text('name: div2\n')
+        cp_module.find_contest_yaml.cache_clear()
+        token = selected_variant_id_var.set('div2')
+        try:
+            assert (
+                cp_module.find_contest_yaml(tmp_path)
+                == tmp_path / 'contest.div2.rbx.yml'
+            )
+        finally:
+            selected_variant_id_var.reset(token)
+            cp_module.find_contest_yaml.cache_clear()
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_package.py::TestFindContestYamlVariantAware -v`
+Expected: FAIL (signature doesn't accept `contest_id`).
+
+**Step 3: Implementation**
+
+Replace `find_contest_yaml` and `find_contest_package` in `rbx/box/contest/contest_package.py`:
+
+```python
+@functools.cache
+def find_contest_yaml(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> Optional[pathlib.Path]:
+    from rbx.box.contest.contest_state import resolve_explicit_selection
+
+    root = utils.abspath(root)
+    contest_yaml_path = root / YAML_NAME
+    while root != pathlib.PosixPath('/') and not contest_yaml_path.is_file():
+        root = root.parent
+        contest_yaml_path = root / YAML_NAME
+    if not contest_yaml_path.is_file():
+        return None
+
+    contest_root = contest_yaml_path.parent
+    canonical_contest = load_yaml_model(contest_yaml_path, Contest)
+
+    effective_id = contest_id if contest_id is not None else resolve_explicit_selection()
+
+    if not canonical_contest.is_dispatcher:
+        if effective_id is not None:
+            console.console.print(
+                f'[error]Contest at {contest_root} is not a dispatcher (no '
+                f'use_variants). Cannot select variant {effective_id!r}.[/error]'
+            )
+            raise typer.Exit(1)
+        return contest_yaml_path
+
+    # Dispatcher mode.
+    variants = discover_contest_variants(contest_root)
+    if effective_id is None:
+        return None
+    if effective_id not in variants:
+        console.console.print(
+            f'[error]Contest variant {effective_id!r} not found. '
+            f'Available: {sorted(variants.keys())}.[/error]'
+        )
+        raise typer.Exit(1)
+    return variants[effective_id]
+
+
+@functools.cache
+def find_contest_package(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> Optional[Contest]:
+    contest_yaml_path = find_contest_yaml(root, contest_id=contest_id)
+    if not contest_yaml_path:
+        return None
+    contest = load_yaml_model(contest_yaml_path, Contest)
+
+    contest_root = contest_yaml_path.parent
+    validate_problem_folders_exist(contest, contest_root)
+    validate_problem_folders_are_packages(contest, contest_root)
+    return contest
+```
+
+Update `find_contest_package_or_die` and `find_contest` to forward `contest_id`:
+
+```python
+def find_contest_package_or_die(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> Contest:
+    package = find_contest_package(root, contest_id=contest_id)
+    if package is None:
+        from rbx.box.contest.contest_state import resolve_explicit_selection
+        # Distinguish "no contest at all" from "dispatcher with no selection".
+        if find_contest_yaml.__wrapped__(root, contest_id=contest_id) is None and \
+                resolve_explicit_selection() is None and contest_id is None:
+            # We need a clearer message. Try to detect dispatcher case.
+            ...
+        console.console.print(...)  # Use the picker message here.
+        raise typer.Exit(1)
+    return package
+```
+
+Cleaner alternative: split the error reporting into a helper:
+
+```python
+def _die_no_contest(root: pathlib.Path) -> 'NoReturn':
+    contest_yaml_path = root / YAML_NAME
+    while root != pathlib.PosixPath('/') and not contest_yaml_path.is_file():
+        root = root.parent
+        contest_yaml_path = root / YAML_NAME
+    if contest_yaml_path.is_file():
+        canonical = load_yaml_model(contest_yaml_path, Contest)
+        if canonical.is_dispatcher:
+            variants = discover_contest_variants(contest_yaml_path.parent)
+            console.console.print(
+                f'[error]Multiple contests are defined in this directory. '
+                f'Pass -C <id> or set RBX_CONTEST=<id>. '
+                f'Available contests: {sorted(variants.keys())}.[/error]'
+            )
+            raise typer.Exit(1)
+    console.console.print(f'Contest not found in {root.absolute()}', style='error')
+    raise typer.Exit(1)
+
+
+def find_contest_package_or_die(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> Contest:
+    package = find_contest_package(root, contest_id=contest_id)
+    if package is None:
+        _die_no_contest(utils.abspath(root))
+    return package
+
+
+def find_contest(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> pathlib.Path:
+    found = find_contest_yaml(root, contest_id=contest_id)
+    if found is None:
+        _die_no_contest(utils.abspath(root))
+    return found.parent
+```
+
+Update `within_contest`, `save_contest`, and `get_ruyaml` to forward `contest_id` (or accept it). For `within_contest`, no change to signature is needed because the contextvar is already set by the caller; just call `find_contest()` which honors the contextvar.
+
+**Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/rbx/box/contest/ -v -n auto`
+Expected: All pass (existing tests must still pass under new signatures with default `contest_id=None`).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/contest_package.py tests/rbx/box/contest/test_contest_package.py
+git commit -m "feat(contest): make find_contest_yaml variant-aware"
+```
+
+---
+
+## Task 5: Naming auto-pick when problem is in exactly one variant
+
+**Files:**
+- Modify: `rbx/box/naming.py`
+- Test: `tests/rbx/box/test_naming.py` (create if absent).
+
+**Step 1: Write the failing tests**
+
+Tests should cover:
+
+1. `get_problem_entry_in_contest()` when the canonical `contest.rbx.yml` is a real contest containing the current problem → returns the entry. (Existing behavior.)
+2. Dispatcher mode with two variants, problem in exactly one variant, no `-C` selection → returns the entry from the containing variant.
+3. Dispatcher mode, problem in two variants, no selection → returns `None`.
+4. Dispatcher mode, problem in two variants, `-C div1` set → returns the div1 entry.
+5. New helper `naming.require_problem_in_contest()` — errors via `typer.Exit` if the entry can't be uniquely determined.
+
+Use `cleandir` and `pkg_from_testdata` patterns from `tests/rbx/box/conftest.py`. Mock `package.find_problem` and `find_contest_yaml`/`find_contest_package` if needed; prefer real fixtures.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_naming.py -v`
+Expected: FAIL.
+
+**Step 3: Implementation**
+
+In `rbx/box/naming.py`, change `get_problem_entry_in_contest`:
+
+```python
+def get_problem_entry_in_contest() -> Optional[Tuple[int, ContestProblem]]:
+    from rbx.box.contest import contest_state
+    from rbx.box.contest.contest_package import (
+        discover_contest_variants,
+        find_contest,
+        find_contest_yaml,
+    )
+
+    # Fast path: explicit selection or single-contest mode.
+    contest = contest_package.find_contest_package()
+    if contest is not None:
+        return _entry_in_contest(contest)
+
+    # Dispatcher mode with no selection: walk all variants.
+    if contest_state.resolve_explicit_selection() is not None:
+        return None  # User selected an id but contest still didn't load -> upstream error.
+
+    # Find the dispatcher root (without selection it's None, so re-walk).
+    try:
+        contest_root = find_contest()
+    except typer.Exit:
+        return None
+    variants = discover_contest_variants(contest_root)
+    matches = []
+    for vid, _ in variants.items():
+        if vid is None:
+            continue
+        candidate = contest_package.find_contest_package(contest_id=vid)
+        if candidate is None:
+            continue
+        entry = _entry_in_contest(candidate)
+        if entry is not None:
+            matches.append((vid, entry))
+
+    if len(matches) == 1:
+        return matches[0][1]
+    return None
+
+
+def _entry_in_contest(contest) -> Optional[Tuple[int, ContestProblem]]:
+    problem_path = package.find_problem()
+    contest_path = contest_package.find_contest()
+    for i, problem in enumerate(contest.problems):
+        if problem.path is None:
+            continue
+        if (problem_path / 'problem.rbx.yml').samefile(
+            contest_path / problem.path / 'problem.rbx.yml'
+        ):
+            return i, problem
+    return None
+```
+
+Add the new `require_problem_in_contest` helper:
+
+```python
+def require_problem_in_contest() -> Tuple[int, ContestProblem]:
+    """Like get_problem_entry_in_contest but errors if not uniquely resolvable."""
+    entry = get_problem_entry_in_contest()
+    if entry is not None:
+        return entry
+    from rbx.box.contest import contest_state
+    from rbx.box.contest.contest_package import discover_contest_variants, find_contest
+    try:
+        contest_root = find_contest()
+    except typer.Exit:
+        console.print('[error]No contest found for the current problem.[/error]')
+        raise typer.Exit(1) from None
+    variants = discover_contest_variants(contest_root)
+    if len(variants) > 1 and contest_state.resolve_explicit_selection() is None:
+        console.print(
+            f'[error]This problem is part of multiple contests. '
+            f'Pass -C <id> or set RBX_CONTEST=<id>. '
+            f'Available contests: {sorted(k for k in variants if k is not None)}.[/error]'
+        )
+        raise typer.Exit(1)
+    console.print('[error]Problem is not registered in the active contest.[/error]')
+    raise typer.Exit(1)
+```
+
+**Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/rbx/box/test_naming.py tests/rbx/box/contest/ -v -n auto`
+Expected: All pass.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/naming.py tests/rbx/box/test_naming.py
+git commit -m "feat(contest): auto-pick variant when problem is in exactly one"
+```
+
+---
+
+## Task 6: Statement-extends ambiguity error
+
+**Files:**
+- Modify: `rbx/box/contest/statement_overriding.py:65-89`
+- Test: `tests/rbx/box/contest/test_statement_overriding.py`
+
+**Step 1: Write the failing test**
+
+Add a test where:
+- Dispatcher mode, two variants, both define a matching `ContestStatement`.
+- Problem statement uses `extends: contest`.
+- No `-C` selection.
+- `get_inheritance_overrides()` raises `StatementInheritanceError` with a message mentioning `-C` and listing variants.
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/contest/test_statement_overriding.py -v`
+Expected: FAIL.
+
+**Step 3: Implementation**
+
+In `get_inheritance_overrides`, before the existing single-contest path:
+
+```python
+def get_inheritance_overrides(statement: Statement) -> StatementOverrideData:
+    from rbx.box.contest import contest_state
+    from rbx.box.contest.contest_package import discover_contest_variants, find_contest
+
+    contest = contest_package.find_contest_package()
+    if contest is None:
+        # Dispatcher mode without selection: surface a precise error.
+        try:
+            contest_root = find_contest()
+        except typer.Exit:
+            contest_root = None
+        if contest_root is not None:
+            variants = discover_contest_variants(contest_root)
+            if len(variants) > 1 and contest_state.resolve_explicit_selection() is None:
+                with StatementInheritanceError() as e:
+                    e.print(
+                        f'[error]Statement [item]{statement.name}[/item] extends '
+                        f'a contest statement, but multiple contests are defined. '
+                        f'Pass -C <id> or set RBX_CONTEST=<id>. '
+                        f'Available: {sorted(k for k in variants if k is not None)}.[/error]'
+                    )
+                raise e
+        with StatementInheritanceError() as e:
+            e.print(
+                f'[error][item]{statement.name}[/item] inherits its configuration '
+                f'from the contest, but no contest was found.[/error]'
+            )
+        raise e
+
+    # ... existing matching code ...
+```
+
+**Step 4: Run test to verify pass**
+
+Run: `uv run pytest tests/rbx/box/contest/test_statement_overriding.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/statement_overriding.py tests/rbx/box/contest/test_statement_overriding.py
+git commit -m "feat(contest): raise picker error for statement extends in dispatcher mode"
+```
+
+---
+
+## Task 7: Wire `-C/--contest` flag in CLI callbacks
+
+**Files:**
+- Modify: `rbx/box/cli.py:125-200` (root callback).
+- Modify: `rbx/box/contest/main.py:26-40` (contest sub-app, add a callback).
+- Test: `tests/rbx/box/cli/` (CLI tests, slow). Plus a unit-level test.
+
+**Step 1: Write the failing test**
+
+Unit-level test in `tests/rbx/box/contest/test_contest_state.py`:
+
+```python
+def test_root_callback_sets_contextvar_from_flag(monkeypatch):
+    """Smoke: invoking the root callback with --contest sets the contextvar."""
+    from typer.testing import CliRunner
+    from rbx.box import cli
+    from rbx.box.contest.contest_state import selected_variant_id_var
+
+    captured = {}
+
+    @cli.app.command('probe-contest')
+    def probe():
+        captured['value'] = selected_variant_id_var.get()
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ['-C', 'div1', 'probe-contest'])
+    assert result.exit_code == 0, result.output
+    assert captured['value'] == 'div1'
+```
+
+**Step 2: Run tests to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_state.py::test_root_callback_sets_contextvar_from_flag -v`
+Expected: FAIL.
+
+**Step 3: Implementation**
+
+In `rbx/box/cli.py:main`, add new option after `version` (before the body):
+
+```python
+contest_id: Annotated[
+    Optional[str],
+    typer.Option(
+        '-C',
+        '--contest',
+        help='Select a contest variant by id (when contest.rbx.yml has '
+        'use_variants: true). Defaults to the RBX_CONTEST env var.',
+        envvar='RBX_CONTEST',
+    ),
+] = None,
+```
+
+At the start of the body:
+
+```python
+from rbx.box.contest import contest_state as _contest_state
+if contest_id is not None and not _contest_state.is_valid_variant_id(contest_id):
+    console.console.print(f'[error]Invalid contest id: {contest_id!r}[/error]')
+    raise typer.Exit(1)
+if contest_id is not None:
+    _contest_state.selected_variant_id_var.set(contest_id)
+```
+
+In `rbx/box/contest/main.py`, add a callback right after `app = typer.Typer(...)`:
+
+```python
+@app.callback()
+def contest_main(
+    contest_id: Annotated[
+        Optional[str],
+        typer.Option(
+            '-C', '--contest',
+            help='Select a contest variant by id.',
+            envvar='RBX_CONTEST',
+        ),
+    ] = None,
+):
+    if contest_id is not None:
+        if not contest_state.is_valid_variant_id(contest_id):
+            console.console.print(f'[error]Invalid contest id: {contest_id!r}[/error]')
+            raise typer.Exit(1)
+        contest_state.selected_variant_id_var.set(contest_id)
+```
+
+(Imports: `from rbx.box.contest import contest_state`, `Optional`, `Annotated`.)
+
+Note: typer envvar handling means `RBX_CONTEST=foo rbx ...` works without the flag.
+
+**Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_state.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/cli.py rbx/box/contest/main.py tests/rbx/box/contest/test_contest_state.py
+git commit -m "feat(contest): add -C/--contest flag to root and contest CLI"
+```
+
+---
+
+## Task 8: Switch packaging consumers to `require_problem_in_contest`
+
+**Files:**
+- Modify: `rbx/box/packaging/packager.py:81` (and the `find_contest_package_or_die` calls at 146, 157).
+- Modify: `rbx/box/packaging/pkg/packager.py:29, 103`.
+- Modify: `rbx/box/packaging/boca/packager.py:85`.
+- Modify: `rbx/box/tooling/boca/submitter.py:45-48`.
+- Modify: `rbx/box/tooling/boca/scraper.py:385, 392, 400`.
+- Test: existing tests under `tests/rbx/box/packaging/`, `tests/rbx/box/tooling/`.
+
+**Step 1: Write the failing tests**
+
+Add tests for each consumer that exercise dispatcher mode without `-C`:
+
+1. `rbx package build` for a problem in 2 variants → exits with picker message.
+2. `rbx package build` with `-C div1` → succeeds, output uses div1's letter.
+
+Likely best handled at the unit level by mocking `naming.get_problem_shortname` is **not** allowed (we want to test the new `require_problem_in_contest`). Instead, set up a fixture with two variants and call the packager directly.
+
+**Step 2: Run tests to verify they fail**
+
+Run targeted tests; expect new behavior to error.
+
+**Step 3: Implementation**
+
+In each call site that previously did:
+
+```python
+shortname = naming.get_problem_shortname()
+```
+
+and assumed it could be `None`, switch to `_, problem_entry = naming.require_problem_in_contest(); shortname = problem_entry.short_name` **only** when the call site cannot tolerate a `None` (packaging always uses the letter for naming). Sites that already handle `None` (e.g., `get_problem_name_with_contest_info`) stay as-is.
+
+Concretely:
+
+- `rbx/box/packaging/packager.py:81` — uses `shortname` to compute output filename. Switch to `require_problem_in_contest`.
+- `pkg/packager.py:29` — same.
+- `boca/packager.py:85` — same.
+- `tooling/boca/submitter.py:45` — uses `get_problem_shortname() or ''` to look up in a dict; if `None`, the next line errors with a message that doesn't mention contest variants. Replace with `require_problem_in_contest()` so the error is clearer.
+- `tooling/boca/scraper.py` — three lookups. Replace with `require_problem_in_contest()` and use the entry's `short_name`/index.
+
+For `find_contest_package_or_die()` calls at `packager.py:146, 157` and `pkg/packager.py:103`: the new error path inside `find_contest_package_or_die` already produces the right message, so these need no further change.
+
+**Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/rbx/box/packaging/ tests/rbx/box/tooling/ -v -n auto`
+Expected: PASS, including new dispatcher-mode tests.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/packaging/ rbx/box/tooling/ tests/rbx/box/packaging/ tests/rbx/box/tooling/
+git commit -m "feat(contest): require explicit variant for packaging and BOCA tooling"
+```
+
+---
+
+## Task 9: `rbx contest list` command
+
+**Files:**
+- Modify: `rbx/box/contest/main.py`
+- Test: `tests/rbx/box/contest/test_contest_main.py` (create if absent) or e2e.
+
+**Step 1: Write the failing test**
+
+Use Typer's `CliRunner` to exercise:
+
+1. Single-contest dir → `rbx contest list` prints the canonical contest name.
+2. Dispatcher dir with two variants → prints both ids, marks active selection if `-C div1` is set.
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_main.py -v`
+Expected: FAIL (command doesn't exist).
+
+**Step 3: Implementation**
+
+Add to `rbx/box/contest/main.py`:
+
+```python
+@app.command('list, ls', help='List all contests in the current directory.')
+def list_contests():
+    contest_root = find_contest()
+    variants = contest_package.discover_contest_variants(contest_root)
+    active = contest_state.resolve_explicit_selection()
+    if not variants:
+        console.console.print('[warning]No contests found.[/warning]')
+        return
+    if list(variants.keys()) == [None]:
+        console.console.print('[item]contest.rbx.yml[/item] (single contest)')
+        return
+    for vid in sorted(k for k in variants if k is not None):
+        marker = ' [active]' if vid == active else ''
+        console.console.print(f'[item]{vid}[/item]{marker}')
+```
+
+**Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_main.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/main.py tests/rbx/box/contest/test_contest_main.py
+git commit -m "feat(contest): add rbx contest list command"
+```
+
+---
+
+## Task 10: E2E fixture for multi-contest
+
+**Files:**
+- Create: `tests/e2e/testdata/multi-contest/contest.rbx.yml` (`use_variants: true`).
+- Create: `tests/e2e/testdata/multi-contest/contest.div1.rbx.yml`.
+- Create: `tests/e2e/testdata/multi-contest/contest.div2.rbx.yml`.
+- Create: `tests/e2e/testdata/multi-contest/A/problem.rbx.yml` (shared, in both variants).
+- Create: `tests/e2e/testdata/multi-contest/B/problem.rbx.yml` (only in div1).
+- Create: `tests/e2e/testdata/multi-contest/e2e.rbx.yml`.
+
+**Step 1: Author the e2e scenarios**
+
+`e2e.rbx.yml` should cover:
+
+1. `rbx -C div1 contest each rbx run` succeeds.
+2. `rbx contest list` lists `div1` and `div2`.
+3. `rbx contest each rbx run` (no `-C`) errors with picker message.
+4. Inside `A/`: `rbx package build` (no `-C`) errors (A is in both contests).
+5. Inside `A/`: `rbx -C div1 package build` succeeds.
+6. Inside `B/`: `rbx package build` (no `-C`) succeeds — auto-pick because B is only in div1.
+
+Refer to `tests/e2e/README.md` for the schema.
+
+**Step 2: Run the e2e suite**
+
+Run: `mise run test-e2e` (or `uv run pytest tests/e2e/testdata/multi-contest/ -v`).
+Expected: all scenarios pass.
+
+**Step 3: Commit**
+
+```bash
+git add tests/e2e/testdata/multi-contest/
+git commit -m "test(contest): add e2e fixture for multi-contest dispatcher mode"
+```
+
+---
+
+## Task 11: Update CLAUDE.md docs
+
+**Files:**
+- Modify: `rbx/box/CLAUDE.md` (Package Discovery section).
+- Modify: `CLAUDE.md` (Configuration Files section).
+
+**Step 1: Document changes**
+
+- Note that `contest.rbx.yml` may be a dispatcher (`use_variants: true`) and that variants live in `contest.<id>.rbx.yml`.
+- Document `-C/--contest` and `RBX_CONTEST` env var.
+- Note that `find_contest_yaml(root, contest_id=None)` consults the contextvar from `rbx.box.contest.contest_state`.
+
+**Step 2: Commit**
+
+```bash
+git add CLAUDE.md rbx/box/CLAUDE.md
+git commit -m "docs(contest): document multi-contest dispatcher mode"
+```
+
+---
+
+## Task 12: Open follow-up issue
+
+After merge, open a GitHub issue tracking `rbx contest add_variant <id>` scaffolding command (decision deferred during design — see design doc "Follow-ups").
+
+---
+
+## Verification
+
+After all tasks land:
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+uv run pytest --ignore=tests/rbx/box/cli -n auto
+mise run test-e2e
+```
+
+All must pass. The pre-existing failure in `tests/rbx/box/testcase_utils_test.py::TestClearBuiltTestcases::test_clear_built_testcases_nonexistent` is unrelated and already fails on `main`; do not block on it.

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -38,7 +38,7 @@ Each has a `match(outcome: Outcome) -> bool` method. `INCORRECT` matches WA/RTE/
 
 ### Multi-contest mode
 
-`contest.rbx.yml` may be either a real Contest or a dispatcher sentinel (`use_variants: true`) with sibling `contest.<id>.rbx.yml` variants. Variant selection comes from `-C <id>` (CLI flag) or `RBX_CONTEST=<id>` env var, materialized into `rbx.box.contest.contest_state.selected_variant_id_var`.
+`contest.rbx.yml` may be a real Contest, a dispatcher sentinel (`use_variants: true`), or a real Contest that ALSO has sibling `contest.<id>.rbx.yml` variants. In the third case the canonical is the default selection and siblings are additional selectable variants. Dispatcher mode (`use_variants: true`) is purely a permission flag that allows the canonical to be empty (all contests live in siblings). Variant selection comes from `-C <id>` (CLI flag) or `RBX_CONTEST=<id>` env var, materialized into `rbx.box.contest.contest_state.selected_variant_id_var`.
 
 `find_contest_yaml(root, contest_id=None)` consults the contextvar when no explicit `contest_id` is passed. In dispatcher mode without selection, problem-side helpers in `naming.py` walk all variants and auto-pick when the current problem belongs to exactly one. Sites that REQUIRE a deterministic letter use `naming.require_problem_in_contest()` (errors with picker hint) or `naming.get_problem_shortname_or_require()` (lenient when no contest exists).
 

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -36,6 +36,12 @@ Each has a `match(outcome: Outcome) -> bool` method. `INCORRECT` matches WA/RTE/
 - **`find_problem_package_or_die()`** -- Returns loaded `Package` or exits
 - Package loading merges `env.rbx.yml` (language/sandbox config) with `problem.rbx.yml`
 
+### Multi-contest mode
+
+`contest.rbx.yml` may be either a real Contest or a dispatcher sentinel (`use_variants: true`) with sibling `contest.<id>.rbx.yml` variants. Variant selection comes from `-C <id>` (CLI flag) or `RBX_CONTEST=<id>` env var, materialized into `rbx.box.contest.contest_state.selected_variant_id_var`.
+
+`find_contest_yaml(root, contest_id=None)` consults the contextvar when no explicit `contest_id` is passed. In dispatcher mode without selection, problem-side helpers in `naming.py` walk all variants and auto-pick when the current problem belongs to exactly one. Sites that REQUIRE a deterministic letter use `naming.require_problem_in_contest()` (errors with picker hint) or `naming.get_problem_shortname_or_require()` (lenient when no contest exists).
+
 ## Build Pipeline (`builder.py`)
 
 ### `build()` function

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -33,6 +33,7 @@ from rbx.box import (
     timing,
     validators,
 )
+from rbx.box.contest import contest_state
 from rbx.box.contest import main as contest
 from rbx.box.contest.contest_package import find_contest_yaml
 from rbx.box.environment import VerificationLevel, get_app_environment_path
@@ -180,15 +181,9 @@ def main(
     # Load .env variables.
     utils.load_dotenv()
 
-    from rbx.box.contest import contest_state as _contest_state
-
-    if contest_id is not None:
-        if not _contest_state.is_valid_variant_id(contest_id):
-            console.console.print(f'[error]Invalid contest id: {contest_id!r}[/error]')
-            raise typer.Exit(1)
-        # Note: when both this callback and the contest sub-app callback fire
-        # in one process, the sub-app's -C runs later and wins (local override).
-        _contest_state.selected_variant_id_var.set(contest_id)
+    # Note: when both this callback and the contest sub-app callback fire
+    # in one process, the sub-app's -C runs later and wins (local override).
+    contest_state.apply_cli_selection(contest_id)
 
     presets.check_active_preset_compatibility()
     if cd.is_problem_package() and not package.is_cache_valid():

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -161,12 +161,34 @@ def main(
         '--profiling',
         help='Whether to profile (capture performance statistics) of the execution.',
     ),
+    contest_id: Annotated[
+        Optional[str],
+        typer.Option(
+            '-C',
+            '--contest',
+            help=(
+                'Select a contest variant by id (when contest.rbx.yml has '
+                'use_variants: true). Defaults to the RBX_CONTEST env var.'
+            ),
+            envvar='RBX_CONTEST',
+        ),
+    ] = None,
     version: Annotated[
         bool, typer.Option('--version', '-v', callback=version_callback, is_eager=True)
     ] = False,
 ):
     # Load .env variables.
     utils.load_dotenv()
+
+    from rbx.box.contest import contest_state as _contest_state
+
+    if contest_id is not None:
+        if not _contest_state.is_valid_variant_id(contest_id):
+            console.console.print(f'[error]Invalid contest id: {contest_id!r}[/error]')
+            raise typer.Exit(1)
+        # Note: when both this callback and the contest sub-app callback fire
+        # in one process, the sub-app's -C runs later and wins (local override).
+        _contest_state.selected_variant_id_var.set(contest_id)
 
     presets.check_active_preset_compatibility()
     if cd.is_problem_package() and not package.is_cache_valid():

--- a/rbx/box/contest/contest_package.py
+++ b/rbx/box/contest/contest_package.py
@@ -108,6 +108,21 @@ def validate_problem_folders_are_packages(
     raise typer.Exit(1)
 
 
+def find_contest_root(
+    root: pathlib.Path = pathlib.Path(),
+) -> Optional[pathlib.Path]:
+    """Walks up from `root` looking for a directory containing contest.rbx.yml.
+
+    Does NOT load the file. Returns the directory or None.
+    """
+    walker = utils.abspath(root)
+    while walker != pathlib.PosixPath('/') and not (walker / YAML_NAME).is_file():
+        walker = walker.parent
+    if not (walker / YAML_NAME).is_file():
+        return None
+    return walker
+
+
 # NOTE: `find_contest_yaml` is `@functools.cache`d. The contextvar fallback
 # (via `resolve_explicit_selection`) is consulted only when `contest_id` is
 # None, which means a cache hit may return a stale result if the contextvar
@@ -121,15 +136,10 @@ def find_contest_yaml(
 ) -> Optional[pathlib.Path]:
     from rbx.box.contest.contest_state import resolve_explicit_selection
 
-    root = utils.abspath(root)
-    contest_yaml_path = root / YAML_NAME
-    while root != pathlib.PosixPath('/') and not contest_yaml_path.is_file():
-        root = root.parent
-        contest_yaml_path = root / YAML_NAME
-    if not contest_yaml_path.is_file():
+    contest_root = find_contest_root(root)
+    if contest_root is None:
         return None
-
-    contest_root = contest_yaml_path.parent
+    contest_yaml_path = contest_root / YAML_NAME
     canonical_contest = load_yaml_model(contest_yaml_path, Contest)
 
     effective_id = (
@@ -181,21 +191,13 @@ def find_contest_package(
 
 
 def _die_no_contest(root: pathlib.Path) -> NoReturn:
-    """Errors with a contextual message when no contest is resolved.
-
-    Re-walks the tree to detect dispatcher mode. This duplicates the walk
-    in `find_contest_yaml`, but keeps the public signature minimal.
-    """
+    """Errors with a contextual message when no contest is resolved."""
     abs_root = utils.abspath(root)
-    walker = abs_root
-    contest_yaml_path = walker / YAML_NAME
-    while walker != pathlib.PosixPath('/') and not contest_yaml_path.is_file():
-        walker = walker.parent
-        contest_yaml_path = walker / YAML_NAME
-    if contest_yaml_path.is_file():
-        canonical = load_yaml_model(contest_yaml_path, Contest)
+    contest_root = find_contest_root(abs_root)
+    if contest_root is not None:
+        canonical = load_yaml_model(contest_root / YAML_NAME, Contest)
         if canonical.is_dispatcher:
-            variants = discover_contest_variants(contest_yaml_path.parent)
+            variants = discover_contest_variants(contest_root)
             # Dispatcher mode never produces a None key.
             available = sorted(variants)
             console.console.print(

--- a/rbx/box/contest/contest_package.py
+++ b/rbx/box/contest/contest_package.py
@@ -1,12 +1,13 @@
 import functools
 import pathlib
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import ruyaml
 import typer
 
 from rbx import console, utils
 from rbx.box import cd
+from rbx.box.contest.contest_state import is_valid_variant_id
 from rbx.box.contest.schema import Contest
 from rbx.box.package import find_problem_package_or_die
 from rbx.box.sanitizers import issue_stack
@@ -15,6 +16,45 @@ from rbx.box.yaml_validation import load_yaml_model
 
 YAML_NAME = 'contest.rbx.yml'
 PROBLEM_YAML_NAME = 'problem.rbx.yml'
+VARIANT_GLOB = 'contest.*.rbx.yml'
+
+
+def discover_contest_variants(
+    contest_root: pathlib.Path,
+) -> Dict[Optional[str], pathlib.Path]:
+    """Returns variant_id -> yaml path. Single-contest mode uses key None.
+
+    Errors via typer.Exit if contest.rbx.yml is a real contest AND there are
+    sibling contest.<id>.rbx.yml files (ambiguous).
+    """
+    canonical = contest_root / YAML_NAME
+    if not canonical.is_file():
+        return {}
+
+    canonical_contest = load_yaml_model(canonical, Contest)
+    sibling_paths = sorted(contest_root.glob(VARIANT_GLOB))
+    siblings: Dict[str, pathlib.Path] = {}
+    for path in sibling_paths:
+        # path.name is e.g. 'contest.div1.rbx.yml' -> id 'div1'
+        # Strip leading 'contest.' and trailing '.rbx.yml'.
+        name = path.name[len('contest.') : -len('.rbx.yml')]
+        if not is_valid_variant_id(name):
+            continue
+        siblings[name] = path
+
+    if canonical_contest.is_dispatcher:
+        return {vid: p for vid, p in siblings.items()}
+
+    if siblings:
+        console.console.print(
+            f'[error]{canonical} is a real contest but sibling variant files '
+            f'exist: {[p.name for p in siblings.values()]}. Set '
+            f'use_variants: true on contest.rbx.yml to enable dispatcher '
+            f'mode.[/error]'
+        )
+        raise typer.Exit(1)
+
+    return {None: canonical}
 
 
 def validate_problem_folders_exist(

--- a/rbx/box/contest/contest_package.py
+++ b/rbx/box/contest/contest_package.py
@@ -1,6 +1,6 @@
 import functools
 import pathlib
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, NoReturn, Optional, Tuple
 
 import ruyaml
 import typer
@@ -154,9 +154,11 @@ def find_contest_yaml(
     if effective_id is None:
         return None
     if effective_id not in variants:
+        # Dispatcher mode never produces a None key.
         console.console.print(
             f'[error]Contest variant {effective_id!r} not found. '
-            f'Available: {sorted(k for k in variants if k is not None)}.[/error]'
+            f'Pass -C <id> or set RBX_CONTEST=<id>. '
+            f'Available: {sorted(variants)}.[/error]'
         )
         raise typer.Exit(1)
     return variants[effective_id]
@@ -178,7 +180,7 @@ def find_contest_package(
     return contest
 
 
-def _die_no_contest(root: pathlib.Path) -> None:
+def _die_no_contest(root: pathlib.Path) -> NoReturn:
     """Errors with a contextual message when no contest is resolved.
 
     Re-walks the tree to detect dispatcher mode. This duplicates the walk
@@ -194,7 +196,8 @@ def _die_no_contest(root: pathlib.Path) -> None:
         canonical = load_yaml_model(contest_yaml_path, Contest)
         if canonical.is_dispatcher:
             variants = discover_contest_variants(contest_yaml_path.parent)
-            available = sorted(k for k in variants if k is not None)
+            # Dispatcher mode never produces a None key.
+            available = sorted(variants)
             console.console.print(
                 f'[error]Multiple contests are defined in this directory. '
                 f'Pass -C <id> or set RBX_CONTEST=<id>. '
@@ -212,7 +215,6 @@ def find_contest_package_or_die(
     package = find_contest_package(root, contest_id=contest_id)
     if package is None:
         _die_no_contest(root)
-    assert package is not None  # _die_no_contest raises
     return package
 
 
@@ -223,7 +225,6 @@ def find_contest(
     found = find_contest_yaml(root, contest_id=contest_id)
     if found is None:
         _die_no_contest(root)
-        return pathlib.Path()  # unreachable, satisfies type checker
     return found.parent
 
 
@@ -243,10 +244,12 @@ def within_contest(func):
 
 
 def save_contest(
-    package: Optional[Contest] = None, root: pathlib.Path = pathlib.Path()
+    package: Optional[Contest] = None,
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
 ) -> None:
-    package = package or find_contest_package_or_die(root)
-    contest_yaml_path = find_contest_yaml(root)
+    package = package or find_contest_package_or_die(root, contest_id=contest_id)
+    contest_yaml_path = find_contest_yaml(root, contest_id=contest_id)
     if not contest_yaml_path:
         console.console.print(f'Contest not found in {root.absolute()}', style='error')
         raise typer.Exit(1)
@@ -260,8 +263,11 @@ def get_problems(contest: Contest) -> List[Package]:
     return problems
 
 
-def get_ruyaml(root: pathlib.Path = pathlib.Path()) -> Tuple[ruyaml.YAML, ruyaml.Any]:
-    contest_yaml_path = find_contest_yaml(root)
+def get_ruyaml(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> Tuple[ruyaml.YAML, ruyaml.Any]:
+    contest_yaml_path = find_contest_yaml(root, contest_id=contest_id)
     if contest_yaml_path is None:
         console.console.print(f'[error]Contest not found in {root.absolute()}[/error]')
         raise typer.Exit(1)

--- a/rbx/box/contest/contest_package.py
+++ b/rbx/box/contest/contest_package.py
@@ -39,18 +39,23 @@ def discover_contest_variants(
         # Strip leading 'contest.' and trailing '.rbx.yml'.
         name = path.name[len('contest.') : -len('.rbx.yml')]
         if not is_valid_variant_id(name):
+            console.console.print(
+                f'[warning]Skipping {path.name}: not a valid contest '
+                f'variant id.[/warning]'
+            )
             continue
         siblings[name] = path
 
     if canonical_contest.is_dispatcher:
-        return {vid: p for vid, p in siblings.items()}
+        return dict(siblings)
 
     if siblings:
+        names = [p.name for p in siblings.values()]
         console.console.print(
-            f'[error]{canonical} is a real contest but sibling variant files '
-            f'exist: {[p.name for p in siblings.values()]}. Set '
-            f'use_variants: true on contest.rbx.yml to enable dispatcher '
-            f'mode.[/error]'
+            f'[error]contest.rbx.yml at {contest_root} is configured as a '
+            f'real contest but sibling variant files exist: {names}. Either '
+            f'set `use_variants: true` on contest.rbx.yml to enable '
+            f'dispatcher mode, or rename/remove the sibling files.[/error]'
         )
         raise typer.Exit(1)
 

--- a/rbx/box/contest/contest_package.py
+++ b/rbx/box/contest/contest_package.py
@@ -108,8 +108,19 @@ def validate_problem_folders_are_packages(
     raise typer.Exit(1)
 
 
+# NOTE: `find_contest_yaml` is `@functools.cache`d. The contextvar fallback
+# (via `resolve_explicit_selection`) is consulted only when `contest_id` is
+# None, which means a cache hit may return a stale result if the contextvar
+# changes between calls with the same `(root, None)` key. Production callers
+# resolve selection once at the CLI callback boundary; tests must
+# `cache_clear()` when manipulating the contextvar.
 @functools.cache
-def find_contest_yaml(root: pathlib.Path = pathlib.Path()) -> Optional[pathlib.Path]:
+def find_contest_yaml(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> Optional[pathlib.Path]:
+    from rbx.box.contest.contest_state import resolve_explicit_selection
+
     root = utils.abspath(root)
     contest_yaml_path = root / YAML_NAME
     while root != pathlib.PosixPath('/') and not contest_yaml_path.is_file():
@@ -117,12 +128,46 @@ def find_contest_yaml(root: pathlib.Path = pathlib.Path()) -> Optional[pathlib.P
         contest_yaml_path = root / YAML_NAME
     if not contest_yaml_path.is_file():
         return None
-    return contest_yaml_path
+
+    contest_root = contest_yaml_path.parent
+    canonical_contest = load_yaml_model(contest_yaml_path, Contest)
+
+    effective_id = (
+        contest_id if contest_id is not None else resolve_explicit_selection()
+    )
+
+    if not canonical_contest.is_dispatcher:
+        if effective_id is not None:
+            console.console.print(
+                f'[error]Contest at {contest_root} is not a dispatcher (no '
+                f'use_variants). Cannot select variant {effective_id!r}.[/error]'
+            )
+            raise typer.Exit(1)
+        # Single-mode: return canonical without calling
+        # `discover_contest_variants`, which would error if stray sibling
+        # variant files exist. The strict check is deferred to explicit
+        # callers (e.g. `rbx contest list`).
+        return contest_yaml_path
+
+    # Dispatcher mode.
+    variants = discover_contest_variants(contest_root)
+    if effective_id is None:
+        return None
+    if effective_id not in variants:
+        console.console.print(
+            f'[error]Contest variant {effective_id!r} not found. '
+            f'Available: {sorted(k for k in variants if k is not None)}.[/error]'
+        )
+        raise typer.Exit(1)
+    return variants[effective_id]
 
 
 @functools.cache
-def find_contest_package(root: pathlib.Path = pathlib.Path()) -> Optional[Contest]:
-    contest_yaml_path = find_contest_yaml(root)
+def find_contest_package(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> Optional[Contest]:
+    contest_yaml_path = find_contest_yaml(root, contest_id=contest_id)
     if not contest_yaml_path:
         return None
     contest = load_yaml_model(contest_yaml_path, Contest)
@@ -133,19 +178,52 @@ def find_contest_package(root: pathlib.Path = pathlib.Path()) -> Optional[Contes
     return contest
 
 
-def find_contest_package_or_die(root: pathlib.Path = pathlib.Path()) -> Contest:
-    package = find_contest_package(root)
+def _die_no_contest(root: pathlib.Path) -> None:
+    """Errors with a contextual message when no contest is resolved.
+
+    Re-walks the tree to detect dispatcher mode. This duplicates the walk
+    in `find_contest_yaml`, but keeps the public signature minimal.
+    """
+    abs_root = utils.abspath(root)
+    walker = abs_root
+    contest_yaml_path = walker / YAML_NAME
+    while walker != pathlib.PosixPath('/') and not contest_yaml_path.is_file():
+        walker = walker.parent
+        contest_yaml_path = walker / YAML_NAME
+    if contest_yaml_path.is_file():
+        canonical = load_yaml_model(contest_yaml_path, Contest)
+        if canonical.is_dispatcher:
+            variants = discover_contest_variants(contest_yaml_path.parent)
+            available = sorted(k for k in variants if k is not None)
+            console.console.print(
+                f'[error]Multiple contests are defined in this directory. '
+                f'Pass -C <id> or set RBX_CONTEST=<id>. '
+                f'Available contests: {available}.[/error]'
+            )
+            raise typer.Exit(1)
+    console.console.print(f'Contest not found in {abs_root}', style='error')
+    raise typer.Exit(1)
+
+
+def find_contest_package_or_die(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> Contest:
+    package = find_contest_package(root, contest_id=contest_id)
     if package is None:
-        console.console.print(f'Contest not found in {root.absolute()}', style='error')
-        raise typer.Exit(1)
+        _die_no_contest(root)
+    assert package is not None  # _die_no_contest raises
     return package
 
 
-def find_contest(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
-    found = find_contest_yaml(root)
+def find_contest(
+    root: pathlib.Path = pathlib.Path(),
+    contest_id: Optional[str] = None,
+) -> pathlib.Path:
+    found = find_contest_yaml(root, contest_id=contest_id)
     if found is None:
-        console.console.print(f'Contest not found in {root.absolute()}', style='error')
-        raise typer.Exit(1)
+        _die_no_contest(root)
+        return pathlib.Path()  # unreachable, satisfies type checker
     return found.parent
 
 

--- a/rbx/box/contest/contest_package.py
+++ b/rbx/box/contest/contest_package.py
@@ -22,10 +22,12 @@ VARIANT_GLOB = 'contest.*.rbx.yml'
 def discover_contest_variants(
     contest_root: pathlib.Path,
 ) -> Dict[Optional[str], pathlib.Path]:
-    """Returns variant_id -> yaml path. Single-contest mode uses key None.
+    """Returns variant_id -> yaml path.
 
-    Errors via typer.Exit if contest.rbx.yml is a real contest AND there are
-    sibling contest.<id>.rbx.yml files (ambiguous).
+    - No contest.rbx.yml -> {}.
+    - Dispatcher canonical (`use_variants: true`) -> {sibling ids only}.
+    - Real canonical -> {None: canonical, **siblings}; the canonical is the
+      default selection, siblings are additional selectable variants.
     """
     canonical = contest_root / YAML_NAME
     if not canonical.is_file():
@@ -49,17 +51,7 @@ def discover_contest_variants(
     if canonical_contest.is_dispatcher:
         return dict(siblings)
 
-    if siblings:
-        names = [p.name for p in siblings.values()]
-        console.console.print(
-            f'[error]contest.rbx.yml at {contest_root} is configured as a '
-            f'real contest but sibling variant files exist: {names}. Either '
-            f'set `use_variants: true` on contest.rbx.yml to enable '
-            f'dispatcher mode, or rename/remove the sibling files.[/error]'
-        )
-        raise typer.Exit(1)
-
-    return {None: canonical}
+    return {None: canonical, **siblings}
 
 
 def validate_problem_folders_exist(
@@ -139,39 +131,27 @@ def find_contest_yaml(
     contest_root = find_contest_root(root)
     if contest_root is None:
         return None
-    contest_yaml_path = contest_root / YAML_NAME
-    canonical_contest = load_yaml_model(contest_yaml_path, Contest)
 
     effective_id = (
         contest_id if contest_id is not None else resolve_explicit_selection()
     )
-
-    if not canonical_contest.is_dispatcher:
-        if effective_id is not None:
-            console.console.print(
-                f'[error]Contest at {contest_root} is not a dispatcher (no '
-                f'use_variants). Cannot select variant {effective_id!r}.[/error]'
-            )
-            raise typer.Exit(1)
-        # Single-mode: return canonical without calling
-        # `discover_contest_variants`, which would error if stray sibling
-        # variant files exist. The strict check is deferred to explicit
-        # callers (e.g. `rbx contest list`).
-        return contest_yaml_path
-
-    # Dispatcher mode.
     variants = discover_contest_variants(contest_root)
+
     if effective_id is None:
-        return None
-    if effective_id not in variants:
-        # Dispatcher mode never produces a None key.
-        console.console.print(
-            f'[error]Contest variant {effective_id!r} not found. '
-            f'Pass -C <id> or set RBX_CONTEST=<id>. '
-            f'Available: {sorted(variants)}.[/error]'
-        )
-        raise typer.Exit(1)
-    return variants[effective_id]
+        # Returns the canonical default if there is one, else None
+        # (dispatcher with no selection).
+        return variants.get(None)
+
+    if effective_id in variants and effective_id is not None:
+        return variants[effective_id]
+
+    available = sorted(k for k in variants if k is not None)
+    console.console.print(
+        f'[error]Contest variant {effective_id!r} not found. '
+        f'Pass -C <id> or set RBX_CONTEST=<id>. '
+        f'Available: {available}.[/error]'
+    )
+    raise typer.Exit(1)
 
 
 @functools.cache
@@ -198,8 +178,7 @@ def _die_no_contest(root: pathlib.Path) -> NoReturn:
         canonical = load_yaml_model(contest_root / YAML_NAME, Contest)
         if canonical.is_dispatcher:
             variants = discover_contest_variants(contest_root)
-            # Dispatcher mode never produces a None key.
-            available = sorted(variants)
+            available = sorted(k for k in variants if k is not None)
             console.console.print(
                 f'[error]Multiple contests are defined in this directory. '
                 f'Pass -C <id> or set RBX_CONTEST=<id>. '

--- a/rbx/box/contest/contest_state.py
+++ b/rbx/box/contest/contest_state.py
@@ -1,0 +1,30 @@
+import contextvars
+import os
+import re
+from typing import Optional
+
+VARIANT_ID_PATTERN = re.compile(r'^[A-Za-z][A-Za-z0-9_-]*$')
+ENV_VAR = 'RBX_CONTEST'
+
+selected_variant_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    'rbx_selected_variant_id', default=None
+)
+
+
+def is_valid_variant_id(value: str) -> bool:
+    return bool(VARIANT_ID_PATTERN.match(value))
+
+
+def get_selected_variant_id() -> Optional[str]:
+    return selected_variant_id_var.get()
+
+
+def resolve_explicit_selection() -> Optional[str]:
+    """Returns the selected variant id, preferring contextvar over env var."""
+    explicit = selected_variant_id_var.get()
+    if explicit is not None:
+        return explicit
+    env_value = os.environ.get(ENV_VAR)
+    if env_value:
+        return env_value
+    return None

--- a/rbx/box/contest/contest_state.py
+++ b/rbx/box/contest/contest_state.py
@@ -19,6 +19,24 @@ def get_selected_variant_id() -> Optional[str]:
     return selected_variant_id_var.get()
 
 
+def apply_cli_selection(contest_id: Optional[str]) -> None:
+    """Validate and apply a contest variant id from the CLI/env, exiting on bad input.
+
+    No-op when `contest_id` is None.
+    """
+    if contest_id is None:
+        return
+    if not is_valid_variant_id(contest_id):
+        # Imported here to avoid a CLI dependency at import time.
+        import typer
+
+        from rbx.console import console
+
+        console.print(f'[error]Invalid contest id: {contest_id!r}[/error]')
+        raise typer.Exit(1)
+    selected_variant_id_var.set(contest_id)
+
+
 def resolve_explicit_selection() -> Optional[str]:
     """Returns the selected variant id, preferring contextvar over env var."""
     explicit = selected_variant_id_var.get()

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -314,3 +314,25 @@ def on(ctx: typer.Context, problems: str) -> None:
 async def summary_cmd():
     contest = find_contest_package_or_die()
     await summary.print_contest_summary(contest, get_problems(contest))
+
+
+@app.command('list, ls', help='List all contests in the current directory.')
+def list_contests():
+    contest_root = contest_package.find_contest_root()
+    if contest_root is None:
+        console.console.print('[warning]No contests found in this directory.[/warning]')
+        return
+
+    variants = contest_package.discover_contest_variants(contest_root)
+    if not variants:
+        console.console.print('[warning]No contests found in this directory.[/warning]')
+        return
+
+    if list(variants.keys()) == [None]:
+        console.console.print('[item]contest.rbx.yml[/item] (single contest)')
+        return
+
+    active = contest_state.resolve_explicit_selection()
+    for vid in sorted(k for k in variants if k is not None):
+        marker = ' *' if vid == active else ''
+        console.console.print(f'[item]{vid}[/item]{marker}')

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -327,11 +327,22 @@ def list_contests():
     # find_contest_root returned a real path, so canonical contest.rbx.yml exists.
     variants = contest_package.discover_contest_variants(contest_root)
 
+    if not variants:
+        console.console.print('[warning]No contests found in this directory.[/warning]')
+        return
+
     if list(variants.keys()) == [None]:
         console.console.print('[item]contest.rbx.yml[/item] (single contest)')
         return
 
     active = contest_state.resolve_explicit_selection()
+    default_path = variants.get(None)
+
+    if default_path is not None:
+        # When no explicit selection is set, the default is implicitly active.
+        marker = ' *' if active is None else ''
+        console.console.print(f'[item]contest.rbx.yml[/item] (default){marker}')
+
     for vid in sorted(k for k in variants if k is not None):
         marker = ' *' if vid == active else ''
         console.console.print(f'[item]{vid}[/item]{marker}')

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -38,13 +38,9 @@ def contest_main(
         ),
     ] = None,
 ):
-    if contest_id is not None:
-        if not contest_state.is_valid_variant_id(contest_id):
-            console.console.print(f'[error]Invalid contest id: {contest_id!r}[/error]')
-            raise typer.Exit(1)
-        # When the root cli callback also set this, the sub-app's value wins
-        # (local override beats global), since this fires after the root.
-        contest_state.selected_variant_id_var.set(contest_id)
+    # When the root cli callback also set this, the sub-app's value wins
+    # (local override beats global), since this fires after the root.
+    contest_state.apply_cli_selection(contest_id)
 
 
 app.add_typer(

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -9,7 +9,7 @@ import typer
 
 from rbx import annotations, console, utils
 from rbx.box import cd, creation, presets, summary
-from rbx.box.contest import contest_package, contest_utils, statements
+from rbx.box.contest import contest_package, contest_state, contest_utils, statements
 from rbx.box.contest.contest_package import (
     find_contest,
     find_contest_package_or_die,
@@ -24,6 +24,29 @@ from rbx.box.ui.command_app import CommandEntry, start_command_app
 from rbx.config import open_editor
 
 app = typer.Typer(no_args_is_help=True, cls=annotations.AliasGroup)
+
+
+@app.callback()
+def contest_main(
+    contest_id: Annotated[
+        Optional[str],
+        typer.Option(
+            '-C',
+            '--contest',
+            help='Select a contest variant by id.',
+            envvar='RBX_CONTEST',
+        ),
+    ] = None,
+):
+    if contest_id is not None:
+        if not contest_state.is_valid_variant_id(contest_id):
+            console.console.print(f'[error]Invalid contest id: {contest_id!r}[/error]')
+            raise typer.Exit(1)
+        # When the root cli callback also set this, the sub-app's value wins
+        # (local override beats global), since this fires after the root.
+        contest_state.selected_variant_id_var.set(contest_id)
+
+
 app.add_typer(
     statements.app,
     name='statements, st',

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -323,10 +323,9 @@ def list_contests():
         console.console.print('[warning]No contests found in this directory.[/warning]')
         return
 
+    # discover_contest_variants always returns a non-empty dict here:
+    # find_contest_root returned a real path, so canonical contest.rbx.yml exists.
     variants = contest_package.discover_contest_variants(contest_root)
-    if not variants:
-        console.console.print('[warning]No contests found in this directory.[/warning]')
-        return
 
     if list(variants.keys()) == [None]:
         console.console.print('[item]contest.rbx.yml[/item] (single contest)')

--- a/rbx/box/contest/schema.py
+++ b/rbx/box/contest/schema.py
@@ -1,12 +1,13 @@
 import pathlib
-import re
 from typing import Annotated, Dict, List, Optional, Set
 
+import pydantic
 from pydantic import (
     AfterValidator,
     BaseModel,
     ConfigDict,
     Field,
+    TypeAdapter,
     model_validator,
 )
 
@@ -256,9 +257,7 @@ If not provided, will try to infer a color name from the color provided.
         return {self.short_name.lower()} | {a.lower() for a in self.aliases}
 
 
-_CONTEST_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9\-_]*$')
-_CONTEST_NAME_MIN_LENGTH = 3
-_CONTEST_NAME_MAX_LENGTH = 32
+_CONTEST_NAME_VALIDATOR = TypeAdapter(Annotated[str, NameField()])
 
 
 class Contest(BaseModel):
@@ -291,6 +290,8 @@ class Contest(BaseModel):
 
     @model_validator(mode='after')
     def _validate_dispatcher_or_real(self):
+        # Maintenance contract: keep this tuple in sync with Contest's non-dispatcher
+        # fields. `use_variants` is the only field allowed alongside dispatcher mode.
         if self.use_variants:
             for field in ('name', 'titles', 'problems', 'statements', 'vars'):
                 value = getattr(self, field)
@@ -299,20 +300,10 @@ class Contest(BaseModel):
                         f'Field {field!r} cannot be set when use_variants is true.'
                     )
             return self
-        if not self.name:
-            raise ValueError('Field "name" is required for a contest.')
-        if (
-            len(self.name) < _CONTEST_NAME_MIN_LENGTH
-            or len(self.name) > _CONTEST_NAME_MAX_LENGTH
-        ):
-            raise ValueError(
-                f'Field "name" must be between {_CONTEST_NAME_MIN_LENGTH} and '
-                f'{_CONTEST_NAME_MAX_LENGTH} characters long.'
-            )
-        if not _CONTEST_NAME_PATTERN.match(self.name):
-            raise ValueError(
-                f'Field "name" must match pattern {_CONTEST_NAME_PATTERN.pattern!r}.'
-            )
+        try:
+            _CONTEST_NAME_VALIDATOR.validate_python(self.name)
+        except pydantic.ValidationError as exc:
+            raise ValueError(f'Invalid contest name: {exc}') from exc
         return self
 
     @property

--- a/rbx/box/contest/schema.py
+++ b/rbx/box/contest/schema.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 from typing import Annotated, Dict, List, Optional, Set
 
 from pydantic import (
@@ -255,10 +256,28 @@ If not provided, will try to infer a color name from the color provided.
         return {self.short_name.lower()} | {a.lower() for a in self.aliases}
 
 
+_CONTEST_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9\-_]*$')
+_CONTEST_NAME_MIN_LENGTH = 3
+_CONTEST_NAME_MAX_LENGTH = 32
+
+
 class Contest(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
-    name: str = NameField(description='Name of this contest.')
+    use_variants: bool = Field(
+        default=False,
+        description=(
+            'When true, this file is a sentinel marking the directory as a '
+            'multi-contest dispatcher. The actual contests live in sibling '
+            'files matching contest.<id>.rbx.yml. When set, no other Contest '
+            'fields may be specified.'
+        ),
+    )
+
+    name: str = Field(
+        default='',
+        description='Name of this contest.',
+    )
 
     titles: Dict[str, str] = Field(
         default={},
@@ -269,6 +288,36 @@ class Contest(BaseModel):
     problems: List[ContestProblem] = Field(
         default=[], description='List of problems in this contest.'
     )
+
+    @model_validator(mode='after')
+    def _validate_dispatcher_or_real(self):
+        if self.use_variants:
+            for field in ('name', 'titles', 'problems', 'statements', 'vars'):
+                value = getattr(self, field)
+                if value:
+                    raise ValueError(
+                        f'Field {field!r} cannot be set when use_variants is true.'
+                    )
+            return self
+        if not self.name:
+            raise ValueError('Field "name" is required for a contest.')
+        if (
+            len(self.name) < _CONTEST_NAME_MIN_LENGTH
+            or len(self.name) > _CONTEST_NAME_MAX_LENGTH
+        ):
+            raise ValueError(
+                f'Field "name" must be between {_CONTEST_NAME_MIN_LENGTH} and '
+                f'{_CONTEST_NAME_MAX_LENGTH} characters long.'
+            )
+        if not _CONTEST_NAME_PATTERN.match(self.name):
+            raise ValueError(
+                f'Field "name" must match pattern {_CONTEST_NAME_PATTERN.pattern!r}.'
+            )
+        return self
+
+    @property
+    def is_dispatcher(self) -> bool:
+        return self.use_variants
 
     @model_validator(mode='after')
     def check_problem_identifiers_unique(self):

--- a/rbx/box/contest/statement_overriding.py
+++ b/rbx/box/contest/statement_overriding.py
@@ -4,7 +4,11 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from rbx import utils
 from rbx.box import naming
-from rbx.box.contest import contest_package
+from rbx.box.contest import contest_package, contest_state
+from rbx.box.contest.contest_package import (
+    discover_contest_variants,
+    find_contest_root,
+)
 from rbx.box.contest.schema import ContestStatement
 from rbx.box.exception import RbxException
 from rbx.box.fields import Primitive
@@ -65,6 +69,26 @@ def get_overrides(
 def get_inheritance_overrides(statement: Statement) -> StatementOverrideData:
     contest = contest_package.find_contest_package()
     if contest is None:
+        # Either there's no contest at all, OR we're in dispatcher mode
+        # without an explicit selection. Disambiguate to give a clearer
+        # error message.
+        contest_root = find_contest_root()
+        if contest_root is not None:
+            variants = discover_contest_variants(contest_root)
+            available = sorted(k for k in variants if k is not None)
+            if (
+                len(available) > 0
+                and contest_state.resolve_explicit_selection() is None
+            ):
+                with StatementInheritanceError() as e:
+                    e.print(
+                        f'[error]Statement [item]{statement.name}[/item] extends '
+                        f'a contest statement, but multiple contests are defined. '
+                        f'Pass -C <id> or set RBX_CONTEST=<id>. '
+                        f'Available contests: {available}.[/error]'
+                    )
+                raise e
+
         with StatementInheritanceError() as e:
             e.print(
                 f'[error][item]{statement.name}[/item] inherits its configuration from the contest, but no contest was found.[/error]'

--- a/rbx/box/contest/statement_overriding.py
+++ b/rbx/box/contest/statement_overriding.py
@@ -5,10 +5,6 @@ from typing import Any, Dict, List, Optional, Tuple
 from rbx import utils
 from rbx.box import naming
 from rbx.box.contest import contest_package, contest_state
-from rbx.box.contest.contest_package import (
-    discover_contest_variants,
-    find_contest_root,
-)
 from rbx.box.contest.schema import ContestStatement
 from rbx.box.exception import RbxException
 from rbx.box.fields import Primitive
@@ -72,9 +68,9 @@ def get_inheritance_overrides(statement: Statement) -> StatementOverrideData:
         # Either there's no contest at all, OR we're in dispatcher mode
         # without an explicit selection. Disambiguate to give a clearer
         # error message.
-        contest_root = find_contest_root()
+        contest_root = contest_package.find_contest_root()
         if contest_root is not None:
-            variants = discover_contest_variants(contest_root)
+            variants = contest_package.discover_contest_variants(contest_root)
             available = sorted(k for k in variants if k is not None)
             if (
                 len(available) > 0
@@ -83,7 +79,8 @@ def get_inheritance_overrides(statement: Statement) -> StatementOverrideData:
                 with StatementInheritanceError() as e:
                     e.print(
                         f'[error]Statement [item]{statement.name}[/item] extends '
-                        f'a contest statement, but multiple contests are defined. '
+                        f'a contest statement, but the contest is a dispatcher '
+                        f'with no explicit selection. '
                         f'Pass -C <id> or set RBX_CONTEST=<id>. '
                         f'Available contests: {available}.[/error]'
                     )

--- a/rbx/box/naming.py
+++ b/rbx/box/naming.py
@@ -125,13 +125,21 @@ def get_problem_shortname() -> Optional[str]:
 
 
 def get_problem_shortname_or_require() -> Optional[str]:
-    """Return the problem's contest letter, or None if no contest exists.
+    """Return the problem's contest letter, or None if the problem is outside any contest.
 
-    Unlike `get_problem_shortname`, this raises the picker `typer.Exit` error
-    when a contest is present but the active variant is ambiguous (dispatcher
-    mode with no `-C`). Use this at call sites that compose filenames or
-    archive keys: returning `None` is fine for stand-alone problems, but
-    silently dropping the letter in dispatcher mode is not.
+    Unlike `get_problem_shortname`, this raises `typer.Exit(1)` with a picker
+    message (delegating to `require_problem_in_contest`) whenever a contest
+    root is present but the entry cannot be uniquely resolved. Concretely:
+
+    - dispatcher mode without explicit selection, AND multiple variants
+      contain (or could contain) this problem,
+    - explicit selection set but the problem is not listed in the selected
+      variant's problems[],
+    - single-mode contest exists but does not list this problem.
+
+    Returning `None` is reserved for the stand-alone case (no contest at all).
+    Use this at call sites that compose filenames or archive keys: silently
+    dropping the letter in any of the above cases would be wrong.
     """
     entry = get_problem_entry_in_contest()
     if entry is not None:

--- a/rbx/box/naming.py
+++ b/rbx/box/naming.py
@@ -75,16 +75,44 @@ def require_problem_in_contest() -> Tuple[int, ContestProblem]:
     if contest_root is None:
         console.print('[error]No contest found for the current problem.[/error]')
         raise typer.Exit(1)
+
     variants = discover_contest_variants(contest_root)
+    selection = contest_state.resolve_explicit_selection()
     available = sorted(v for v in variants if v is not None)
-    if len(available) > 1 and contest_state.resolve_explicit_selection() is None:
+
+    if len(available) > 1 and selection is None:
         console.print(
             f'[error]This problem is part of multiple contests. '
             f'Pass -C <id> or set RBX_CONTEST=<id>. '
             f'Available contests: {available}.[/error]'
         )
         raise typer.Exit(1)
-    console.print('[error]Problem is not registered in the active contest.[/error]')
+
+    # Single mode, OR dispatcher with explicit selection: the problem isn't in
+    # the active contest. Tell the user which variants DO contain it (if any).
+    containing: List[str] = []
+    for vid in variants:
+        if vid is None:
+            continue
+        candidate = contest_package.find_contest_package(contest_root, contest_id=vid)
+        if candidate is None:
+            continue
+        if _entry_in_contest(candidate, contest_root) is not None:
+            containing.append(vid)
+
+    if selection is not None:
+        msg = (
+            f'[error]This problem directory is not listed in the problems[] of '
+            f'contest variant {selection!r}.[/error]'
+        )
+        if containing:
+            msg += f' [info]It is listed in: {sorted(containing)}.[/info]'
+        console.print(msg)
+    else:
+        console.print(
+            "[error]This problem directory is not listed in the active contest's "
+            'problems[] field.[/error]'
+        )
     raise typer.Exit(1)
 
 

--- a/rbx/box/naming.py
+++ b/rbx/box/naming.py
@@ -124,6 +124,32 @@ def get_problem_shortname() -> Optional[str]:
     return problem.short_name
 
 
+def get_problem_shortname_or_require() -> Optional[str]:
+    """Return the problem's contest letter, or None if no contest exists.
+
+    Unlike `get_problem_shortname`, this raises the picker `typer.Exit` error
+    when a contest is present but the active variant is ambiguous (dispatcher
+    mode with no `-C`). Use this at call sites that compose filenames or
+    archive keys: returning `None` is fine for stand-alone problems, but
+    silently dropping the letter in dispatcher mode is not.
+    """
+    entry = get_problem_entry_in_contest()
+    if entry is not None:
+        _, problem = entry
+        return problem.short_name
+
+    # No entry — distinguish "no contest at all" (graceful) from
+    # "contest present but ambiguous/mismatched" (error).
+    if contest_package.find_contest_root() is None:
+        return None
+
+    # There is a contest root: defer to require_problem_in_contest so the
+    # user gets the picker / mismatch error message.
+    require_problem_in_contest()
+    # Unreachable: require_problem_in_contest always raises in this branch.
+    return None
+
+
 def get_problem_index() -> Optional[int]:
     entry = get_problem_entry_in_contest()
     if entry is None:

--- a/rbx/box/naming.py
+++ b/rbx/box/naming.py
@@ -1,30 +1,91 @@
-from typing import Optional, Tuple
+import pathlib
+from typing import List, Optional, Tuple
 
 import typer
 
 from rbx.box import package
-from rbx.box.contest import contest_package
+from rbx.box.contest import contest_package, contest_state
+from rbx.box.contest.contest_package import discover_contest_variants
 from rbx.box.contest.schema import Contest, ContestProblem, ContestStatement
 from rbx.box.schema import Package
 from rbx.box.statements.schema import Statement
 from rbx.console import console
 
 
-def get_problem_entry_in_contest() -> Optional[Tuple[int, ContestProblem]]:
-    contest = contest_package.find_contest_package()
-    if contest is None:
-        return None
+def _entry_in_contest(
+    contest: Contest,
+    contest_root: pathlib.Path,
+) -> Optional[Tuple[int, ContestProblem]]:
     problem_path = package.find_problem()
-    contest_path = contest_package.find_contest()
-
     for i, problem in enumerate(contest.problems):
         if problem.path is None:
             continue
-        if (problem_path / 'problem.rbx.yml').samefile(
-            contest_path / problem.path / 'problem.rbx.yml'
-        ):
+        candidate = contest_root / problem.path / 'problem.rbx.yml'
+        if not candidate.is_file():
+            continue
+        if (problem_path / 'problem.rbx.yml').samefile(candidate):
             return i, problem
     return None
+
+
+def get_problem_entry_in_contest() -> Optional[Tuple[int, ContestProblem]]:
+    # Fast path: explicit selection or single-mode contest.
+    contest = contest_package.find_contest_package()
+    if contest is not None:
+        contest_path = contest_package.find_contest()
+        return _entry_in_contest(contest, contest_path)
+
+    # Past this point: find_contest_package returned None. Either there's
+    # no contest at all, or we're in dispatcher mode without a selection.
+    if contest_state.resolve_explicit_selection() is not None:
+        # Selection set but contest_package returned None -> upstream
+        # already errored or there is no matching variant.
+        return None
+
+    contest_root = contest_package.find_contest_root()
+    if contest_root is None:
+        return None
+
+    variants = discover_contest_variants(contest_root)
+    matches: List[Tuple[int, ContestProblem]] = []
+    for vid, _yaml_path in variants.items():
+        if vid is None:
+            continue
+        candidate_contest = contest_package.find_contest_package(
+            contest_root, contest_id=vid
+        )
+        if candidate_contest is None:
+            continue
+        entry = _entry_in_contest(candidate_contest, contest_root)
+        if entry is not None:
+            matches.append(entry)
+
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def require_problem_in_contest() -> Tuple[int, ContestProblem]:
+    """Like `get_problem_entry_in_contest` but errors if not uniquely resolvable."""
+    entry = get_problem_entry_in_contest()
+    if entry is not None:
+        return entry
+
+    contest_root = contest_package.find_contest_root()
+    if contest_root is None:
+        console.print('[error]No contest found for the current problem.[/error]')
+        raise typer.Exit(1)
+    variants = discover_contest_variants(contest_root)
+    available = sorted(v for v in variants if v is not None)
+    if len(available) > 1 and contest_state.resolve_explicit_selection() is None:
+        console.print(
+            f'[error]This problem is part of multiple contests. '
+            f'Pass -C <id> or set RBX_CONTEST=<id>. '
+            f'Available contests: {available}.[/error]'
+        )
+        raise typer.Exit(1)
+    console.print('[error]Problem is not registered in the active contest.[/error]')
+    raise typer.Exit(1)
 
 
 def get_problem_shortname() -> Optional[str]:

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -82,9 +82,10 @@ class BocaPackager(BasePackager):
 
     def _get_problem_basename(self) -> str:
         extension = get_extension_or_default('boca', BocaExtension)
-        shortname = naming.get_problem_shortname()
-        if extension.preferContestLetter and shortname is not None:
-            return shortname
+        if extension.preferContestLetter:
+            shortname = naming.get_problem_shortname_or_require()
+            if shortname is not None:
+                return shortname
         return self._get_problem_name()
 
     def _get_problem_info(self) -> str:

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -83,10 +83,17 @@ class BocaPackager(BasePackager):
     def _get_problem_basename(self) -> str:
         extension = get_extension_or_default('boca', BocaExtension)
         if extension.preferContestLetter:
+            # Strict path: enforce explicit variant selection in dispatcher mode.
             shortname = naming.get_problem_shortname_or_require()
             if shortname is not None:
                 return shortname
-        return self._get_problem_name()
+            # Stand-alone problem (no contest at all): no letter to use.
+            return package.find_problem_package_or_die().name.replace('-', '_')
+        # Lenient path: user opted out of the letter prefix, so we use the
+        # package name directly without going through the strict letter
+        # resolution. This matches the pre-strictness behavior for
+        # preferContestLetter=False.
+        return package.find_problem_package_or_die().name.replace('-', '_')
 
     def _get_problem_info(self) -> str:
         statement = self._get_main_statement()

--- a/rbx/box/packaging/packager.py
+++ b/rbx/box/packaging/packager.py
@@ -78,7 +78,7 @@ class BasePackager(ABC):
 
     def package_basename(self):
         pkg = package.find_problem_package_or_die()
-        shortname = naming.get_problem_shortname()
+        shortname = naming.get_problem_shortname_or_require()
         if shortname is not None:
             return f'{shortname}-{pkg.name}'
         return pkg.name

--- a/rbx/box/packaging/pkg/packager.py
+++ b/rbx/box/packaging/pkg/packager.py
@@ -26,7 +26,7 @@ class PkgPackager(BasePackager):
         return 'pkg'
 
     def _get_problem_basename(self) -> str:
-        shortname = naming.get_problem_shortname()
+        shortname = naming.get_problem_shortname_or_require()
         if shortname is not None:
             return shortname
         return self.package_basename()

--- a/rbx/box/tooling/boca/scraper.py
+++ b/rbx/box/tooling/boca/scraper.py
@@ -382,25 +382,8 @@ class BocaScraper:
             problem_shortname = 'A'
             hex_color = None
         else:
-            problem_index = naming.get_problem_index()
-            if problem_index is None:
-                console.console.print(
-                    'It seems this problem is not part of a contest. Cannot upload it to BOCA.'
-                )
-                raise typer.Exit(1)
-
-            problem_shortname = naming.get_problem_shortname()
-            assert problem_shortname is not None
-            if problem_shortname is None:
-                console.console.print(
-                    'It seems this problem is not part of a contest. Cannot upload it to BOCA.'
-                )
-                raise typer.Exit(1)
-
-            entry = naming.get_problem_entry_in_contest()
-            assert entry is not None
-            _, problem_entry = entry
-
+            problem_index, problem_entry = naming.require_problem_in_contest()
+            problem_shortname = problem_entry.short_name
             hex_color = problem_entry.hex_color
 
         if hex_color is None:

--- a/rbx/box/tooling/boca/submitter.py
+++ b/rbx/box/tooling/boca/submitter.py
@@ -41,11 +41,13 @@ def submit_all_solutions(scraper: BocaScraper) -> Iterable[JudgedSolution]:
         console.console.print('[error]Failed to login to BOCA.[/error]')
         raise typer.Exit(1)
 
+    _, problem_entry = naming.require_problem_in_contest()
+    problem_shortname = problem_entry.short_name
     problem_indices = scraper.list_problems_as_judge()
-    problem_index = problem_indices.get(naming.get_problem_shortname() or '')
+    problem_index = problem_indices.get(problem_shortname)
     if problem_index is None:
         console.console.print(
-            f'[error]Problem [item]{naming.get_problem_shortname()}[/item] not found in BOCA.[/error]'
+            f'[error]Problem [item]{problem_shortname}[/item] not found in BOCA.[/error]'
         )
         raise typer.Exit(1)
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -75,10 +75,18 @@ scenarios:
 
 ```yaml
 - cmd: build              # required, parsed via shlex.split, no `rbx` prefix
+  cwd: A                  # optional, path relative to the package root
   expect_exit: 0          # optional, defaults to 0
   expect:                 # optional, all sub-fields below are optional
     ...
 ```
+
+* `cwd`: optional path relative to the package root. The step runs with
+  cwd set to `pkg_dir / cwd`. Default is the package root. Use this to
+  invoke problem-level commands inside a specific problem subdirectory
+  while keeping the contest tree available above. A missing directory
+  fails the step. `expect.files_exist` and friends remain rooted at the
+  package root (the contest root), not the step `cwd`.
 
 ### `Expect`
 

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -159,11 +159,21 @@ class E2EScenarioItem(pytest.Item):
             # scenario.
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
+            # Snapshot contextvars that the CLI mutates, so a scenario that
+            # sets `-C <id>` does not leak its variant id into the next
+            # scenario run in the same process. Mirrors the autouse
+            # `_isolate_global_state` fixture in tests/rbx/conftest.py.
+            from rbx.box.contest import contest_state as _contest_state
+
+            context_vars = [_contest_state.selected_variant_id_var]
+            snapshots = [(v, v.get()) for v in context_vars]
             try:
                 testing_utils.clear_all_functools_cache()
                 for step in self.scenario.steps:
                     run_step(self.path, self.scenario.name, step, pkg_dir)
             finally:
+                for var, value in snapshots:
+                    var.set(value)
                 testing_utils.clear_all_functools_cache()
                 try:
                     loop.run_until_complete(loop.shutdown_asyncgens())

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -16,6 +16,7 @@ runner instead just chdirs into the copied package and lets ``rbx`` discover
 """
 
 import asyncio
+import contextlib
 import os
 import pathlib
 import shlex
@@ -28,6 +29,7 @@ from typer.testing import CliRunner
 
 from rbx import testing_utils
 from rbx.box.cli import app as rbx_app
+from rbx.box.contest import contest_state
 from tests.e2e.assertions import (
     AssertionContext,
     check_file_contains,
@@ -72,6 +74,22 @@ _GENERIC_CHECKS = (
     ('solutions', check_solutions),
     ('tests', check_tests),
 )
+
+
+@contextlib.contextmanager
+def _snapshot_e2e_contextvars():
+    """Snapshots and restores ContextVars that scenarios may mutate.
+
+    Keep the list of vars in sync with ``_isolate_global_state`` in
+    ``tests/rbx/conftest.py`` so unit and e2e suites have matching isolation.
+    """
+    context_vars = [contest_state.selected_variant_id_var]
+    snapshots = [(v, v.get()) for v in context_vars]
+    try:
+        yield
+    finally:
+        for var, value in snapshots:
+            var.set(value)
 
 
 def _run_generic_assertions(ctx: AssertionContext, expect: Expect) -> None:
@@ -163,17 +181,12 @@ class E2EScenarioItem(pytest.Item):
             # sets `-C <id>` does not leak its variant id into the next
             # scenario run in the same process. Mirrors the autouse
             # `_isolate_global_state` fixture in tests/rbx/conftest.py.
-            from rbx.box.contest import contest_state as _contest_state
-
-            context_vars = [_contest_state.selected_variant_id_var]
-            snapshots = [(v, v.get()) for v in context_vars]
             try:
                 testing_utils.clear_all_functools_cache()
-                for step in self.scenario.steps:
-                    run_step(self.path, self.scenario.name, step, pkg_dir)
+                with _snapshot_e2e_contextvars():
+                    for step in self.scenario.steps:
+                        run_step(self.path, self.scenario.name, step, pkg_dir)
             finally:
-                for var, value in snapshots:
-                    var.set(value)
                 testing_utils.clear_all_functools_cache()
                 try:
                     loop.run_until_complete(loop.shutdown_asyncgens())

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -114,8 +114,14 @@ def run_step(
     expected vs actual exit codes, and stdout/stderr if the exit code does
     not match.
     """
+    target_cwd = cwd / step.cwd if step.cwd else cwd
+    if not target_cwd.is_dir():
+        raise AssertionError(
+            f'[{scenario_path.parent.name}::{scenario_name}] '
+            f'step cwd {step.cwd!r} does not exist under {cwd}'
+        )
     old_cwd = pathlib.Path.cwd()
-    os.chdir(cwd)
+    os.chdir(target_cwd)
     try:
         result = CliRunner().invoke(rbx_app, shlex.split(step.cmd))
     finally:

--- a/tests/e2e/spec.py
+++ b/tests/e2e/spec.py
@@ -113,6 +113,7 @@ class Expect(_Forbid):
 
 class Step(_Forbid):
     cmd: str
+    cwd: Optional[str] = None
     expect_exit: int = 0
     expect: Expect = Field(default_factory=Expect)
 

--- a/tests/e2e/test_runner_cwd.py
+++ b/tests/e2e/test_runner_cwd.py
@@ -1,0 +1,43 @@
+"""Tests for ``Step.cwd`` handling in :func:`tests.e2e.runner.run_step`."""
+
+import pathlib
+
+import pytest
+
+from tests.e2e.runner import run_step
+from tests.e2e.spec import Step
+
+
+def test_run_step_honors_cwd(tmp_path: pathlib.Path):
+    sub = tmp_path / 'A'
+    sub.mkdir()
+    original = pathlib.Path.cwd()
+    run_step(
+        scenario_path=tmp_path / 'e2e.rbx.yml',
+        scenario_name='probe',
+        step=Step(cmd='--help', cwd='A', expect_exit=0),
+        cwd=tmp_path,
+    )
+    # Runner must restore cwd even after chdir-ing into the subdir.
+    assert pathlib.Path.cwd() == original
+
+
+def test_run_step_default_cwd_is_package_root(tmp_path: pathlib.Path):
+    original = pathlib.Path.cwd()
+    run_step(
+        scenario_path=tmp_path / 'e2e.rbx.yml',
+        scenario_name='probe',
+        step=Step(cmd='--help', expect_exit=0),
+        cwd=tmp_path,
+    )
+    assert pathlib.Path.cwd() == original
+
+
+def test_run_step_errors_on_missing_cwd(tmp_path: pathlib.Path):
+    with pytest.raises(AssertionError, match='does not exist'):
+        run_step(
+            scenario_path=tmp_path / 'e2e.rbx.yml',
+            scenario_name='probe',
+            step=Step(cmd='--help', cwd='nope', expect_exit=0),
+            cwd=tmp_path,
+        )

--- a/tests/e2e/test_runner_isolation.py
+++ b/tests/e2e/test_runner_isolation.py
@@ -1,0 +1,22 @@
+"""Verifies the e2e runner restores mutated contextvars between scenarios."""
+
+from rbx.box.contest import contest_state
+from tests.e2e.runner import _snapshot_e2e_contextvars
+
+
+def test_snapshot_restores_selected_variant_id_var():
+    assert contest_state.selected_variant_id_var.get() is None
+    with _snapshot_e2e_contextvars():
+        contest_state.selected_variant_id_var.set('div1')
+        assert contest_state.selected_variant_id_var.get() == 'div1'
+    assert contest_state.selected_variant_id_var.get() is None
+
+
+def test_snapshot_restores_prior_value():
+    contest_state.selected_variant_id_var.set('outer')
+    try:
+        with _snapshot_e2e_contextvars():
+            contest_state.selected_variant_id_var.set('inner')
+        assert contest_state.selected_variant_id_var.get() == 'outer'
+    finally:
+        contest_state.selected_variant_id_var.set(None)

--- a/tests/e2e/testdata/multi-contest/A/gens/gen.cpp
+++ b/tests/e2e/testdata/multi-contest/A/gens/gen.cpp
@@ -1,0 +1,14 @@
+#include <cstdio>
+#include <cstdlib>
+
+// Minimal generator: takes two integers as args and prints them as the input.
+// Usage: gen <a> <b>
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        return 1;
+    }
+    int a = atoi(argv[1]);
+    int b = atoi(argv[2]);
+    printf("%d %d\n", a, b);
+    return 0;
+}

--- a/tests/e2e/testdata/multi-contest/A/problem.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/A/problem.rbx.yml
@@ -1,3 +1,23 @@
 name: prob-a
 timeLimit: 1000
 memoryLimit: 256
+
+generators:
+  - name: gen
+    path: gens/gen.cpp
+
+solutions:
+  - path: sols/main.cpp
+    outcome: ac
+
+testcases:
+  - name: main
+    subgroups:
+      - name: gen
+        generators:
+          - name: gen
+            args: 1 2
+          - name: gen
+            args: 3 4
+          - name: gen
+            args: 5 6

--- a/tests/e2e/testdata/multi-contest/A/problem.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/A/problem.rbx.yml
@@ -1,0 +1,3 @@
+name: prob-a
+timeLimit: 1000
+memoryLimit: 256

--- a/tests/e2e/testdata/multi-contest/A/sols/main.cpp
+++ b/tests/e2e/testdata/multi-contest/A/sols/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+using namespace std;
+
+int main() {
+    int a, b;
+    cin >> a >> b;
+    cout << a + b << endl;
+    return 0;
+}

--- a/tests/e2e/testdata/multi-contest/B/gens/gen.cpp
+++ b/tests/e2e/testdata/multi-contest/B/gens/gen.cpp
@@ -1,0 +1,14 @@
+#include <cstdio>
+#include <cstdlib>
+
+// Minimal generator: takes two integers as args and prints them as the input.
+// Usage: gen <a> <b>
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        return 1;
+    }
+    int a = atoi(argv[1]);
+    int b = atoi(argv[2]);
+    printf("%d %d\n", a, b);
+    return 0;
+}

--- a/tests/e2e/testdata/multi-contest/B/problem.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/B/problem.rbx.yml
@@ -1,0 +1,3 @@
+name: prob-b
+timeLimit: 1000
+memoryLimit: 256

--- a/tests/e2e/testdata/multi-contest/B/problem.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/B/problem.rbx.yml
@@ -1,3 +1,23 @@
 name: prob-b
 timeLimit: 1000
 memoryLimit: 256
+
+generators:
+  - name: gen
+    path: gens/gen.cpp
+
+solutions:
+  - path: sols/main.cpp
+    outcome: ac
+
+testcases:
+  - name: main
+    subgroups:
+      - name: gen
+        generators:
+          - name: gen
+            args: 1 2
+          - name: gen
+            args: 3 4
+          - name: gen
+            args: 5 6

--- a/tests/e2e/testdata/multi-contest/B/sols/main.cpp
+++ b/tests/e2e/testdata/multi-contest/B/sols/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+using namespace std;
+
+int main() {
+    int a, b;
+    cin >> a >> b;
+    cout << a + b << endl;
+    return 0;
+}

--- a/tests/e2e/testdata/multi-contest/contest.div1.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/contest.div1.rbx.yml
@@ -1,0 +1,6 @@
+name: div1-c
+problems:
+  - short_name: A
+    path: A
+  - short_name: B
+    path: B

--- a/tests/e2e/testdata/multi-contest/contest.div2.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/contest.div2.rbx.yml
@@ -1,0 +1,4 @@
+name: div2-c
+problems:
+  - short_name: A
+    path: A

--- a/tests/e2e/testdata/multi-contest/contest.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/contest.rbx.yml
@@ -1,0 +1,1 @@
+use_variants: true

--- a/tests/e2e/testdata/multi-contest/e2e.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/e2e.rbx.yml
@@ -62,3 +62,77 @@ scenarios:
         expect:
           stdout_contains:
             - 'Invalid contest id'
+
+  - name: run-inside-A-without-c
+    description: >-
+      `rbx run` inside problem A succeeds without -C: it does not require a
+      deterministic contest letter, so dispatcher mode without a selection
+      is fine here.
+    steps:
+      - cmd: run
+        cwd: A
+        expect:
+          stdout_contains:
+            - sols/main.cpp
+
+  - name: build-inside-A-with-c
+    description: >-
+      `rbx -C div1 build` inside problem A builds the 3 generated tests.
+    steps:
+      - cmd: -C div1 build
+        cwd: A
+        expect:
+          files_exist:
+            - A/build/tests/main/*.in
+            - A/build/tests/main/*.out
+
+  - name: run-inside-B-autopicks-div1
+    description: >-
+      B is only listed in div1, so the naming chain auto-picks div1 even
+      without -C. `rbx run` succeeds.
+    steps:
+      - cmd: run
+        cwd: B
+        expect:
+          stdout_contains:
+            - sols/main.cpp
+
+  - name: package-inside-A-without-c-errors-with-picker
+    description: >-
+      A is in both div1 and div2, so `rbx package pkg` (which routes through
+      naming.get_problem_shortname_or_require) fails with the picker hint.
+    steps:
+      - cmd: package pkg
+        cwd: A
+        expect_exit: 1
+        expect:
+          stdout_contains:
+            - '-C'
+            - RBX_CONTEST
+            - div1
+            - div2
+
+  - name: package-inside-A-with-c-succeeds
+    description: >-
+      With -C div1, the naming chain resolves A's contest letter and the
+      pkg package is built. The output filename includes the contest letter
+      `A` (the short_name in div1).
+    markers: [slow]
+    steps:
+      - cmd: -C div1 package pkg
+        cwd: A
+        expect:
+          files_exist:
+            - A/build/A.zip
+
+  - name: package-inside-B-autopicks-div1
+    description: >-
+      B is only in div1, so naming auto-picks the variant and pkg packaging
+      succeeds without -C. Output uses B's contest letter.
+    markers: [slow]
+    steps:
+      - cmd: package pkg
+        cwd: B
+        expect:
+          files_exist:
+            - B/build/B.zip

--- a/tests/e2e/testdata/multi-contest/e2e.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/e2e.rbx.yml
@@ -1,0 +1,64 @@
+scenarios:
+  - name: list-shows-all-variants
+    description: 'rbx contest list enumerates all sibling variant files.'
+    steps:
+      - cmd: contest list
+        expect:
+          stdout_contains:
+            - div1
+            - div2
+
+  - name: list-marks-active-with-flag
+    description: 'rbx -C div1 contest list marks the active variant with " *".'
+    steps:
+      - cmd: -C div1 contest list
+        expect:
+          stdout_contains:
+            - 'div1 *'
+            - div2
+
+  - name: summary-without-c-errors-with-picker
+    description: >-
+      In dispatcher mode, contest summary without -C exits 1 and prints the
+      picker hint listing both variants.
+    steps:
+      - cmd: contest summary
+        expect_exit: 1
+        expect:
+          stdout_contains:
+            - '-C'
+            - RBX_CONTEST
+            - div1
+            - div2
+
+  - name: summary-with-c-succeeds
+    description: 'rbx -C div1 contest summary loads the div1 variant successfully.'
+    steps:
+      - cmd: -C div1 contest summary
+        expect:
+          stdout_contains:
+            - div1-c
+
+  - name: bogus-c-rejected
+    description: >-
+      Unknown variant id passed via -C is rejected by find_contest_yaml.
+      Uses contest summary because contest list does not validate -C.
+    steps:
+      - cmd: -C bogus contest summary
+        expect_exit: 1
+        expect:
+          stdout_contains:
+            - bogus
+            - div1
+            - div2
+
+  - name: invalid-c-pattern-rejected
+    description: >-
+      Variant id failing the is_valid_variant_id regex is rejected by the
+      root callback before any contest discovery happens.
+    steps:
+      - cmd: -C "bad id" contest list
+        expect_exit: 1
+        expect:
+          stdout_contains:
+            - 'Invalid contest id'

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -1,0 +1,106 @@
+"""Tests for `rbx contest` Typer commands."""
+
+import pathlib
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box.contest import main as contest_main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_single_contest(root: pathlib.Path) -> None:
+    (root / 'contest.rbx.yml').write_text('name: ctt\nproblems: []\n')
+
+
+def _write_dispatcher(root: pathlib.Path, *variant_ids: str) -> None:
+    (root / 'contest.rbx.yml').write_text('use_variants: true\n')
+    for vid in variant_ids:
+        (root / f'contest.{vid}.rbx.yml').write_text(f'name: ctt-{vid}\nproblems: []\n')
+
+
+class TestContestList:
+    def test_list_in_single_contest_dir(
+        self,
+        runner: CliRunner,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        _write_single_contest(tmp_path)
+
+        result = runner.invoke(contest_main.app, ['list'])
+
+        assert result.exit_code == 0, result.output
+        assert 'contest.rbx.yml' in result.output
+        assert 'single' in result.output
+
+    def test_list_in_dispatcher_dir(
+        self,
+        runner: CliRunner,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path, 'div1', 'div2')
+
+        result = runner.invoke(contest_main.app, ['list'])
+
+        assert result.exit_code == 0, result.output
+        assert 'div1' in result.output
+        assert 'div2' in result.output
+
+    def test_list_marks_active_selection_via_flag(
+        self,
+        runner: CliRunner,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path, 'div1', 'div2')
+
+        result = runner.invoke(contest_main.app, ['-C', 'div1', 'list'])
+
+        assert result.exit_code == 0, result.output
+        assert 'div1' in result.output
+        assert 'div2' in result.output
+        # 'div1' line should have a marker; 'div2' line should not.
+        div1_line = next(line for line in result.output.splitlines() if 'div1' in line)
+        div2_line = next(line for line in result.output.splitlines() if 'div2' in line)
+        assert '*' in div1_line
+        assert '*' not in div2_line
+
+    def test_list_marks_active_selection_via_env(
+        self,
+        runner: CliRunner,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path, 'div1', 'div2')
+        monkeypatch.setenv('RBX_CONTEST', 'div2')
+
+        result = runner.invoke(contest_main.app, ['list'])
+
+        assert result.exit_code == 0, result.output
+        div1_line = next(line for line in result.output.splitlines() if 'div1' in line)
+        div2_line = next(line for line in result.output.splitlines() if 'div2' in line)
+        assert '*' in div2_line
+        assert '*' not in div1_line
+
+    def test_list_no_contest_dir_warns(
+        self,
+        runner: CliRunner,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(contest_main.app, ['list'])
+
+        assert result.exit_code == 0, result.output
+        assert 'No contests found' in result.output

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -104,3 +104,21 @@ class TestContestList:
 
         assert result.exit_code == 0, result.output
         assert 'No contests found' in result.output
+
+    def test_list_errors_on_real_contest_with_siblings(
+        self,
+        runner: CliRunner,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'contest.rbx.yml').write_text('name: real-c\nproblems: []\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-c\nproblems: []\n')
+
+        result = runner.invoke(contest_main.app, ['list'])
+
+        assert result.exit_code != 0
+        # The error message in discover_contest_variants mentions 'use_variants'.
+        stderr = getattr(result, 'stderr', '') or ''
+        combined = result.output + stderr
+        assert 'use_variants' in combined

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -105,20 +105,60 @@ class TestContestList:
         assert result.exit_code == 0, result.output
         assert 'No contests found' in result.output
 
-    def test_list_errors_on_real_contest_with_siblings(
+    def test_list_in_real_contest_with_siblings_lists_default_and_variants(
         self,
         runner: CliRunner,
         tmp_path: pathlib.Path,
         monkeypatch: pytest.MonkeyPatch,
     ):
         monkeypatch.chdir(tmp_path)
-        (tmp_path / 'contest.rbx.yml').write_text('name: real-c\nproblems: []\n')
+        (tmp_path / 'contest.rbx.yml').write_text('name: main-c\nproblems: []\n')
         (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-c\nproblems: []\n')
 
         result = runner.invoke(contest_main.app, ['list'])
 
-        assert result.exit_code != 0
-        # The error message in discover_contest_variants mentions 'use_variants'.
-        stderr = getattr(result, 'stderr', '') or ''
-        combined = result.output + stderr
-        assert 'use_variants' in combined
+        assert result.exit_code == 0, result.output
+        # The default contest is listed, plus the sibling variant.
+        assert 'contest.rbx.yml' in result.output
+        assert 'default' in result.output
+        assert 'div1' in result.output
+
+    def test_list_real_contest_with_siblings_marks_default_when_no_selection(
+        self,
+        runner: CliRunner,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'contest.rbx.yml').write_text('name: main-c\nproblems: []\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-c\nproblems: []\n')
+
+        result = runner.invoke(contest_main.app, ['list'])
+
+        assert result.exit_code == 0, result.output
+        default_line = next(
+            line for line in result.output.splitlines() if 'default' in line
+        )
+        div1_line = next(line for line in result.output.splitlines() if 'div1' in line)
+        assert '*' in default_line
+        assert '*' not in div1_line
+
+    def test_list_real_contest_with_siblings_marks_active_variant(
+        self,
+        runner: CliRunner,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'contest.rbx.yml').write_text('name: main-c\nproblems: []\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-c\nproblems: []\n')
+
+        result = runner.invoke(contest_main.app, ['-C', 'div1', 'list'])
+
+        assert result.exit_code == 0, result.output
+        default_line = next(
+            line for line in result.output.splitlines() if 'default' in line
+        )
+        div1_line = next(line for line in result.output.splitlines() if 'div1' in line)
+        assert '*' not in default_line
+        assert '*' in div1_line

--- a/tests/rbx/box/contest/test_contest_package.py
+++ b/tests/rbx/box/contest/test_contest_package.py
@@ -210,12 +210,17 @@ class TestDiscoverVariants:
         assert set(variants.keys()) == {'div1', 'div2'}
         assert variants['div1'].name == 'contest.div1.rbx.yml'
 
-    def test_dispatcher_with_invalid_id_silently_skipped(self, tmp_path):
+    def test_dispatcher_with_invalid_id_skipped_with_warning(
+        self, tmp_path, capsys: pytest.CaptureFixture[str]
+    ):
         (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
         (tmp_path / 'contest.bad name.rbx.yml').write_text('name: bad-id-contest\n')
         variants = cp_module.discover_contest_variants(tmp_path)
-        # Files with invalid ids are silently skipped.
+        # Files with invalid ids are skipped, with a warning printed.
         assert variants == {}
+        out = capsys.readouterr().out
+        assert 'Skipping contest.bad name.rbx.yml' in out
+        assert 'not a valid contest variant id' in out
 
     def test_no_yaml_returns_empty(self, tmp_path):
         assert cp_module.discover_contest_variants(tmp_path) == {}

--- a/tests/rbx/box/contest/test_contest_package.py
+++ b/tests/rbx/box/contest/test_contest_package.py
@@ -194,3 +194,34 @@ class TestFindContestPackageValidation:
         out = capsys.readouterr().out
         assert '- A:' in out
         assert 'problem.rbx.yml' in out
+
+
+class TestDiscoverVariants:
+    def test_single_mode_returns_default(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+        variants = cp_module.discover_contest_variants(tmp_path)
+        assert variants == {None: tmp_path / 'contest.rbx.yml'}
+
+    def test_dispatcher_mode_lists_siblings(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-contest\n')
+        (tmp_path / 'contest.div2.rbx.yml').write_text('name: div2-contest\n')
+        variants = cp_module.discover_contest_variants(tmp_path)
+        assert set(variants.keys()) == {'div1', 'div2'}
+        assert variants['div1'].name == 'contest.div1.rbx.yml'
+
+    def test_dispatcher_with_invalid_id_silently_skipped(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.bad name.rbx.yml').write_text('name: bad-id-contest\n')
+        variants = cp_module.discover_contest_variants(tmp_path)
+        # Files with invalid ids are silently skipped.
+        assert variants == {}
+
+    def test_no_yaml_returns_empty(self, tmp_path):
+        assert cp_module.discover_contest_variants(tmp_path) == {}
+
+    def test_real_contest_with_siblings_errors(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-contest\n')
+        with pytest.raises(typer.Exit):
+            cp_module.discover_contest_variants(tmp_path)

--- a/tests/rbx/box/contest/test_contest_package.py
+++ b/tests/rbx/box/contest/test_contest_package.py
@@ -230,3 +230,68 @@ class TestDiscoverVariants:
         (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-contest\n')
         with pytest.raises(typer.Exit):
             cp_module.discover_contest_variants(tmp_path)
+
+
+class TestFindContestYamlVariantAware:
+    def test_single_mode_returns_canonical(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+        cp_module.find_contest_yaml.cache_clear()
+        assert cp_module.find_contest_yaml(tmp_path) == tmp_path / 'contest.rbx.yml'
+
+    def test_dispatcher_with_explicit_selection(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-contest\n')
+        cp_module.find_contest_yaml.cache_clear()
+        assert (
+            cp_module.find_contest_yaml(tmp_path, contest_id='div1')
+            == tmp_path / 'contest.div1.rbx.yml'
+        )
+
+    def test_dispatcher_unknown_id_errors(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        cp_module.find_contest_yaml.cache_clear()
+        with pytest.raises(typer.Exit):
+            cp_module.find_contest_yaml(tmp_path, contest_id='ghost')
+
+    def test_dispatcher_no_selection_returns_none(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-contest\n')
+        cp_module.find_contest_yaml.cache_clear()
+        assert cp_module.find_contest_yaml(tmp_path) is None
+
+    def test_single_mode_with_id_errors(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+        cp_module.find_contest_yaml.cache_clear()
+        with pytest.raises(typer.Exit):
+            cp_module.find_contest_yaml(tmp_path, contest_id='div1')
+
+    def test_uses_contextvar_when_no_arg(self, tmp_path):
+        from rbx.box.contest.contest_state import selected_variant_id_var
+
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.div2.rbx.yml').write_text('name: div2-contest\n')
+        cp_module.find_contest_yaml.cache_clear()
+        token = selected_variant_id_var.set('div2')
+        try:
+            assert (
+                cp_module.find_contest_yaml(tmp_path)
+                == tmp_path / 'contest.div2.rbx.yml'
+            )
+        finally:
+            selected_variant_id_var.reset(token)
+            cp_module.find_contest_yaml.cache_clear()
+
+
+class TestFindContestPackageOrDieDispatcher:
+    def test_die_lists_available_variants(self, tmp_path, capsys):
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-contest\n')
+        (tmp_path / 'contest.div2.rbx.yml').write_text('name: div2-contest\n')
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+        with pytest.raises(typer.Exit):
+            cp_module.find_contest_package_or_die(tmp_path)
+        out = capsys.readouterr().out
+        assert 'div1' in out
+        assert 'div2' in out
+        assert '-C' in out  # picker hint

--- a/tests/rbx/box/contest/test_contest_package.py
+++ b/tests/rbx/box/contest/test_contest_package.py
@@ -225,11 +225,14 @@ class TestDiscoverVariants:
     def test_no_yaml_returns_empty(self, tmp_path):
         assert cp_module.discover_contest_variants(tmp_path) == {}
 
-    def test_real_contest_with_siblings_errors(self, tmp_path):
+    def test_real_contest_with_siblings_returns_default_plus_variants(self, tmp_path):
         (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
         (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-contest\n')
-        with pytest.raises(typer.Exit):
-            cp_module.discover_contest_variants(tmp_path)
+        variants = cp_module.discover_contest_variants(tmp_path)
+        assert variants == {
+            None: tmp_path / 'contest.rbx.yml',
+            'div1': tmp_path / 'contest.div1.rbx.yml',
+        }
 
 
 class TestFindContestYamlVariantAware:
@@ -259,11 +262,26 @@ class TestFindContestYamlVariantAware:
         cp_module.find_contest_yaml.cache_clear()
         assert cp_module.find_contest_yaml(tmp_path) is None
 
-    def test_single_mode_with_id_errors(self, tmp_path):
+    def test_single_mode_with_unknown_id_errors(self, tmp_path):
         (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
         cp_module.find_contest_yaml.cache_clear()
         with pytest.raises(typer.Exit):
+            cp_module.find_contest_yaml(tmp_path, contest_id='ghost')
+
+    def test_single_mode_with_known_id_resolves_to_sibling(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-c\n')
+        cp_module.find_contest_yaml.cache_clear()
+        assert (
             cp_module.find_contest_yaml(tmp_path, contest_id='div1')
+            == tmp_path / 'contest.div1.rbx.yml'
+        )
+
+    def test_real_canonical_with_siblings_no_id_returns_canonical(self, tmp_path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: div1-c\n')
+        cp_module.find_contest_yaml.cache_clear()
+        assert cp_module.find_contest_yaml(tmp_path) == tmp_path / 'contest.rbx.yml'
 
     def test_uses_contextvar_when_no_arg(self, tmp_path):
         from rbx.box.contest.contest_state import selected_variant_id_var

--- a/tests/rbx/box/contest/test_contest_schema.py
+++ b/tests/rbx/box/contest/test_contest_schema.py
@@ -106,12 +106,20 @@ def test_contest_dispatcher_skips_required_validation():
 
 
 def test_contest_dispatcher_rejects_problems_field():
-    import pydantic
-
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(ValidationError):
         Contest.model_validate(
             {
                 'use_variants': True,
                 'problems': [{'short_name': 'A'}],
             }
         )
+
+
+def test_contest_rejects_invalid_name():
+    with pytest.raises(ValidationError):
+        Contest(name='ab')  # below min_length=3
+
+
+def test_contest_rejects_name_with_bad_chars():
+    with pytest.raises(ValidationError):
+        Contest(name='has space')  # violates regex

--- a/tests/rbx/box/contest/test_contest_schema.py
+++ b/tests/rbx/box/contest/test_contest_schema.py
@@ -90,3 +90,28 @@ class TestContestProblemIdentifiersUnique:
         assert len(contest.problems) == 2
         assert contest.problems[0].all_identifiers() == {'a', 'apple'}
         assert contest.problems[1].all_identifiers() == {'b', 'banana'}
+
+
+def test_contest_default_is_not_dispatcher():
+    contest = Contest(name='abc')
+    assert contest.use_variants is False
+    assert contest.is_dispatcher is False
+
+
+def test_contest_dispatcher_skips_required_validation():
+    contest = Contest.model_validate({'use_variants': True})
+    assert contest.is_dispatcher is True
+    assert contest.problems == []
+    assert contest.statements == []
+
+
+def test_contest_dispatcher_rejects_problems_field():
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        Contest.model_validate(
+            {
+                'use_variants': True,
+                'problems': [{'short_name': 'A'}],
+            }
+        )

--- a/tests/rbx/box/contest/test_contest_state.py
+++ b/tests/rbx/box/contest/test_contest_state.py
@@ -1,0 +1,44 @@
+import pytest
+
+from rbx.box.contest import contest_state
+
+
+def test_variant_id_pattern_accepts_typical_ids():
+    assert contest_state.is_valid_variant_id('div1')
+    assert contest_state.is_valid_variant_id('warmup')
+    assert contest_state.is_valid_variant_id('A1')
+    assert contest_state.is_valid_variant_id('ioi-2024_main')
+
+
+def test_variant_id_pattern_rejects_invalid():
+    assert not contest_state.is_valid_variant_id('')
+    assert not contest_state.is_valid_variant_id('1div')
+    assert not contest_state.is_valid_variant_id('div 1')
+    assert not contest_state.is_valid_variant_id('div.1')
+
+
+def test_selection_default_is_none():
+    assert contest_state.get_selected_variant_id() is None
+
+
+def test_set_selected_variant_id_round_trip():
+    token = contest_state.selected_variant_id_var.set('div1')
+    try:
+        assert contest_state.get_selected_variant_id() == 'div1'
+    finally:
+        contest_state.selected_variant_id_var.reset(token)
+    assert contest_state.get_selected_variant_id() is None
+
+
+def test_resolve_from_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('RBX_CONTEST', 'envdiv')
+    assert contest_state.resolve_explicit_selection() == 'envdiv'
+
+
+def test_resolve_prefers_var_over_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('RBX_CONTEST', 'envdiv')
+    token = contest_state.selected_variant_id_var.set('flagdiv')
+    try:
+        assert contest_state.resolve_explicit_selection() == 'flagdiv'
+    finally:
+        contest_state.selected_variant_id_var.reset(token)

--- a/tests/rbx/box/contest/test_contest_state.py
+++ b/tests/rbx/box/contest/test_contest_state.py
@@ -44,6 +44,25 @@ def test_resolve_prefers_var_over_env(monkeypatch: pytest.MonkeyPatch):
         contest_state.selected_variant_id_var.reset(token)
 
 
+def test_apply_cli_selection_sets_var():
+    contest_state.apply_cli_selection('div1')
+    assert contest_state.get_selected_variant_id() == 'div1'
+
+
+def test_apply_cli_selection_rejects_invalid(capsys):
+    import typer
+
+    with pytest.raises(typer.Exit):
+        contest_state.apply_cli_selection('bad id')
+    out = capsys.readouterr().out
+    assert 'Invalid contest id' in out
+
+
+def test_apply_cli_selection_noop_on_none():
+    contest_state.apply_cli_selection(None)
+    assert contest_state.get_selected_variant_id() is None
+
+
 def test_root_callback_sets_contextvar_from_flag():
     """Smoke: invoking the root callback with -C sets the contextvar."""
     from typer.testing import CliRunner

--- a/tests/rbx/box/contest/test_contest_state.py
+++ b/tests/rbx/box/contest/test_contest_state.py
@@ -42,3 +42,81 @@ def test_resolve_prefers_var_over_env(monkeypatch: pytest.MonkeyPatch):
         assert contest_state.resolve_explicit_selection() == 'flagdiv'
     finally:
         contest_state.selected_variant_id_var.reset(token)
+
+
+def test_root_callback_sets_contextvar_from_flag():
+    """Smoke: invoking the root callback with -C sets the contextvar."""
+    from typer.testing import CliRunner
+
+    from rbx.box import cli
+    from rbx.box.contest.contest_state import selected_variant_id_var
+
+    captured = {}
+
+    @cli.app.command('probe-contest-rcv')
+    def probe():
+        captured['value'] = selected_variant_id_var.get()
+
+    try:
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ['-C', 'div1', 'probe-contest-rcv'])
+        assert result.exit_code == 0, result.output
+        assert captured['value'] == 'div1'
+    finally:
+        # Best-effort cleanup of the registered command. Typer doesn't expose a
+        # public removal API, so leak is fine for a unit test.
+        pass
+
+
+def test_root_callback_rejects_invalid_id():
+    from typer.testing import CliRunner
+
+    from rbx.box import cli
+
+    @cli.app.command('probe-contest-invalid')
+    def probe():
+        pass
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ['-C', 'has space', 'probe-contest-invalid'])
+    assert result.exit_code != 0
+    assert 'Invalid contest id' in result.output
+
+
+def test_contest_subapp_callback_sets_contextvar_from_flag():
+    from typer.testing import CliRunner
+
+    from rbx.box.contest import main as contest_main
+    from rbx.box.contest.contest_state import selected_variant_id_var
+
+    captured = {}
+
+    @contest_main.app.command('probe-contest-cv')
+    def probe():
+        captured['value'] = selected_variant_id_var.get()
+
+    runner = CliRunner()
+    result = runner.invoke(contest_main.app, ['-C', 'div2', 'probe-contest-cv'])
+    assert result.exit_code == 0, result.output
+    assert captured['value'] == 'div2'
+
+
+def test_root_callback_resolves_from_env(monkeypatch: pytest.MonkeyPatch):
+    """RBX_CONTEST env var alone (no -C flag) populates the contextvar."""
+    from typer.testing import CliRunner
+
+    from rbx.box import cli
+    from rbx.box.contest.contest_state import selected_variant_id_var
+
+    monkeypatch.setenv('RBX_CONTEST', 'envdiv')
+
+    captured = {}
+
+    @cli.app.command('probe-contest-env')
+    def probe():
+        captured['value'] = selected_variant_id_var.get()
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ['probe-contest-env'])
+    assert result.exit_code == 0, result.output
+    assert captured['value'] == 'envdiv'

--- a/tests/rbx/box/contest/test_statement_overriding.py
+++ b/tests/rbx/box/contest/test_statement_overriding.py
@@ -169,6 +169,8 @@ class TestGetInheritanceOverrides:
         mock_get_overrides.assert_called_once_with(contest_stm, inherit=True)
 
     def test_dispatcher_ambiguous_raises_picker_error(self, tmp_path, monkeypatch):
+        # Real-fs fixture: we're verifying dispatcher discovery + resolve_explicit_selection
+        # interplay, which mocks would short-circuit.
         # Set up dispatcher mode with two variants in tmp_path.
         (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
         (tmp_path / 'contest.div1.rbx.yml').write_text('name: Div1\n')

--- a/tests/rbx/box/contest/test_statement_overriding.py
+++ b/tests/rbx/box/contest/test_statement_overriding.py
@@ -168,6 +168,24 @@ class TestGetInheritanceOverrides:
 
         mock_get_overrides.assert_called_once_with(contest_stm, inherit=True)
 
+    def test_dispatcher_ambiguous_raises_picker_error(self, tmp_path, monkeypatch):
+        # Set up dispatcher mode with two variants in tmp_path.
+        (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')
+        (tmp_path / 'contest.div1.rbx.yml').write_text('name: Div1\n')
+        (tmp_path / 'contest.div2.rbx.yml').write_text('name: Div2\n')
+        monkeypatch.chdir(tmp_path)
+
+        statement = Statement(name='problem', inheritFromContest=True)
+
+        with pytest.raises(StatementInheritanceError) as exc:
+            get_inheritance_overrides(statement)
+
+        rendered = str(exc.value)
+        assert '-C' in rendered
+        assert 'RBX_CONTEST' in rendered
+        assert 'div1' in rendered
+        assert 'div2' in rendered
+
     @patch('rbx.box.contest.statement_overriding.contest_package.find_contest_package')
     def test_no_match_due_to_missing_joiner(self, mock_find_pkg):
         contest_stm = ContestStatement(name='english', language='en')

--- a/tests/rbx/box/packaging/test_packager_naming.py
+++ b/tests/rbx/box/packaging/test_packager_naming.py
@@ -1,0 +1,135 @@
+"""Tests verifying packaging call sites raise the picker error in dispatcher mode.
+
+These exercise the naming path directly via small helpers on each packager,
+without spinning up a full build. Mirrors the fixture style in
+`tests/rbx/box/test_naming.py`.
+"""
+
+import os
+import pathlib
+
+import pytest
+import typer
+
+from rbx.box.contest import contest_package as cp_module
+from rbx.box.contest.contest_state import selected_variant_id_var
+from rbx.box.packaging.boca.packager import BocaPackager
+from rbx.box.packaging.pkg.packager import PkgPackager
+
+
+def _write_problem(folder: pathlib.Path, name: str) -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / 'problem.rbx.yml').write_text(
+        f'name: {name}\ntimeLimit: 1000\nmemoryLimit: 256\n'
+    )
+
+
+def _write_dispatcher(
+    root: pathlib.Path, variants: dict[str, list[tuple[str, str]]]
+) -> None:
+    (root / 'contest.rbx.yml').write_text('use_variants: true\n')
+    for vid, problems in variants.items():
+        body = '\n'.join(
+            f'  - short_name: {sn}\n    path: {path}' for sn, path in problems
+        )
+        (root / f'contest.{vid}.rbx.yml').write_text(
+            f'name: {vid}-c\nproblems:\n{body}\n'
+        )
+
+
+def _write_environment(folder: pathlib.Path) -> None:
+    # Minimal env file so get_extension_or_default('boca', ...) is safe to
+    # call: the packager only needs a valid problem environment to exist.
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    cp_module.find_contest_yaml.cache_clear()
+    cp_module.find_contest_package.cache_clear()
+    token = selected_variant_id_var.set(None)
+    try:
+        yield
+    finally:
+        selected_variant_id_var.reset(token)
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+
+def _setup_ambiguous_problem(tmp_path: pathlib.Path) -> None:
+    _write_dispatcher(
+        tmp_path,
+        {
+            'div1': [('A', 'A')],
+            'div2': [('A', 'A')],
+        },
+    )
+    _write_problem(tmp_path / 'A', 'prob-a')
+    os.chdir(tmp_path / 'A')
+
+
+class TestBasePackagerBasename:
+    def test_package_basename_errors_in_ambiguous_dispatcher(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        _setup_ambiguous_problem(tmp_path)
+
+        # BasePackager is abstract; use a concrete subclass to exercise
+        # the inherited package_basename().
+        packager = PkgPackager.__new__(PkgPackager)
+        packager.testcase_entries = []
+
+        with pytest.raises(typer.Exit):
+            packager.package_basename()
+
+        out = capsys.readouterr().out
+        assert '-C' in out
+        assert 'div1' in out and 'div2' in out
+
+
+class TestPkgPackagerBasename:
+    def test_pkg_basename_errors_in_ambiguous_dispatcher(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        _setup_ambiguous_problem(tmp_path)
+
+        packager = PkgPackager.__new__(PkgPackager)
+        packager.testcase_entries = []
+
+        with pytest.raises(typer.Exit):
+            packager._get_problem_basename()  # noqa: SLF001
+
+        out = capsys.readouterr().out
+        assert '-C' in out
+
+
+class TestBocaPackagerBasename:
+    def test_boca_basename_errors_in_ambiguous_dispatcher_when_prefer_letter(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        _setup_ambiguous_problem(tmp_path)
+
+        # Force preferContestLetter=True via a stand-in extension; BocaPackager
+        # only reads the boolean attribute and (downstream) the shortname.
+        from rbx.box.packaging.boca import packager as boca_mod
+        from rbx.box.packaging.boca.extension import BocaExtension
+
+        ext = BocaExtension(preferContestLetter=True)
+        monkeypatch.setattr(boca_mod, 'get_extension_or_default', lambda name, cls: ext)
+
+        packager = BocaPackager.__new__(BocaPackager)
+        packager.testcase_entries = []
+        packager.language = None
+
+        with pytest.raises(typer.Exit):
+            packager._get_problem_basename()  # noqa: SLF001
+
+        out = capsys.readouterr().out
+        assert '-C' in out

--- a/tests/rbx/box/packaging/test_packager_naming.py
+++ b/tests/rbx/box/packaging/test_packager_naming.py
@@ -133,3 +133,27 @@ class TestBocaPackagerBasename:
 
         out = capsys.readouterr().out
         assert '-C' in out
+
+    def test_boca_basename_returns_package_name_when_prefer_letter_false(
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        # No -C selection. Even though the dispatcher is ambiguous, with
+        # preferContestLetter=False the basename should fall back to the
+        # package name without raising. Guards the gating at packager.py:84-89.
+        _setup_ambiguous_problem(tmp_path)
+
+        from rbx.box.packaging.boca import packager as boca_mod
+        from rbx.box.packaging.boca.extension import BocaExtension
+
+        ext = BocaExtension(preferContestLetter=False)
+        monkeypatch.setattr(boca_mod, 'get_extension_or_default', lambda name, cls: ext)
+
+        packager = BocaPackager.__new__(BocaPackager)
+        packager.testcase_entries = []
+        packager.language = None
+
+        result = packager._get_problem_basename()  # noqa: SLF001
+        # _get_problem_name() replaces '-' with '_' in the package name.
+        assert result == 'prob_a'

--- a/tests/rbx/box/test_naming.py
+++ b/tests/rbx/box/test_naming.py
@@ -206,6 +206,57 @@ class TestRequireProblemInContest:
         assert 'div2' in out
 
 
+class TestGetProblemShortnameOrRequire:
+    @pytest.fixture(autouse=True)
+    def _clear_state(self):
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+        token = selected_variant_id_var.set(None)
+        try:
+            yield
+        finally:
+            selected_variant_id_var.reset(token)
+            cp_module.find_contest_yaml.cache_clear()
+            cp_module.find_contest_package.cache_clear()
+
+    def test_returns_none_when_no_contest_at_all(self, tmp_path: pathlib.Path):
+        _write_problem(tmp_path, 'lonely')
+        os.chdir(tmp_path)
+
+        assert naming.get_problem_shortname_or_require() is None
+
+    def test_returns_shortname_in_single_contest(self, tmp_path: pathlib.Path):
+        _write_single_contest(tmp_path, [('A', 'A')])
+        _write_problem(tmp_path / 'A', 'prob-a')
+
+        os.chdir(tmp_path / 'A')
+
+        assert naming.get_problem_shortname_or_require() == 'A'
+
+    def test_errors_in_dispatcher_ambiguous_mode(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        _write_dispatcher(
+            tmp_path,
+            {
+                'div1': [('A', 'A')],
+                'div2': [('A', 'A')],
+            },
+        )
+        _write_problem(tmp_path / 'A', 'prob-a')
+
+        os.chdir(tmp_path / 'A')
+
+        with pytest.raises(typer.Exit):
+            naming.get_problem_shortname_or_require()
+
+        out = capsys.readouterr().out
+        assert '-C' in out
+        assert 'div1' in out and 'div2' in out
+
+
 class TestGetTitle:
     def test_returns_pkg_title_for_lang_when_present(self):
         pkg = Package(

--- a/tests/rbx/box/test_naming.py
+++ b/tests/rbx/box/test_naming.py
@@ -37,12 +37,16 @@ def _write_dispatcher(
 
 class TestGetProblemEntryInContest:
     @pytest.fixture(autouse=True)
-    def _clear_caches(self):
+    def _clear_state(self):
         cp_module.find_contest_yaml.cache_clear()
         cp_module.find_contest_package.cache_clear()
-        yield
-        cp_module.find_contest_yaml.cache_clear()
-        cp_module.find_contest_package.cache_clear()
+        token = selected_variant_id_var.set(None)
+        try:
+            yield
+        finally:
+            selected_variant_id_var.reset(token)
+            cp_module.find_contest_yaml.cache_clear()
+            cp_module.find_contest_package.cache_clear()
 
     def test_get_entry_in_single_contest_returns_entry(self, tmp_path: pathlib.Path):
         _write_single_contest(tmp_path, [('A', 'A'), ('B', 'B')])
@@ -50,8 +54,6 @@ class TestGetProblemEntryInContest:
         _write_problem(tmp_path / 'B', 'prob-b')
 
         os.chdir(tmp_path / 'A')
-        cp_module.find_contest_yaml.cache_clear()
-        cp_module.find_contest_package.cache_clear()
 
         entry = naming.get_problem_entry_in_contest()
         assert entry is not None
@@ -73,8 +75,6 @@ class TestGetProblemEntryInContest:
         _write_problem(tmp_path / 'B', 'prob-b')
 
         os.chdir(tmp_path / 'A')
-        cp_module.find_contest_yaml.cache_clear()
-        cp_module.find_contest_package.cache_clear()
 
         entry = naming.get_problem_entry_in_contest()
         assert entry is not None
@@ -95,8 +95,6 @@ class TestGetProblemEntryInContest:
         _write_problem(tmp_path / 'A', 'prob-a')
 
         os.chdir(tmp_path / 'A')
-        cp_module.find_contest_yaml.cache_clear()
-        cp_module.find_contest_package.cache_clear()
 
         assert naming.get_problem_entry_in_contest() is None
 
@@ -113,30 +111,28 @@ class TestGetProblemEntryInContest:
         _write_problem(tmp_path / 'A', 'prob-a')
 
         os.chdir(tmp_path / 'A')
-        cp_module.find_contest_yaml.cache_clear()
-        cp_module.find_contest_package.cache_clear()
 
-        token = selected_variant_id_var.set('div2')
-        try:
-            entry = naming.get_problem_entry_in_contest()
-            assert entry is not None
-            idx, problem = entry
-            assert idx == 0
-            assert problem.short_name == 'A'
-        finally:
-            selected_variant_id_var.reset(token)
-            cp_module.find_contest_yaml.cache_clear()
-            cp_module.find_contest_package.cache_clear()
+        # Autouse fixture handles the contextvar reset.
+        selected_variant_id_var.set('div2')
+        entry = naming.get_problem_entry_in_contest()
+        assert entry is not None
+        idx, problem = entry
+        assert idx == 0
+        assert problem.short_name == 'A'
 
 
 class TestRequireProblemInContest:
     @pytest.fixture(autouse=True)
-    def _clear_caches(self):
+    def _clear_state(self):
         cp_module.find_contest_yaml.cache_clear()
         cp_module.find_contest_package.cache_clear()
-        yield
-        cp_module.find_contest_yaml.cache_clear()
-        cp_module.find_contest_package.cache_clear()
+        token = selected_variant_id_var.set(None)
+        try:
+            yield
+        finally:
+            selected_variant_id_var.reset(token)
+            cp_module.find_contest_yaml.cache_clear()
+            cp_module.find_contest_package.cache_clear()
 
     def test_require_problem_in_contest_errors_when_ambiguous(
         self,
@@ -153,8 +149,6 @@ class TestRequireProblemInContest:
         _write_problem(tmp_path / 'A', 'prob-a')
 
         os.chdir(tmp_path / 'A')
-        cp_module.find_contest_yaml.cache_clear()
-        cp_module.find_contest_package.cache_clear()
 
         with pytest.raises(typer.Exit):
             naming.require_problem_in_contest()
@@ -179,12 +173,37 @@ class TestRequireProblemInContest:
         _write_problem(tmp_path / 'B', 'prob-b')
 
         os.chdir(tmp_path / 'A')
-        cp_module.find_contest_yaml.cache_clear()
-        cp_module.find_contest_package.cache_clear()
 
         idx, problem = naming.require_problem_in_contest()
         assert idx == 0
         assert problem.short_name == 'A'
+
+    def test_require_problem_in_contest_errors_when_selection_does_not_contain_problem(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        _write_dispatcher(
+            tmp_path,
+            {
+                'div1': [('B', 'B')],
+                'div2': [('A', 'A')],
+            },
+        )
+        _write_problem(tmp_path / 'A', 'prob-a')
+        _write_problem(tmp_path / 'B', 'prob-b')
+
+        os.chdir(tmp_path / 'A')
+
+        # Autouse fixture handles the contextvar reset.
+        selected_variant_id_var.set('div1')
+
+        with pytest.raises(typer.Exit):
+            naming.require_problem_in_contest()
+
+        out = capsys.readouterr().out
+        assert 'div1' in out
+        assert 'div2' in out
 
 
 class TestGetTitle:

--- a/tests/rbx/box/test_naming.py
+++ b/tests/rbx/box/test_naming.py
@@ -1,11 +1,190 @@
+import os
+import pathlib
 from unittest.mock import patch
 
 import pytest
 import typer
 
 from rbx.box import naming
+from rbx.box.contest import contest_package as cp_module
+from rbx.box.contest.contest_state import selected_variant_id_var
 from rbx.box.schema import Package
 from rbx.box.statements.schema import Statement
+
+
+def _write_problem(folder: pathlib.Path, name: str) -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / 'problem.rbx.yml').write_text(f'name: {name}\n')
+
+
+def _write_single_contest(root: pathlib.Path, problems: list[tuple[str, str]]) -> None:
+    body = '\n'.join(f'  - short_name: {sn}\n    path: {path}' for sn, path in problems)
+    (root / 'contest.rbx.yml').write_text(f'name: ctt\nproblems:\n{body}\n')
+
+
+def _write_dispatcher(
+    root: pathlib.Path, variants: dict[str, list[tuple[str, str]]]
+) -> None:
+    (root / 'contest.rbx.yml').write_text('use_variants: true\n')
+    for vid, problems in variants.items():
+        body = '\n'.join(
+            f'  - short_name: {sn}\n    path: {path}' for sn, path in problems
+        )
+        (root / f'contest.{vid}.rbx.yml').write_text(
+            f'name: {vid}-c\nproblems:\n{body}\n'
+        )
+
+
+class TestGetProblemEntryInContest:
+    @pytest.fixture(autouse=True)
+    def _clear_caches(self):
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+        yield
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+    def test_get_entry_in_single_contest_returns_entry(self, tmp_path: pathlib.Path):
+        _write_single_contest(tmp_path, [('A', 'A'), ('B', 'B')])
+        _write_problem(tmp_path / 'A', 'prob-a')
+        _write_problem(tmp_path / 'B', 'prob-b')
+
+        os.chdir(tmp_path / 'A')
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+        entry = naming.get_problem_entry_in_contest()
+        assert entry is not None
+        idx, problem = entry
+        assert idx == 0
+        assert problem.short_name == 'A'
+
+    def test_get_entry_dispatcher_problem_in_one_variant_auto_picks(
+        self, tmp_path: pathlib.Path
+    ):
+        _write_dispatcher(
+            tmp_path,
+            {
+                'div1': [('A', 'A'), ('B', 'B')],
+                'div2': [('B', 'B')],
+            },
+        )
+        _write_problem(tmp_path / 'A', 'prob-a')
+        _write_problem(tmp_path / 'B', 'prob-b')
+
+        os.chdir(tmp_path / 'A')
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+        entry = naming.get_problem_entry_in_contest()
+        assert entry is not None
+        idx, problem = entry
+        assert idx == 0
+        assert problem.short_name == 'A'
+
+    def test_get_entry_dispatcher_problem_in_two_variants_no_selection_returns_none(
+        self, tmp_path: pathlib.Path
+    ):
+        _write_dispatcher(
+            tmp_path,
+            {
+                'div1': [('A', 'A')],
+                'div2': [('A', 'A')],
+            },
+        )
+        _write_problem(tmp_path / 'A', 'prob-a')
+
+        os.chdir(tmp_path / 'A')
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+        assert naming.get_problem_entry_in_contest() is None
+
+    def test_get_entry_dispatcher_problem_in_two_variants_with_selection_returns_selected(
+        self, tmp_path: pathlib.Path
+    ):
+        _write_dispatcher(
+            tmp_path,
+            {
+                'div1': [('A', 'A')],
+                'div2': [('A', 'A')],
+            },
+        )
+        _write_problem(tmp_path / 'A', 'prob-a')
+
+        os.chdir(tmp_path / 'A')
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+        token = selected_variant_id_var.set('div2')
+        try:
+            entry = naming.get_problem_entry_in_contest()
+            assert entry is not None
+            idx, problem = entry
+            assert idx == 0
+            assert problem.short_name == 'A'
+        finally:
+            selected_variant_id_var.reset(token)
+            cp_module.find_contest_yaml.cache_clear()
+            cp_module.find_contest_package.cache_clear()
+
+
+class TestRequireProblemInContest:
+    @pytest.fixture(autouse=True)
+    def _clear_caches(self):
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+        yield
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+    def test_require_problem_in_contest_errors_when_ambiguous(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        _write_dispatcher(
+            tmp_path,
+            {
+                'div1': [('A', 'A')],
+                'div2': [('A', 'A')],
+            },
+        )
+        _write_problem(tmp_path / 'A', 'prob-a')
+
+        os.chdir(tmp_path / 'A')
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+        with pytest.raises(typer.Exit):
+            naming.require_problem_in_contest()
+
+        out = capsys.readouterr().out
+        assert '-C' in out
+        assert 'RBX_CONTEST' in out
+        assert 'div1' in out
+        assert 'div2' in out
+
+    def test_require_problem_in_contest_returns_entry_when_unique(
+        self, tmp_path: pathlib.Path
+    ):
+        _write_dispatcher(
+            tmp_path,
+            {
+                'div1': [('A', 'A'), ('B', 'B')],
+                'div2': [('B', 'B')],
+            },
+        )
+        _write_problem(tmp_path / 'A', 'prob-a')
+        _write_problem(tmp_path / 'B', 'prob-b')
+
+        os.chdir(tmp_path / 'A')
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+        idx, problem = naming.require_problem_in_contest()
+        assert idx == 0
+        assert problem.short_name == 'A'
 
 
 class TestGetTitle:

--- a/tests/rbx/box/tooling/boca/test_scraper_naming.py
+++ b/tests/rbx/box/tooling/boca/test_scraper_naming.py
@@ -1,0 +1,88 @@
+"""Verify the BOCA scraper's upload() raises the picker error in dispatcher mode.
+
+The scraper's upload() call site at scraper.py:~385 calls
+`naming.require_problem_in_contest()` after fetching the upload form. We
+exercise that path with the form-fetching layer mocked out so we don't
+need a real BOCA server.
+"""
+
+import os
+import pathlib
+from unittest import mock
+
+import pytest
+import typer
+
+from rbx.box.contest import contest_package as cp_module
+from rbx.box.contest.contest_state import selected_variant_id_var
+from rbx.box.tooling.boca.scraper import BocaScraper
+
+
+def _write_problem(folder: pathlib.Path, name: str) -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / 'problem.rbx.yml').write_text(f'name: {name}\n')
+
+
+def _write_dispatcher(
+    root: pathlib.Path, variants: dict[str, list[tuple[str, str]]]
+) -> None:
+    (root / 'contest.rbx.yml').write_text('use_variants: true\n')
+    for vid, problems in variants.items():
+        body = '\n'.join(
+            f'  - short_name: {sn}\n    path: {path}' for sn, path in problems
+        )
+        (root / f'contest.{vid}.rbx.yml').write_text(
+            f'name: {vid}-c\nproblems:\n{body}\n'
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    cp_module.find_contest_yaml.cache_clear()
+    cp_module.find_contest_package.cache_clear()
+    token = selected_variant_id_var.set(None)
+    try:
+        yield
+    finally:
+        selected_variant_id_var.reset(token)
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+
+def test_upload_errors_in_ambiguous_dispatcher(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    _write_dispatcher(
+        tmp_path,
+        {
+            'div1': [('A', 'A')],
+            'div2': [('A', 'A')],
+        },
+    )
+    _write_problem(tmp_path / 'A', 'prob-a')
+    os.chdir(tmp_path / 'A')
+
+    # Bypass __init__ so we don't need real BOCA credentials or a network.
+    scraper = BocaScraper.__new__(BocaScraper)
+    scraper.base_url = 'http://example.invalid'
+
+    # Stub out the form-fetching layer: upload() opens the admin page and
+    # selects a form before reaching the require_problem_in_contest() call.
+    fake_form = mock.MagicMock()
+    fake_form.set_all_readonly = mock.MagicMock()
+    fake_br = mock.MagicMock()
+    fake_br.form = fake_form
+    scraper.br = fake_br
+    scraper.open = mock.MagicMock(return_value=(None, ''))
+
+    file_arg = tmp_path / 'pkg.zip'
+    file_arg.write_bytes(b'')
+
+    with pytest.raises(typer.Exit):
+        scraper.upload(file_arg)
+
+    out = capsys.readouterr().out
+    assert '-C' in out
+    assert 'RBX_CONTEST' in out
+    assert 'div1' in out and 'div2' in out

--- a/tests/rbx/box/tooling/boca/test_submitter_naming.py
+++ b/tests/rbx/box/tooling/boca/test_submitter_naming.py
@@ -1,0 +1,77 @@
+"""Verify the BOCA submitter raises the picker error in dispatcher mode."""
+
+import os
+import pathlib
+from unittest import mock
+
+import pytest
+import typer
+
+from rbx.box.contest import contest_package as cp_module
+from rbx.box.contest.contest_state import selected_variant_id_var
+from rbx.box.tooling.boca import submitter
+
+
+def _write_problem(folder: pathlib.Path, name: str) -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / 'problem.rbx.yml').write_text(f'name: {name}\n')
+
+
+def _write_dispatcher(
+    root: pathlib.Path, variants: dict[str, list[tuple[str, str]]]
+) -> None:
+    (root / 'contest.rbx.yml').write_text('use_variants: true\n')
+    for vid, problems in variants.items():
+        body = '\n'.join(
+            f'  - short_name: {sn}\n    path: {path}' for sn, path in problems
+        )
+        (root / f'contest.{vid}.rbx.yml').write_text(
+            f'name: {vid}-c\nproblems:\n{body}\n'
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    cp_module.find_contest_yaml.cache_clear()
+    cp_module.find_contest_package.cache_clear()
+    token = selected_variant_id_var.set(None)
+    try:
+        yield
+    finally:
+        selected_variant_id_var.reset(token)
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.find_contest_package.cache_clear()
+
+
+def test_submit_all_solutions_errors_in_ambiguous_dispatcher(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _write_dispatcher(
+        tmp_path,
+        {
+            'div1': [('A', 'A')],
+            'div2': [('A', 'A')],
+        },
+    )
+    _write_problem(tmp_path / 'A', 'prob-a')
+    os.chdir(tmp_path / 'A')
+
+    # The submitter logs into BOCA and reads env vars — we only care that the
+    # picker error triggers before any of that matters when ambiguous.
+    monkeypatch.setenv('BOCA_BASE_URL', 'http://example.invalid')
+    monkeypatch.setenv('BOCA_JUDGE_USERNAME', 'judge')
+
+    fake_scraper = mock.MagicMock()
+    fake_scraper.loggedIn = True
+    fake_scraper.list_problems_as_judge.return_value = {'A': 1}
+
+    with pytest.raises(typer.Exit):
+        # submit_all_solutions is a generator — must consume it to trigger the
+        # body to execute.
+        list(submitter.submit_all_solutions(fake_scraper))
+
+    out = capsys.readouterr().out
+    assert '-C' in out
+    assert 'div1' in out and 'div2' in out

--- a/tests/rbx/conftest.py
+++ b/tests/rbx/conftest.py
@@ -80,6 +80,7 @@ def mock_app_path(monkeysession, tmp_path_factory):
 def _isolate_global_state() -> Iterator[None]:
     from rbx import testing_utils
     from rbx.box import package as _package
+    from rbx.box.contest import contest_state as _contest_state
     from rbx.grading import grading_context as _gc
 
     original_cwd = os.getcwd()
@@ -90,6 +91,7 @@ def _isolate_global_state() -> Iterator[None]:
         _gc.use_compression_var,
         _gc.check_integrity_var,
         _gc.is_stress_var,
+        _contest_state.selected_variant_id_var,
     ]
     snapshots = [(v, v.get()) for v in context_vars]
     try:


### PR DESCRIPTION
Closes #431. Follow-up: #432.

## Summary

A single contest directory can now back multiple `Contest` configurations sharing the underlying filesystem (statement templates, problems, assets).

- `contest.rbx.yml` is the **default contest**. Sibling `contest.<id>.rbx.yml` files (filesystem-globbed; ids match `^[A-Za-z][A-Za-z0-9_-]*$`) are **additional selectable variants**. The default and variants coexist freely.
- `use_variants: true` on `contest.rbx.yml` is a permission flag that lets the canonical file be empty. With it, all contests live in the variant siblings (no default).
- Selection: `-C <id>` (CLI flag) or `RBX_CONTEST=<id>` (env var). Materialised into `rbx.box.contest.contest_state.selected_variant_id_var`.
- `find_contest_yaml(root, contest_id=None)` consults the contextvar when no explicit id is passed; resolves to the default when no selection.
- Auto-pick: when canonical is sentinel mode and a problem belongs to exactly one variant, problem-side helpers in `naming.py` pick that variant without `-C`.
- New `rbx contest list` command — shows the default and siblings, marks the active selection.

## Design and plan

- Design: `docs/plans/2026-05-06-multi-contest-design.md`
- Plan: `docs/plans/2026-05-06-multi-contest.md`

YAML inheritance between variants (`extends:`) is deferred — variants share files on disk, YAML duplication accepted for now. `rbx contest add_variant` scaffolding is tracked at #432.

## Behavior changes worth flagging

1. **BOCA tooling now hard-errors** when invoked on a problem outside any contest (`require_problem_in_contest`). Previously failed at the BOCA lookup with a confusing "Problem  not found" message; now exits early with "No contest found for the current problem."
2. **Picker error wording is now a contract.** The string `Pass -C <id> or set RBX_CONTEST=<id>. Available contests: [...]` is shared by `find_contest_yaml`, statement-extends, packaging, and BOCA tooling. Future changes should preserve the literal `-C` and `RBX_CONTEST` substrings so users searching docs/issues find a stable token.
3. **When canonical is a real contest and the current problem isn't listed in its `problems[]`**, the user gets `None` from auto-pick (problem builds standalone). Sibling variants are NOT walked in this case — pass `-C <id>` to switch lenses. Documented inline.

## Naming surface (`rbx/box/naming.py`)

Three contracts for "what's the problem's letter?":

| Helper | Returns | When to use |
|---|---|---|
| `get_problem_shortname()` | `Optional[str]`, never errors | Cosmetic — falls back gracefully. |
| `get_problem_shortname_or_require()` | `Optional[str]`, errors when contest exists but unresolvable | Filename composition where standalone problems should still work. |
| `require_problem_in_contest()` | `Tuple[int, ContestProblem]`, always errors when not uniquely resolvable | Sites that cannot function without a letter (BOCA tooling). |

## Test Plan

- [ ] `uv run pytest --ignore=tests/rbx/box/cli -n auto` — full unit suite green (modulo two pre-existing failures unrelated to this branch).
- [ ] `uv run pytest tests/e2e/testdata/multi-contest -v` — 6 e2e scenarios.
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean.
- [ ] Manual: scaffold a real-contest-plus-variants directory locally, run `rbx contest list`, run `rbx -C div1 contest summary`, verify the default and siblings both work.

## Mechanics

24 commits, organised per-task with `feat / refactor / test` micro-stories. **Squash-merge recommended.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)