### PR TITLE
fix: parenthesize multi-exception handlers for py3.10 compat

### DIFF
--- a/rbx/box/fields.py
+++ b/rbx/box/fields.py
@@ -84,7 +84,7 @@ def expand_vars(recvars: RecVars) -> Vars:
             else:
                 try:
                     new_ctx[k] = expand_var(v, ctx)
-                except safeeval.NameNotDefined, safeeval.AttributeDoesNotExist:
+                except (safeeval.NameNotDefined, safeeval.AttributeDoesNotExist):
                     if should_raise:
                         raise
 

--- a/rbx/box/main.py
+++ b/rbx/box/main.py
@@ -99,7 +99,7 @@ def app():
         nest_asyncio.apply()
 
         run_app_cli()
-    except KeyboardInterrupt, typer.Abort:
+    except (KeyboardInterrupt, typer.Abort):
         _abort()
     except SystemExit as e:
         if e.code == 130:

--- a/rbx/box/statements/demacro_utils.py
+++ b/rbx/box/statements/demacro_utils.py
@@ -290,7 +290,7 @@ def _collect_recursive(
 
     try:
         content = tex_path.read_text(encoding='utf-8')
-    except OSError, UnicodeDecodeError:
+    except (OSError, UnicodeDecodeError):
         return MacroDefinitions()
 
     defs = extract_definitions(content, source_file=str(resolved))

--- a/rbx/box/tooling/boca/debug_utils.py
+++ b/rbx/box/tooling/boca/debug_utils.py
@@ -60,7 +60,7 @@ def pretty_print_request_data(req: Any) -> None:
                                                 console.console.print(
                                                     f'  [green]{field_name}[/green]: [white]{field_value}[/white]'
                                                 )
-                                    except ValueError, IndexError:
+                                    except (ValueError, IndexError):
                                         console.console.print(
                                             f'  [green]{field_name}[/green]: [dim](could not parse value)[/dim]'
                                         )

--- a/rbx/testing_utils.py
+++ b/rbx/testing_utils.py
@@ -92,7 +92,7 @@ def walk_directory(
                     resolved = path.resolve()
                     text_filename.append(' → ', 'cyan')
                     text_filename.append(str(resolved), 'cyan italic')
-                except OSError, RuntimeError:
+                except (OSError, RuntimeError):
                     text_filename.append(' → ', 'red')
                     text_filename.append(f'{os.readlink(path)}', 'red italic')
 

--- a/tests/rbx/box/packaging/e2e/test_boca_e2e.py
+++ b/tests/rbx/box/packaging/e2e/test_boca_e2e.py
@@ -73,7 +73,7 @@ def boca_environment(
     try:
         subprocess.run(['docker', '--version'], check=True, capture_output=True)
         subprocess.run(['docker-compose', '--version'], check=True, capture_output=True)
-    except subprocess.CalledProcessError, FileNotFoundError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         pytest.skip('Docker or docker-compose not available')
 
     # Start the BOCA environment

--- a/tests/rbx/conftest.py
+++ b/tests/rbx/conftest.py
@@ -99,7 +99,7 @@ def _isolate_global_state() -> Iterator[None]:
     finally:
         try:
             os.chdir(original_cwd)
-        except FileNotFoundError, OSError:
+        except (FileNotFoundError, OSError):
             pass
         _package.TEMP_DIR = original_temp_dir
         for var, value in snapshots:


### PR DESCRIPTION
## Problem

#468 lowered `requires-python` to `>=3.10`, but CI's **lint job is now broken on `main`**: ruff infers its target version from `requires-python` and correctly rejects seven `except A, B:` handlers that use **PEP 758 unparenthesized syntax — a Python 3.14-only feature** (this was missed in the #468 audit).

## Fix

Convert all seven to the parenthesized `except (A, B):` form, which is **semantically identical** and valid on every Python version (3.10–3.14):

- `rbx/box/main.py`
- `rbx/box/fields.py`
- `rbx/box/tooling/boca/debug_utils.py`
- `rbx/box/statements/demacro_utils.py`
- `rbx/testing_utils.py`
- `tests/rbx/conftest.py`
- `tests/rbx/box/packaging/e2e/test_boca_e2e.py`

## Verification

- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → 355 files already formatted
- `py_compile` clean on all 7 modified files
- Grep confirms zero remaining unparenthesized multi-exception handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)