### PR TITLE
fix(package): make get_digest_as_string cache loop-agnostic (#462)

### DIFF
--- a/rbx/box/package.py
+++ b/rbx/box/package.py
@@ -11,7 +11,6 @@ from typing import (
     TypeVar,
 )
 
-import async_lru
 import ruyaml
 import typer
 from filelock import BaseAsyncFileLock
@@ -238,7 +237,7 @@ def get_file_cacher(root: pathlib.Path = pathlib.Path()) -> FileCacher:
     return FileCacher(get_cache_storage(root))
 
 
-@async_lru.alru_cache(maxsize=None)
+@utils.loop_agnostic_async_cache
 async def get_digest_as_string(
     digest: Optional[str], root: pathlib.Path = pathlib.Path()
 ) -> Optional[str]:

--- a/rbx/utils.py
+++ b/rbx/utils.py
@@ -12,7 +12,17 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import dotenv
 import rich
@@ -32,6 +42,43 @@ from rbx import __version__
 from rbx.console import console
 
 T = TypeVar('T', bound=BaseModel)
+_R = TypeVar('_R')
+
+
+def loop_agnostic_async_cache(
+    fn: Callable[..., Awaitable[_R]],
+) -> Callable[..., Awaitable[_R]]:
+    """Memoize a coroutine function with a plain, loop-agnostic dict.
+
+    Unlike ``async_lru.alru_cache``, this does not bind the cache (nor any
+    in-flight ``asyncio.Task``) to the event loop that first awaited it. That
+    makes it safe to reach the same cached coroutine from multiple event loops
+    -- e.g. the main loop during ``rbx build`` and the detached
+    ``AsyncExecutor`` loop during ``rbx run``'s checker phase (see #462).
+
+    Only completed results are cached, so concurrent callers may recompute the
+    value; this is fine for idempotent, content-addressed lookups.
+
+    Exposes ``cache_clear()`` so it stays compatible with the test-isolation
+    sweep in ``rbx.testing_utils.clear_all_functools_cache``.
+    """
+    cache: Dict[Any, _R] = {}
+
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> _R:
+        key = (args, tuple(sorted(kwargs.items())))
+        try:
+            return cache[key]
+        except KeyError:
+            pass
+        result = await fn(*args, **kwargs)
+        cache[key] = result
+        return result
+
+    wrapper.cache_clear = cache.clear  # type: ignore[attr-defined]
+    return wrapper
+
+
 APP_NAME = 'rbx'
 PIP_NAME = 'rbx.cp'
 DOTENV_FILES = ['.env', '.env.local']

--- a/tests/rbx/box/package_digest_cache_test.py
+++ b/tests/rbx/box/package_digest_cache_test.py
@@ -1,0 +1,93 @@
+import asyncio
+import threading
+import time
+from unittest import mock
+
+from rbx.box import package
+from rbx.box.testing import testing_package
+from rbx.grading.judge.cacher import FileCacher
+
+
+def _store_content(content: bytes) -> str:
+    async def _put() -> str:
+        cacher = package.get_file_cacher()
+        return await cacher.put_file_content(content)
+
+    return asyncio.run(_put())
+
+
+def test_get_digest_as_string_caches_results(
+    testing_pkg: testing_package.TestingPackage,
+):
+    digest = _store_content(b'cached payload')
+
+    async def _scenario() -> None:
+        assert await package.get_digest_as_string(digest) == 'cached payload'
+        # Cached: a second call returns the memoized value.
+        assert await package.get_digest_as_string(digest) == 'cached payload'
+        assert await package.get_digest_as_string(None) is None
+
+    asyncio.run(_scenario())
+
+
+def test_get_digest_as_string_cache_clearable():
+    assert hasattr(package.get_digest_as_string, 'cache_clear')
+    package.get_digest_as_string.cache_clear()
+
+
+def test_get_digest_as_string_safe_across_concurrent_event_loops(
+    testing_pkg: testing_package.TestingPackage,
+):
+    """Regression test for #462.
+
+    `rbx run` runs the checker (which calls `get_digest_as_string`) on the
+    detached `AsyncExecutor` background loop, while the main loop is still
+    alive. A loop-bound cache (``alru_cache``) shares an in-flight
+    ``asyncio.Task`` across both loops and crashes. The cache must be
+    loop-agnostic.
+    """
+    digest = _store_content(b'payload')
+    package.get_digest_as_string.cache_clear()
+
+    release = threading.Event()
+    original_get_file_content = FileCacher.get_file_content
+
+    async def slow_get_file_content(self, d):
+        # Stay in-flight (off the event loop) until released, so the cache
+        # entry is a not-yet-done task while a second loop reaches it.
+        await asyncio.get_running_loop().run_in_executor(None, release.wait)
+        return await original_get_file_content(self, d)
+
+    # Background event loop, mirroring AsyncExecutor(detach=True).
+    background_loop = asyncio.new_event_loop()
+
+    def _run_background() -> None:
+        asyncio.set_event_loop(background_loop)
+        background_loop.run_forever()
+
+    bg_thread = threading.Thread(target=_run_background, daemon=True)
+    bg_thread.start()
+
+    # Make sure both loops finish even if the (buggy) cross-loop path stalls.
+    timer = threading.Timer(1.0, release.set)
+    timer.start()
+
+    try:
+        with mock.patch.object(FileCacher, 'get_file_content', slow_get_file_content):
+            # In-flight call on the background loop populates the cache entry.
+            bg_future = asyncio.run_coroutine_threadsafe(
+                package.get_digest_as_string(digest), background_loop
+            )
+            time.sleep(0.2)
+
+            # Cache hit from a different, concurrently-alive loop.
+            main_result = asyncio.run(package.get_digest_as_string(digest))
+
+            assert main_result == 'payload'
+            assert bg_future.result(timeout=5) == 'payload'
+    finally:
+        timer.cancel()
+        release.set()
+        background_loop.call_soon_threadsafe(background_loop.stop)
+        bg_thread.join(timeout=5)
+        background_loop.close()


### PR DESCRIPTION
Fixes #462.

## Problem

`rbx run` crashes during the checker phase with `alru_cache is not safe to use across event loops` (older `async_lru`) / `Task ... got Future ... attached to a different loop` (current `async_lru` 2.1.0).

Root cause: `package.get_digest_as_string` is memoized with `@async_lru.alru_cache`, which binds the cache — and any in-flight `asyncio.Task` — to the event loop that first awaits it. `rbx build` awaits it on the main loop; `rbx run` then reaches it from the detached `AsyncExecutor` background loop (`rbx/grading/async_executor.py`, `detach=True`) during checking, while the main loop is still alive. `async_lru` rejects the cross-loop access.

## Fix

Add a small reusable `loop_agnostic_async_cache` decorator in `rbx/utils.py` that memoizes a coroutine in a plain dict, never touching the running loop or sharing tasks across loops. Apply it to `get_digest_as_string`. Results are content-addressed and immutable, so dropping in-flight deduplication is safe. The wrapper exposes `cache_clear()` so it stays compatible with the `clear_all_functools_cache` test-isolation sweep.

## Tests

New `tests/rbx/box/package_digest_cache_test.py`:
- A deterministic reproduction that drives an in-flight call on a detached background loop and a concurrent cache hit from the main loop (mirrors the `AsyncExecutor` architecture). This **fails on `main`** with the exact cross-loop `RuntimeError` and passes with the fix.
- Caching behavior and `cache_clear` compatibility.

Verified `tests/rbx/box/checkers_test.py`, `solutions_test.py`, `test_package_loading.py` (61 tests) still pass, plus ruff lint/format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)