### PR TITLE
fix(statements): stop merge_interaction_entries from mutating input (#459)

### DIFF
--- a/rbx/box/testcase_utils.py
+++ b/rbx/box/testcase_utils.py
@@ -118,7 +118,7 @@ def merge_interaction_entries(
         if len(merged_entries) > 0 and merged_entries[-1].pipe == entry.pipe:
             merged_entries[-1].data += '\n' + entry.data
         else:
-            merged_entries.append(entry)
+            merged_entries.append(entry.model_copy())
     return merged_entries
 
 

--- a/tests/rbx/box/testcase_utils_test.py
+++ b/tests/rbx/box/testcase_utils_test.py
@@ -452,16 +452,19 @@ class TestMergeInteractionEntries:
         assert result[1].data == 'c\nd'
         assert result[1].pipe == 1
 
-    def test_mutates_first_entry_of_consecutive_group(self):
-        """The first entry of a consecutive group is mutated in-place."""
+    def test_does_not_mutate_input_entries(self):
+        """merge_interaction_entries must not mutate its input list (#459)."""
         entries = [
             TestcaseInteractionEntry(data='a', pipe=0),
             TestcaseInteractionEntry(data='b', pipe=0),
         ]
         result = merge_interaction_entries(entries)
-        # Result shares the same object as the first input entry
-        assert result[0] is entries[0]
-        assert entries[0].data == 'a\nb'
+        # The original entries are left pristine.
+        assert entries[0].data == 'a'
+        assert entries[1].data == 'b'
+        # The merged result is a distinct object from the input.
+        assert result[0] is not entries[0]
+        assert result[0].data == 'a\nb'
 
 
 class TestGetAlternateInteractionTexts:


### PR DESCRIPTION
## Summary

Fixes #459.

`merge_interaction_entries` appended input `TestcaseInteractionEntry` objects **by reference** and then mutated them in place (`merged_entries[-1].data += ...`). Because `_build_sample_interaction` passes the original `interaction.entries` list to the templates — and the default templates iterate `sample.interaction.entries` (not `chunks`) — the first entry of every same-pipe contiguous run got mutated to contain the whole merged block, while the remaining entries of that run still rendered their own content. Visually, the first line of each judge-output run repeated everything after it.

## Fix

Applied the issue's **preferred approach (Option 1)**: append `entry.model_copy()` instead of the original reference, so the list-returning helper never mutates its input. `entries` (raw) and `chunks` (merged-per-direction) stay semantically distinct, with no template churn.

## Tests

Replaced the test that asserted the buggy in-place mutation with `test_does_not_mutate_input_entries`, which verifies the input list is left pristine and the merged result is a distinct object. All 56 tests in `testcase_utils_test.py` / `testcase_sample_utils_test.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)