### PR TITLE
fix(statements): strip \titleformat/\titlespacing before TexSoup parse (#419)

### DIFF
--- a/rbx/box/statements/demacro_utils.py
+++ b/rbx/box/statements/demacro_utils.py
@@ -1,11 +1,80 @@
 import dataclasses
 import json
 import pathlib
+import re
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple
 
 from TexSoup.data import BraceGroup, BracketGroup, TexCmd, TexNode
 
 from rbx.box.statements.texsoup_utils import parse_latex
+
+# Commands whose argument shape (a bare ``\command`` as a mandatory argument,
+# e.g. ``\titleformat{\section}{...}``) makes TexSoup's argument parser throw.
+# They never define macros we care about, so we strip them before parsing.
+# See https://github.com/rsalesc/rbx/issues/419.
+_PROBLEMATIC_COMMANDS_RE = re.compile(r'\\(?:titleformat|titlespacing)(?![a-zA-Z])\*?')
+
+
+def _skip_balanced(text: str, idx: int, open_ch: str, close_ch: str) -> int:
+    """Return the index just past a balanced *open_ch*...*close_ch* group."""
+    depth = 0
+    while idx < len(text):
+        ch = text[idx]
+        if ch == '\\' and idx + 1 < len(text):
+            idx += 2  # Skip escaped char (e.g. \{).
+            continue
+        if ch == open_ch:
+            depth += 1
+        elif ch == close_ch:
+            depth -= 1
+            if depth == 0:
+                return idx + 1
+        idx += 1
+    return idx
+
+
+def _strip_problematic_commands(content: str) -> str:
+    r"""Remove ``\titleformat``/``\titlespacing`` invocations (with their
+    arguments) so TexSoup can parse the rest of the file.
+
+    These commands take a bare control sequence as an argument
+    (``\titleformat{\section}{...}`` or ``\titlespacing\section{...}``), which
+    TexSoup's argument parser rejects. They are irrelevant to macro collection.
+    """
+    result: List[str] = []
+    pos = 0
+    for match in _PROBLEMATIC_COMMANDS_RE.finditer(content):
+        if match.start() < pos:
+            continue
+        result.append(content[pos : match.start()])
+        idx = match.end()
+        # Consume the trailing argument groups: bare control sequences,
+        # mandatory {...} groups and optional [...] groups, separated only by
+        # spaces/tabs (a newline ends the invocation).
+        while idx < len(content):
+            while idx < len(content) and content[idx] in ' \t':
+                idx += 1
+            if idx >= len(content):
+                break
+            ch = content[idx]
+            if ch == '\\' and idx + 1 < len(content):
+                idx += 2
+                while idx < len(content) and content[idx].isalpha():
+                    idx += 1
+            elif ch == '{':
+                idx = _skip_balanced(content, idx, '{', '}')
+            elif ch == '[':
+                idx = _skip_balanced(content, idx, '[', ']')
+            else:
+                break
+        pos = idx
+    result.append(content[pos:])
+    return ''.join(result)
+
+
+def _safe_parse_latex(content: str) -> TexNode:
+    """Parse LaTeX after stripping commands TexSoup cannot handle."""
+    return parse_latex(_strip_problematic_commands(content))
 
 
 @dataclasses.dataclass
@@ -166,7 +235,7 @@ def extract_definitions(
     source_file: Optional[str] = None,
 ) -> MacroDefinitions:
     """Extract all macro definitions from a TeX string."""
-    soup = parse_latex(tex_content)
+    soup = _safe_parse_latex(tex_content)
     defs = MacroDefinitions()
 
     # Iterate descendants in document order so that later definitions
@@ -226,7 +295,7 @@ def _collect_recursive(
 
     defs = extract_definitions(content, source_file=str(resolved))
 
-    soup = parse_latex(content)
+    soup = _safe_parse_latex(content)
 
     for cmd_name in ('input', 'include'):
         for node in soup.find_all(cmd_name):

--- a/tests/rbx/box/statements/test_demacro_utils.py
+++ b/tests/rbx/box/statements/test_demacro_utils.py
@@ -516,3 +516,54 @@ def test_macro_definitions_json_empty(tmp_path: pathlib.Path):
 
     loaded = MacroDefinitions.from_json_file(path)
     assert len(loaded) == 0
+
+
+def test_extract_definitions_with_titleformat_does_not_crash():
+    # TexSoup chokes on \titleformat{\section}{...} (issue #419).
+    tex = (
+        r'\titleformat{\section}{\LARGE\bfseries}{\thesection}{1em}{}'
+        '\n'
+        r'\newcommand{\afterTitleFormat}{ok}'
+    )
+    defs = extract_definitions(tex)
+    assert 'afterTitleFormat' in defs
+    assert defs.get('afterTitleFormat').body == 'ok'
+
+
+def test_extract_definitions_with_titlespacing_bare_command_arg():
+    # \titlespacing\section{...}{...}{...} — first arg is a bare command.
+    tex = (
+        r'\titlespacing\section{0pt}{12pt plus 0pt}{10pt plus 0pt}'
+        '\n'
+        r'\newcommand{\afterSpacing}{ok}'
+    )
+    defs = extract_definitions(tex)
+    assert 'afterSpacing' in defs
+
+
+def test_extract_definitions_with_starred_titleformat():
+    tex = (
+        r'\titleformat*{\section}{\bfseries}'
+        '\n'
+        r'\newcommand{\afterStar}{ok}'
+    )
+    defs = extract_definitions(tex)
+    assert 'afterStar' in defs
+
+
+def test_collect_from_default_icpc_preset_does_not_crash():
+    # The shipped default preset's icpc.sty has three \titleformat lines and
+    # three \titlespacing lines (issue #419). It must parse cleanly.
+    import rbx
+
+    sty = (
+        pathlib.Path(rbx.__file__).parent
+        / 'resources'
+        / 'presets'
+        / 'default'
+        / 'shared'
+        / 'icpc.sty'
+    )
+    defs = collect_macro_definitions(sty)
+    # icpc.sty defines several macros via \newcommand; make sure we still see them.
+    assert 'insereArquivo' in defs


### PR DESCRIPTION
## Summary

Fixes #419. `rbx pkg polygon` ran every `.sty` file through `demacro_utils._collect_recursive`, which parses with TexSoup. TexSoup's argument parser throws a `TypeError` on the bare control-sequence argument of `\titleformat{\section}{...}` (and the `\titlespacing\section{...}` form), so packaging any problem using the default preset's `icpc.sty` failed before producing a package.

## Fix

`demacro_utils` now strips `\titleformat`/`\titlespacing` (including starred variants) along with their following argument groups before handing the content to TexSoup, via a small balanced-group scanner (`_strip_problematic_commands` + `_safe_parse_latex`). These commands never define macros, so removing them is safe for macro collection. Applied in both `extract_definitions` and the recursive `\input`/`\usepackage` scan.

## Verification

- `collect_macro_definitions` on the shipped `rbx/resources/presets/default/shared/icpc.sty` now succeeds (42 macros collected, e.g. `insereArquivo`), previously raised `TypeError`.
- Added 4 regression tests (titleformat, bare-command titlespacing, starred titleformat, full default-preset `icpc.sty`).
- Full `tests/rbx/box/statements/` suite passes (252 passed); `ruff check`/`format` clean.

Note: the e2e fixture mentioned in the issue (with the three `\titleformat` lines commented out, on `feat/e2e-testing-strategy`) can be reverted to the real preset once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)