### PR TITLE
feat: show skip reason in compilation LiveTasks (#448)

### DIFF
--- a/rbx/box/parallel/live_tasks.py
+++ b/rbx/box/parallel/live_tasks.py
@@ -157,6 +157,7 @@ class CompilationTask(LiveTask):
     status: CompilationStatus
     exception: Optional[RbxException] = None
     warning_summary: Optional[str] = None
+    skip_reason: Optional[str] = None
 
     def __init__(self, item: CodeItem) -> None:
         self.item = item
@@ -168,6 +169,8 @@ class CompilationTask(LiveTask):
         status_text = Text.from_markup(self.status.markup())
         if self.status is CompilationStatus.WARNINGS and self.warning_summary:
             status_text.append(f' ({self.warning_summary})', style='warning')
+        if self.status is CompilationStatus.SKIPPED and self.skip_reason:
+            status_text.append(f' ({self.skip_reason})', style='status')
         return TaskRenderable(
             columns=[
                 Text.from_markup(

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -283,9 +283,10 @@ class SolutionCompilationTask(live_tasks.CompilationTask):
         if rendered is None:
             return None
         if self.status == live_tasks.CompilationStatus.SKIPPED:
-            rendered.columns[1] = rich.text.Text.from_markup(
-                '[error]FAILED, skipped[/error]'
-            )
+            status_text = rich.text.Text.from_markup('[error]FAILED, skipped[/error]')
+            if self.skip_reason:
+                status_text.append(f' ({self.skip_reason})', style='status')
+            rendered.columns[1] = status_text
 
         return rendered
 
@@ -330,6 +331,8 @@ async def compile_solutions(
                     key.status = live_tasks.CompilationStatus.FAILED
                     raise exception
                 key.exception = exception
+                if exception.not_found_executable:
+                    key.skip_reason = f"'{exception.not_found_executable}' not found"
                 issue_stack.add_issue(
                     FailedToCompileSolutionIssue(key.solution, exception=exception)
                 )

--- a/tests/rbx/box/parallel/live_tasks_test.py
+++ b/tests/rbx/box/parallel/live_tasks_test.py
@@ -33,3 +33,25 @@ def test_warning_summary_ignored_when_not_warnings_status():
     rendered = _task(live_tasks.CompilationStatus.FAILED, summary='x').render()
     assert rendered is not None
     assert rendered.columns[1].plain == 'FAILED'
+
+
+def test_skipped_without_reason_shows_plain_label():
+    rendered = _task(live_tasks.CompilationStatus.SKIPPED).render()
+    assert rendered is not None
+    assert rendered.columns[1].plain == 'SKIPPED'
+
+
+def test_skipped_with_reason_appends_it():
+    task = _task(live_tasks.CompilationStatus.SKIPPED)
+    task.skip_reason = "'python3' not found"
+    rendered = task.render()
+    assert rendered is not None
+    assert rendered.columns[1].plain == "SKIPPED ('python3' not found)"
+
+
+def test_skip_reason_ignored_when_not_skipped_status():
+    task = _task(live_tasks.CompilationStatus.FAILED)
+    task.skip_reason = "'python3' not found"
+    rendered = task.render()
+    assert rendered is not None
+    assert rendered.columns[1].plain == 'FAILED'


### PR DESCRIPTION
## Summary
- Adds `skip_reason` to `CompilationTask`; render appends ` (<reason>)` when status is `SKIPPED`, mirroring the existing `WARNINGS (<summary>)` pattern from #447.
- `compile_solutions()` populates `skip_reason` from `CompilationError.not_found_executable` (surfaced by #374), so a missing `python3`/`g++`/etc. now shows as `SKIPPED ('python3' not found)` in the live view instead of a bare `SKIPPED`.
- Bare `SKIPPED` is preserved when no structured reason is available.

Closes #448.

## Test plan
- [x] `uv run pytest tests/rbx/box/parallel/live_tasks_test.py` — 3 new tests cover plain `SKIPPED`, `SKIPPED (<reason>)`, and that `skip_reason` is ignored for non-skipped statuses.
- [x] `uv run pytest tests/rbx/box/solutions_compile_warnings_test.py tests/rbx/box/sanitizers/compilation_warnings_helper_test.py` — existing warning-path tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)