### PR TITLE
feat: clearer 'executable not found' errors (#374)

### DIFF
--- a/docs/plans/2026-05-12-clearer-executable-not-found-errors-design.md
+++ b/docs/plans/2026-05-12-clearer-executable-not-found-errors-design.md
@@ -1,0 +1,102 @@
+# Clearer "executable not found" errors (#374)
+
+## Problem
+
+When a command fails because the referenced executable does not exist — a typo in
+a generator/checker/validator/interactor command, or a missing compiler/interpreter
+for a solution's language — `rbx` currently surfaces a generic failure. During
+execution the user sees `INTERNAL ERROR` (or `FAILED with ... sandbox status
+sandbox error`) with no hint that the real cause is a missing binary; the helpful
+diagnostic produced internally is dropped on the floor.
+
+## Current state (as found)
+
+- `rbx/grading/judge/program.py:265-268` already detects the case: a
+  `FileNotFoundError`/`PermissionError` from `subprocess.Popen` is turned into a
+  `ProgramError("Command <exe> not found")`.
+- Compilation path (`rbx/grading/steps.py:compile`, ~lines 749-755): the
+  `ProgramError` message **is** printed via `CompilationError`. Functional but
+  terse.
+- Execution path (`rbx/grading/steps.py:run` → `_build_program_error_run_log`,
+  ~lines 668-680, 824-825): the `ProgramError` becomes a `RunLog` with
+  `exitstatus == EXIT_SANDBOX_ERROR` and the message stored in `RunLog.sandbox`.
+  Nothing ever reads `RunLog.sandbox` for display — `get_summary()` ignores it,
+  and `rbx/box/checkers.py` maps `EXIT_SANDBOX_ERROR` to `Outcome.INTERNAL_ERROR`
+  with an empty (or hardcoded `"sandbox failed to run checker"`) message.
+- Solution compile-failure semantics are already what we want:
+  - `rbx run <single solution>` / `-s` selecting one: `compile_solutions()` sets
+    `should_fail` (because `len(expanded_solutions) <= 1`) and re-raises the
+    `CompilationError` — the command aborts with the full compiler error.
+  - `rbx run` over many solutions / `rbx build` verify: the failing solution is
+    marked `SKIPPED`, a `FailedToCompileSolutionIssue` is recorded, and the rest
+    continue.
+  - Main/model solution missing its compiler during `rbx build`: always aborts
+    (`rbx/box/generators.py:641-670`) — you cannot generate outputs without it.
+
+So the gap is **message quality**, not control flow. No new `Outcome` or sandbox
+exit-status values are needed.
+
+## Design
+
+### 1. `ProgramNotFoundError`
+
+Add `class ProgramNotFoundError(ProgramError)` in `rbx/grading/judge/program.py`.
+The `FileNotFoundError`/`PermissionError` handlers raise it instead of a bare
+`ProgramError`, with an actionable message that names the executable, e.g.:
+
+> `Executable 'python3' was not found — is it installed and on your PATH?`
+
+Because it is a strict subclass, every existing `except ProgramError` and
+`except CompilationError` keeps catching it; nothing about control flow changes.
+It just lets call sites format a friendlier message and detect the case without
+string-sniffing.
+
+### 2. Compilation path
+
+In `rbx/grading/steps.py:compile()`, when the caught `ProgramError` is a
+`ProgramNotFoundError`, print a "compiler/interpreter not found" framing rather
+than the bare message — including the executable name and the offending command.
+
+### 3. Execution path — stop dropping `RunLog.sandbox`
+
+- `RunLog.get_summary()`: when `exitstatus == EXIT_SANDBOX_ERROR` and `sandbox`
+  is non-empty, append the `sandbox` message to the summary string. (Only on that
+  exitstatus — on success `sandbox` holds a JSON log dump, not a message.)
+- `rbx/box/checkers.py`: at the two sites mapping `EXIT_SANDBOX_ERROR` →
+  `Outcome.INTERNAL_ERROR`, set `CheckerResult.message` from `run_log.sandbox`
+  (falling back to the existing text when empty).
+
+With these, generators already print `get_summary()` and solution reporters
+already print `eval.result.message`, so the not-found diagnostic reaches the user
+on the execution path with no further plumbing.
+
+### 4. Skipped-solution summary reason
+
+`FailedToCompileSolutionIssue` takes the underlying exception (already stashed on
+`key.exception`) and includes its reason in `get_detailed_message()`, so the
+end-of-run skipped-solutions summary reads e.g.
+`sol.py could not be compiled (python3 not found) and was skipped.`
+
+## Testing
+
+- `tests/rbx/grading/judge/test_program.py::test_nonexistent_program`: assert
+  `ProgramNotFoundError` is raised and the message names the executable.
+- `rbx/grading/steps.py`: unit test that `RunLog.get_summary()` includes the
+  `sandbox` message when `exitstatus == EXIT_SANDBOX_ERROR`.
+- `rbx/box/checkers.py`: a checker run hitting `EXIT_SANDBOX_ERROR` yields a
+  `CheckerResult` whose `message` carries the sandbox text.
+- Test-package fixture(s):
+  - a generator referencing a bogus executable → `rbx build` shows the
+    not-found message;
+  - a solution whose language compiler is (test-)missing: run alone → abort with
+    a clear message; run alongside other solutions → skipped, and the
+    skipped-solutions summary names the reason.
+
+## Out of scope
+
+- `SKIPPED (<reason>)` in the `LiveTasks` progress view — tracked in #448
+  (mirrors the `WARNINGS (<summary>)` pattern from #447), to be done after this
+  PR merges.
+- The shell exit-code-127 "command not found" case (command run via a shell that
+  reports the failure itself rather than Python raising `FileNotFoundError`).
+- Any new `Outcome` enum value or sandbox exit-status value.

--- a/docs/plans/2026-05-12-clearer-executable-not-found-errors.md
+++ b/docs/plans/2026-05-12-clearer-executable-not-found-errors.md
@@ -1,0 +1,444 @@
+# Clearer "executable not found" errors (#374) — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** When a command fails because the referenced executable does not exist (typo in a generator/checker command, or a missing compiler/interpreter), surface a clear "executable not found" message instead of a generic `INTERNAL ERROR` / terse `Command X not found`.
+
+**Architecture:** Introduce a `ProgramNotFoundError(ProgramError)` subclass raised when `subprocess.Popen` hits `FileNotFoundError`/`PermissionError`. On the compilation path, format a friendlier message and stash the missing executable name on the raised `CompilationError`. On the execution path, stop dropping `RunLog.sandbox` — include it in `get_summary()` and propagate it as `CheckerResult.message`. The skipped-solutions end-of-run summary names the reason. No new `Outcome` or sandbox exit-status values.
+
+**Tech Stack:** Python 3, pytest, Pydantic v2, Typer/Rich. Run tests with `uv run pytest`.
+
+**Design doc:** `docs/plans/2026-05-12-clearer-executable-not-found-errors-design.md`
+
+**Conventions:** single quotes; absolute imports only; commits via the `/commit` skill (conventional commits — use `feat`/`test`/`refactor` as appropriate). Run `uv run ruff check . && uv run ruff format .` before each commit.
+
+---
+
+### Task 1: `ProgramNotFoundError` exception
+
+**Files:**
+- Modify: `rbx/grading/judge/program.py` (around `class ProgramError` at line 183, and the `_run` handlers at lines 265-268)
+- Test: `tests/rbx/grading/judge/test_program.py` (`TestEdgeCases.test_nonexistent_program`, line 672)
+
+**Step 1: Update the failing test**
+
+In `tests/rbx/grading/judge/test_program.py`, replace `test_nonexistent_program`:
+
+```python
+    def test_nonexistent_program(self):
+        """Test execution of non-existent program."""
+        from rbx.grading.judge.program import ProgramNotFoundError
+
+        params = ProgramParams()
+        command = ['/nonexistent/program']
+
+        with pytest.raises(ProgramNotFoundError) as exc_info:
+            Program(command, params)
+
+        assert exc_info.value.executable == '/nonexistent/program'
+        assert '/nonexistent/program' in str(exc_info.value)
+```
+
+**Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/rbx/grading/judge/test_program.py::TestEdgeCases::test_nonexistent_program -v`
+Expected: FAIL — `ImportError`/`AttributeError` for `ProgramNotFoundError`.
+
+**Step 3: Implement**
+
+In `rbx/grading/judge/program.py`, after `class ProgramError(Exception): pass` (line ~184), add:
+
+```python
+class ProgramNotFoundError(ProgramError):
+    def __init__(self, executable: str, *, permission_denied: bool = False):
+        self.executable = executable
+        self.permission_denied = permission_denied
+        if permission_denied:
+            msg = f"Permission denied when running executable '{executable}'."
+        else:
+            msg = (
+                f"Executable '{executable}' was not found "
+                '— is it installed and on your PATH?'
+            )
+        super().__init__(msg)
+```
+
+Then change the handlers in `_run` (lines 265-268) from:
+
+```python
+        except FileNotFoundError as e:
+            raise ProgramError(f'Command {self.command[0]} not found') from e
+        except PermissionError as e:
+            raise ProgramError(f'Permission denied for command {self.command}') from e
+```
+
+to:
+
+```python
+        except FileNotFoundError as e:
+            raise ProgramNotFoundError(self.command[0]) from e
+        except PermissionError as e:
+            raise ProgramNotFoundError(
+                self.command[0], permission_denied=True
+            ) from e
+```
+
+**Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/rbx/grading/judge/test_program.py -v`
+Expected: PASS.
+
+**Step 5: Commit** (via `/commit` skill)
+
+`feat(grading): add ProgramNotFoundError for missing executables`
+
+---
+
+### Task 2: Friendlier compilation message + stash missing executable on `CompilationError`
+
+**Files:**
+- Modify: `rbx/box/exception.py` (`class CompilationError` lives in `rbx/grading/steps.py`, line ~714 — check; `RbxException` base is in `rbx/box/exception.py`)
+- Modify: `rbx/grading/steps.py` — import (`from rbx.grading.judge.program import ProgramError` at line 24) and the `except ProgramError` block at lines 753-759
+- Test: `tests/rbx/grading/steps_compile_test.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/rbx/grading/steps_compile_test.py` (mirror the style of existing tests there — they use the `sandbox` and `cleandir` fixtures and `steps.compile`). The test compiles a "compilable" whose compilation command references a bogus executable and asserts the raised `CompilationError` mentions the executable and exposes `not_found_executable`:
+
+```python
+async def test_compile_missing_compiler_reports_not_found(
+    sandbox: SandboxBase, cleandir: pathlib.Path
+):
+    artifacts = steps.GradingArtifacts(root=cleandir)
+    with pytest.raises(steps.CompilationError) as exc_info:
+        await steps.compile(
+            commands=['definitely-not-a-real-compiler-xyz src.cpp -o exe'],
+            params=SandboxParams(),
+            sandbox=sandbox,
+            artifacts=artifacts,
+        )
+    assert exc_info.value.not_found_executable == 'definitely-not-a-real-compiler-xyz'
+    assert 'definitely-not-a-real-compiler-xyz' in str(exc_info.value)
+    assert 'not found' in str(exc_info.value).lower()
+```
+
+(Check `steps.compile`'s actual signature in `rbx/grading/steps.py` near line 720 and adjust kwarg names if needed.)
+
+**Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/rbx/grading/steps_compile_test.py::test_compile_missing_compiler_reports_not_found -v`
+Expected: FAIL — `not_found_executable` attribute missing (and/or message not friendly).
+
+**Step 3: Implement**
+
+(a) In `rbx/grading/steps.py`, add `ProgramNotFoundError` to the import on line 24:
+
+```python
+from rbx.grading.judge.program import ProgramError, ProgramNotFoundError
+```
+
+(b) Give `CompilationError` an optional attribute. Find `class CompilationError(RbxException)` in `rbx/grading/steps.py` (~line 714) and add a class-level default:
+
+```python
+class CompilationError(RbxException):
+    not_found_executable: Optional[str] = None
+```
+
+(c) In the `except ProgramError as e:` block inside `compile()` (lines 753-759), special-case `ProgramNotFoundError`:
+
+```python
+        except ProgramError as e:
+            with CompilationError() as err:
+                if isinstance(e, ProgramNotFoundError):
+                    err.not_found_executable = e.executable
+                    err.print(
+                        f"[error]FAILED[/error] The compiler/interpreter "
+                        f"'[item]{e.executable}[/item]' was not found while running",
+                        utils.highlight_json_obj(cmd),
+                    )
+                    err.print(
+                        '[warning]Is it installed and on your PATH?[/warning]'
+                    )
+                else:
+                    err.print(
+                        '[error]FAILED[/error] Preprocessing failed with command',
+                        utils.highlight_json_obj(cmd),
+                    )
+                    err.print(e)
+```
+
+Note: the `with CompilationError() as err:` block raises the `err` on exit (see `RbxException.__exit__`), so `not_found_executable` is carried to the caller.
+
+**Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/rbx/grading/steps_compile_test.py -v`
+Expected: PASS.
+
+**Step 5: Commit** (`/commit` skill)
+
+`feat(grading): clearer compilation error when compiler is missing`
+
+---
+
+### Task 3: `RunLog.get_summary()` surfaces the sandbox error message
+
+**Files:**
+- Modify: `rbx/grading/steps.py` — `RunLog.get_summary()` at lines 266-271
+- Test: `tests/rbx/grading/steps_run_test.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/rbx/grading/steps_run_test.py` (no fixtures needed — it's a pure model test; put it near `test_run_handles_program_error_and_returns_sandbox_error`):
+
+```python
+def test_run_log_summary_includes_sandbox_message_on_sandbox_error():
+    log = steps.RunLog(
+        exitcode=1,
+        exitstatus=SandboxBase.EXIT_SANDBOX_ERROR,
+        sandbox="Executable 'python3' was not found — is it installed and on your PATH?",
+    )
+    summary = log.get_summary()
+    assert 'python3' in summary
+    assert 'not found' in summary.lower()
+
+
+def test_run_log_summary_no_sandbox_message_when_empty():
+    log = steps.RunLog(exitcode=1, exitstatus=SandboxBase.EXIT_SANDBOX_ERROR, sandbox='')
+    assert 'None' not in log.get_summary()  # sanity: no dangling text
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/grading/steps_run_test.py -k run_log_summary -v`
+Expected: FAIL — `python3` not in summary.
+
+**Step 3: Implement**
+
+Replace `RunLog.get_summary()` (lines 266-271):
+
+```python
+    def get_summary(self) -> str:
+        if self.exitcode == 0:
+            return 'OK'
+        time = self.time or 0.0
+        memory = self.memory or 0
+        summary = (
+            f'FAILED with exit code {self.exitcode} and sandbox status '
+            f'{self.exitstatus} (time: {time}s, memory: {memory // (1024 * 1024)}MB)'
+        )
+        if self.exitstatus == SandboxBase.EXIT_SANDBOX_ERROR and self.sandbox:
+            summary += f'\nReason: {self.sandbox}'
+        return summary
+```
+
+(`SandboxBase` is already imported in `steps.py`.)
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/grading/steps_run_test.py -k run_log_summary -v`
+Expected: PASS.
+
+**Step 5: Commit** (`/commit` skill)
+
+`feat(grading): include sandbox failure reason in RunLog summary`
+
+---
+
+### Task 4: Propagate the sandbox message into `CheckerResult.message`
+
+**Files:**
+- Modify: `rbx/box/checkers.py` — `_check_pre_output` (line 168-169) and `process_checker_run_log` (lines 220-231)
+- Test: `tests/rbx/box/checkers_test.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/rbx/box/checkers_test.py` (check existing imports; `Outcome` and `SandboxBase` should be importable; build a minimal `RunLog`):
+
+```python
+def test_process_checker_run_log_surfaces_sandbox_message():
+    from rbx.box import checkers
+    from rbx.grading import steps
+    from rbx.grading.judge.sandbox import SandboxBase
+    from rbx.grading.steps import Outcome
+
+    run_log = steps.RunLog(
+        exitcode=1,
+        exitstatus=SandboxBase.EXIT_SANDBOX_ERROR,
+        sandbox="Executable 'checker' was not found — is it installed and on your PATH?",
+    )
+    result = checkers.process_checker_run_log(run_log, message='')
+    assert result.outcome == Outcome.INTERNAL_ERROR
+    assert 'checker' in result.message
+    assert 'not found' in result.message.lower()
+
+
+def test_process_checker_run_log_falls_back_when_no_sandbox_message():
+    from rbx.box import checkers
+    from rbx.grading import steps
+    from rbx.grading.judge.sandbox import SandboxBase
+
+    run_log = steps.RunLog(
+        exitcode=1, exitstatus=SandboxBase.EXIT_SANDBOX_ERROR, sandbox=''
+    )
+    result = checkers.process_checker_run_log(run_log, message='')
+    assert result.message == 'sandbox failed to run checker'
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/checkers_test.py -k surfaces_sandbox_message -v`
+Expected: FAIL — message is the hardcoded string, no `checker`/`not found`.
+
+**Step 3: Implement**
+
+In `rbx/box/checkers.py`:
+
+(a) `process_checker_run_log` (lines ~220-231) — change the `EXIT_SANDBOX_ERROR` branch:
+
+```python
+    if (
+        checker_run_log is not None
+        and checker_run_log.exitstatus == SandboxBase.EXIT_SANDBOX_ERROR
+    ):
+        # When the sandbox fails, it means the checker failed to run.
+        return CheckerResult(
+            outcome=Outcome.INTERNAL_ERROR,
+            message=checker_run_log.sandbox or 'sandbox failed to run checker',
+        )
+```
+
+(b) `_check_pre_output` (line 168-169) — change:
+
+```python
+    if run_log.exitstatus == SandboxBase.EXIT_SANDBOX_ERROR:
+        return CheckerResult(
+            outcome=Outcome.INTERNAL_ERROR, message=run_log.sandbox or ''
+        )
+```
+
+Leave the other `INTERNAL_ERROR` returns (`run_log is None`, line 234, etc.) as-is — there's no message available there.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/checkers_test.py -v`
+Expected: PASS (all of `checkers_test.py`, to catch regressions).
+
+**Step 5: Commit** (`/commit` skill)
+
+`feat(box): surface sandbox failure reason in checker results`
+
+---
+
+### Task 5: Name the reason in the skipped-solutions summary
+
+**Files:**
+- Modify: `rbx/box/solutions.py` — `FailedToCompileSolutionIssue` (lines ~248-256) and its construction in `compile_solutions().failed` (line ~317)
+- Test: `tests/rbx/box/solutions_test.py` (or `tests/rbx/box/solutions_compile_warnings_test.py` — pick whichever has the lighter fixture setup; a direct unit test of the issue class is fine)
+
+**Step 1: Write the failing test**
+
+Add a focused unit test (no package fixture needed):
+
+```python
+def test_failed_to_compile_issue_includes_not_found_reason():
+    from rbx.box.solutions import FailedToCompileSolutionIssue
+    from rbx.box.schema import Solution, ExpectedOutcome
+    from rbx.grading.steps import CompilationError
+
+    sol = Solution(path=pathlib.Path('sols/wa.py'), outcome=ExpectedOutcome.WRONG_ANSWER)
+    exc = CompilationError()
+    exc.not_found_executable = 'python3'
+    issue = FailedToCompileSolutionIssue(sol, exception=exc)
+    msg = issue.get_detailed_message()
+    assert 'wa.py' in msg
+    assert 'python3' in msg
+
+
+def test_failed_to_compile_issue_generic_message_without_reason():
+    from rbx.box.solutions import FailedToCompileSolutionIssue
+    from rbx.box.schema import Solution, ExpectedOutcome
+
+    sol = Solution(path=pathlib.Path('sols/wa.py'), outcome=ExpectedOutcome.WRONG_ANSWER)
+    issue = FailedToCompileSolutionIssue(sol)
+    assert 'could not be compiled and was skipped' in issue.get_detailed_message()
+```
+
+(Adjust `Solution` construction to match the real schema — check `rbx/box/schema.py` for required fields. Use `package`/conftest fixtures if `Solution` can't be built standalone.)
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/solutions_test.py -k failed_to_compile_issue -v`
+Expected: FAIL — `FailedToCompileSolutionIssue` doesn't accept `exception`.
+
+**Step 3: Implement**
+
+In `rbx/box/solutions.py`:
+
+```python
+class FailedToCompileSolutionIssue(issue_stack.Issue):
+    def __init__(self, solution: Solution, exception: Optional[BaseException] = None):
+        self.solution = solution
+        self.exception = exception
+
+    def get_detailed_section(self) -> Tuple[str, ...]:
+        return ('solutions',)
+
+    def _reason(self) -> Optional[str]:
+        from rbx.grading.steps import CompilationError
+
+        if isinstance(self.exception, CompilationError) and self.exception.not_found_executable:
+            return f"'{self.exception.not_found_executable}' not found"
+        return None
+
+    def get_detailed_message(self) -> str:
+        reason = self._reason()
+        if reason is not None:
+            return f'{self.solution.href()} could not be compiled ({reason}) and was skipped.'
+        return f'{self.solution.href()} could not be compiled and was skipped.'
+```
+
+And in `compile_solutions().failed` (line ~317), pass the exception:
+
+```python
+                key.exception = exception
+                issue_stack.add_issue(
+                    FailedToCompileSolutionIssue(key.solution, exception=exception)
+                )
+```
+
+(`Optional` is already imported in `solutions.py`; if not, add it.)
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/solutions_test.py -k failed_to_compile_issue -v`
+Expected: PASS.
+
+**Step 5: Commit** (`/commit` skill)
+
+`feat(box): name the reason in the skipped-solutions summary`
+
+---
+
+### Task 6: Full-suite check + lint
+
+**Step 1:** Run: `uv run ruff check . && uv run ruff format --check .` — fix anything reported (`uv run ruff check --fix . && uv run ruff format .`).
+
+**Step 2:** Run the touched test modules together:
+
+```bash
+uv run pytest tests/rbx/grading/judge/test_program.py tests/rbx/grading/steps_compile_test.py tests/rbx/grading/steps_run_test.py tests/rbx/box/checkers_test.py tests/rbx/box/solutions_test.py -v
+```
+
+Expected: all pass. (The repo has known pre-existing unrelated failures in `validators_test.py` / `code_run_test.py` / docker e2e — out of scope; verify on `main` if unsure.)
+
+**Step 3:** If any formatting/lint changes were made, commit them: `style: ruff formatting` (only if needed).
+
+---
+
+### Notes for the implementer
+
+- `superpowers:test-driven-development` — follow the red/green cycle per task.
+- `superpowers:verification-before-completion` — run the listed commands and confirm output before claiming done.
+- Do **not** add a new `Outcome` value or sandbox exit-status; that was explicitly ruled out.
+- The `SKIPPED (<reason>)` LiveTasks UI is out of scope — tracked in issue #448.
+- If `steps.compile`'s signature differs from what Task 2's test assumes, look at an existing test in `tests/rbx/grading/steps_compile_test.py` and copy its call shape.

--- a/rbx/box/checkers.py
+++ b/rbx/box/checkers.py
@@ -166,7 +166,9 @@ def _check_pre_output(run_log: Optional[RunLog]) -> CheckerResult:
     if run_log.exitstatus == SandboxBase.EXIT_MEMORY_LIMIT_EXCEEDED:
         return CheckerResult(outcome=Outcome.MEMORY_LIMIT_EXCEEDED)
     if run_log.exitstatus == SandboxBase.EXIT_SANDBOX_ERROR:
-        return CheckerResult(outcome=Outcome.INTERNAL_ERROR)
+        return CheckerResult(
+            outcome=Outcome.INTERNAL_ERROR, message=run_log.sandbox or ''
+        )
     if run_log.exitstatus == SandboxBase.EXIT_OUTPUT_LIMIT_EXCEEDED:
         return CheckerResult(outcome=Outcome.OUTPUT_LIMIT_EXCEEDED)
     return CheckerResult(outcome=Outcome.ACCEPTED)
@@ -227,7 +229,7 @@ def process_checker_run_log(
         # We don't know what happened.
         return CheckerResult(
             outcome=Outcome.INTERNAL_ERROR,
-            message='sandbox failed to run checker',
+            message=checker_run_log.sandbox or 'sandbox failed to run checker',
         )
 
     if checker_run_log is None:

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -258,7 +258,7 @@ class FailedToCompileSolutionIssue(issue_stack.Issue):
             isinstance(self.exception, steps.CompilationError)
             and self.exception.not_found_executable
         ):
-            return f"'{self.exception.not_found_executable}' not found"
+            return f"'{self.exception.not_found_executable}' was not found"
         return None
 
     def get_detailed_message(self) -> str:

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -246,13 +246,28 @@ def get_exact_matching_solutions(expected_outcome: ExpectedOutcome) -> List[Solu
 
 
 class FailedToCompileSolutionIssue(issue_stack.Issue):
-    def __init__(self, solution: Solution):
+    def __init__(self, solution: Solution, exception: Optional[BaseException] = None):
         self.solution = solution
+        self.exception = exception
 
     def get_detailed_section(self) -> Tuple[str, ...]:
         return ('solutions',)
 
+    def _reason(self) -> Optional[str]:
+        if (
+            isinstance(self.exception, steps.CompilationError)
+            and self.exception.not_found_executable
+        ):
+            return f"'{self.exception.not_found_executable}' not found"
+        return None
+
     def get_detailed_message(self) -> str:
+        reason = self._reason()
+        if reason is not None:
+            return (
+                f'{self.solution.href()} could not be compiled ({reason}) '
+                'and was skipped.'
+            )
         return f'{self.solution.href()} could not be compiled and was skipped.'
 
 
@@ -314,7 +329,9 @@ async def compile_solutions(
                     key.status = live_tasks.CompilationStatus.FAILED
                     raise exception
                 key.exception = exception
-                issue_stack.add_issue(FailedToCompileSolutionIssue(key.solution))
+                issue_stack.add_issue(
+                    FailedToCompileSolutionIssue(key.solution, exception=exception)
+                )
 
         streamer = SolutionCompilationStreamer(
             setter_config.get_async_executor(detach=True)

--- a/rbx/grading/judge/program.py
+++ b/rbx/grading/judge/program.py
@@ -184,6 +184,20 @@ class ProgramError(Exception):
     pass
 
 
+class ProgramNotFoundError(ProgramError):
+    def __init__(self, executable: str, *, permission_denied: bool = False):
+        self.executable = executable
+        self.permission_denied = permission_denied
+        if permission_denied:
+            msg = f"Permission denied when running executable '{executable}'."
+        else:
+            msg = (
+                f"Executable '{executable}' was not found "
+                '— is it installed and on your PATH?'
+            )
+        super().__init__(msg)
+
+
 class Program:
     def __init__(self, command: List[str], params: ProgramParams):
         self.command = command
@@ -263,9 +277,9 @@ class Program:
                 pipesize=self.params.pipesize,
             )
         except FileNotFoundError as e:
-            raise ProgramError(f'Command {self.command[0]} not found') from e
+            raise ProgramNotFoundError(self.command[0]) from e
         except PermissionError as e:
-            raise ProgramError(f'Permission denied for command {self.command}') from e
+            raise ProgramNotFoundError(self.command[0], permission_denied=True) from e
         self.start_time = monotonic()
 
         threading.Thread(target=self._handle_wall, daemon=True).start()

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -21,7 +21,7 @@ from rbx.config import get_bits_stdcpp, get_jngen, get_testlib, get_tgen
 from rbx.console import console
 from rbx.grading import grading_context
 from rbx.grading.judge.cacher import FileCacher
-from rbx.grading.judge.program import ProgramError
+from rbx.grading.judge.program import ProgramError, ProgramNotFoundError
 from rbx.grading.judge.sandbox import (
     CommunicationParams,
     SandboxBase,
@@ -716,7 +716,7 @@ def _build_run_log(
 
 
 class CompilationError(RbxException):
-    pass
+    not_found_executable: Optional[str] = None
 
 
 async def compile(
@@ -752,11 +752,20 @@ async def compile(
             sandbox_log = await asyncio.to_thread(sandbox.run, cmd, params)
         except ProgramError as e:
             with CompilationError() as err:
-                err.print(
-                    '[error]FAILED[/error] Preprocessing failed with command',
-                    utils.highlight_json_obj(cmd),
-                )
-                err.print(e)
+                if isinstance(e, ProgramNotFoundError):
+                    err.not_found_executable = e.executable
+                    err.print(
+                        '[error]FAILED[/error] The compiler/interpreter '
+                        f"'[item]{e.executable}[/item]' was not found while running",
+                        utils.highlight_json_obj(cmd),
+                    )
+                    err.print('[warning]Is it installed and on your PATH?[/warning]')
+                else:
+                    err.print(
+                        '[error]FAILED[/error] Preprocessing failed with command',
+                        utils.highlight_json_obj(cmd),
+                    )
+                    err.print(e)
 
         std_outputs = [
             sandbox.get_file_to_string(stderr_file, maxlen=None)

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -268,7 +268,13 @@ class RunLog(BaseModel):
             return 'OK'
         time = self.time or 0.0
         memory = self.memory or 0
-        return f'FAILED with exit code {self.exitcode} and sandbox status {self.exitstatus} (time: {time}s, memory: {memory // (1024 * 1024)}MB)'
+        summary = (
+            f'FAILED with exit code {self.exitcode} and sandbox status '
+            f'{self.exitstatus} (time: {time}s, memory: {memory // (1024 * 1024)}MB)'
+        )
+        if self.exitstatus == SandboxBase.EXIT_SANDBOX_ERROR and self.sandbox:
+            summary += f'\nReason: {self.sandbox}'
+        return summary
 
 
 class PreprocessLog(RunLog):

--- a/tests/rbx/box/checkers_test.py
+++ b/tests/rbx/box/checkers_test.py
@@ -886,3 +886,22 @@ def test_process_checker_run_log_uses_last_line() -> None:
 
     assert result.outcome == Outcome.WRONG_ANSWER
     assert result.message == 'Actual error message'
+
+
+def test_process_checker_run_log_surfaces_sandbox_message() -> None:
+    run_log = RunLog(
+        exitcode=1,
+        exitstatus=SandboxBase.EXIT_SANDBOX_ERROR,
+        sandbox="Executable 'checker' was not found — is it installed and on your PATH?",
+    )
+    result = checkers.process_checker_run_log(run_log, message='')
+    assert result.outcome == Outcome.INTERNAL_ERROR
+    assert 'checker' in result.message
+    assert 'not found' in result.message.lower()
+
+
+def test_process_checker_run_log_falls_back_when_no_sandbox_message() -> None:
+    run_log = RunLog(exitcode=1, exitstatus=SandboxBase.EXIT_SANDBOX_ERROR, sandbox='')
+    result = checkers.process_checker_run_log(run_log, message='')
+    assert result.outcome == Outcome.INTERNAL_ERROR
+    assert result.message == 'sandbox failed to run checker'

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -17,6 +17,7 @@ from rbx.box.schema import (
     Testcase,
 )
 from rbx.box.solutions import (
+    FailedToCompileSolutionIssue,
     GroupSkeleton,
     SolutionOutcomeStatus,
     SolutionReportSkeleton,
@@ -31,6 +32,7 @@ from rbx.box.testcase_schema import TestcaseEntry
 from rbx.grading.limits import Limits
 from rbx.grading.steps import (
     CheckerResult,
+    CompilationError,
     Evaluation,
     Outcome,
     TestcaseIO,
@@ -687,3 +689,27 @@ def test_solution_outcome_report_points_scoring_with_dependencies(
             solution, skeleton, evals_g3_fail, VerificationLevel.FULL
         )
     assert report.gotScore == 60
+
+
+def test_failed_to_compile_issue_includes_not_found_reason():
+    sol = Solution(
+        path=pathlib.Path('sols/wa.py'), outcome=ExpectedOutcome.WRONG_ANSWER
+    )
+    exc = CompilationError()
+    exc.not_found_executable = 'python3'
+    issue = FailedToCompileSolutionIssue(sol, exception=exc)
+
+    msg = issue.get_detailed_message()
+    assert 'python3' in msg
+    assert 'sols/wa.py' in msg
+
+
+def test_failed_to_compile_issue_generic_message_without_reason():
+    sol = Solution(
+        path=pathlib.Path('sols/wa.py'), outcome=ExpectedOutcome.WRONG_ANSWER
+    )
+    issue = FailedToCompileSolutionIssue(sol)
+
+    msg = issue.get_detailed_message()
+    assert 'could not be compiled and was skipped' in msg
+    assert 'sols/wa.py' in msg

--- a/tests/rbx/grading/judge/test_program.py
+++ b/tests/rbx/grading/judge/test_program.py
@@ -10,8 +10,8 @@ import pytest
 from rbx.grading.judge.program import (
     Program,
     ProgramCode,
-    ProgramError,
     ProgramIO,
+    ProgramNotFoundError,
     ProgramParams,
     ProgramResult,
     get_cpu_time,
@@ -674,8 +674,11 @@ class TestEdgeCases:
         params = ProgramParams()
         command = ['/nonexistent/program']
 
-        with pytest.raises(ProgramError):
+        with pytest.raises(ProgramNotFoundError) as exc_info:
             Program(command, params)
+
+        assert exc_info.value.executable == '/nonexistent/program'
+        assert '/nonexistent/program' in str(exc_info.value)
 
     def test_empty_command(self):
         """Test execution with empty command."""

--- a/tests/rbx/grading/steps_compile_test.py
+++ b/tests/rbx/grading/steps_compile_test.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 from unittest.mock import patch
 
 import pytest
@@ -863,3 +864,24 @@ InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault
 
         assert artifacts.logs.preprocess is not None
         assert len(artifacts.logs.preprocess) == 1
+
+    async def test_compile_missing_compiler_reports_not_found(
+        self, sandbox: SandboxBase, cleandir: pathlib.Path
+    ):
+        """A missing compiler/interpreter yields a clear error and stashes the exe."""
+        artifacts = GradingArtifacts(root=cleandir)
+        params = SandboxParams()
+        with pytest.raises(steps.CompilationError) as exc_info:
+            await steps.compile(
+                ['definitely-not-a-real-compiler-xyz src.cpp -o exe'],
+                params,
+                sandbox,
+                artifacts,
+            )
+        assert (
+            exc_info.value.not_found_executable == 'definitely-not-a-real-compiler-xyz'
+        )
+        plain = re.sub(r'\x1b\[[0-9;]*m', '', str(exc_info.value))
+        message = ' '.join(plain.split()).lower()
+        assert 'definitely-not-a-real-compiler-xyz' in message
+        assert 'not found' in message

--- a/tests/rbx/grading/steps_run_test.py
+++ b/tests/rbx/grading/steps_run_test.py
@@ -958,3 +958,23 @@ class TestStepsRun:
         assert 'glob_test.py' in glob_output_content
         assert 'test1.py' in glob_output_content
         assert 'test2.py' in glob_output_content
+
+
+def test_run_log_summary_includes_sandbox_message_on_sandbox_error():
+    log = steps.RunLog(
+        exitcode=1,
+        exitstatus=SandboxBase.EXIT_SANDBOX_ERROR,
+        sandbox="Executable 'python3' was not found — is it installed and on your PATH?",
+    )
+    summary = log.get_summary()
+    assert 'python3' in summary
+    assert 'not found' in summary.lower()
+
+
+def test_run_log_summary_omits_sandbox_message_when_empty():
+    log = steps.RunLog(
+        exitcode=1, exitstatus=SandboxBase.EXIT_SANDBOX_ERROR, sandbox=''
+    )
+    summary = log.get_summary()
+    assert summary.startswith('FAILED')
+    assert 'Reason:' not in summary


### PR DESCRIPTION
Closes #374.

## What

When a command fails because the referenced executable doesn't exist — a typo in a generator/checker/validator/interactor command, or a missing compiler/interpreter for a solution's language — `rbx` now says so clearly instead of surfacing a generic `INTERNAL ERROR` / terse `Command X not found`.

## How

- **`ProgramNotFoundError(ProgramError)`** (`rbx/grading/judge/program.py`) — raised when `subprocess.Popen` hits `FileNotFoundError`/`PermissionError`, carrying `.executable` and `.permission_denied`, with an actionable message. Strict subclass, so every existing `except ProgramError` / `except CompilationError` still catches it — no control-flow change.
- **Compilation path** (`rbx/grading/steps.py:compile`) — special-cases `ProgramNotFoundError`: prints a friendly "the compiler/interpreter 'X' was not found … is it installed and on your PATH?" message and stashes `not_found_executable` on the raised `CompilationError`.
- **Execution path** — `RunLog.get_summary()` now appends `Reason: <sandbox message>` on `EXIT_SANDBOX_ERROR` (the message was already captured in `RunLog.sandbox` but never displayed); `rbx/box/checkers.py` propagates `run_log.sandbox` into `CheckerResult.message` for the `EXIT_SANDBOX_ERROR → INTERNAL_ERROR` mappings.
- **Skipped-solutions summary** — `FailedToCompileSolutionIssue` (`rbx/box/solutions.py`) names the reason, e.g. `sol.py could not be compiled ('python3' was not found) and was skipped.`

No new `Outcome` value or sandbox exit-status. Existing solution compile-failure semantics are unchanged: a single-solution `rbx run` aborts with the full error; a multi-solution run skips the failing solution and continues.

## Out of scope

- `SKIPPED (<reason>)` in the `LiveTasks` progress view — tracked in #448 (mirrors the `WARNINGS (<summary>)` pattern from #447).
- The shell exit-code-127 "command not found" case.

## Design & plan

`docs/plans/2026-05-12-clearer-executable-not-found-errors-design.md`, `docs/plans/2026-05-12-clearer-executable-not-found-errors.md`.

## Testing

`uv run ruff check . && uv run ruff format --check .` clean. `uv run pytest tests/rbx/grading/judge/test_program.py tests/rbx/grading/steps_compile_test.py tests/rbx/grading/steps_run_test.py tests/rbx/box/checkers_test.py` → 130 passed, 1 skipped; `tests/rbx/box/solutions_test.py` → 17 passed. New/updated tests cover `ProgramNotFoundError`, the friendly compile message + `not_found_executable`, `RunLog.get_summary()`, checker message propagation, and the skipped-solution reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
