### PR TITLE
feat: show WARNINGS in compilation LiveTasks (#397)

### DIFF
--- a/docs/plans/2026-05-12-compilation-warnings-livetasks-design.md
+++ b/docs/plans/2026-05-12-compilation-warnings-livetasks-design.md
@@ -1,0 +1,142 @@
+# Design: Surface compilation warnings in Compilation LiveTasks (#397)
+
+## Problem
+
+When `rbx` compiles solutions or generators, the live progress display
+(`LiveTasks` of `CompilationTask`) shows `SUCCESS` for a compilable even when the
+compiler emitted warnings. There is no way to tell, from the live view, that a
+file compiled with warnings. The issue asks for a `WARNINGS` status to be shown
+instead of `SUCCESS` in that case.
+
+## Background: how Compilation LiveTasks work today
+
+- `rbx/box/parallel/live_tasks.py` defines the display layer. `LiveTasks` wraps a
+  `rich.live.Live`; callers `append()` `LiveTask` objects and call `update()`.
+  Each task's `render()` returns a `TaskRenderable` (columns + optional panel),
+  laid out by `TaskGrid`.
+- `CompilationTask(LiveTask)` holds a `CodeItem`, a `CompilationStatus`, and an
+  optional `exception`. `render()` returns `None` when status is `PENDING` or
+  `SUCCESS` (so finished-OK rows disappear), otherwise renders
+  `Compiling <href>...` plus the status markup, plus a cropped error panel if
+  there is an exception. `is_finished()` is true unless `PENDING`/`RUNNING`.
+- `CompilationStatus` **already has a `WARNINGS` member** with markup
+  `[warning]WARNINGS[/warning]` — it was stubbed but is never set anywhere.
+- Producers of compilation LiveTasks:
+  - `rbx/box/solutions.py::compile_solutions()` builds a `LiveTasks` of
+    `SolutionCompilationTask`, submits `compile_item` per solution through an
+    `AsyncStreamer`. Streamer callbacks set status: `scheduled→RUNNING`,
+    `succeeded→SUCCESS`, `failed→SKIPPED` (or `FAILED` when it should hard-fail).
+  - `rbx/box/generators.py::GeneratorCompilationTask` follows the same pattern.
+  - These two are the **only** LiveTasks consumers of compilation. Checker /
+    validator / interactor / visualizer also call `compile_item` but not via
+    LiveTasks — out of scope here.
+- `rbx/box/code.py::compile_item()` already detects warnings: after
+  `steps_with_caching.compile`, it inspects `artifacts.logs.preprocess[].warnings`
+  (set by `steps.py::_check_for_compilation_warnings()`, which greps compiler
+  stderr for warning lines). When `cfg.warnings.enabled or force_warnings` and any
+  preprocess log has warnings, it calls
+  `warning_stack.get_warning_stack().add_warning(code)`. That stack feeds the
+  end-of-run `print_warning_stack_report()`.
+- `compile_item` returns only the compiled digest (`str`); callers learn nothing
+  about warnings. It has ~12 call sites, so changing the return type is invasive.
+- The async executor used by the streamers is a `ThreadPoolExecutor` (same
+  process), so module-level state (`@functools.cache`, `WarningStack`) is shared
+  with the streamer callbacks — no process-boundary concerns.
+
+## Decisions
+
+- **Trigger**: show `WARNINGS` only when warning tracking is on
+  (`cfg.warnings.enabled` or `force_warnings`) — the same gate that feeds the
+  existing warning-stack report. This keeps the live view and the report
+  consistent.
+- **Detail shown**: the row shows `WARNINGS`, optionally followed by a short line
+  produced by a **pluggable, language-keyed summarizer**. The base summarizer
+  returns `None` (nothing extra shown for now). A C++ summarizer is deferred to a
+  separate issue (to be brainstormed: extracting concise lines from GCC/clang
+  output).
+- **Scope**: solutions + generators compilation LiveTasks only.
+- **Summarizer location**: its own module — `rbx/box/sanitizers/compilation_warnings.py`
+  (co-located with `warning_stack.py`, which already handles compilation- and
+  sanitizer-warning bookkeeping). Not in `live_tasks.py`.
+
+## Changes
+
+1. **`rbx/box/sanitizers/warning_stack.py`** — also stash the compiler logs that
+   triggered each warning:
+   - Add `warning_logs: Dict[pathlib.Path, List[PreprocessLog]]` to `WarningStack`.
+   - `add_warning(code, logs: Optional[List[PreprocessLog]] = None)` stores the
+     subset of preprocess logs with `.warnings == True`.
+   - `clear()` clears `warning_logs` too.
+   - Import `PreprocessLog` from `rbx.grading.steps`.
+
+2. **`rbx/box/code.py::compile_item()`** — at the existing warning-detection site,
+   pass the warning-bearing preprocess logs into `add_warning(code, logs=...)`. No
+   signature/return-type change; all existing callers untouched.
+
+3. **`rbx/box/sanitizers/compilation_warnings.py`** (new):
+   ```python
+   class CompilationWarningSummarizer:
+       """Given the compiler logs that produced warnings, return a short line
+       to show next to 'WARNINGS' in the live view, or None."""
+
+       def summarize(self, logs: List[PreprocessLog]) -> Optional[str]:
+           return None
+
+   _DEFAULT_SUMMARIZER = CompilationWarningSummarizer()
+   # Per-language summarizers register here. C++ summarizer is deferred to a
+   # separate issue (extracting concise lines from GCC/clang output).
+   _SUMMARIZERS: Dict[str, CompilationWarningSummarizer] = {}
+
+   def get_compilation_warning_summarizer(language: str) -> CompilationWarningSummarizer:
+       return _SUMMARIZERS.get(language, _DEFAULT_SUMMARIZER)
+   ```
+
+4. **`rbx/box/parallel/live_tasks.py::CompilationTask`** — add
+   `warning_summary: Optional[str] = None`. In `render()`, when `status ==
+   WARNINGS` and `warning_summary` is set, append ` ({warning_summary})` (warning
+   style) to the status text. `CompilationStatus.markup()` is unchanged.
+
+5. **Streamer callbacks** — `solutions.py::SolutionCompilationStreamer.succeeded`
+   and the equivalent in `generators.py`:
+   - After a successful compile, if `code.path in
+     warning_stack.get_warning_stack().warnings`:
+     - `key.status = CompilationStatus.WARNINGS`
+     - `language = find_language_name(key.item)`
+     - `logs = warning_stack.get_warning_stack().warning_logs.get(code.path, [])`
+     - `key.warning_summary = get_compilation_warning_summarizer(language).summarize(logs)`
+   - Otherwise `key.status = CompilationStatus.SUCCESS` as before.
+   - `SolutionCompilationTask.render()`'s existing `SKIPPED` override is kept;
+     `WARNINGS` flows through the base `render()`.
+
+6. **Follow-up issue** — file a new GitHub issue: "Implement C++ compilation-warning
+   summarizer — extract concise lines from GCC/clang output", and reference it in a
+   comment near `_SUMMARIZERS` / `_DEFAULT_SUMMARIZER`.
+
+## Data flow
+
+`compile_item` → `steps_with_caching.compile` populates
+`artifacts.logs.preprocess[].warnings` → if tracking on,
+`WarningStack.add_warning(code, logs)` → streamer `succeeded()` reads the stack →
+sets task status `WARNINGS` + summary → `LiveTasks.update()` re-renders the row.
+
+## Known limitation (out of scope)
+
+If a compilation is served from the dependency cache, `artifacts.logs.preprocess`
+may be absent, so warnings won't be re-detected on cached runs — pre-existing for
+the warning-stack report too. A future option is to persist `has_warnings` (and a
+summary) in `CompilationMetadata`. Not part of this change.
+
+## Testing
+
+- Add a fixture compilable that triggers a real compiler warning (e.g. an unused
+  variable) and a setter config with `warnings.enabled: true`.
+- `compile_solutions()` over that fixture → task status is `WARNINGS`. With
+  `warnings.enabled: false` → `SUCCESS`.
+- Same for the generator compilation path.
+- `WarningStack.add_warning` records logs; `clear()` resets `warning_logs`.
+- `CompilationWarningSummarizer` base returns `None`;
+  `get_compilation_warning_summarizer("cpp")` returns the default for now.
+- `CompilationTask.render()`: plain `WARNINGS` when `warning_summary is None`,
+  `WARNINGS (...)` when set.
+- Reuse `cleandir_with_testdata` / existing compilation fixtures; add a small
+  `testdata/` compilable with an unused-variable warning if needed.

--- a/docs/plans/2026-05-12-compilation-warnings-livetasks.md
+++ b/docs/plans/2026-05-12-compilation-warnings-livetasks.md
@@ -1,0 +1,514 @@
+# Compilation Warnings in LiveTasks — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Show `WARNINGS` (instead of `SUCCESS`) for a solution/generator row in the compilation LiveTasks display when the compiler emitted warnings and warning tracking is enabled, with an optional pluggable language-specific summary line.
+
+**Architecture:** `compile_item` already detects compiler warnings via `artifacts.logs.preprocess[].warnings` and records them in `WarningStack` when `cfg.warnings.enabled`. We (1) extend `WarningStack` to also keep the warning-bearing `PreprocessLog`s per path, (2) add a tiny pluggable `CompilationWarningSummarizer` registry in a new module, (3) add a `warning_summary` field to `CompilationTask` and render it next to `WARNINGS`, and (4) flip the streamer callbacks in `solutions.py`/`generators.py` to set `WARNINGS` + the summary when the path is in the warning stack. `compile_item`'s signature/return type does not change.
+
+**Tech Stack:** Python 3, Pydantic v2, `rich`, pytest. Project commands: `uv run pytest ...`, `uv run ruff check . && uv run ruff format .`. Commits MUST follow conventional commits — use the `/commit` skill (`.claude/skills/commit.md`); every commit message ends with the `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer.
+
+**Reference docs to skim first:** `docs/plans/2026-05-12-compilation-warnings-livetasks-design.md`, `rbx/box/CLAUDE.md` (sections "Code Compilation", "Global State" — note the test-isolation rule for `@functools.cache`), `rbx/box/parallel/live_tasks.py`, `rbx/box/sanitizers/warning_stack.py`, `rbx/box/code.py` (around line 710).
+
+---
+
+## Task 1: Stash warning-bearing logs in `WarningStack`
+
+**Files:**
+- Modify: `rbx/box/sanitizers/warning_stack.py`
+- Test: `tests/rbx/box/sanitizers/warning_stack_test.py` (create; check whether `tests/rbx/box/sanitizers/` already has test files and match the existing naming convention — `*_test.py` vs `test_*.py`)
+
+**Context:** `WarningStack` currently holds `self.warnings: set` (paths of code items that compiled with warnings) and `self.sanitizer_warnings: dict`. `add_warning(self, code: CodeItem)` does `self.warnings.add(code.path)`. `clear()` clears both. We add a parallel dict mapping `code.path -> List[PreprocessLog]`.
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/sanitizers/warning_stack_test.py
+import pathlib
+
+from rbx.box.schema import CodeItem
+from rbx.box.sanitizers.warning_stack import WarningStack
+from rbx.grading.steps import PreprocessLog
+
+
+def _log(warnings: bool) -> PreprocessLog:
+    return PreprocessLog(cmd=['g++', 'a.cpp'], log='some warning text', warnings=warnings)
+
+
+def test_add_warning_records_path_and_logs(tmp_path: pathlib.Path):
+    stack = WarningStack(tmp_path)
+    code = CodeItem(path=pathlib.Path('sols/a.cpp'), language='cpp')
+    logs = [_log(True)]
+
+    stack.add_warning(code, logs=logs)
+
+    assert code.path in stack.warnings
+    assert stack.warning_logs[code.path] == logs
+
+
+def test_add_warning_without_logs_still_records_path(tmp_path: pathlib.Path):
+    stack = WarningStack(tmp_path)
+    code = CodeItem(path=pathlib.Path('sols/a.cpp'), language='cpp')
+
+    stack.add_warning(code)
+
+    assert code.path in stack.warnings
+    assert stack.warning_logs.get(code.path) in (None, [])
+
+
+def test_clear_resets_warning_logs(tmp_path: pathlib.Path):
+    stack = WarningStack(tmp_path)
+    code = CodeItem(path=pathlib.Path('sols/a.cpp'), language='cpp')
+    stack.add_warning(code, logs=[_log(True)])
+
+    stack.clear()
+
+    assert not stack.warnings
+    assert not stack.warning_logs
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/sanitizers/warning_stack_test.py -v`
+Expected: FAIL — `WarningStack` has no `warning_logs` attribute / `add_warning()` got an unexpected keyword argument `logs`.
+
+**Step 3: Implement**
+
+In `rbx/box/sanitizers/warning_stack.py`:
+- Add import: `from typing import Dict, List, Optional` (merge with existing imports) and `from rbx.grading.steps import GradingFileOutput, PreprocessLog` (extend the existing `from rbx.grading.steps import GradingFileOutput`).
+- In `__init__`: add `self.warning_logs: Dict[pathlib.Path, List[PreprocessLog]] = {}`.
+- Change signature/body of `add_warning`:
+  ```python
+  def add_warning(
+      self, code: CodeItem, logs: Optional[List[PreprocessLog]] = None
+  ):
+      self.warnings.add(code.path)
+      if logs:
+          self.warning_logs[code.path] = logs
+  ```
+- In `clear()`: add `self.warning_logs.clear()`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/sanitizers/warning_stack_test.py -v`
+Expected: PASS (3 tests).
+
+Also run: `uv run ruff check rbx/box/sanitizers/warning_stack.py` — Expected: clean.
+
+**Step 5: Commit** (use the `/commit` skill)
+
+```
+feat(sanitizers): stash warning logs in WarningStack
+```
+
+---
+
+## Task 2: New `CompilationWarningSummarizer` module
+
+**Files:**
+- Create: `rbx/box/sanitizers/compilation_warnings.py`
+- Test: `tests/rbx/box/sanitizers/compilation_warnings_test.py`
+
+**Context:** A pluggable, language-keyed object that turns the warning-bearing `PreprocessLog`s into one short string shown next to `WARNINGS`. For now the base returns `None` and the registry is empty (so every language gets the base). A C++ implementation is intentionally deferred to a follow-up issue (see Task 6).
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/sanitizers/compilation_warnings_test.py
+from rbx.box.sanitizers.compilation_warnings import (
+    CompilationWarningSummarizer,
+    get_compilation_warning_summarizer,
+)
+from rbx.grading.steps import PreprocessLog
+
+
+def _log() -> PreprocessLog:
+    return PreprocessLog(cmd=['g++', 'a.cpp'], log='a.cpp:1:1: warning: x', warnings=True)
+
+
+def test_base_summarizer_returns_none():
+    assert CompilationWarningSummarizer().summarize([_log()]) is None
+
+
+def test_get_summarizer_returns_base_for_unknown_language():
+    summarizer = get_compilation_warning_summarizer('cpp')
+    assert isinstance(summarizer, CompilationWarningSummarizer)
+    assert summarizer.summarize([_log()]) is None
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/sanitizers/compilation_warnings_test.py -v`
+Expected: FAIL — `ModuleNotFoundError: rbx.box.sanitizers.compilation_warnings`.
+
+**Step 3: Implement**
+
+```python
+# rbx/box/sanitizers/compilation_warnings.py
+from typing import Dict, List, Optional
+
+from rbx.grading.steps import PreprocessLog
+
+
+class CompilationWarningSummarizer:
+    """Turns the compiler logs that produced warnings into a short, single-line
+    summary to show next to the ``WARNINGS`` status in the compilation live view.
+
+    The base implementation returns ``None`` (no extra line). Language-specific
+    subclasses register themselves in ``_SUMMARIZERS``.
+    """
+
+    def summarize(self, logs: List[PreprocessLog]) -> Optional[str]:
+        return None
+
+
+_DEFAULT_SUMMARIZER = CompilationWarningSummarizer()
+
+# Per-language summarizers register here, keyed by the language name returned by
+# ``rbx.box.code.find_language_name``. A C++ summarizer that extracts concise
+# lines from GCC/clang output is deferred to a separate issue (see the plan /
+# the linked GitHub issue) and should be brainstormed before implementing.
+_SUMMARIZERS: Dict[str, CompilationWarningSummarizer] = {}
+
+
+def get_compilation_warning_summarizer(language: str) -> CompilationWarningSummarizer:
+    return _SUMMARIZERS.get(language, _DEFAULT_SUMMARIZER)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/sanitizers/compilation_warnings_test.py -v` — Expected: PASS (2 tests).
+Run: `uv run ruff check rbx/box/sanitizers/compilation_warnings.py` — Expected: clean.
+
+**Step 5: Commit** (use the `/commit` skill)
+
+```
+feat(sanitizers): add pluggable compilation warning summarizer
+```
+
+---
+
+## Task 3: Render `warning_summary` on `CompilationTask`
+
+**Files:**
+- Modify: `rbx/box/parallel/live_tasks.py` (`CompilationTask`, ~lines 155-187)
+- Test: `tests/rbx/box/parallel/live_tasks_test.py` (create; if `tests/rbx/box/parallel/` does not exist, create it with an empty `__init__.py` only if sibling test dirs have one — check `tests/rbx/box/sanitizers/`)
+
+**Context:** `CompilationTask` has fields `item`, `status`, `exception`. `render()` returns `None` for `PENDING`/`SUCCESS`, otherwise a `TaskRenderable` with `columns=[Text("Compiling <href>..."), Text(status.markup())]` plus an optional exception panel. `CompilationStatus.WARNINGS.markup()` is `'[warning]WARNINGS[/warning]'`. We add an optional `warning_summary` and, when present and status is `WARNINGS`, append ` (<summary>)` to the status column text.
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/parallel/live_tasks_test.py
+from rbx.box.parallel import live_tasks
+from rbx.box.schema import CodeItem
+
+
+def _task(status: live_tasks.CompilationStatus, summary=None) -> live_tasks.CompilationTask:
+    task = live_tasks.CompilationTask(CodeItem(path='sols/a.cpp', language='cpp'))
+    task.status = status
+    task.warning_summary = summary
+    return task
+
+
+def test_success_renders_nothing():
+    assert _task(live_tasks.CompilationStatus.SUCCESS).render() is None
+
+
+def test_warnings_without_summary_shows_plain_label():
+    rendered = _task(live_tasks.CompilationStatus.WARNINGS).render()
+    assert rendered is not None
+    assert rendered.columns[1].plain == 'WARNINGS'
+
+
+def test_warnings_with_summary_appends_it():
+    rendered = _task(
+        live_tasks.CompilationStatus.WARNINGS, summary='3 warnings'
+    ).render()
+    assert rendered is not None
+    assert rendered.columns[1].plain == 'WARNINGS (3 warnings)'
+
+
+def test_warning_summary_ignored_when_not_warnings_status():
+    rendered = _task(live_tasks.CompilationStatus.FAILED, summary='x').render()
+    assert rendered is not None
+    assert rendered.columns[1].plain == 'FAILED'
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/parallel/live_tasks_test.py -v`
+Expected: FAIL — `CompilationTask` has no attribute `warning_summary` (and/or the summary assertion fails).
+
+**Step 3: Implement**
+
+In `rbx/box/parallel/live_tasks.py`, `CompilationTask`:
+- Add class attribute `warning_summary: Optional[str] = None` next to `exception`.
+- In `render()`, build the status column with the optional suffix:
+  ```python
+  status_text = Text.from_markup(self.status.markup())
+  if self.status is CompilationStatus.WARNINGS and self.warning_summary:
+      status_text.append(f' ({self.warning_summary})', style='warning')
+  return TaskRenderable(
+      columns=[
+          Text.from_markup(f'[info]Compiling {self.item.href()}...[/info]'),
+          status_text,
+      ],
+      panel=...,  # unchanged
+  )
+  ```
+  (`Text` is already imported in this module.)
+
+Note: `SolutionCompilationTask.render()` in `solutions.py` calls `super().render()` then, only for `SKIPPED`, replaces `columns[1]`. Leave that as-is — `WARNINGS` flows through unchanged.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/parallel/live_tasks_test.py -v` — Expected: PASS (4 tests).
+Run: `uv run ruff check rbx/box/parallel/live_tasks.py` — Expected: clean.
+
+**Step 5: Commit** (use the `/commit` skill)
+
+```
+feat(parallel): render compilation warning summary in LiveTasks
+```
+
+---
+
+## Task 4: `compile_item` passes warning logs to the stack
+
+**Files:**
+- Modify: `rbx/box/code.py` (the "Write compiler warnings." block, ~lines 710-719)
+- Test: `tests/rbx/box/code_compile_test.py` (add a test to the existing `TestCompileItem` class, or a new test module if cleaner)
+
+**Context:** Today:
+```python
+# Write compiler warnings.
+cfg = setter_config.get_setter_config()
+if (
+    (cfg.warnings.enabled or force_warnings)
+    and artifacts.logs is not None
+    and artifacts.logs.preprocess is not None
+):
+    any_warning = any(log.warnings for log in artifacts.logs.preprocess)
+    if any_warning:
+        warning_stack.get_warning_stack().add_warning(code)
+```
+We change the last two lines to also forward the warning-bearing logs.
+
+**Step 1: Write the failing test**
+
+The existing `TestCompileItem` mocks `rbx.box.code.steps_with_caching.compile`. Add a variant that also populates `artifacts.logs.preprocess`, force warnings on, and assert the stack got the logs. Sketch:
+
+```python
+async def test_compile_records_warning_logs_when_warnings_enabled(
+    self, testing_pkg, monkeypatch
+):
+    from rbx.box import setter_config
+    from rbx.box.sanitizers import warning_stack
+    from rbx.grading import steps
+    from rbx.grading.steps import GradingLogsHolder, PreprocessLog
+
+    cpp_file = testing_pkg.add_file('solution.cpp', src='compile_test/simple.cpp')
+    code_item = CodeItem(path=cpp_file, language='cpp')
+
+    warning_log = PreprocessLog(
+        cmd=['g++', 'solution.cpp'],
+        log='solution.cpp:1:1: warning: unused variable',
+        warnings=True,
+    )
+
+    async def compile_side_effect(commands, params, artifacts, sandbox, dependency_cache):
+        for output in artifacts.outputs:
+            if output.digest is not None:
+                output.digest.value = await package.get_file_cacher().put_file_content(b'x')
+        artifacts.logs = GradingLogsHolder(preprocess=[warning_log])
+        return True
+
+    monkeypatch.setattr('rbx.box.code.steps_with_caching.compile', mock.AsyncMock(side_effect=compile_side_effect))
+    # Ensure warnings tracking is on regardless of repo setter config.
+    cfg = setter_config.get_setter_config()
+    monkeypatch.setattr(cfg.warnings, 'enabled', True)
+
+    warning_stack.get_warning_stack().clear()
+    await code.compile_item(code_item)
+
+    stack = warning_stack.get_warning_stack()
+    assert code_item.path in stack.warnings
+    assert stack.warning_logs[code_item.path] == [warning_log]
+```
+
+Notes for the implementer:
+- `simple.cpp` already exists under the testdata used by `code_compile_test.py` (it's referenced as `compile_test/simple.cpp`); reuse it. We do NOT need it to actually emit a warning — the mock injects the warning log.
+- The autouse `mock_steps_with_caching` fixture in `TestCompileItem` already patches `compile`; you can instead override `artifacts.logs` inside that fixture's side effect for this test, or put this test outside `TestCompileItem` with its own mock. Pick whichever is least disruptive; don't fight the existing fixtures.
+- `mock_precompile_header` autouse fixture handles `_precompile_header`.
+- The `_isolate_global_state` autouse fixture clears `@functools.cache`d state between tests, so the warning stack starts empty — the explicit `.clear()` is belt-and-suspenders.
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/code_compile_test.py -k warning_logs -v`
+Expected: FAIL — `stack.warning_logs[code_item.path]` raises `KeyError` (Task 1 stores logs only when `add_warning` is *called with* `logs=`, which `compile_item` does not do yet).
+
+**Step 3: Implement**
+
+In `rbx/box/code.py`, change the warnings block to:
+```python
+if (
+    (cfg.warnings.enabled or force_warnings)
+    and artifacts.logs is not None
+    and artifacts.logs.preprocess is not None
+):
+    warning_logs = [log for log in artifacts.logs.preprocess if log.warnings]
+    if warning_logs:
+        warning_stack.get_warning_stack().add_warning(code, logs=warning_logs)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/code_compile_test.py -k warning_logs -v` — Expected: PASS.
+Run the whole compile test module to be safe: `uv run pytest tests/rbx/box/code_compile_test.py -v` — Expected: PASS.
+
+**Step 5: Commit** (use the `/commit` skill)
+
+```
+feat(code): forward compiler warning logs to the warning stack
+```
+
+---
+
+## Task 5: Set `WARNINGS` status in the compilation streamers
+
+**Files:**
+- Modify: `rbx/box/solutions.py` (`SolutionCompilationStreamer.succeeded`, ~lines 305-307; imports near top)
+- Modify: `rbx/box/generators.py` (`GeneratorCompilationStreamer.succeeded`, ~lines 313-317; imports near top)
+- Test: `tests/rbx/box/solutions_compile_warnings_test.py` (create) — and ideally a parallel one for generators, or extend `tests/rbx/box/generators_test.py`.
+
+**Context:** Each streamer's `succeeded(self, key, value)` currently records the digest and sets `key.status = CompilationStatus.SUCCESS`. We add: if the compiled item's path is in the warning stack, set `WARNINGS` and compute the summary via the language summarizer fed with the stashed logs. Factor the shared logic into one helper to keep it DRY.
+
+Add a helper (put it in `rbx/box/parallel/live_tasks.py` since it operates on a `CompilationTask`, OR — to avoid `live_tasks.py` importing `code.py`/`warning_stack` — put it in `rbx/box/sanitizers/compilation_warnings.py` and import `find_language_name` lazily inside it). Recommended: add to `compilation_warnings.py`:
+
+```python
+def apply_warning_status(task: 'CompilationTask') -> None:
+    """If ``task.item`` compiled with warnings (per the warning stack), flip the
+    task to WARNINGS and attach a language-specific summary line."""
+    from rbx.box.code import find_language_name
+    from rbx.box.parallel.live_tasks import CompilationStatus
+    from rbx.box.sanitizers import warning_stack
+
+    stack = warning_stack.get_warning_stack()
+    if task.item.path not in stack.warnings:
+        return
+    task.status = CompilationStatus.WARNINGS
+    logs = stack.warning_logs.get(task.item.path, [])
+    language = find_language_name(task.item)
+    task.warning_summary = get_compilation_warning_summarizer(language).summarize(logs)
+```
+
+(Use a `TYPE_CHECKING` import or string annotation for `CompilationTask` to avoid a real import cycle; the runtime imports inside the function body are deliberate.)
+
+Then in `solutions.py::SolutionCompilationStreamer.succeeded`:
+```python
+async def succeeded(self, key: SolutionCompilationTask, value: str) -> None:
+    compiled_solutions[key.solution.path] = value
+    key.status = live_tasks.CompilationStatus.SUCCESS
+    compilation_warnings.apply_warning_status(key)
+```
+and the analogous change in `generators.py::GeneratorCompilationStreamer.succeeded` (after `key.status = live_tasks.CompilationStatus.SUCCESS`). Add `from rbx.box.sanitizers import compilation_warnings` imports to both modules.
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/solutions_compile_warnings_test.py
+from unittest import mock
+
+import pytest
+
+from rbx.box import code, package, solutions
+from rbx.box.parallel import live_tasks
+from rbx.box.sanitizers import warning_stack
+from rbx.box.testing import testing_package
+from rbx.grading.steps import GradingLogsHolder, PreprocessLog
+
+
+async def _compile_with(testing_pkg, *, emit_warning: bool, warnings_enabled: bool):
+    from rbx.box import setter_config
+
+    testing_pkg.add_solution('sol.cpp', src='compile_test/simple.cpp', outcome='accepted')
+    testing_pkg.save()  # adjust to the actual TestingPackage API used elsewhere
+
+    warning_log = PreprocessLog(
+        cmd=['g++', 'sol.cpp'], log='sol.cpp:1:1: warning: x', warnings=True
+    )
+
+    async def compile_side_effect(commands, params, artifacts, sandbox, dependency_cache):
+        for output in artifacts.outputs:
+            if output.digest is not None:
+                output.digest.value = await package.get_file_cacher().put_file_content(b'x')
+        artifacts.logs = GradingLogsHolder(
+            preprocess=[warning_log] if emit_warning else []
+        )
+        return True
+
+    cfg = setter_config.get_setter_config()
+    with mock.patch('rbx.box.code.steps_with_caching.compile', mock.AsyncMock(side_effect=compile_side_effect)), \
+         mock.patch('rbx.box.code._precompile_header'), \
+         mock.patch.object(cfg.warnings, 'enabled', warnings_enabled):
+        warning_stack.get_warning_stack().clear()
+        # Capture the task by patching SolutionCompilationTask, or re-create
+        # compile_solutions to expose tasks. Simplest: call compile_solutions and
+        # then inspect... it does not return tasks. Instead, drive the streamer
+        # directly OR add a small seam. Recommended approach: assert via the
+        # warning stack + a direct call to compilation_warnings.apply_warning_status
+        # on a fresh SolutionCompilationTask.
+        ...
+```
+
+Practical guidance for the implementer: `compile_solutions()` does not return the `LiveTask` objects, so the cleanest test is two-layered:
+1. **Unit test `compilation_warnings.apply_warning_status`** directly: seed `warning_stack.get_warning_stack().add_warning(code, logs=[...])`, build a `SolutionCompilationTask(solution)`, call `apply_warning_status(task)`, assert `task.status is CompilationStatus.WARNINGS` and `task.warning_summary is None` (base summarizer). Also assert that when the path is *not* in the stack, status is left untouched.
+2. **Integration smoke test**: run `compile_solutions([...])` end to end with the mocked `compile` that injects a warning log + `warnings.enabled=True`, and assert it returns normally and the warning stack contains the solution path (this proves `compile_item` → stack wiring works inside the streamer flow). You generally cannot easily assert the task status from outside without a seam — don't add one unless trivial; the unit test in (1) covers the status logic.
+
+Match `tests/rbx/box/conftest.py` fixtures (`testing_pkg`, `testing_pkg_from_testdata`) and the `TestingPackage` API used in `solutions_test.py` / `code_compile_test.py` for adding solutions — mirror an existing test rather than guessing the API.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/solutions_compile_warnings_test.py -v`
+Expected: FAIL — `compilation_warnings.apply_warning_status` does not exist / `compilation_warnings` not importable from streamers.
+
+**Step 3: Implement** — as described in Context above (helper in `compilation_warnings.py`; call it from both streamers' `succeeded`; add imports).
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/solutions_compile_warnings_test.py tests/rbx/box/generators_test.py -v` — Expected: PASS.
+Run the broader suite touched by this change:
+`uv run pytest tests/rbx/box/code_compile_test.py tests/rbx/box/solutions_test.py tests/rbx/box/generators_test.py tests/rbx/box/sanitizers tests/rbx/box/parallel -v` — Expected: PASS.
+Run: `uv run ruff check . && uv run ruff format --check .` — Expected: clean.
+
+**Step 5: Commit** (use the `/commit` skill)
+
+```
+feat(box): show WARNINGS in compilation LiveTasks (#397)
+```
+
+---
+
+## Task 6: File the C++ summarizer follow-up issue
+
+**Not a code change.** Create a GitHub issue in `rsalesc/rbx` titled roughly:
+
+> Implement C++ compilation-warning summarizer (extract concise lines from GCC/clang output)
+
+Body: link issue #397 and `docs/plans/2026-05-12-compilation-warnings-livetasks.md`; note that `rbx/box/sanitizers/compilation_warnings.py` has a pluggable `CompilationWarningSummarizer` registry (`_SUMMARIZERS`) with only the no-op base implementation, and that designing how to distill GCC/clang warning output into a one-line summary deserves its own brainstorm. Use:
+
+```bash
+gh issue create --repo rsalesc/rbx --title "..." --body "..."
+```
+
+Then update the comment near `_SUMMARIZERS` in `compilation_warnings.py` to reference the new issue number, and commit (`docs(sanitizers): link C++ warning summarizer follow-up issue` — use the `/commit` skill).
+
+---
+
+## Final verification
+
+- `uv run pytest --ignore=tests/rbx/box/cli` — full suite green.
+- `uv run ruff check . && uv run ruff format --check .` — clean.
+- Manual smoke (optional): in a sample package, add `-Wall`-triggering code to a solution, set `warnings.enabled: true` in the setter config, run `rbx build` / `rbx run`, and confirm the solution row shows `WARNINGS` and stays visible; with `warnings.enabled: false` it shows `SUCCESS` (row disappears) as before.
+- Confirm `git log` shows conventional-commit messages each ending with the `Co-Authored-By:` trailer.

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -716,9 +716,9 @@ async def compile_item(
             and artifacts.logs is not None
             and artifacts.logs.preprocess is not None
         ):
-            any_warning = any(log.warnings for log in artifacts.logs.preprocess)
-            if any_warning:
-                warning_stack.get_warning_stack().add_warning(code)
+            warning_logs = [log for log in artifacts.logs.preprocess if log.warnings]
+            if warning_logs:
+                warning_stack.get_warning_stack().add_warning(code, logs=warning_logs)
 
         # Create sentinel to indicate this executable is sanitized.
         cacher = package.get_file_cacher()

--- a/rbx/box/generators.py
+++ b/rbx/box/generators.py
@@ -21,6 +21,7 @@ from rbx.box.environment import VerificationLevel
 from rbx.box.exception import RbxException
 from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
 from rbx.box.parallel import live_tasks
+from rbx.box.sanitizers import compilation_warnings
 from rbx.box.schema import (
     CodeItem,
     GeneratorCall,
@@ -315,6 +316,7 @@ async def compile_generators(
             ) -> None:
                 generator_to_compiled_digest[key.generator_name] = value
                 key.status = live_tasks.CompilationStatus.SUCCESS
+                compilation_warnings.apply_warning_status(key)
 
             async def failed(
                 self, key: GeneratorCompilationTask, exception: BaseException

--- a/rbx/box/parallel/live_tasks.py
+++ b/rbx/box/parallel/live_tasks.py
@@ -156,6 +156,7 @@ class CompilationTask(LiveTask):
     item: CodeItem
     status: CompilationStatus
     exception: Optional[RbxException] = None
+    warning_summary: Optional[str] = None
 
     def __init__(self, item: CodeItem) -> None:
         self.item = item
@@ -164,12 +165,15 @@ class CompilationTask(LiveTask):
     def render(self) -> Optional[TaskRenderable]:
         if self.status in (CompilationStatus.PENDING, CompilationStatus.SUCCESS):
             return None
+        status_text = Text.from_markup(self.status.markup())
+        if self.status is CompilationStatus.WARNINGS and self.warning_summary:
+            status_text.append(f' ({self.warning_summary})', style='warning')
         return TaskRenderable(
             columns=[
                 Text.from_markup(
                     f'[info]Compiling {self.item.href()}...[/info]',
                 ),
-                Text.from_markup(self.status.markup()),
+                status_text,
             ],
             panel=self.exception.cropped(
                 max_lines=15,

--- a/rbx/box/sanitizers/compilation_warnings.py
+++ b/rbx/box/sanitizers/compilation_warnings.py
@@ -1,0 +1,28 @@
+from typing import Dict, List, Optional
+
+from rbx.grading.steps import PreprocessLog
+
+
+class CompilationWarningSummarizer:
+    """Turns the compiler logs that produced warnings into a short, single-line
+    summary to show next to the ``WARNINGS`` status in the compilation live view.
+
+    The base implementation returns ``None`` (no extra line). Language-specific
+    subclasses register themselves in ``_SUMMARIZERS``.
+    """
+
+    def summarize(self, logs: List[PreprocessLog]) -> Optional[str]:
+        return None
+
+
+_DEFAULT_SUMMARIZER = CompilationWarningSummarizer()
+
+# Per-language summarizers register here, keyed by the language name returned by
+# ``rbx.box.code.find_language_name``. A C++ summarizer that extracts concise
+# lines from GCC/clang output is deferred to a separate issue (see issue #397 /
+# the linked follow-up) and should be brainstormed before implementing.
+_SUMMARIZERS: Dict[str, CompilationWarningSummarizer] = {}
+
+
+def get_compilation_warning_summarizer(language: str) -> CompilationWarningSummarizer:
+    return _SUMMARIZERS.get(language, _DEFAULT_SUMMARIZER)

--- a/rbx/box/sanitizers/compilation_warnings.py
+++ b/rbx/box/sanitizers/compilation_warnings.py
@@ -22,8 +22,8 @@ _DEFAULT_SUMMARIZER = CompilationWarningSummarizer()
 
 # Per-language summarizers register here, keyed by the language name returned by
 # ``rbx.box.code.find_language_name``. A C++ summarizer that extracts concise
-# lines from GCC/clang output is deferred to a separate issue (see issue #397 /
-# the linked follow-up) and should be brainstormed before implementing.
+# lines from GCC/clang output is deferred to a separate issue (#446) and should
+# be brainstormed before implementing.
 _SUMMARIZERS: Dict[str, CompilationWarningSummarizer] = {}
 
 

--- a/rbx/box/sanitizers/compilation_warnings.py
+++ b/rbx/box/sanitizers/compilation_warnings.py
@@ -1,6 +1,9 @@
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from rbx.grading.steps import PreprocessLog
+
+if TYPE_CHECKING:
+    from rbx.box.parallel.live_tasks import CompilationTask
 
 
 class CompilationWarningSummarizer:
@@ -26,3 +29,24 @@ _SUMMARIZERS: Dict[str, CompilationWarningSummarizer] = {}
 
 def get_compilation_warning_summarizer(language: str) -> CompilationWarningSummarizer:
     return _SUMMARIZERS.get(language, _DEFAULT_SUMMARIZER)
+
+
+def apply_warning_status(task: 'CompilationTask') -> None:
+    """If ``task.item`` compiled with warnings (per the warning stack), flip the
+    task to ``WARNINGS`` and attach a language-specific summary line.
+
+    The cross-module imports are intentionally done lazily inside the function
+    body to avoid an import cycle (``live_tasks.py`` must not import ``code.py``
+    or ``warning_stack``).
+    """
+    from rbx.box.code import find_language_name
+    from rbx.box.parallel.live_tasks import CompilationStatus
+    from rbx.box.sanitizers import warning_stack
+
+    stack = warning_stack.get_warning_stack()
+    if task.item.path not in stack.warnings:
+        return
+    task.status = CompilationStatus.WARNINGS
+    logs = stack.warning_logs.get(task.item.path, [])
+    language = find_language_name(task.item)
+    task.warning_summary = get_compilation_warning_summarizer(language).summarize(logs)

--- a/rbx/box/sanitizers/warning_stack.py
+++ b/rbx/box/sanitizers/warning_stack.py
@@ -1,22 +1,26 @@
 import functools
 import pathlib
 import shutil
+from typing import Dict, List, Optional
 
 from rbx import console, utils
 from rbx.box.formatting import href
 from rbx.box.schema import CodeItem
 from rbx.grading.judge.cacher import FileCacher
-from rbx.grading.steps import GradingFileOutput
+from rbx.grading.steps import GradingFileOutput, PreprocessLog
 
 
 class WarningStack:
     def __init__(self, root: pathlib.Path):
         self.root = root
         self.warnings = set()
+        self.warning_logs: Dict[pathlib.Path, List[PreprocessLog]] = {}
         self.sanitizer_warnings = {}
 
-    def add_warning(self, code: CodeItem):
+    def add_warning(self, code: CodeItem, logs: Optional[List[PreprocessLog]] = None):
         self.warnings.add(code.path)
+        if logs:
+            self.warning_logs[code.path] = logs
 
     async def add_sanitizer_warning(
         self, cacher: FileCacher, code: CodeItem, reference: GradingFileOutput
@@ -37,6 +41,7 @@ class WarningStack:
 
     def clear(self):
         self.warnings.clear()
+        self.warning_logs.clear()
         self.sanitizer_warnings.clear()
 
 

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -51,7 +51,7 @@ from rbx.box.generators import (
 )
 from rbx.box.parallel import live_tasks
 from rbx.box.rendering import CellSlot, Throttling
-from rbx.box.sanitizers import issue_stack
+from rbx.box.sanitizers import compilation_warnings, issue_stack
 from rbx.box.schema import (
     ExpectedOutcome,
     GeneratorCall,
@@ -305,6 +305,7 @@ async def compile_solutions(
             async def succeeded(self, key: SolutionCompilationTask, value: str) -> None:
                 compiled_solutions[key.solution.path] = value
                 key.status = live_tasks.CompilationStatus.SUCCESS
+                compilation_warnings.apply_warning_status(key)
 
             async def failed(
                 self, key: SolutionCompilationTask, exception: BaseException

--- a/tests/rbx/box/code_compile_test.py
+++ b/tests/rbx/box/code_compile_test.py
@@ -603,3 +603,51 @@ int custom_function();
         assert len(result) > 0
         # Digest should be hex-like
         assert all(c in '0123456789abcdef' for c in result.lower())
+
+    async def test_compile_records_warning_logs_when_warnings_enabled(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """Warning-bearing compiler logs are forwarded to the warning stack."""
+        from rbx.box import setter_config
+        from rbx.box.sanitizers import warning_stack
+        from rbx.grading.steps import GradingLogsHolder, PreprocessLog
+
+        cpp_file = testing_pkg.add_file('solution.cpp', src='compile_test/simple.cpp')
+        code_item = CodeItem(path=cpp_file, language='cpp')
+
+        warning_log = PreprocessLog(
+            cmd=['g++', 'solution.cpp'],
+            log='solution.cpp:1:1: warning: unused variable',
+            warnings=True,
+        )
+        clean_log = PreprocessLog(
+            cmd=['jar', 'cvf', 'Main.jar'],
+            log='',
+            warnings=False,
+        )
+
+        async def compile_side_effect(
+            commands, params, artifacts, sandbox, dependency_cache
+        ):
+            for output in artifacts.outputs:
+                if output.digest is not None:
+                    cacher = package.get_file_cacher()
+                    output.digest.value = await cacher.put_file_content(
+                        b'mock file content'
+                    )
+            artifacts.logs = GradingLogsHolder(preprocess=[warning_log, clean_log])
+            return True
+
+        monkeypatch.setattr(
+            'rbx.box.code.steps_with_caching.compile',
+            mock.AsyncMock(side_effect=compile_side_effect),
+        )
+        cfg = setter_config.get_setter_config()
+        monkeypatch.setattr(cfg.warnings, 'enabled', True)
+
+        warning_stack.get_warning_stack().clear()
+        await code.compile_item(code_item)
+
+        stack = warning_stack.get_warning_stack()
+        assert code_item.path in stack.warnings
+        assert stack.warning_logs[code_item.path] == [warning_log]

--- a/tests/rbx/box/parallel/live_tasks_test.py
+++ b/tests/rbx/box/parallel/live_tasks_test.py
@@ -1,0 +1,35 @@
+from rbx.box.parallel import live_tasks
+from rbx.box.schema import CodeItem
+
+
+def _task(
+    status: live_tasks.CompilationStatus, summary=None
+) -> live_tasks.CompilationTask:
+    task = live_tasks.CompilationTask(CodeItem(path='sols/a.cpp', language='cpp'))
+    task.status = status
+    task.warning_summary = summary
+    return task
+
+
+def test_success_renders_nothing():
+    assert _task(live_tasks.CompilationStatus.SUCCESS).render() is None
+
+
+def test_warnings_without_summary_shows_plain_label():
+    rendered = _task(live_tasks.CompilationStatus.WARNINGS).render()
+    assert rendered is not None
+    assert rendered.columns[1].plain == 'WARNINGS'
+
+
+def test_warnings_with_summary_appends_it():
+    rendered = _task(
+        live_tasks.CompilationStatus.WARNINGS, summary='3 warnings'
+    ).render()
+    assert rendered is not None
+    assert rendered.columns[1].plain == 'WARNINGS (3 warnings)'
+
+
+def test_warning_summary_ignored_when_not_warnings_status():
+    rendered = _task(live_tasks.CompilationStatus.FAILED, summary='x').render()
+    assert rendered is not None
+    assert rendered.columns[1].plain == 'FAILED'

--- a/tests/rbx/box/sanitizers/compilation_warnings_helper_test.py
+++ b/tests/rbx/box/sanitizers/compilation_warnings_helper_test.py
@@ -1,0 +1,63 @@
+from rbx.box.parallel import live_tasks
+from rbx.box.sanitizers import compilation_warnings, warning_stack
+from rbx.box.schema import CodeItem
+from rbx.grading.steps import PreprocessLog
+
+
+def _task(path: str = 'sols/a.cpp') -> live_tasks.CompilationTask:
+    task = live_tasks.CompilationTask(CodeItem(path=path, language='cpp'))
+    task.status = live_tasks.CompilationStatus.SUCCESS
+    return task
+
+
+def _log() -> PreprocessLog:
+    return PreprocessLog(
+        cmd=['g++', 'a.cpp'], log='a.cpp:1:1: warning: x', warnings=True
+    )
+
+
+def test_apply_warning_status_flips_to_warnings_when_in_stack():
+    stack = warning_stack.get_warning_stack()
+    stack.clear()
+    task = _task()
+    stack.add_warning(task.item, logs=[_log()])
+
+    compilation_warnings.apply_warning_status(task)
+
+    assert task.status is live_tasks.CompilationStatus.WARNINGS
+    assert task.warning_summary is None  # empty registry -> base summarizer
+    stack.clear()
+
+
+def test_apply_warning_status_leaves_status_when_not_in_stack():
+    stack = warning_stack.get_warning_stack()
+    stack.clear()
+    task = _task()
+
+    compilation_warnings.apply_warning_status(task)
+
+    assert task.status is live_tasks.CompilationStatus.SUCCESS
+    assert task.warning_summary is None
+
+
+def test_apply_warning_status_uses_language_summarizer(monkeypatch):
+    class FakeSummarizer(compilation_warnings.CompilationWarningSummarizer):
+        def summarize(self, logs):
+            return f'{len(logs)} warnings'
+
+    monkeypatch.setitem(
+        compilation_warnings._SUMMARIZERS,  # noqa: SLF001
+        'cpp',
+        FakeSummarizer(),
+    )
+
+    stack = warning_stack.get_warning_stack()
+    stack.clear()
+    task = _task()
+    stack.add_warning(task.item, logs=[_log(), _log()])
+
+    compilation_warnings.apply_warning_status(task)
+
+    assert task.status is live_tasks.CompilationStatus.WARNINGS
+    assert task.warning_summary == '2 warnings'
+    stack.clear()

--- a/tests/rbx/box/sanitizers/compilation_warnings_test.py
+++ b/tests/rbx/box/sanitizers/compilation_warnings_test.py
@@ -1,0 +1,21 @@
+from rbx.box.sanitizers.compilation_warnings import (
+    CompilationWarningSummarizer,
+    get_compilation_warning_summarizer,
+)
+from rbx.grading.steps import PreprocessLog
+
+
+def _log() -> PreprocessLog:
+    return PreprocessLog(
+        cmd=['g++', 'a.cpp'], log='a.cpp:1:1: warning: x', warnings=True
+    )
+
+
+def test_base_summarizer_returns_none():
+    assert CompilationWarningSummarizer().summarize([_log()]) is None
+
+
+def test_get_summarizer_returns_base_for_unknown_language():
+    summarizer = get_compilation_warning_summarizer('cpp')
+    assert isinstance(summarizer, CompilationWarningSummarizer)
+    assert summarizer.summarize([_log()]) is None

--- a/tests/rbx/box/sanitizers/warning_stack_test.py
+++ b/tests/rbx/box/sanitizers/warning_stack_test.py
@@ -1,0 +1,43 @@
+import pathlib
+
+from rbx.box.sanitizers.warning_stack import WarningStack
+from rbx.box.schema import CodeItem
+from rbx.grading.steps import PreprocessLog
+
+
+def _log(warnings: bool) -> PreprocessLog:
+    return PreprocessLog(
+        cmd=['g++', 'a.cpp'], log='some warning text', warnings=warnings
+    )
+
+
+def test_add_warning_records_path_and_logs(tmp_path: pathlib.Path):
+    stack = WarningStack(tmp_path)
+    code = CodeItem(path=pathlib.Path('sols/a.cpp'), language='cpp')
+    logs = [_log(True)]
+
+    stack.add_warning(code, logs=logs)
+
+    assert code.path in stack.warnings
+    assert stack.warning_logs[code.path] == logs
+
+
+def test_add_warning_without_logs_still_records_path(tmp_path: pathlib.Path):
+    stack = WarningStack(tmp_path)
+    code = CodeItem(path=pathlib.Path('sols/a.cpp'), language='cpp')
+
+    stack.add_warning(code)
+
+    assert code.path in stack.warnings
+    assert stack.warning_logs.get(code.path) in (None, [])
+
+
+def test_clear_resets_warning_logs(tmp_path: pathlib.Path):
+    stack = WarningStack(tmp_path)
+    code = CodeItem(path=pathlib.Path('sols/a.cpp'), language='cpp')
+    stack.add_warning(code, logs=[_log(True)])
+
+    stack.clear()
+
+    assert not stack.warnings
+    assert not stack.warning_logs

--- a/tests/rbx/box/solutions_compile_warnings_test.py
+++ b/tests/rbx/box/solutions_compile_warnings_test.py
@@ -1,0 +1,58 @@
+import pathlib
+from unittest import mock
+
+from rbx.box import package, setter_config, solutions
+from rbx.box.sanitizers import warning_stack
+from rbx.box.schema import ExpectedOutcome
+from rbx.box.testing import testing_package
+from rbx.grading.steps import GradingFileInput, GradingLogsHolder, PreprocessLog
+
+
+async def test_compile_solutions_records_warnings_in_stack(
+    testing_pkg: testing_package.TestingPackage, monkeypatch
+):
+    """compile_solutions drives compile_item, which forwards warning logs to the
+    warning stack -- proving the streamer flow wires warnings end to end."""
+    sol_path = testing_pkg.add_solution('sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    testing_pkg.add_from_testdata('sol.cpp', 'compile_test/simple.cpp')
+
+    warning_log = PreprocessLog(
+        cmd=['g++', 'sol.cpp'],
+        log='sol.cpp:1:1: warning: unused variable',
+        warnings=True,
+    )
+
+    async def compile_side_effect(
+        commands, params, artifacts, sandbox, dependency_cache
+    ):
+        for output in artifacts.outputs:
+            if output.digest is not None:
+                cacher = package.get_file_cacher()
+                output.digest.value = await cacher.put_file_content(b'mock content')
+        artifacts.logs = GradingLogsHolder(preprocess=[warning_log])
+        return True
+
+    monkeypatch.setattr(
+        'rbx.box.code.steps_with_caching.compile',
+        mock.AsyncMock(side_effect=compile_side_effect),
+    )
+    monkeypatch.setattr(
+        'rbx.box.code._precompile_header',
+        mock.AsyncMock(
+            return_value=GradingFileInput(
+                src=pathlib.Path('test.h.gch'),
+                dest=pathlib.Path('test.h.gch'),
+                hash=False,
+            )
+        ),
+    )
+    cfg = setter_config.get_setter_config()
+    monkeypatch.setattr(cfg.warnings, 'enabled', True)
+
+    warning_stack.get_warning_stack().clear()
+    compiled = await solutions.compile_solutions(['sol.cpp'])
+
+    assert pathlib.Path(sol_path).name == 'sol.cpp'
+    assert pathlib.Path('sol.cpp') in compiled
+    assert pathlib.Path('sol.cpp') in warning_stack.get_warning_stack().warnings
+    warning_stack.get_warning_stack().clear()

--- a/tests/rbx/box/solutions_compile_warnings_test.py
+++ b/tests/rbx/box/solutions_compile_warnings_test.py
@@ -2,6 +2,7 @@ import pathlib
 from unittest import mock
 
 from rbx.box import package, setter_config, solutions
+from rbx.box.parallel import live_tasks
 from rbx.box.sanitizers import warning_stack
 from rbx.box.schema import ExpectedOutcome
 from rbx.box.testing import testing_package
@@ -12,9 +13,20 @@ async def test_compile_solutions_records_warnings_in_stack(
     testing_pkg: testing_package.TestingPackage, monkeypatch
 ):
     """compile_solutions drives compile_item, which forwards warning logs to the
-    warning stack -- proving the streamer flow wires warnings end to end."""
+    warning stack, and the streamer flips the LiveTask to WARNINGS -- proving the
+    flow wires warnings end to end."""
     sol_path = testing_pkg.add_solution('sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
     testing_pkg.add_from_testdata('sol.cpp', 'compile_test/simple.cpp')
+
+    created_tasks: list[solutions.SolutionCompilationTask] = []
+    real_task_cls = solutions.SolutionCompilationTask
+
+    class RecordingTask(real_task_cls):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created_tasks.append(self)
+
+    monkeypatch.setattr(solutions, 'SolutionCompilationTask', RecordingTask)
 
     warning_log = PreprocessLog(
         cmd=['g++', 'sol.cpp'],
@@ -55,4 +67,7 @@ async def test_compile_solutions_records_warnings_in_stack(
     assert pathlib.Path(sol_path).name == 'sol.cpp'
     assert pathlib.Path('sol.cpp') in compiled
     assert pathlib.Path('sol.cpp') in warning_stack.get_warning_stack().warnings
+    assert len(created_tasks) == 1
+    assert created_tasks[0].status is live_tasks.CompilationStatus.WARNINGS
+    assert created_tasks[0].warning_summary is None  # empty summarizer registry
     warning_stack.get_warning_stack().clear()


### PR DESCRIPTION
Closes #397.

## What

When `rbx` compiles solutions or generators through the live progress display
(`LiveTasks`), a compilable that compiled with compiler warnings now shows
`WARNINGS` instead of `SUCCESS` (and the row stays visible), optionally followed
by a short language-specific summary line.

`WARNINGS` is shown only when warning tracking is on (`cfg.warnings.enabled` or
`force_warnings`) — the same gate that feeds the existing end-of-run warning-stack
report, so the two stay consistent.

## How

- `WarningStack` now also stashes the warning-bearing compiler logs per code path
  (`warning_logs: Dict[Path, List[PreprocessLog]]`; `add_warning(code, logs=None)`).
- `compile_item` forwards those logs to `add_warning` (no signature/return-type
  change — its ~12 call sites are untouched).
- New `rbx/box/sanitizers/compilation_warnings.py`: a pluggable, language-keyed
  `CompilationWarningSummarizer` (base returns `None`; registry empty for now) and
  a shared `apply_warning_status(task)` helper (lazy imports inside the body to
  avoid an import cycle).
- `CompilationTask` gains `warning_summary`, rendered as `WARNINGS (<summary>)`.
- The `succeeded` callbacks of both compilation streamers (`solutions.py`,
  `generators.py`) call `apply_warning_status`.

A C++ summarizer that distills GCC/clang output into a concise line is
intentionally deferred to #446 (to be brainstormed separately).

Design and implementation plan: `docs/plans/2026-05-12-compilation-warnings-livetasks-design.md`,
`docs/plans/2026-05-12-compilation-warnings-livetasks.md`.

## Known limitation (out of scope)

If a compilation is served from the dependency cache, the preprocess logs aren't
repopulated, so warnings aren't re-detected on cached runs — pre-existing for the
warning-stack report too. A possible future fix is persisting a `has_warnings`
flag in `CompilationMetadata`.

## Testing

`uv run pytest tests/rbx/box/sanitizers tests/rbx/box/parallel tests/rbx/box/code_compile_test.py tests/rbx/box/solutions_compile_warnings_test.py` → all pass; `ruff check`/`ruff format` clean. (Note: this machine has ~50 pre-existing, unrelated test failures — `validators_test.py`/`code_run_test.py`/docker e2e — that reproduce on `main` with no changes; the affected modules above are green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)