### PR TITLE
feat(contest): show problem name in `rbx on` and `rbx each`

### DIFF
--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -8,7 +8,7 @@ import syncer
 import typer
 
 from rbx import annotations, console, utils
-from rbx.box import cd, creation, presets, summary
+from rbx.box import cd, creation, package, presets, summary
 from rbx.box.contest import contest_package, contest_state, contest_utils, statements
 from rbx.box.contest.contest_package import (
     find_contest,
@@ -245,6 +245,19 @@ def remove(path_or_short_name: str):
     )
 
 
+def _problem_command_name(problem: ContestProblem) -> str:
+    """Display label for a contest problem: '<short_name>. <problem name>'.
+
+    Falls back to just the short name when the problem package cannot be
+    loaded (e.g. missing or broken problem.rbx.yml) so the command runner
+    keeps working on a partially set-up contest.
+    """
+    pkg = package.find_problem_package(problem.get_path())
+    if pkg is not None and pkg.name:
+        return f'{problem.short_name}. {pkg.name}'
+    return problem.short_name
+
+
 @app.command(
     'each',
     help='Run a command for each problem in the contest.',
@@ -261,7 +274,7 @@ def each(ctx: typer.Context) -> None:
         CommandEntry(
             argv=argv,
             placeholder_prefix=placeholder_prefix,
-            name=f'{problem.short_name}',
+            name=_problem_command_name(problem),
             cwd=str(problem.get_path()),
         )
         for problem in contest.problems
@@ -287,7 +300,7 @@ def on(ctx: typer.Context, problems: str) -> None:
     if len(problems_of_interest) == 1:
         command = ' '.join(['rbx'] + ctx.args)
         console.console.print(
-            f'[status]Running [item]{command}[/item] for [item]{problems_of_interest[0].short_name}[/item]...[/status]'
+            f'[status]Running [item]{command}[/item] for [item]{_problem_command_name(problems_of_interest[0])}[/item]...[/status]'
         )
         subprocess.call(command, cwd=problems_of_interest[0].get_path(), shell=True)
         return
@@ -297,7 +310,7 @@ def on(ctx: typer.Context, problems: str) -> None:
         CommandEntry(
             argv=argv,
             placeholder_prefix=placeholder_prefix,
-            name=f'{p.short_name}',
+            name=_problem_command_name(p),
             cwd=str(p.get_path()),
         )
         for p in problems_of_interest

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -8,7 +8,7 @@ import syncer
 import typer
 
 from rbx import annotations, console, utils
-from rbx.box import cd, creation, package, presets, summary
+from rbx.box import cd, creation, naming, presets, summary
 from rbx.box.contest import contest_package, contest_state, contest_utils, statements
 from rbx.box.contest.contest_package import (
     find_contest,
@@ -245,19 +245,6 @@ def remove(path_or_short_name: str):
     )
 
 
-def _problem_command_name(problem: ContestProblem) -> str:
-    """Display label for a contest problem: '<short_name>. <problem name>'.
-
-    Falls back to just the short name when the problem package cannot be
-    loaded (e.g. missing or broken problem.rbx.yml) so the command runner
-    keeps working on a partially set-up contest.
-    """
-    pkg = package.find_problem_package(problem.get_path())
-    if pkg is not None and pkg.name:
-        return f'{problem.short_name}. {pkg.name}'
-    return problem.short_name
-
-
 @app.command(
     'each',
     help='Run a command for each problem in the contest.',
@@ -274,7 +261,7 @@ def each(ctx: typer.Context) -> None:
         CommandEntry(
             argv=argv,
             placeholder_prefix=placeholder_prefix,
-            name=_problem_command_name(problem),
+            name=naming.get_contest_problem_label(problem),
             cwd=str(problem.get_path()),
         )
         for problem in contest.problems
@@ -300,7 +287,7 @@ def on(ctx: typer.Context, problems: str) -> None:
     if len(problems_of_interest) == 1:
         command = ' '.join(['rbx'] + ctx.args)
         console.console.print(
-            f'[status]Running [item]{command}[/item] for [item]{_problem_command_name(problems_of_interest[0])}[/item]...[/status]'
+            f'[status]Running [item]{command}[/item] for [item]{naming.get_contest_problem_label(problems_of_interest[0])}[/item]...[/status]'
         )
         subprocess.call(command, cwd=problems_of_interest[0].get_path(), shell=True)
         return
@@ -310,7 +297,7 @@ def on(ctx: typer.Context, problems: str) -> None:
         CommandEntry(
             argv=argv,
             placeholder_prefix=placeholder_prefix,
-            name=_problem_command_name(p),
+            name=naming.get_contest_problem_label(p),
             cwd=str(p.get_path()),
         )
         for p in problems_of_interest

--- a/rbx/box/naming.py
+++ b/rbx/box/naming.py
@@ -174,6 +174,19 @@ def get_problem_name_with_contest_info() -> str:
     return f'{contest.name}-{short_name}-{problem.name}'
 
 
+def get_contest_problem_label(problem: ContestProblem) -> str:
+    """Human-readable label for a contest problem: '<short_name>. <name>'.
+
+    Falls back to just the short name when the problem package cannot be
+    loaded (e.g. missing or broken problem.rbx.yml) or has no name, so
+    callers keep working on a partially set-up contest.
+    """
+    pkg = package.find_problem_package(problem.get_path())
+    if pkg is not None and pkg.name:
+        return f'{problem.short_name}. {pkg.name}'
+    return problem.short_name
+
+
 def get_problem_title(
     lang: Optional[str] = None,
     statement: Optional[Statement] = None,

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -1,13 +1,11 @@
 """Tests for `rbx contest` Typer commands."""
 
 import pathlib
-from unittest import mock
 
 import pytest
 from typer.testing import CliRunner
 
 from rbx.box.contest import main as contest_main
-from rbx.box.contest.schema import ContestProblem
 
 
 @pytest.fixture
@@ -164,30 +162,3 @@ class TestContestList:
         div1_line = next(line for line in result.output.splitlines() if 'div1' in line)
         assert '*' not in default_line
         assert '*' in div1_line
-
-
-class TestProblemCommandName:
-    def test_includes_problem_name_when_package_loads(self):
-        problem = ContestProblem(short_name='A')
-        fake_pkg = mock.Mock()
-        fake_pkg.name = 'Two Sum'
-        with mock.patch.object(
-            contest_main.package, 'find_problem_package', return_value=fake_pkg
-        ):
-            assert contest_main._problem_command_name(problem) == 'A. Two Sum'  # noqa: SLF001
-
-    def test_falls_back_to_short_name_when_package_missing(self):
-        problem = ContestProblem(short_name='B')
-        with mock.patch.object(
-            contest_main.package, 'find_problem_package', return_value=None
-        ):
-            assert contest_main._problem_command_name(problem) == 'B'  # noqa: SLF001
-
-    def test_falls_back_to_short_name_when_name_empty(self):
-        problem = ContestProblem(short_name='C')
-        fake_pkg = mock.Mock()
-        fake_pkg.name = ''
-        with mock.patch.object(
-            contest_main.package, 'find_problem_package', return_value=fake_pkg
-        ):
-            assert contest_main._problem_command_name(problem) == 'C'  # noqa: SLF001

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -1,11 +1,13 @@
 """Tests for `rbx contest` Typer commands."""
 
 import pathlib
+from unittest import mock
 
 import pytest
 from typer.testing import CliRunner
 
 from rbx.box.contest import main as contest_main
+from rbx.box.contest.schema import ContestProblem
 
 
 @pytest.fixture
@@ -162,3 +164,30 @@ class TestContestList:
         div1_line = next(line for line in result.output.splitlines() if 'div1' in line)
         assert '*' not in default_line
         assert '*' in div1_line
+
+
+class TestProblemCommandName:
+    def test_includes_problem_name_when_package_loads(self):
+        problem = ContestProblem(short_name='A')
+        fake_pkg = mock.Mock()
+        fake_pkg.name = 'Two Sum'
+        with mock.patch.object(
+            contest_main.package, 'find_problem_package', return_value=fake_pkg
+        ):
+            assert contest_main._problem_command_name(problem) == 'A. Two Sum'  # noqa: SLF001
+
+    def test_falls_back_to_short_name_when_package_missing(self):
+        problem = ContestProblem(short_name='B')
+        with mock.patch.object(
+            contest_main.package, 'find_problem_package', return_value=None
+        ):
+            assert contest_main._problem_command_name(problem) == 'B'  # noqa: SLF001
+
+    def test_falls_back_to_short_name_when_name_empty(self):
+        problem = ContestProblem(short_name='C')
+        fake_pkg = mock.Mock()
+        fake_pkg.name = ''
+        with mock.patch.object(
+            contest_main.package, 'find_problem_package', return_value=fake_pkg
+        ):
+            assert contest_main._problem_command_name(problem) == 'C'  # noqa: SLF001

--- a/tests/rbx/box/test_naming.py
+++ b/tests/rbx/box/test_naming.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 import typer
@@ -8,6 +8,7 @@ import typer
 from rbx.box import naming
 from rbx.box.contest import contest_package as cp_module
 from rbx.box.contest.contest_state import selected_variant_id_var
+from rbx.box.contest.schema import ContestProblem
 from rbx.box.schema import Package
 from rbx.box.statements.schema import Statement
 
@@ -255,6 +256,30 @@ class TestGetProblemShortnameOrRequire:
         out = capsys.readouterr().out
         assert '-C' in out
         assert 'div1' in out and 'div2' in out
+
+
+class TestGetContestProblemLabel:
+    def test_includes_problem_name_when_package_loads(self):
+        problem = ContestProblem(short_name='A')
+        pkg = Mock()
+        pkg.name = 'Two Sum'
+
+        with patch('rbx.box.naming.package.find_problem_package', return_value=pkg):
+            assert naming.get_contest_problem_label(problem) == 'A. Two Sum'
+
+    def test_falls_back_to_short_name_when_package_missing(self):
+        problem = ContestProblem(short_name='B')
+
+        with patch('rbx.box.naming.package.find_problem_package', return_value=None):
+            assert naming.get_contest_problem_label(problem) == 'B'
+
+    def test_falls_back_to_short_name_when_name_empty(self):
+        problem = ContestProblem(short_name='C')
+        pkg = Mock()
+        pkg.name = ''
+
+        with patch('rbx.box.naming.package.find_problem_package', return_value=pkg):
+            assert naming.get_contest_problem_label(problem) == 'C'
 
 
 class TestGetTitle:


### PR DESCRIPTION
## Summary

Closes #466.

`rbx on` and `rbx each` previously labeled each problem in the command-runner UI with only its short name (`A`, `B`, `C`). This adds the problem name so entries read like `A. Two Sum`, which makes larger contests far easier to navigate.

## Changes

- Add `_problem_command_name(problem)` helper in `rbx/box/contest/main.py` that loads the problem package via the lenient `package.find_problem_package(...)` and returns `"<short_name>. <name>"`.
- Falls back to just the short name when the package can't be loaded (missing/broken `problem.rbx.yml`) or the name is empty, so the runner keeps working on a partially set-up contest.
- Used in both `each` and `on` (including `on`'s single-problem status line).
- Uses the problem **`name`** (not `titles`), per the issue intent.

## Testing

- New `TestProblemCommandName` unit tests cover: name present, package missing, empty name.
- `uv run pytest tests/rbx/box/contest/` — 85 passed.
- `uv run ruff check` / `ruff format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)