### PR TITLE
feat(statements): render interaction chunks in default preset

### DIFF
--- a/rbx/box/testcase_utils.py
+++ b/rbx/box/testcase_utils.py
@@ -80,14 +80,41 @@ class TestcaseData(BaseModel):
 
 
 class TestcaseInteractionEntry(BaseModel):
+    """A single line of dialogue exchanged in an interactive testcase.
+
+    An *entry* is the finest-grained unit of an interaction: exactly one line
+    as it was parsed from the ``.interaction``/``.pio`` file, with its origin
+    recorded in ``pipe``.
+
+    This contrasts with an interaction *chunk* (see
+    :class:`rbx.box.testcase_sample_utils.SampleInteractionChunk`): a chunk
+    merges consecutive entries from the *same* participant into a single block,
+    so a chunk represents one uninterrupted "turn" rather than one line. Chunks
+    are derived from entries via :func:`merge_interaction_entries`.
+    """
+
     __test__ = False
+
+    # The text exchanged on this line (participant prefix already stripped).
     data: str
+    # Which participant produced this line: 0 = interactor, 1 = solution.
     pipe: int
 
 
 class TestcaseInteraction(BaseModel):
+    """The full, unmerged dialogue of an interactive testcase.
+
+    Holds every :class:`TestcaseInteractionEntry` in chronological order. This
+    is the line-by-line source of truth; the merged, "chunked" view used for
+    statement rendering is derived from ``entries`` via
+    :func:`merge_interaction_entries`.
+    """
+
     __test__ = False
+
+    # All dialogue lines, in chronological order, one per exchanged line.
     entries: List[TestcaseInteractionEntry]
+    # (interactor_prefix, solution_prefix) used when parsing the source file.
     prefixes: Tuple[str, str]
 
 
@@ -113,6 +140,17 @@ class TestcaseInteractionParsingError(Exception):
 def merge_interaction_entries(
     entries: List[TestcaseInteractionEntry],
 ) -> List[TestcaseInteractionEntry]:
+    """Collapse a list of entries into "chunks".
+
+    Consecutive entries produced by the same participant (same ``pipe``) are
+    merged into a single entry, joining their ``data`` with newlines. The
+    result is the chunked view of the dialogue: one entry per uninterrupted
+    turn instead of one entry per line. Used to build
+    :class:`rbx.box.testcase_sample_utils.SampleInteractionChunk` for statement
+    rendering.
+
+    The input list is not mutated; merged entries are copied.
+    """
     merged_entries: List[TestcaseInteractionEntry] = []
     for entry in entries:
         if len(merged_entries) > 0 and merged_entries[-1].pipe == entry.pipe:
@@ -123,6 +161,14 @@ def merge_interaction_entries(
 
 
 def parse_interaction(file: pathlib.Path) -> TestcaseInteraction:
+    """Parse an interaction file into its unmerged :class:`TestcaseInteraction`.
+
+    ``.interaction`` files use the predetermined prefixes ``<`` (interactor)
+    and ``>`` (solution); any other suffix (e.g. ``.pio``) reads the two
+    prefixes from the first two lines of the file. Each remaining non-empty
+    line becomes one :class:`TestcaseInteractionEntry` (no merging is done
+    here -- see :func:`merge_interaction_entries` for the chunked view).
+    """
     entries = []
     with file.open('r') as f:
         if file.suffix == '.interaction':

--- a/rbx/resources/presets/default/shared/icpc.sty
+++ b/rbx/resources/presets/default/shared/icpc.sty
@@ -287,6 +287,43 @@
 	}
 } % interaction
 
