### PR TITLE
fix(ui): keep entry list aligned with OptionList after dividers

### DIFF
--- a/rbx/box/ui/utils/run_ui.py
+++ b/rbx/box/ui/utils/run_ui.py
@@ -89,8 +89,14 @@ def get_entries_options(
         renderable: Union[VisualType, Option, None],
         entry: Optional[GenerationTestcaseEntry] = None,
     ):
-        expanded_entries.append(entry)
         options.append(renderable)
+        # A ``None`` renderable is a divider: Textual's OptionList does not
+        # allocate an index for it (it only flags the preceding option as a
+        # divider), so it must NOT get a slot in ``expanded_entries`` or the
+        # parallel list drifts out of sync with ``OptionList.highlighted``
+        # once a divider is crossed (#464).
+        if renderable is not None:
+            expanded_entries.append(entry)
 
     total_got_score = 0
     max_score = 0

--- a/tests/rbx/box/ui/test_run_ui.py
+++ b/tests/rbx/box/ui/test_run_ui.py
@@ -17,7 +17,11 @@ from rbx.box.solutions import (
     SolutionSkeleton,
 )
 from rbx.box.testcase_schema import TestcaseEntry
-from rbx.box.ui.utils.run_ui import get_solution_eval, get_solution_evals
+from rbx.box.ui.utils.run_ui import (
+    get_entries_options,
+    get_solution_eval,
+    get_solution_evals,
+)
 from rbx.grading.limits import Limits
 from rbx.grading.steps import (
     CheckerResult,
@@ -115,6 +119,52 @@ def test_get_solution_eval_reads_legacy_numeric_stem(tmp_path):
     eval = get_solution_eval(skeleton, sol, TestcaseEntry(group='main', index=1))
     assert eval is not None
     assert eval.result.outcome == Outcome.ACCEPTED
+
+
+def _entry(group: str, index: int) -> GenerationTestcaseEntry:
+    te = TestcaseEntry(group=group, index=index)
+    return GenerationTestcaseEntry(
+        group_entry=te,
+        subgroup_entry=te,
+        metadata=GenerationMetadata(
+            copied_to=Testcase(inputPath=pathlib.Path(f'{group}-{index}.in'))
+        ),
+    )
+
+
+def test_entries_options_align_with_optionlist_indices():
+    """Regression for #464.
+
+    ``OptionList.highlighted`` indexes into the *options-only* list that
+    Textual builds: a ``None`` separator does not occupy an index, it just
+    turns the preceding option into a divider. The parallel ``expanded_entries``
+    list returned by ``get_entries_options`` must therefore align 1:1 with the
+    real ``OptionList._options`` so highlighting maps to the right testcase.
+    """
+    from textual.widgets import OptionList
+
+    entries = [
+        _entry('group-a', 0),
+        _entry('group-a', 1),
+        _entry('group-b', 0),
+        _entry('group-b', 1),
+    ]
+
+    options, expanded_entries = get_entries_options(entries)
+
+    option_list = OptionList(*options)
+
+    # One expanded-entry slot per real option Textual tracks.
+    assert len(expanded_entries) == option_list.option_count
+
+    # Every selectable (non-disabled) option must map to a real entry, and
+    # those entries must appear in the original order.
+    selectable_entries = [
+        expanded_entries[i]
+        for i in range(option_list.option_count)
+        if not option_list.get_option_at_index(i).disabled
+    ]
+    assert selectable_entries == entries
 
 
 def test_get_solution_evals_finds_all_for_subgroup_stems(tmp_path):


### PR DESCRIPTION
## Problem

Fixes #464. After adding dividers and disabled headers to the test-explorer `OptionList`s, keyboard navigation became unreliable: crossing a divider froze the selection and rendered a different test than the one highlighted.

## Root cause

`get_entries_options` (`rbx/box/ui/utils/run_ui.py`) builds a `expanded_entries` list parallel to the options, appending one slot for **every** `_add()` call — including the `_add(None)` divider calls.

In Textual 8.0.0, a `None` passed to `OptionList.add_options` does **not** create an indexed option. It only sets `_divider = True` on the *preceding* option and is skipped (`rbx/.venv/.../textual/widgets/_option_list.py:397-400`). So `OptionList.highlighted` indexes into the options-only list (separators excluded, disabled options included).

Result: each group's trailing divider added a phantom slot to `expanded_entries` that didn't exist in Textual's option index. After the first divider every index was off by one, after the second by two, etc. — `self._option_entries[highlighted]` mapped to the wrong (or `None`) entry. Disabled group headers were unaffected because they *are* real options.

## Fix

Skip the `expanded_entries` slot for `None` divider renderables, keeping the parallel list 1:1 with `OptionList.option_count`. This corrects all consumers (`run_test_explorer.py`, `test_explorer.py`) since they share `get_entries_options`. `run_explorer.py` was already correct (it indexes the original solutions list, not a parallel list).

## Testing

Added `test_entries_options_align_with_optionlist_indices` — a regression test that builds entries across multiple groups, feeds the options into a real Textual `OptionList`, and asserts the entry list aligns 1:1 with `option_count` and that selectable options map to the correct entries in order. Verified RED before the fix (`assert 8 == 6`), GREEN after. Full `tests/rbx/box/ui/` suite (26 tests) passes; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)