### PR TITLE
feat(contest): add 'rbx contest add_variant <id>' scaffolding command

### DIFF
--- a/docs/plans/2026-05-12-contest-add-variant-design.md
+++ b/docs/plans/2026-05-12-contest-add-variant-design.md
@@ -1,0 +1,119 @@
+# `rbx contest add_variant <id>`
+
+**Issue:** [#432](https://github.com/rsalesc/rbx/issues/432) — Add a scaffolding
+command for `contest.<id>.rbx.yml` variants. Follow-up from the multi-contest
+work ([#431](https://github.com/rsalesc/rbx/issues/431),
+[`docs/plans/2026-05-06-multi-contest-design.md`](2026-05-06-multi-contest-design.md)).
+
+## Problem
+
+After turning a contest directory into dispatcher mode (`use_variants: true`),
+or when adding extra variants alongside a real `contest.rbx.yml`, users must
+hand-author each `contest.<id>.rbx.yml` from scratch. We want a command that
+scaffolds one for them, seeded from a preset's contest template.
+
+## Command shape
+
+```
+rbx contest add_variant <id> [--preset/-p <name>]
+```
+
+Aliased `add_variant, av`, registered in `rbx/box/contest/main.py` next to
+`init`/`add`.
+
+- `<id>` — positional, required. Validated against
+  `contest_state.VARIANT_ID_PATTERN` (`^[A-Za-z][A-Za-z0-9_-]*$`). Invalid →
+  error + exit 1.
+- `--preset/-p` — optional preset to scaffold from. When omitted, falls back to
+  the active preset in the cwd, then the default preset, via the existing
+  `presets.get_preset_fetch_info_with_fallback`. A URI preset is fetched.
+
+## Behavior
+
+### Preconditions / errors
+
+1. **Must be inside a contest directory.** Resolve the contest root with
+   `contest_package.find_contest_root()` — *not* `within_contest`, which dies in
+   dispatcher mode when there is no canonical selection. `None` → error + exit 1.
+2. **No flip required.** Works in both modes. Real-contest mode already supports
+   sibling `contest.<id>.rbx.yml` files as additional selectable variants, and
+   dispatcher mode obviously does. `contest.rbx.yml` is never modified.
+3. **Variant must not already exist.** If `<contest_root>/contest.<id>.rbx.yml`
+   exists → error + exit 1.
+4. **Preset must define a contest template.** After resolving the preset, if
+   `preset.contest is None` → error (same message style as `install_contest`).
+
+### Scaffolding
+
+- Read the preset's contest-template `contest.rbx.yml` via `ruyaml` (preserving
+  comments/formatting), applying the same expansions `install_contest` uses
+  (`_collect_expansions(preset.expansion.contest)`).
+- Override two keys on the loaded mapping:
+  - `name: <id>-c`
+  - `problems: []` — the scaffold is empty; the user adds problems with
+    `rbx contest add` after selecting the variant (`-C <id>`).
+- Write to `<contest_root>/contest.<id>.rbx.yml` with `utils.save_ruyaml`.
+- Statement templates / assets are **not** re-copied — the variant shares the
+  directory's existing files (created when the contest dir was first set up). If
+  the chosen preset references assets absent from the dir, that is a documented
+  limitation; `add_variant` does not try to reconcile it.
+- Validate the result parses as a `Contest` (`load_yaml_model`). On failure,
+  remove the half-written file and error.
+- `contest_utils.clear_all_caches()` and `find_contest_yaml.cache_clear()`
+  afterwards. Print a success message pointing at the new file and reminding the
+  user to select it with `-C <id>`.
+
+### Refactor
+
+Factor a small helper in `rbx/box/presets/__init__.py` — e.g.
+`read_contest_template_yaml(preset, preset_path) -> (ruyaml.YAML, mapping)` —
+so `add_variant` reuses the preset-template lookup + expansion logic instead of
+duplicating `install_contest`'s internals. `install_contest` itself is unchanged
+(it installs the whole dir; `add_variant` only wants the yaml).
+
+## Out of scope
+
+- `rbx contest remove_variant <id>` — tracked separately, pairs naturally.
+- YAML inheritance / `extends:` between variants — still deferred (see the
+  multi-contest design's follow-ups).
+- `--from <existing-id>` copying — superseded by the preset-driven scaffold.
+
+## Testing
+
+### Unit — `tests/rbx/box/contest/test_contest_main.py`
+
+Invoked via Typer's `CliRunner`, using the contest fixtures in
+`tests/rbx/box/conftest.py`.
+
+1. Invalid id (`"bad id"`, `1abc`) → exit 1, no file written.
+2. Existing variant (`add_variant div1` in a dispatcher fixture that has
+   `contest.div1.rbx.yml`) → exit 1, original file untouched.
+3. Not inside a contest dir → exit 1.
+4. Successful scaffold in dispatcher mode → `contest.div3.rbx.yml` exists, parses
+   as `Contest`, `name == 'div3-c'`, `problems == []`.
+5. Successful scaffold in real-contest mode → canonical `contest.rbx.yml`
+   unchanged, new sibling discoverable via `discover_contest_variants`.
+6. `--preset <name>` honored → scaffold reflects that preset's contest template
+   (e.g. its statements config), still with `name`/`problems` overridden.
+
+### e2e — `tests/e2e/testdata/multi-contest/e2e.rbx.yml`
+
+Piggybacks on the existing `multi-contest/` fixture (dispatcher mode). Relies on
+the default bundled preset having a contest template, like `rbx contest create`.
+
+- `add-variant-scaffolds-sibling`: `contest add_variant div3` →
+  `files_exist: [contest.div3.rbx.yml]`; then `contest list` →
+  `stdout_contains: [div3]`; then `-C div3 contest summary` →
+  `stdout_contains: [div3-c]`.
+- `add-variant-existing-rejected`: `contest add_variant div1` → `expect_exit: 1`.
+- `add-variant-invalid-id-rejected`: `contest add_variant "bad id"` →
+  `expect_exit: 1`.
+
+## Acceptance (from the issue)
+
+- New command under `rbx/box/contest/main.py`. ✔
+- Unit tests cover id validation, refusal on existing variant, successful
+  scaffold, preset handling. ✔ (refusal on single-contest mode dropped — that
+  mode is supported, per the multi-contest design.)
+- e2e fixture `tests/e2e/testdata/multi-contest/` gains an `add_variant`
+  scenario. ✔

--- a/docs/plans/2026-05-12-contest-add-variant-design.md
+++ b/docs/plans/2026-05-12-contest-add-variant-design.md
@@ -63,13 +63,18 @@ Aliased `add_variant, av`, registered in `rbx/box/contest/main.py` next to
   afterwards. Print a success message pointing at the new file and reminding the
   user to select it with `-C <id>`.
 
-### Refactor
+### Implementation note (as built)
 
-Factor a small helper in `rbx/box/presets/__init__.py` — e.g.
-`read_contest_template_yaml(preset, preset_path) -> (ruyaml.YAML, mapping)` —
-so `add_variant` reuses the preset-template lookup + expansion logic instead of
-duplicating `install_contest`'s internals. `install_contest` itself is unchanged
-(it installs the whole dir; `add_variant` only wants the yaml).
+The original design proposed factoring a `read_contest_template_yaml` helper in
+`rbx/box/presets/__init__.py`. In implementation we instead reuse
+`presets.install_contest` against a `tempfile.TemporaryDirectory()`: install the
+preset's contest template into the scratch dir (pre-installing the active
+preset's `.local.rbx` there first when no explicit `--preset` is given), read the
+produced `contest.rbx.yml`, override `name`/`problems`, and write it to the real
+`contest.<id>.rbx.yml`. This avoids duplicating `install_contest`'s
+expansion/lookup internals and keeps `presets/__init__.py` untouched. The scratch
+dir is discarded; statement assets are not re-copied (the documented limitation
+above still holds).
 
 ## Out of scope
 

--- a/docs/plans/2026-05-12-contest-add-variant.md
+++ b/docs/plans/2026-05-12-contest-add-variant.md
@@ -1,0 +1,427 @@
+# `rbx contest add_variant` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `rbx contest add_variant <id> [--preset/-p <name>]` command that scaffolds a new `contest.<id>.rbx.yml` variant file, seeded from a preset's contest template.
+
+**Architecture:** New Typer command in `rbx/box/contest/main.py`. It validates the id, ensures we're in a contest directory, refuses to overwrite an existing variant, then installs the chosen preset's contest template into a throwaway temp dir (reusing `presets.install_contest`), reads its `contest.rbx.yml`, overrides `name`→`<id>-c` and `problems`→`[]`, and writes it to `<contest_root>/contest.<id>.rbx.yml`. Works in both real-contest and dispatcher modes — `contest.rbx.yml` is never modified.
+
+**Tech Stack:** Python, Typer, Pydantic v2, `ruyaml` (round-trip YAML), `pytest` + `typer.testing.CliRunner`, the e2e YAML DSL under `tests/e2e/`.
+
+**Design doc:** [`docs/plans/2026-05-12-contest-add-variant-design.md`](2026-05-12-contest-add-variant-design.md)
+
+---
+
+## Background notes for the implementer
+
+- The variant id regex lives at `rbx/box/contest/contest_state.py`: `VARIANT_ID_PATTERN` / `is_valid_variant_id(value: str) -> bool`.
+- `rbx/box/contest/contest_package.py` has:
+  - `find_contest_root(root: pathlib.Path) -> Optional[pathlib.Path]` — walks up to the dir containing `contest.rbx.yml`. **Use this** (NOT `within_contest`, which dies in dispatcher mode when no variant is selected).
+  - `VARIANT_GLOB = 'contest.*.rbx.yml'`, `discover_contest_variants(contest_root)`.
+  - `find_contest_yaml` is `@functools.cache`d — call `find_contest_yaml.cache_clear()` after writing a new variant file.
+  - `load_yaml_model` (re-exported / imported there) is used as `load_yaml_model(path, Contest)`; `Contest` is `rbx.box.contest.schema.Contest`.
+- `rbx/box/presets/__init__.py`:
+  - `get_preset_fetch_info_with_fallback(uri: Optional[str], local: bool = False) -> Optional[PresetFetchInfo]` — returns `None` when `uri is None` **and** there is an active preset in the cwd (meaning "use the active preset"); otherwise returns fetch info (for the named/URI preset, or the bundled `default` preset).
+  - `install_contest(dest_pkg: pathlib.Path, fetch_info: Optional[PresetFetchInfo] = None)` — when `fetch_info` is given, installs the preset into `dest_pkg/.local.rbx` first; then reads the active preset from `dest_pkg` and copies its `preset.contest` dir into `dest_pkg`. When `fetch_info` is `None`, it does **not** install anything and relies on an already-present `.local.rbx` under `dest_pkg`.
+  - `install_preset_from_dir(src, dest, ensure_contest=False, ...)` — copies a preset directory tree to `dest`.
+  - `get_active_preset_path(root=pathlib.Path()) -> pathlib.Path` — path to the cwd's active preset (`.local.rbx`).
+- `rbx/box/contest/contest_utils.py` has `clear_all_caches()`.
+- `rbx/utils` has `save_ruyaml(path, yaml_obj, data)` (used in `contest add`/`remove`). For loading raw round-trip YAML, `ruyaml.YAML()` then `.load(text)` (see `presets.get_ruyaml`).
+- `rbx/box/contest/main.py` already imports: `pathlib`, `typer`, `console`, `utils`, `presets`, `contest_utils`, `contest_package`. The command file uses the alias style `@app.command('name, alias', help='...')` (see `init, i`, `add, a`).
+
+### Test setup notes
+
+- Existing unit tests live in `tests/rbx/box/contest/test_contest_main.py` and use `CliRunner`, `tmp_path`, `monkeypatch.chdir`, plus local helpers `_write_single_contest` / `_write_dispatcher`. Follow that style.
+- To make `add_variant` resolve a preset **without network**, install a local preset into the test dir's `.local.rbx` so it becomes the active preset:
+  `presets.install_preset_from_dir(simple_preset_testdata, tmp_path / '.local.rbx')` — see `tests/rbx/box/presets/test_presets.py` (`contest_package_with_preset` fixture, `simple_preset_testdata` fixture pointing at `rbx/testdata/presets/simple-preset`).
+  - **Caveat:** `rbx/testdata/presets/simple-preset/contest/contest.rbx.yml` is *not* a valid `Contest` (it has `duration`/`startTime`/`problems[].label`). If the validation step rejects it, build a valid preset in the test instead via `rbx.box.testing.testing_preset.TestingPreset` + `preset.create_contest_package()` (see `preset_with_contest_package` fixture in `test_presets.py`), or write a tiny preset dir by hand with a `contest/contest.rbx.yml` of just `name: x` / `problems: []`. Resolve this when you hit it during TDD.
+- For the e2e scenario, `rbx contest add_variant` inside `tests/e2e/testdata/multi-contest/` will need a preset available without network. The runner copies the whole package dir to a tmpdir, so the cleanest fix is to **check a minimal `.local.rbx/` preset into `tests/e2e/testdata/multi-contest/`** (a `preset.rbx.yml` with `contest: contest` + `env: env.rbx.yml` and a `contest/contest.rbx.yml` containing `name: placeholder` / `problems: []`, mirroring an existing tiny preset). Verify it isn't swallowed by a `.gitignore` (`git status` / `git check-ignore`); if it is, add an exception. Confirm `uv run pytest tests/e2e/testdata/multi-contest/ -v` is still offline.
+
+---
+
+## Task 1: Add the `add_variant` command (id validation + contest-dir + existing-file guards)
+
+**Files:**
+- Modify: `rbx/box/contest/main.py` (add a new `add_variant` command after `init`)
+- Test: `tests/rbx/box/contest/test_contest_main.py`
+
+**Step 1: Write the failing tests**
+
+Add a `TestContestAddVariant` class to `tests/rbx/box/contest/test_contest_main.py`:
+
+```python
+class TestContestAddVariant:
+    def test_invalid_id_rejected(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path)
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'bad id'])
+
+        assert result.exit_code != 0, result.output
+        assert not (tmp_path / 'contest.bad id.rbx.yml').exists()
+
+    def test_invalid_id_leading_digit_rejected(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path)
+
+        result = runner.invoke(contest_main.app, ['add_variant', '1abc'])
+
+        assert result.exit_code != 0, result.output
+
+    def test_not_in_contest_dir_rejected(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'div3'])
+
+        assert result.exit_code != 0, result.output
+
+    def test_existing_variant_rejected(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path, 'div1')
+        original = (tmp_path / 'contest.div1.rbx.yml').read_text()
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'div1'])
+
+        assert result.exit_code != 0, result.output
+        assert (tmp_path / 'contest.div1.rbx.yml').read_text() == original
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_main.py::TestContestAddVariant -v`
+Expected: errors / non-zero exit because the `add_variant` command doesn't exist (Typer prints "No such command").
+
+**Step 3: Implement the command skeleton with the three guards**
+
+In `rbx/box/contest/main.py`, add (place after the `init` command; reuse already-imported modules, add `import tempfile` and a `ruyaml` import as needed):
+
+```python
+@app.command('add_variant, av', help='Scaffold a new contest variant file.')
+def add_variant(
+    variant_id: Annotated[
+        str,
+        typer.Argument(
+            help='Id of the new variant. Must match ^[A-Za-z][A-Za-z0-9_-]*$.',
+        ),
+    ],
+    preset: Annotated[
+        Optional[str],
+        typer.Option(
+            '--preset',
+            '-p',
+            help='Preset to scaffold the variant from. Defaults to the active '
+            'preset in the current directory, then the default preset.',
+        ),
+    ] = None,
+):
+    from rbx.box.contest.contest_state import is_valid_variant_id
+
+    if not is_valid_variant_id(variant_id):
+        console.console.print(
+            f'[error]Invalid variant id [item]{variant_id}[/item]. '
+            r'Must match ^[A-Za-z][A-Za-z0-9_-]*$.[/error]'
+        )
+        raise typer.Exit(1)
+
+    contest_root = contest_package.find_contest_root(pathlib.Path())
+    if contest_root is None:
+        console.console.print(
+            '[error]Not inside a contest directory '
+            '(no [item]contest.rbx.yml[/item] found).[/error]'
+        )
+        raise typer.Exit(1)
+
+    dest = contest_root / f'contest.{variant_id}.rbx.yml'
+    if dest.exists():
+        console.console.print(
+            f'[error]Variant file [item]{dest.name}[/item] already exists.[/error]'
+        )
+        raise typer.Exit(1)
+
+    # (scaffolding implemented in Task 2)
+    raise NotImplementedError
+```
+
+> Note: `find_contest_root` may currently be module-private or imported under a different name in `contest_package`; if it isn't exported, import it directly (`from rbx.box.contest.contest_package import find_contest_root`). Confirm the symbol exists before relying on it.
+
+**Step 4: Run the tests to verify the guard tests pass**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_main.py::TestContestAddVariant -v`
+Expected: the four guard tests PASS (they all exit non-zero before reaching `NotImplementedError`). Tests that exercise a successful scaffold come in Task 2.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/main.py tests/rbx/box/contest/test_contest_main.py
+git commit -m "feat(contest): add_variant command skeleton with input guards"
+```
+
+(Use the `/commit` skill workflow for the actual commit message — `feat(contest): ...`.)
+
+---
+
+## Task 2: Implement the preset-driven scaffold
+
+**Files:**
+- Modify: `rbx/box/contest/main.py`
+- Test: `tests/rbx/box/contest/test_contest_main.py`
+
+**Step 1: Write the failing tests**
+
+Add to `TestContestAddVariant` (adjust the preset setup per the "Test setup notes" caveat above — these use the bundled `simple-preset`; swap to a `TestingPreset` or hand-written minimal preset if `Contest` validation rejects it):
+
+```python
+    def test_scaffold_in_dispatcher_mode(self, runner, tmp_path, monkeypatch, testdata_path):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path)
+        from rbx.box import presets
+        presets.install_preset_from_dir(
+            testdata_path / 'presets' / 'simple-preset', tmp_path / '.local.rbx'
+        )
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'div3'])
+
+        assert result.exit_code == 0, result.output
+        dest = tmp_path / 'contest.div3.rbx.yml'
+        assert dest.exists()
+        from rbx.box.contest.schema import Contest
+        from rbx.utils import model_from_yaml  # or whatever the loader is
+        contest = model_from_yaml(Contest, dest.read_text())
+        assert contest.name == 'div3-c'
+        assert contest.problems == []
+
+    def test_scaffold_in_real_contest_mode(self, runner, tmp_path, monkeypatch, testdata_path):
+        monkeypatch.chdir(tmp_path)
+        _write_single_contest(tmp_path)
+        original = (tmp_path / 'contest.rbx.yml').read_text()
+        from rbx.box import presets
+        presets.install_preset_from_dir(
+            testdata_path / 'presets' / 'simple-preset', tmp_path / '.local.rbx'
+        )
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'extra'])
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / 'contest.extra.rbx.yml').exists()
+        assert (tmp_path / 'contest.rbx.yml').read_text() == original
+        from rbx.box.contest import contest_package
+        contest_package.find_contest_yaml.cache_clear()
+        variants = contest_package.discover_contest_variants(tmp_path)
+        assert 'extra' in variants
+```
+
+> Resolve the exact `Contest`-from-YAML loader name during implementation (grep `load_yaml_model` in `rbx/box/contest/contest_package.py`). The `testdata_path` fixture already exists (used in `tests/rbx/box/presets/test_presets.py`); if it isn't visible in `tests/rbx/box/contest/`, add it locally or import from a shared conftest.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_main.py::TestContestAddVariant -v`
+Expected: the two new tests FAIL (currently hit `NotImplementedError` → non-zero exit / no file written).
+
+**Step 3: Implement the scaffold**
+
+Replace the `raise NotImplementedError` in `add_variant` with:
+
+```python
+    from rbx.box.contest.contest_package import find_contest_yaml
+    from rbx.box.contest.schema import Contest
+
+    fetch_info = presets.get_preset_fetch_info_with_fallback(preset)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        scratch = pathlib.Path(tmp)
+        if fetch_info is None:
+            # `None` means: use the active preset in the cwd. Install it into
+            # the scratch dir so `install_contest` can resolve it there.
+            presets.install_preset_from_dir(
+                presets.get_active_preset_path(),
+                scratch / '.local.rbx',
+                ensure_contest=True,
+            )
+        presets.install_contest(scratch, fetch_info)
+        template_text = (scratch / 'contest.rbx.yml').read_text()
+
+    ru = ruyaml.YAML()
+    data = ru.load(template_text)
+    data['name'] = f'{variant_id}-c'
+    data['problems'] = []
+    utils.save_ruyaml(dest, ru, data)
+
+    # Make sure the result is a valid Contest before declaring success.
+    try:
+        contest_package.load_yaml_model(dest, Contest)
+    except Exception as e:  # noqa: BLE001 - want to surface any validation error
+        dest.unlink(missing_ok=True)
+        console.console.print(
+            f'[error]Scaffolded variant did not validate against the contest '
+            f'schema: {e}[/error]'
+        )
+        raise typer.Exit(1)
+
+    find_contest_yaml.cache_clear()
+    contest_utils.clear_all_caches()
+    console.console.print(
+        f'Created contest variant at [item]{dest}[/item]. '
+        f'Select it with [item]-C {variant_id}[/item].'
+    )
+```
+
+> Adjust import paths to match the codebase (`load_yaml_model` may already be importable from `contest_package`; `ruyaml` import style — `import ruyaml`). `install_contest` prints progress lines and (for some preset sources) may prompt; that's acceptable for the active/local-dir/default cases. If `model_to_yaml`/`save_ruyaml` differs, mirror what `contest add` does in the same file.
+
+**Step 4: Run the tests**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_main.py::TestContestAddVariant -v`
+Expected: all `TestContestAddVariant` tests PASS.
+
+**Step 5: Run the full contest test module + lint**
+
+Run:
+```
+uv run pytest tests/rbx/box/contest/ -v
+uv run ruff check rbx/box/contest/main.py tests/rbx/box/contest/test_contest_main.py
+uv run ruff format rbx/box/contest/main.py tests/rbx/box/contest/test_contest_main.py
+```
+Expected: all green, no lint errors.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/contest/main.py tests/rbx/box/contest/test_contest_main.py
+git commit -m "feat(contest): scaffold add_variant from preset contest template"
+```
+
+---
+
+## Task 3: `--preset` flag explicitly honored (unit coverage)
+
+**Files:**
+- Test: `tests/rbx/box/contest/test_contest_main.py`
+
+**Step 1: Write the failing test**
+
+```python
+    def test_preset_flag_is_honored(self, runner, tmp_path, monkeypatch, testdata_path):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path)
+        # No active preset in cwd; pass one explicitly as a local dir.
+        preset_dir = testdata_path / 'presets' / 'simple-preset'
+
+        result = runner.invoke(
+            contest_main.app, ['add_variant', 'div3', '--preset', str(preset_dir)]
+        )
+
+        assert result.exit_code == 0, result.output
+        dest = tmp_path / 'contest.div3.rbx.yml'
+        assert dest.exists()
+        # Came from the simple-preset's contest template (e.g. it carried a key
+        # the bare _write_dispatcher variants don't have), with name overridden.
+        text = dest.read_text()
+        assert 'div3-c' in text
+```
+
+> If `get_preset_fetch_info_with_fallback(str(preset_dir))` doesn't accept a bare local path, use the URI form the preset tests use, or install the preset and rely on the active-preset path. Adapt the assertion to a stable marker from whichever preset template you end up using.
+
+**Step 2: Run it to verify it fails (or passes trivially) — confirm the flag path actually executes**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_main.py::TestContestAddVariant::test_preset_flag_is_honored -v`
+Expected: PASS once `--preset` resolution works; if it errors on path handling, fix `add_variant` / the test until the explicit-preset path is exercised.
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/box/contest/test_contest_main.py
+git commit -m "test(contest): cover add_variant --preset flag"
+```
+
+---
+
+## Task 4: e2e scenarios
+
+**Files:**
+- Modify: `tests/e2e/testdata/multi-contest/e2e.rbx.yml`
+- Possibly create: `tests/e2e/testdata/multi-contest/.local.rbx/...` (a minimal local preset so `add_variant` works offline — see "Test setup notes")
+
+**Step 1: Make a preset available offline in the fixture**
+
+Add a minimal preset under `tests/e2e/testdata/multi-contest/.local.rbx/`:
+- `preset.rbx.yml`: `name: e2e`, `contest: contest`, `env: env.rbx.yml` (mirror the smallest existing preset's required fields — check `rbx/box/presets/schema.py` for what's mandatory; copy from `rbx/testdata/presets/simple-preset` and trim).
+- `contest/contest.rbx.yml`: minimal valid `Contest` — `name: placeholder` and `problems: []` (plus `titles`/`statements` only if `Contest` requires them; keep it as small as the schema allows).
+- `env.rbx.yml`: copy `rbx/testdata/presets/simple-preset/env.rbx.yml`.
+
+Verify it's tracked by git (`git check-ignore tests/e2e/testdata/multi-contest/.local.rbx/preset.rbx.yml` should print nothing; if it's ignored, add a negation in the nearest `.gitignore`).
+
+Sanity check offline: `uv run pytest tests/e2e/testdata/multi-contest/ -v` still passes with no network.
+
+**Step 2: Add the scenarios to `tests/e2e/testdata/multi-contest/e2e.rbx.yml`**
+
+```yaml
+  - name: add-variant-scaffolds-sibling
+    description: >-
+      `rbx contest add_variant div3` writes contest.div3.rbx.yml; it then
+      shows up in `contest list` and loads under `-C div3`.
+    steps:
+      - cmd: contest add_variant div3
+        expect:
+          files_exist:
+            - contest.div3.rbx.yml
+      - cmd: contest list
+        expect:
+          stdout_contains:
+            - div3
+      - cmd: -C div3 contest summary
+        expect:
+          stdout_contains:
+            - div3-c
+
+  - name: add-variant-existing-rejected
+    description: 'add_variant refuses to overwrite an existing variant file.'
+    steps:
+      - cmd: contest add_variant div1
+        expect_exit: 1
+
+  - name: add-variant-invalid-id-rejected
+    description: 'add_variant rejects an id failing the variant id regex.'
+    steps:
+      - cmd: contest add_variant "bad id"
+        expect_exit: 1
+```
+
+> If `-C div3 contest summary` is noisy or slow, fall back to asserting on `contest list` only and/or reading the file via `files_exist`. Match the surrounding scenarios' style.
+
+**Step 3: Run the e2e package**
+
+Run: `uv run pytest tests/e2e/testdata/multi-contest/ -v`
+Expected: all scenarios (old + new) PASS, offline.
+
+**Step 4: Commit**
+
+```bash
+git add tests/e2e/testdata/multi-contest/
+git commit -m "test(e2e): add_variant scenarios for multi-contest fixture"
+```
+
+---
+
+## Task 5: Final verification
+
+**Step 1: Full relevant test runs**
+
+Run:
+```
+uv run pytest tests/rbx/box/contest/ -v
+uv run pytest tests/e2e/testdata/multi-contest/ -v
+uv run ruff check .
+uv run ruff format --check .
+```
+Expected: all green.
+
+**Step 2: Manual smoke (optional)**
+
+In a scratch dir: `mkdir t && cd t && printf 'use_variants: true\n' > contest.rbx.yml && uv run rbx contest add_variant div1` → should create `contest.div1.rbx.yml` with `name: div1-c` / `problems: []`. (This will use the bundled default preset and may hit the network — that's expected for a real run.)
+
+**Step 3: Update the design doc's "Refactor" note if it diverged**
+
+The design proposed factoring a `read_contest_template_yaml` helper in `presets/__init__.py`; this plan instead reuses `install_contest` via a temp dir. If you kept the temp-dir approach, tweak the design doc's "Refactor" section to say so (or note the deviation in the PR description). Commit any doc change.
+
+**Step 4: Open the PR (when ready)**
+
+Per repo convention, branch is already isolated (worktree). Use the `/commit` skill for commits; create the PR with `gh` referencing issue #432.

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -1,9 +1,11 @@
 import pathlib
 import shutil
 import subprocess
+import tempfile
 from typing import Annotated, Optional
 
 import rich.prompt
+import ruyaml
 import syncer
 import typer
 
@@ -170,8 +172,47 @@ def add_variant(
         )
         raise typer.Exit(1)
 
-    # (scaffolding implemented in Task 2)
-    raise NotImplementedError
+    from rbx.box.contest.schema import Contest
+    from rbx.box.yaml_validation import load_yaml_model
+
+    fetch_info = presets.get_preset_fetch_info_with_fallback(preset)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        scratch = pathlib.Path(tmp)
+        if fetch_info is None:
+            # `None` means: use the active preset in the cwd. Install it into
+            # the scratch dir so `install_contest` can resolve it there.
+            presets.install_preset_from_dir(
+                presets.get_active_preset_path(),
+                scratch / '.local.rbx',
+                ensure_contest=True,
+            )
+        presets.install_contest(scratch, fetch_info)
+        template_text = (scratch / 'contest.rbx.yml').read_text()
+
+    ru = ruyaml.YAML()
+    data = ru.load(template_text)
+    data['name'] = f'{variant_id}-c'
+    data['problems'] = []
+    utils.save_ruyaml(dest, ru, data)
+
+    # Make sure the result is a valid Contest before declaring success.
+    try:
+        load_yaml_model(dest, Contest)
+    except Exception as e:  # noqa: BLE001 - want to surface any validation error
+        dest.unlink(missing_ok=True)
+        console.console.print(
+            f'[error]Scaffolded variant did not validate against the contest '
+            f'schema: {e}[/error]'
+        )
+        raise typer.Exit(1) from e
+
+    find_contest_yaml.cache_clear()
+    contest_utils.clear_all_caches()
+    console.console.print(
+        f'Created contest variant at [item]{dest}[/item]. '
+        f'Select it with [item]-C {variant_id}[/item].'
+    )
 
 
 @app.command('edit, e', help='Open contest.rbx.yml in your default editor.')

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -19,10 +19,15 @@ from rbx.box.contest.contest_package import (
     get_problems,
     within_contest,
 )
-from rbx.box.contest.schema import ContestProblem
+from rbx.box.contest.schema import Contest, ContestProblem
 from rbx.box.packaging import contest_main as packaging
 from rbx.box.schema import Package
 from rbx.box.ui.command_app import CommandEntry, start_command_app
+from rbx.box.yaml_validation import (
+    YamlSyntaxError,
+    YamlValidationError,
+    load_yaml_model,
+)
 from rbx.config import open_editor
 
 app = typer.Typer(no_args_is_help=True, cls=annotations.AliasGroup)
@@ -172,9 +177,6 @@ def add_variant(
         )
         raise typer.Exit(1)
 
-    from rbx.box.contest.schema import Contest
-    from rbx.box.yaml_validation import load_yaml_model
-
     fetch_info = presets.get_preset_fetch_info_with_fallback(preset)
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -199,7 +201,7 @@ def add_variant(
     # Make sure the result is a valid Contest before declaring success.
     try:
         load_yaml_model(dest, Contest)
-    except Exception as e:  # noqa: BLE001 - want to surface any validation error
+    except (YamlValidationError, YamlSyntaxError) as e:
         dest.unlink(missing_ok=True)
         console.console.print(
             f'[error]Scaffolded variant did not validate against the contest '

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -130,6 +130,50 @@ def init(
     presets.generate_lock()
 
 
+@app.command('add_variant, av', help='Scaffold a new contest variant file.')
+def add_variant(
+    variant_id: Annotated[
+        str,
+        typer.Argument(
+            help='Id of the new variant. Must match ^[A-Za-z][A-Za-z0-9_-]*$.',
+        ),
+    ],
+    preset: Annotated[
+        Optional[str],
+        typer.Option(
+            '--preset',
+            '-p',
+            help='Preset to scaffold the variant from. Defaults to the active '
+            'preset in the current directory, then the default preset.',
+        ),
+    ] = None,
+):
+    if not contest_state.is_valid_variant_id(variant_id):
+        console.console.print(
+            f'[error]Invalid variant id [item]{variant_id}[/item]. '
+            r'Must match ^[A-Za-z][A-Za-z0-9_-]*$.[/error]'
+        )
+        raise typer.Exit(1)
+
+    contest_root = contest_package.find_contest_root(pathlib.Path())
+    if contest_root is None:
+        console.console.print(
+            '[error]Not inside a contest directory '
+            '(no [item]contest.rbx.yml[/item] found).[/error]'
+        )
+        raise typer.Exit(1)
+
+    dest = contest_root / f'contest.{variant_id}.rbx.yml'
+    if dest.exists():
+        console.console.print(
+            f'[error]Variant file [item]{dest.name}[/item] already exists.[/error]'
+        )
+        raise typer.Exit(1)
+
+    # (scaffolding implemented in Task 2)
+    raise NotImplementedError
+
+
 @app.command('edit, e', help='Open contest.rbx.yml in your default editor.')
 @within_contest
 def edit():

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -60,6 +60,8 @@ def _strip_ansi(text: str) -> str:
 # Patterns excluded when copying a fixture directory into the run tmpdir.
 # These are paths that ``rbx`` (or prior test runs) generates and that should
 # regenerate freshly inside the tmpdir rather than leak in from source.
+# Note: ``.local.rbx`` is intentionally NOT excluded -- a fixture may commit a
+# minimal local preset there (e.g. so ``contest add_variant`` resolves offline).
 COPY_IGNORE_PATTERNS = (
     '.box',
     'build',
@@ -67,7 +69,6 @@ COPY_IGNORE_PATTERNS = (
     '__pycache__',
     '*.pyc',
     'rbx.h',
-    '.local.rbx',
     '.cache',
     '.testdata',
 )

--- a/tests/e2e/testdata/multi-contest/.local.rbx/contest/contest.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/.local.rbx/contest/contest.rbx.yml
@@ -1,0 +1,3 @@
+---
+name: "placeholder"
+problems: []

--- a/tests/e2e/testdata/multi-contest/.local.rbx/env.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/.local.rbx/env.rbx.yml
@@ -1,4 +1,5 @@
 ---
+# Copy of rbx/resources/presets/default/env.rbx.yml; may drift from the original.
 sandbox: "stupid"
 defaultCompilation:
   sandbox:

--- a/tests/e2e/testdata/multi-contest/.local.rbx/env.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/.local.rbx/env.rbx.yml
@@ -1,0 +1,81 @@
+---
+sandbox: "stupid"
+defaultCompilation:
+  sandbox:
+    maxProcesses: 1000
+    timeLimit: 50000 # 50 seconds
+    wallTimeLimit: 50000 # 50 seconds
+    memoryLimit: 1024 # 1gb
+defaultExecution:
+  sandbox:
+    # Useful for checkers, validators, etc.
+    timeLimit: 50000 # 50 seconds
+    wallTimeLimit: 50000 # 50 seconds
+    memoryLimit: 1024 # 1gb
+languages:
+  - name: "cpp"
+    readableName: "C++20"
+    extension: "cpp"
+    compilation:
+      commands: ["g++ -std=c++20 -O2 -o {executable} {compilable}"]
+    execution:
+      command: "./{executable}"
+    extensions:
+      boca:
+        bocaLanguage: "cc"
+      polygon:
+        polygonLanguage: "cpp.gcc13-64-winlibs-g++20"
+  - name: "c"
+    readableName: "C"
+    extension: "c"
+    compilation:
+      commands: ["gcc -std=gnu11 -O2 -o {executable} {compilable} -lm"]
+    execution:
+      command: "./{executable}"
+  - name: "py"
+    readableName: "Python3"
+    extension: "py"
+    execution:
+      command: "python3 {executable}"
+    fileMapping:
+      executable: "{compilable}"
+    extensions:
+      boca:
+        bocaLanguage: "py3"
+  - name: "java"
+    readableName: "Java"
+    extension: "java"
+    compilation:
+      commands:
+        - "javac -Xlint -encoding UTF-8 {compilable}"
+        - "jar cvf {executable} @glob:*.class"
+    execution:
+      command: "java -Xss100m -Xmx{memory}m -Xms{initialMemory}m -cp {executable} {javaClass}"
+    fileMapping:
+      compilable: "{javaClass}.java"
+      executable: "Main.jar"
+    extensions:
+      polygon:
+        polygonLanguage: "java21"
+  - name: "kt"
+    readableName: "Kotlin"
+    extension: "kt"
+    compilation:
+      commands:
+        - "kotlinc -d {executable} -include-runtime {compilable}"
+    execution:
+      command: "java -Xss100m -Xmx{memory}m -Xms{initialMemory}m -cp {executable} MainKt"
+    fileMapping:
+      compilable: "Main.kt"
+      executable: "Main.jar"
+    extensions:
+      boca:
+        bocaLanguage: "kt"
+extensions:
+  boca:
+    languages: ["c", "cc", "java", "py3", "kt"]
+    flags:
+      c: "-O2 -static"
+      cc: "-std=c++20 -O2 -lm -static"
+      cpp: "-std=c++20 -O2 -lm -static"
+    preferContestLetter: true

--- a/tests/e2e/testdata/multi-contest/.local.rbx/preset.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/.local.rbx/preset.rbx.yml
@@ -1,0 +1,6 @@
+---
+name: "e2e-preset"
+uri: "test/e2e-preset"
+min_version: "0.14.0"
+contest: "contest"
+env: "env.rbx.yml"

--- a/tests/e2e/testdata/multi-contest/e2e.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/e2e.rbx.yml
@@ -160,9 +160,15 @@ scenarios:
     steps:
       - cmd: contest add_variant div1
         expect_exit: 1
+        expect:
+          stdout_contains:
+            - 'already exists'
 
   - name: add-variant-invalid-id-rejected
     description: 'add_variant rejects an id failing the variant id regex.'
     steps:
       - cmd: contest add_variant "bad id"
         expect_exit: 1
+        expect:
+          stdout_contains:
+            - 'Invalid variant id'

--- a/tests/e2e/testdata/multi-contest/e2e.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/e2e.rbx.yml
@@ -136,3 +136,33 @@ scenarios:
         expect:
           files_exist:
             - B/build/B.zip
+
+  - name: add-variant-scaffolds-sibling
+    description: >-
+      `rbx contest add_variant div3` writes contest.div3.rbx.yml; it then
+      shows up in `contest list` and loads under `-C div3`.
+    steps:
+      - cmd: contest add_variant div3
+        expect:
+          files_exist:
+            - contest.div3.rbx.yml
+      - cmd: contest list
+        expect:
+          stdout_contains:
+            - div3
+      - cmd: -C div3 contest summary
+        expect:
+          stdout_contains:
+            - div3-c
+
+  - name: add-variant-existing-rejected
+    description: 'add_variant refuses to overwrite an existing variant file.'
+    steps:
+      - cmd: contest add_variant div1
+        expect_exit: 1
+
+  - name: add-variant-invalid-id-rejected
+    description: 'add_variant rejects an id failing the variant id regex.'
+    steps:
+      - cmd: contest add_variant "bad id"
+        expect_exit: 1

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -259,6 +259,29 @@ class TestContestAddVariant:
         # contest.rbx.yml (the dispatcher sentinel) is untouched.
         assert (tmp_path / 'contest.rbx.yml').read_text() == 'use_variants: true\n'
 
+    def test_preset_flag_is_honored(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path)
+        # No active preset in cwd; pass one explicitly as a local dir path. This
+        # exercises the `fetch_info is not None` branch of `add_variant`.
+        preset_dir = _make_minimal_preset(tmp_path / '_src_preset')
+
+        result = runner.invoke(
+            contest_main.app, ['add_variant', 'div3', '--preset', str(preset_dir)]
+        )
+
+        assert result.exit_code == 0, result.output
+        dest = tmp_path / 'contest.div3.rbx.yml'
+        assert dest.exists()
+        from rbx.box.contest.schema import Contest
+        from rbx.utils import model_from_yaml
+
+        contest = model_from_yaml(Contest, dest.read_text())
+        assert contest.name == 'div3-c'
+        assert contest.problems == []
+        # contest.rbx.yml (the dispatcher sentinel) is untouched.
+        assert (tmp_path / 'contest.rbx.yml').read_text() == 'use_variants: true\n'
+
     def test_invalid_scaffold_rolls_back(self, runner, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         _write_dispatcher(tmp_path)

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -162,3 +162,39 @@ class TestContestList:
         div1_line = next(line for line in result.output.splitlines() if 'div1' in line)
         assert '*' not in default_line
         assert '*' in div1_line
+
+
+class TestContestAddVariant:
+    def test_invalid_id_rejected(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path)
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'bad id'])
+
+        assert result.exit_code != 0, result.output
+        assert not (tmp_path / 'contest.bad id.rbx.yml').exists()
+
+    def test_invalid_id_leading_digit_rejected(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path)
+
+        result = runner.invoke(contest_main.app, ['add_variant', '1abc'])
+
+        assert result.exit_code != 0, result.output
+
+    def test_not_in_contest_dir_rejected(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'div3'])
+
+        assert result.exit_code != 0, result.output
+
+    def test_existing_variant_rejected(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path, 'div1')
+        original = (tmp_path / 'contest.div1.rbx.yml').read_text()
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'div1'])
+
+        assert result.exit_code != 0, result.output
+        assert (tmp_path / 'contest.div1.rbx.yml').read_text() == original

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -23,6 +23,38 @@ def _write_dispatcher(root: pathlib.Path, *variant_ids: str) -> None:
         (root / f'contest.{vid}.rbx.yml').write_text(f'name: ctt-{vid}\nproblems: []\n')
 
 
+def _make_minimal_preset(dest: pathlib.Path) -> pathlib.Path:
+    """Create a minimal, valid preset directory tree at ``dest`` and return it.
+
+    The bundled ``simple-preset`` has a ``contest/contest.rbx.yml`` with fields
+    (``duration``, ``startTime``, ``problems[].label``) that do not validate
+    against the ``Contest`` schema, so we build a tiny valid one here.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / 'preset.rbx.yml').write_text(
+        'name: "minimal-preset"\n'
+        'uri: "test/minimal-preset"\n'
+        'contest: "contest"\n'
+        'env: "env.rbx.yml"\n'
+    )
+    (dest / 'env.rbx.yml').write_text(
+        '---\n'
+        'languages:\n'
+        '  - name: cpp\n'
+        '    readableName: C++\n'
+        '    extension: .cpp\n'
+        '    compilation:\n'
+        '      command: g++ -o {executable} {compilable}\n'
+        '    execution:\n'
+        '      command: ./{executable}\n'
+    )
+    (dest / 'contest').mkdir(parents=True, exist_ok=True)
+    (dest / 'contest' / 'contest.rbx.yml').write_text(
+        'name: "placeholder"\nproblems: []\n'
+    )
+    return dest
+
+
 class TestContestList:
     def test_list_in_single_contest_dir(
         self,
@@ -198,3 +230,47 @@ class TestContestAddVariant:
 
         assert result.exit_code != 0, result.output
         assert (tmp_path / 'contest.div1.rbx.yml').read_text() == original
+
+    def test_scaffold_in_dispatcher_mode(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path)
+        from rbx.box import presets
+
+        presets.install_preset_from_dir(
+            _make_minimal_preset(tmp_path / '_src_preset'), tmp_path / '.local.rbx'
+        )
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'div3'])
+
+        assert result.exit_code == 0, result.output
+        dest = tmp_path / 'contest.div3.rbx.yml'
+        assert dest.exists()
+        from rbx.box.contest.schema import Contest
+        from rbx.utils import model_from_yaml
+
+        contest = model_from_yaml(Contest, dest.read_text())
+        assert contest.name == 'div3-c'
+        assert contest.problems == []
+        # contest.rbx.yml (the dispatcher sentinel) is untouched.
+        assert (tmp_path / 'contest.rbx.yml').read_text() == 'use_variants: true\n'
+
+    def test_scaffold_in_real_contest_mode(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_single_contest(tmp_path)
+        original = (tmp_path / 'contest.rbx.yml').read_text()
+        from rbx.box import presets
+
+        presets.install_preset_from_dir(
+            _make_minimal_preset(tmp_path / '_src_preset'), tmp_path / '.local.rbx'
+        )
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'extra'])
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / 'contest.extra.rbx.yml').exists()
+        assert (tmp_path / 'contest.rbx.yml').read_text() == original
+        from rbx.box.contest import contest_package
+
+        contest_package.find_contest_yaml.cache_clear()
+        variants = contest_package.discover_contest_variants(tmp_path)
+        assert 'extra' in variants

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -23,12 +23,16 @@ def _write_dispatcher(root: pathlib.Path, *variant_ids: str) -> None:
         (root / f'contest.{vid}.rbx.yml').write_text(f'name: ctt-{vid}\nproblems: []\n')
 
 
-def _make_minimal_preset(dest: pathlib.Path) -> pathlib.Path:
-    """Create a minimal, valid preset directory tree at ``dest`` and return it.
+def _make_minimal_preset(dest: pathlib.Path, *, invalid: bool = False) -> pathlib.Path:
+    """Create a minimal preset directory tree at ``dest`` and return it.
 
     The bundled ``simple-preset`` has a ``contest/contest.rbx.yml`` with fields
     (``duration``, ``startTime``, ``problems[].label``) that do not validate
     against the ``Contest`` schema, so we build a tiny valid one here.
+
+    When ``invalid`` is set, the ``contest/contest.rbx.yml`` carries an unknown
+    ``duration`` field, which ``Contest`` (``extra='forbid'``) rejects -- useful
+    for exercising the post-scaffold validation rollback path.
     """
     dest.mkdir(parents=True, exist_ok=True)
     (dest / 'preset.rbx.yml').write_text(
@@ -49,9 +53,10 @@ def _make_minimal_preset(dest: pathlib.Path) -> pathlib.Path:
         '      command: ./{executable}\n'
     )
     (dest / 'contest').mkdir(parents=True, exist_ok=True)
-    (dest / 'contest' / 'contest.rbx.yml').write_text(
-        'name: "placeholder"\nproblems: []\n'
-    )
+    contest_yml = 'name: "placeholder"\nproblems: []\n'
+    if invalid:
+        contest_yml += 'duration: 180\n'
+    (dest / 'contest' / 'contest.rbx.yml').write_text(contest_yml)
     return dest
 
 
@@ -253,6 +258,25 @@ class TestContestAddVariant:
         assert contest.problems == []
         # contest.rbx.yml (the dispatcher sentinel) is untouched.
         assert (tmp_path / 'contest.rbx.yml').read_text() == 'use_variants: true\n'
+
+    def test_invalid_scaffold_rolls_back(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_dispatcher(tmp_path)
+        original = (tmp_path / 'contest.rbx.yml').read_text()
+        from rbx.box import presets
+
+        presets.install_preset_from_dir(
+            _make_minimal_preset(tmp_path / '_src_preset', invalid=True),
+            tmp_path / '.local.rbx',
+        )
+
+        result = runner.invoke(contest_main.app, ['add_variant', 'div3'])
+
+        assert result.exit_code != 0, result.output
+        # The scaffolded file was unlinked by the rollback.
+        assert not (tmp_path / 'contest.div3.rbx.yml').exists()
+        # The dispatcher sentinel is untouched.
+        assert (tmp_path / 'contest.rbx.yml').read_text() == original
 
     def test_scaffold_in_real_contest_mode(self, runner, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Closes #432.

## What

Adds `rbx contest add_variant <id> [--preset/-p <name>]` — scaffolds a new `contest.<id>.rbx.yml` variant file in a contest directory, seeded from a preset's contest template. Previously, after `rbx contest init` or hand-editing `contest.rbx.yml` to `use_variants: true`, each variant had to be authored from scratch.

## Behavior

- Validates `<id>` against the variant id pattern (`^[A-Za-z][A-Za-z0-9_-]*$`).
- Errors if not inside a contest directory, or if `contest.<id>.rbx.yml` already exists.
- Works in **both** dispatcher mode (`use_variants: true`) and real-contest mode (where siblings are extra selectable variants) — `contest.rbx.yml` is never modified. (No "flip to `use_variants: true` first" requirement; that mode already supports sibling variants per the multi-contest design.)
- `--preset/-p` selects the preset to scaffold from; defaults to the active preset in the cwd, then the bundled default preset.
- The scaffold installs the preset's contest template into a temp dir (reusing `presets.install_contest`), reads the produced `contest.rbx.yml`, overrides `name` → `<id>-c` and `problems` → `[]`, writes it, and validates the result parses as a `Contest` (rolls back the file on failure).

`--from <existing-id>` from the original issue proposal was dropped in favor of `--preset` (decided during design); `rbx contest remove_variant` remains tracked separately.

## Tests

- Unit (`tests/rbx/box/contest/test_contest_main.py`, `TestContestAddVariant`): id validation, not-in-contest-dir refusal, existing-variant refusal, dispatcher-mode scaffold, real-contest-mode scaffold, validation-failure rollback, `--preset` flag.
- e2e: 3 scenarios added to `tests/e2e/testdata/multi-contest/e2e.rbx.yml` (successful scaffold + `contest list` + `-C div3 contest summary`; refusal on existing variant; refusal on invalid id). A minimal offline `.local.rbx/` preset is committed into that fixture so the scenarios run without network; `tests/e2e/runner.py` no longer strips `.local.rbx` when copying fixtures.

## Docs

Design + implementation plan under `docs/plans/2026-05-12-contest-add-variant{-design,}.md`. The design doc records the implementation choice (reuse `install_contest` via a temp dir rather than extracting a new `presets` helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)