+% Like \interaction, but renders a merged interaction *chunk* read verbatim
+% from a file (#1 = chunk file path, #2 = pipe: 0 = interactor, 1 = solution).
+% A chunk groups consecutive lines from the same participant, so this draws
+% one box per turn instead of one box per line, preserving multi-line content.
+\newcommand{\interactionchunk}[2]{
+	{\small
+
+		\ifthenelse{\equal{#2}{\string 0}}{
+			\vspace{-0.3cm}
+			\begin{tabular}{|l|}
+				\hline
+				\begin{minipage}[t]{0.55\textwidth}
+					\vspace{0.01cm}
+					\insereArquivo{#1}
+					\vspace{0.28cm}
+				\end{minipage}
+				\\
+				\hline
+			\end{tabular}
+		}{
+			\vspace{-0.3cm}
+			\hfill
+			\begin{tabular}{|l|}
+				\hline
+				\begin{minipage}[t]{0.55\textwidth}
+					\vspace{0.01cm}
+					\insereArquivo{#1}
+					\vspace{0.28cm}
+				\end{minipage}
+				\\
+				\hline
+			\end{tabular}
+		}
+
+	}
+} % interactionchunk
+
 \newcommand{\explanation}[1]{
 	\textbf{\strExplanation\theexemplocounter}
 

--- a/rbx/resources/presets/default/shared/problem_template.rbx.tex
+++ b/rbx/resources/presets/default/shared/problem_template.rbx.tex
@@ -48,8 +48,8 @@
 		%- for sample in problem.samples
 			%- if sample.interaction is not none
 				\exampleInteractive
-				%- for entry in sample.interaction.entries
-					\interaction{\VAR{entry.data}}{\VAR{entry.pipe}}
+				%- for chunk in sample.interaction.chunks
+					\interactionchunk{\VAR{chunk.path}}{\VAR{chunk.pipe}}
 				%- endfor
 			%- else
 				\example{\VAR{sample.inputPath}}

--- a/tests/e2e/testdata/default-preset/statement/icpc.sty
+++ b/tests/e2e/testdata/default-preset/statement/icpc.sty
@@ -288,6 +288,43 @@
 	}
 } % interaction
 
+% Like \interaction, but renders a merged interaction *chunk* read verbatim
+% from a file (#1 = chunk file path, #2 = pipe: 0 = interactor, 1 = solution).
+% A chunk groups consecutive lines from the same participant, so this draws
+% one box per turn instead of one box per line, preserving multi-line content.
+\newcommand{\interactionchunk}[2]{
+	{\small
+
+		\ifthenelse{\equal{#2}{\string 0}}{
+			\vspace{-0.3cm}
+			\begin{tabular}{|l|}
+				\hline
+				\begin{minipage}[t]{0.55\textwidth}
+					\vspace{0.01cm}
+					\insereArquivo{#1}
+					\vspace{0.28cm}
+				\end{minipage}
+				\\
+				\hline
+			\end{tabular}
+		}{
+			\vspace{-0.3cm}
+			\hfill
+			\begin{tabular}{|l|}
+				\hline
+				\begin{minipage}[t]{0.55\textwidth}
+					\vspace{0.01cm}
+					\insereArquivo{#1}
+					\vspace{0.28cm}
+				\end{minipage}
+				\\
+				\hline
+			\end{tabular}
+		}
+
+	}
+} % interactionchunk
+
 \newcommand{\explanation}[1]{
 	\textbf{\strExplanation\theexemplocounter}
 

--- a/tests/e2e/testdata/default-preset/statement/template.rbx.tex
+++ b/tests/e2e/testdata/default-preset/statement/template.rbx.tex
@@ -48,8 +48,8 @@
 		%- for sample in problem.samples
 			%- if sample.interaction is not none
 				\exampleInteractive
-				%- for entry in sample.interaction.entries
-					\interaction{\VAR{entry.data}}{\VAR{entry.pipe}}
+				%- for chunk in sample.interaction.chunks
+					\interactionchunk{\VAR{chunk.path}}{\VAR{chunk.pipe}}
 				%- endfor
 			%- else
 				\example{\VAR{sample.inputPath}}


### PR DESCRIPTION
## Summary

- Default preset now renders interactive samples by **chunk** (`sample.interaction.chunks`) instead of line-by-line (`sample.interaction.entries`). Each uninterrupted participant turn becomes a single box, read verbatim from the chunk file so multi-line content and special LaTeX characters render correctly.
- Added a new `\interactionchunk{path}{pipe}` macro to the preset's `icpc.sty` (mirrors `\interaction` but uses `\insereArquivo`/`VerbatimInput`).
- Synced the same changes into `tests/e2e/testdata/default-preset/` since its `e2e.rbx.yml` declares it a verbatim copy of the preset (prevents drift; that fixture is non-interactive so behavior is unchanged).
- Added docstrings to `rbx/box/testcase_utils.py` documenting the interaction **entry vs. chunk** distinction (`TestcaseInteractionEntry`, `TestcaseInteraction`, `merge_interaction_entries`, `parse_interaction`).

## Testing

- `uv run ruff check` / `ruff format --check` pass
- `uv run pytest tests/rbx/box/testcase_sample_utils_test.py tests/rbx/box/statements/test_build_statements.py` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)