### PR TITLE
feat: -p/--profile for statement builds (#456)

### DIFF
--- a/docs/plans/2026-05-15-statements-timing-profile-design.md
+++ b/docs/plans/2026-05-15-statements-timing-profile-design.md
@@ -1,0 +1,114 @@
+# Timing profile flag for statement builds
+
+GitHub issue: [#456](https://github.com/rsalesc/rbx/issues/456)
+
+## Goal
+
+Let users build statements against a specific timing profile, so that the time
+limits shown in the rendered statement reflect the profile rather than the
+package defaults. Cover both the problem-level command (`rbx st b`) and the
+contest-level command (`rbx contest st b`).
+
+## Motivation
+
+A problem package may declare multiple timing profiles in `.limits/<name>.yml`
+(e.g. `local`, `judge`, `icpc`). The statement builder already exposes
+`problem.limits.timelimit_for_language(language)` to rbxTeX templates, and that
+expression already respects the active profile contextvar set by the global
+`rbx -p <profile>` flag. Two gaps make the current behaviour unsafe for
+publishing statements:
+
+- **Silent fallback.** If `-p <profile>` names a profile that does not exist
+  for a given problem, `get_limits_profile(..., fallback_to_package_profile=True)`
+  silently returns the package defaults. The rendered PDF looks plausible but
+  ships the wrong time limits.
+- **No way to opt out per-problem in a contest build.** A contest typically has
+  problems with heterogeneous profiles (e.g. only a subset has an `icpc`
+  profile). Today the build either silently uses package defaults for the
+  missing ones, or the user has to build per-problem.
+
+## Design
+
+### CLI surface
+
+Add `--profile, -p TEXT` to both commands:
+
+- `rbx/box/statements/build_statements.py:476` — problem-level `build()`.
+- `rbx/box/contest/statements.py:30` — contest-level `build()`.
+
+The subcommand-level flag is a convenience alias for the existing global
+`rbx -p <profile>` flag; it sets the same `profile_var` contextvar via
+`limits_info.use_profile(...)`. When both are supplied, the subcommand value
+wins (last set).
+
+### Problem-level semantics (`rbx st b -p <profile>`)
+
+Strict. If `.limits/<profile>.yml` does not exist in the current problem
+package, exit with status 1 and the same error message
+`get_limits_profile(profile, fallback_to_package_profile=False)` already prints
+today (`limits_info.py:140-143`). The validation is performed once at the start
+of `build()`, before any work; the rest of the pipeline runs unchanged inside
+`use_profile(profile)`.
+
+### Contest-level semantics (`rbx contest st b -p <profile>`)
+
+Skip-with-warn. For each problem in the contest:
+
+1. Probe `limits_info.get_saved_limits_profile(profile, root=problem_path)`.
+2. If `None`, print a warning and exclude the problem from this contest
+   statement build. Use the existing `StatementBuildIssue` channel so the
+   skip surfaces consistently with other per-problem failures.
+3. Otherwise include the problem; the inner `build_statement_bytes` call is
+   wrapped in `use_profile(profile)`.
+
+If **zero** problems remain after skipping, exit with status 1 — a contest PDF
+with no problems is almost certainly a mistake and we should not produce one
+silently.
+
+The same eligible-problem subset is computed once and used for both the
+sample-collection loop (`contest/statements.py:93-112`) and the per-problem
+build loop (`contest/build_contest_statements.py:191-229`), so the final
+statement does not reference samples for problems that were excluded.
+
+### Data flow
+
+```
+CLI flag (-p) → limits_info.use_profile(profile) ctxmgr
+              → profile_var contextvar
+              → build_statement_bytes() reads via get_active_profile()
+              → StatementBuilderProblem.limits = get_limits_profile(active)
+              → exposed to Jinja as problem.limits.timelimit_for_language(...)
+```
+
+No changes to `StatementBuilderProblem`, the Jinja/rbxTeX layer, or any
+template.
+
+### Error handling matrix
+
+| Scenario                                                  | Behaviour                          |
+|-----------------------------------------------------------|------------------------------------|
+| `rbx st b -p missing`                                     | exit 1, error message              |
+| `rbx st b -p ok`                                          | builds against profile             |
+| `rbx contest st b -p ok` (all problems have profile)      | builds normally                    |
+| `rbx contest st b -p partial` (some problems missing)     | warn + skip those, build the rest  |
+| `rbx contest st b -p missing` (no problem has profile)    | exit 1                             |
+
+### Testing
+
+- `tests/rbx/box/statements/test_build_statements.py` — two tests: profile
+  applies (assert the rendered statement reflects the profile's time limit), and
+  missing profile exits 1.
+- `tests/rbx/box/contest/test_statement_overriding.py` (or a sibling) — three
+  tests: all-have-profile builds normally, mixed-availability skips the
+  missing ones (assert the warning and that the missing problem is absent from
+  the output), all-missing exits 1.
+- Reuse `cleandir_with_testdata` fixtures; add a small `.limits/<profile>.yml`
+  to the chosen fixture package.
+
+## Out of scope
+
+- Changing the semantics of the global `-p` flag for commands other than
+  statement build.
+- Introducing additional profile-validation primitives — the existing
+  `fallback_to_package_profile=False` path in `get_limits_profile` is enough.
+- Surfacing the active profile in the statement footer or metadata.

--- a/docs/plans/2026-05-15-statements-timing-profile.md
+++ b/docs/plans/2026-05-15-statements-timing-profile.md
@@ -1,0 +1,393 @@
+# Statement Timing-Profile Flag Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `-p/--profile <name>` to `rbx st b` and `rbx contest st b` so statements render against a specific timing profile, with strict validation (problem level) and skip-with-warn (contest level).
+
+**Architecture:** Both subcommands accept `--profile, -p`. The statement builder already reads the active profile from `rbx.box.limits_info.profile_var` and exposes `problem.limits.timelimit_for_language(...)` to the Jinja/rbxTeX layer — so no template, schema, or builder changes are needed. The only new logic is (a) wiring the flag through `limits_info.use_profile(...)`, (b) strictly validating the profile exists at the problem level, and (c) filtering out problems missing the profile at the contest level (warn + skip; error if zero problems remain).
+
+**Tech Stack:** Python, Typer, Pydantic v2, pytest. Existing primitives: `rbx.box.limits_info.use_profile`, `rbx.box.limits_info.get_saved_limits_profile`, `rbx.box.limits_info.get_limits_profile(..., fallback_to_package_profile=False)`.
+
+**Design doc:** `docs/plans/2026-05-15-statements-timing-profile-design.md`.
+
+**Issue:** [#456](https://github.com/rsalesc/rbx/issues/456).
+
+---
+
+## Background a new engineer must read first
+
+- `rbx/box/limits_info.py` — the whole file (especially `profile_var`, `use_profile`, `get_saved_limits_profile`, `get_limits_profile`).
+- `rbx/box/statements/build_statements.py:300-335` — see how `StatementBuilderProblem.limits` already calls `get_limits_profile(profile=get_active_profile())`. This is why the Jinja side needs no changes.
+- `rbx/box/cli.py:152-217` — the global `-p/--profile` flag on the root callback. The new subcommand flags compose with this (subcommand wins, last set).
+- `rbx/box/CLAUDE.md` and `rbx/box/statements/CLAUDE.md` — module overviews.
+- `tests/rbx/box/test_timing.py:295-360` — examples of writing `.limits/<profile>.yml` files in `testing_pkg` fixtures.
+- `tests/rbx/box/statements/test_build_statements.py` — existing test patterns for the statement builder, including the `mock_environment` and `chdir_tmp_path` fixtures.
+- `tests/rbx/box/conftest.py` and `tests/rbx/box/contest/conftest.py` — `cleandir_with_testdata` and `testing_pkg` fixtures; `.limits/` is already gitignored in the fixture write-out, so `.limits/<x>.yml` files inside a `testdata/` package will be copied through.
+
+**TDD discipline:** every task that changes code starts with a failing test, then implementation, then green test, then commit. Use the existing `mise run lint` / `uv run pytest` invocations.
+
+---
+
+## Task 1: Add `-p/--profile` to `rbx st b` (problem-level), strict validation
+
+**Files:**
+- Modify: `rbx/box/statements/build_statements.py` (around lines 435-513)
+- Test: `tests/rbx/box/statements/test_build_statements.py`
+
+**Approach:** Add a `profile: Optional[str]` Typer option to `build(...)`, thread it through to `execute_build(...)`, and inside `execute_build` (before anything else) call `limits_info.get_limits_profile(profile, fallback_to_package_profile=False)` to validate. Then wrap the rest of `execute_build` in `with limits_info.use_profile(profile):`. The existing inner code (`build_statement_bytes` line 316) already reads the active profile.
+
+### Step 1: Write failing test — strict failure when profile is missing
+
+Add to `tests/rbx/box/statements/test_build_statements.py`. This is a unit-level test against `execute_build` (sync wrapper via `asyncio.run`) inside a `cleandir_with_testdata` package that has statements but no `.limits/icpc.yml`.
+
+```python
+# At the top of the file, augment imports:
+import asyncio
+from rbx.box.statements.build_statements import execute_build
+
+@pytest.mark.test_pkg('box/statements/testdata/with_statement')
+def test_execute_build_strict_profile_missing_exits(cleandir_with_testdata):
+    with pytest.raises(typer.Exit) as exc_info:
+        asyncio.run(
+            execute_build(
+                verification=0,
+                names=None,
+                languages=None,
+                output=StatementType.PDF,
+                samples=False,
+                vars=None,
+                validate=False,
+                profile='does-not-exist',
+            )
+        )
+    assert exc_info.value.exit_code == 1
+```
+
+> If `box/statements/testdata/with_statement` doesn't exist, pick an existing minimal-statement fixture by inspecting `tests/rbx/box/statements/testdata/` and update the marker accordingly. The fixture must (a) parse as a valid problem package and (b) have at least one statement. Do not invoke pdflatex — the missing-profile error must trigger before any rendering.
+
+Run: `uv run pytest tests/rbx/box/statements/test_build_statements.py::test_execute_build_strict_profile_missing_exits -v`
+Expected: FAIL with `TypeError: execute_build() got an unexpected keyword argument 'profile'`.
+
+### Step 2: Add the `profile` parameter and validation logic
+
+In `rbx/box/statements/build_statements.py`:
+
+- Extend `execute_build(...)` signature with `profile: Optional[str] = None` (after `validate`).
+- At the very top of the function (before `pkg = package.find_problem_package_or_die()`), if `profile is not None`, call `limits_info.get_limits_profile(profile, fallback_to_package_profile=False)` to trigger the existing strict error path (prints message and raises `typer.Exit(1)`).
+- Wrap the body of `execute_build` (everything after the validation call) in `with limits_info.use_profile(profile):`.
+- Extend the Typer `build(...)` command (around line 476) with:
+
+```python
+profile: Annotated[
+    Optional[str],
+    typer.Option(
+        '-p',
+        '--profile',
+        help='Timing profile to render the statement against. Must exist in this problem.',
+    ),
+] = None,
+```
+
+- Pass `profile=profile` through the `execute_build(...)` call at line 513.
+- Add the import: `from rbx.box import limits_info` if not already present (it is — confirm).
+
+Run: `uv run pytest tests/rbx/box/statements/test_build_statements.py::test_execute_build_strict_profile_missing_exits -v`
+Expected: PASS.
+
+### Step 3: Write failing test — profile applies and reaches the builder
+
+Add a second test that confirms the profile takes effect. Don't render PDFs; instead assert against `limits_info.get_active_profile()` inside `use_profile`, or call `build_statement_bytes` with `output_type=StatementType.MARKDOWN` (cheap) on a fixture that has a `.limits/icpc.yml` setting `timeLimit: 5000` and verify the rendered markdown contains "5000" via `{{ problem.limits.timeLimit }}` in the template.
+
+Cheapest, most direct version (no template surgery needed): assert that `execute_build(profile='icpc', ...)` does NOT raise when a matching `.limits/icpc.yml` exists in the fixture, AND that during the call the active profile is `'icpc'`. Use `monkeypatch` to replace `execute_build_on_statements` with a sentinel that records `limits_info.get_active_profile()`.
+
+```python
+@pytest.mark.test_pkg('box/statements/testdata/with_statement')
+def test_execute_build_strict_profile_applies(cleandir_with_testdata, monkeypatch):
+    # Provide a profile in the fixture.
+    (pathlib.Path('.limits')).mkdir(exist_ok=True)
+    (pathlib.Path('.limits/icpc.yml')).write_text('timeLimit: 5000\n')
+
+    seen = {}
+    async def fake_execute_build_on_statements(statements, *args, **kwargs):
+        seen['profile'] = limits_info.get_active_profile()
+
+    monkeypatch.setattr(
+        'rbx.box.statements.build_statements.execute_build_on_statements',
+        fake_execute_build_on_statements,
+    )
+    asyncio.run(
+        execute_build(
+            verification=0,
+            names=None,
+            languages=None,
+            output=StatementType.PDF,
+            samples=False,
+            vars=None,
+            validate=False,
+            profile='icpc',
+        )
+    )
+    assert seen['profile'] == 'icpc'
+```
+
+> Add the missing imports (`pathlib`, `from rbx.box import limits_info`).
+
+Run: `uv run pytest tests/rbx/box/statements/test_build_statements.py::test_execute_build_strict_profile_applies -v`
+Expected: PASS (the implementation in Step 2 already does this).
+
+### Step 4: Run the full file to make sure nothing else broke
+
+Run: `uv run pytest tests/rbx/box/statements/test_build_statements.py -v`
+Expected: ALL PASS.
+
+### Step 5: Lint and format
+
+Run: `uv run ruff check rbx/box/statements/build_statements.py tests/rbx/box/statements/test_build_statements.py && uv run ruff format rbx/box/statements/build_statements.py tests/rbx/box/statements/test_build_statements.py`
+Expected: clean / no diffs after format.
+
+### Step 6: Commit
+
+Use the `/commit` skill (conventional commits required):
+
+```
+feat(statements): add -p/--profile to rbx st b with strict validation (#456)
+```
+
+---
+
+## Task 2: Add `-p/--profile` to `rbx contest st b` (contest-level), skip-with-warn
+
+**Files:**
+- Modify: `rbx/box/contest/statements.py:25-132`
+- Modify: `rbx/box/contest/build_contest_statements.py:180-229` (and likely `build_statement` higher up — read the full function)
+- Test: new file `tests/rbx/box/contest/test_statements_profile.py`
+
+**Approach:** Add a `profile: Optional[str]` Typer option to the contest `build(...)`. Before any work, compute the eligible problem subset (problems whose `.limits/<profile>.yml` file exists). If empty, exit 1. Otherwise warn for each skipped problem, then run the existing samples loop and statement loop limited to the eligible subset. Wrap each problem-level `build_statement_bytes` call in `limits_info.use_profile(profile)` (already done via the new `problems_of_interest`/`build_statement` pipeline if you push the profile through; alternatively, set it once at the contest level since the contest already CDs per problem and reads the contextvar — confirm during implementation).
+
+### Step 1: Write failing test — contest build skips problems missing the profile
+
+In a new file `tests/rbx/box/contest/test_statements_profile.py`. Use the existing contest test fixtures. Inspect `tests/rbx/box/contest/testdata/` and pick a small two-problem contest fixture; if none has exactly the shape needed, create one (a contest with problems `A` and `B`, where only `A/.limits/icpc.yml` exists). Mock the heavy per-problem statement build via monkeypatch to record which problems were processed and which were skipped.
+
+```python
+import asyncio
+import pathlib
+
+import pytest
+import typer
+
+from rbx.box import limits_info
+from rbx.box.contest import statements as contest_statements_cli
+from rbx.box.statements.schema import StatementType
+
+
+@pytest.mark.test_pkg('box/contest/testdata/two_problems')
+def test_contest_build_skips_problems_missing_profile(cleandir_with_testdata, monkeypatch):
+    # Only problem A has the icpc profile.
+    (pathlib.Path('A/.limits')).mkdir(parents=True, exist_ok=True)
+    (pathlib.Path('A/.limits/icpc.yml')).write_text('timeLimit: 5000\n')
+
+    built_for = []
+    async def fake_build_statement(statement, contest, *, problems_of_interest=None, **kwargs):
+        built_for.append([p.short_name for p in (problems_of_interest or [])])
+        return pathlib.Path('fake.pdf')
+
+    monkeypatch.setattr(
+        'rbx.box.contest.statements.build_statement',
+        fake_build_statement,
+    )
+
+    asyncio.run(
+        contest_statements_cli.build.__wrapped__(  # bypass @syncer.sync if needed
+            verification=0,
+            names=None,
+            languages=None,
+            validate=False,
+            output=StatementType.PDF,
+            samples=False,
+            vars=None,
+            install_tex=False,
+            profile='icpc',
+        )
+    )
+
+    assert built_for, 'expected at least one statement build call'
+    # B must NOT be in any built statement's problems_of_interest.
+    for problems in built_for:
+        assert 'B' not in problems
+```
+
+> The Typer-decorated `build` may be wrapped by `@syncer.sync` and `@within_contest`. If `.__wrapped__` is the wrong attribute, find the underlying async function or use `typer.testing.CliRunner` to invoke the CLI end-to-end instead. Read how `tests/rbx/box/contest/test_contest_main.py` (if present) calls contest CLI commands and mirror it.
+
+Run: `uv run pytest tests/rbx/box/contest/test_statements_profile.py -v`
+Expected: FAIL (likely `TypeError: unexpected keyword argument 'profile'`).
+
+### Step 2: Add `--profile` option + eligible-subset filtering to the CLI
+
+In `rbx/box/contest/statements.py`:
+
+1. Add the parameter to `build(...)`:
+
+   ```python
+   profile: Annotated[
+       Optional[str],
+       typer.Option(
+           '-p',
+           '--profile',
+           help='Timing profile to render statements against. Problems missing this profile are skipped with a warning.',
+       ),
+   ] = None,
+   ```
+
+2. After `contest = find_contest_package_or_die()`, compute the eligible subset:
+
+   ```python
+   eligible_problems: List[ContestProblem] = list(contest.problems)
+   if profile is not None:
+       eligible_problems = []
+       for problem in contest.problems:
+           saved = limits_info.get_saved_limits_profile(profile, root=problem.get_path())
+           if saved is None:
+               console.console.print(
+                   f'[warning]Skipping problem [item]{problem.short_name}[/item]: timing profile [item]{profile}[/item] is not defined for it.[/warning]'
+               )
+               continue
+           eligible_problems.append(problem)
+       if not eligible_problems:
+           console.console.print(
+               f'[error]No problems in this contest define the timing profile [item]{profile}[/item].[/error]'
+           )
+           raise typer.Exit(1)
+   ```
+
+3. Replace the existing samples loop's iterator from `contest.problems` to `eligible_problems`. After the loop, `problems_of_interest` is already a list filtered by sample success; keep that behaviour, but when `samples=False` the value stays `None` — in that case set `problems_of_interest = eligible_problems` if `profile is not None`, so the downstream `build_statement` sees the restricted subset:
+
+   ```python
+   if profile is not None and problems_of_interest is None:
+       problems_of_interest = eligible_problems
+   ```
+
+4. Wrap the per-statement loop in `with limits_info.use_profile(profile):` so that when the inner `build_statement_bytes` runs (it CDs into each problem) it reads the right active profile. Note: `build_contest_statements._build_problem_statements` itself does NOT currently set a profile context, so this single contest-level `use_profile` wrapper is sufficient because the contextvar is process-global within the request.
+
+5. Add imports: `from rbx.box import limits_info`.
+
+Run: `uv run pytest tests/rbx/box/contest/test_statements_profile.py -v`
+Expected: PASS.
+
+### Step 3: Add failing test — all-missing case exits 1
+
+Append to the same test file:
+
+```python
+@pytest.mark.test_pkg('box/contest/testdata/two_problems')
+def test_contest_build_all_missing_profile_exits(cleandir_with_testdata):
+    with pytest.raises(typer.Exit) as exc_info:
+        asyncio.run(
+            contest_statements_cli.build.__wrapped__(
+                verification=0,
+                names=None,
+                languages=None,
+                validate=False,
+                output=StatementType.PDF,
+                samples=False,
+                vars=None,
+                install_tex=False,
+                profile='nonexistent',
+            )
+        )
+    assert exc_info.value.exit_code == 1
+```
+
+Run: `uv run pytest tests/rbx/box/contest/test_statements_profile.py::test_contest_build_all_missing_profile_exits -v`
+Expected: PASS (Step 2 already implements the empty-subset branch).
+
+### Step 4: Run the full contest test suite
+
+Run: `uv run pytest tests/rbx/box/contest/ -v`
+Expected: ALL PASS. If any pre-existing test fails because it called `build(...)` positionally and our new `profile=None` parameter shifted positions, fix those call sites (they should already use keyword arguments — Typer commands are typically called via the CLI, not directly).
+
+### Step 5: Lint and format
+
+Run: `uv run ruff check rbx/box/contest/statements.py tests/rbx/box/contest/test_statements_profile.py && uv run ruff format rbx/box/contest/statements.py tests/rbx/box/contest/test_statements_profile.py`
+Expected: clean.
+
+### Step 6: Commit
+
+```
+feat(contest/statements): add -p/--profile to rbx contest st b with skip-with-warn (#456)
+```
+
+---
+
+## Task 3: End-to-end CLI smoke (optional but recommended)
+
+**Files:**
+- Test: `tests/e2e/<existing-statement-fixture>/e2e.rbx.yml` — add a case OR new fixture directory.
+
+This is a guard against regressions in the full Typer wiring. The unit tests above use direct function calls; an E2E run exercises argument parsing, the global callback, and Typer help routing. See `tests/e2e/README.md` for the DSL.
+
+### Step 1: Add a scenario that runs `rbx st b -p localprofile --output markdown --no-samples` on a fixture that has a `.limits/localprofile.yml`
+
+Pick an existing E2E fixture under `tests/e2e/` that already builds a markdown statement. Add a `.limits/localprofile.yml` (with `timeLimit: 7777`) and append a step that runs `rbx st b -p localprofile -o MARKDOWN --no-samples` and greps the output markdown for `7777`. If no such fixture exists, skip this task — the unit tests are sufficient.
+
+Run: `mise run test-e2e -- -k <new-scenario>`
+Expected: PASS.
+
+### Step 2: Commit
+
+```
+test(e2e): cover statements -p profile selection (#456)
+```
+
+---
+
+## Task 4: Update user-facing docs
+
+**Files:**
+- Modify: any markdown under `docs/` that documents `rbx st b` or `rbx contest st b` (search with `rg -l "rbx st b|rbx statements build|rbx contest st b" docs/`).
+
+### Step 1: Add a short paragraph and example
+
+Document the new flag in the appropriate place. Mention:
+
+- Behaviour: validates the profile exists; for contests, skips problems missing the profile.
+- Equivalent to `rbx -p <profile> st b` for the problem-level command (subcommand wins if both passed).
+
+### Step 2: Commit
+
+```
+docs: document -p/--profile on statement build commands (#456)
+```
+
+---
+
+## Task 5: Final verification
+
+### Step 1: Run the test subset relevant to this change
+
+Run: `uv run pytest tests/rbx/box/statements tests/rbx/box/contest tests/rbx/box/test_timing.py -v`
+Expected: ALL PASS.
+
+### Step 2: Run lint across touched files
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: clean.
+
+### Step 3: Manual sanity check on a real package
+
+In a real problem package with at least one `.limits/<profile>.yml`:
+
+```bash
+uv run rbx st b -p <profile> --output MARKDOWN --no-samples
+```
+
+Confirm the rendered markdown reflects the profile's time limit. Then:
+
+```bash
+uv run rbx st b -p typo --output MARKDOWN --no-samples
+```
+
+Confirm the command exits non-zero with the "Limits profile not found" error.
+
+### Step 4: Use the finishing-a-development-branch skill
+
+REQUIRED SUB-SKILL: `superpowers:finishing-a-development-branch` to decide between PR, merge, or further cleanup.

--- a/docs/setters/cheatsheet.md
+++ b/docs/setters/cheatsheet.md
@@ -37,6 +37,7 @@ Below you can find a list of common {{rbx}} commands. You can read more about ea
 | Build all statements                               | `rbx statements build`                                         |
 | Build a specific statement                         | `rbx statements build <name>`                                  |
 | Build statements for English                       | `rbx statements build -l en`                                   |
+| Build statements against a timing profile          | `rbx statements build -p icpc`                                 |
 | Package problem for {{polygon}}                    | `rbx package polygon`                                          |
 | Package problem for {{boca}}                       | `rbx package boca`                                             |
 | Package problem for {{boca}} but only validate     | `rbx package boca -v1`                                         |
@@ -57,6 +58,7 @@ Below you can find a list of common {{rbx}} commands. You can read more about ea
 | Build all statements                            | `rbx contest statements build`        |
 | Build a specific statement                      | `rbx contest statements build <name>` |
 | Build statements for English                    | `rbx contest statements build en`     |
+| Build statements against a timing profile       | `rbx contest statements build -p icpc` |
 | Package contest for {{polygon}}                 | `rbx contest package polygon`         |
 | Build each problem in the contest               | `rbx contest each build`              |
 | Package each problem in the contest             | `rbx contest each package boca`       |

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -254,6 +254,21 @@ rbx -p polygon run
 
 This applies the limits from the specified profile instead of the package defaults.
 
+### Using profiles when building statements
+
+The statement build commands accept a `-p` / `--profile` flag so the time limits
+printed in the statement reflect a specific profile:
+
+```bash
+rbx statements build -p icpc
+rbx contest statements build -p icpc
+```
+
+At the problem level the command fails if the profile doesn't exist; at the
+contest level problems missing the profile are skipped with a warning. See
+[Building statements](../statements/index.md#rendering-against-a-timing-profile)
+for details.
+
 ### Profiles and packaging
 
 When you package a problem, {{rbx}} automatically uses the profile that matches the packager name.

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -514,6 +514,7 @@ rbx statements build <NAMES> [OPTIONS]
 | `--samples` | BOOLEAN | Whether to build the statement with samples or not. | `True` |
 | `--vars` | TEXT | Variables to be used in the statements. | - |
 | `--validate` | BOOLEAN | Whether to validate outputs for testcases or not. | `True` |
+| `-p`, `--profile` | TEXT | Timing profile to render the statement against. Must exist in this problem. | - |
 
 
 ---
@@ -954,6 +955,7 @@ rbx contest statements build <NAMES> [OPTIONS]
 | `--samples` | BOOLEAN | Whether to build the statement with samples or not. | `True` |
 | `--vars` | TEXT | Variables to be used in the statements. | - |
 | `--install-tex` | BOOLEAN | Whether to install missing LaTeX packages. | `False` |
+| `-p`, `--profile` | TEXT | Timing profile to render statements against. Problems missing this profile are skipped with a warning. | - |
 
 
 ---

--- a/docs/setters/statements/index.md
+++ b/docs/setters/statements/index.md
@@ -81,6 +81,29 @@ rbx statements build statement-en
 
 # Build for specific languages
 rbx statements build --languages en pt
+
+# Render the statement against a specific timing profile
+rbx statements build -p icpc
 ```
 
 The built statements will be placed in the `build/` directory of your package.
+
+### Rendering against a timing profile
+
+The `-p` / `--profile` flag tells {{rbx}} to render the statement using the time
+limits from a specific [limits profile](../profiling/index.md) instead of the
+package defaults. The flag fails loudly if the named profile doesn't exist for
+the current problem (i.e. there is no `.limits/<profile>.yml`), so you never
+ship a PDF with the wrong time limits.
+
+The contest-level command (`rbx contest statements build -p <profile>`) is
+more lenient: problems that don't define the profile are **skipped with a
+warning** and excluded from the contest statement. If no problem defines the
+profile, the command fails. This makes it easy to assemble a contest book for
+a specific venue (e.g. `-p icpc`) when only a subset of the problems has been
+profiled for it.
+
+!!! note
+    `rbx statements build -p <profile>` is equivalent to the global
+    `rbx -p <profile> statements build`. The subcommand-level flag wins when
+    both are passed.

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -4,7 +4,7 @@ import syncer
 import typer
 
 from rbx import annotations, console
-from rbx.box import cd, environment, package_utils
+from rbx.box import cd, environment, limits_info, package_utils
 from rbx.box.contest.build_contest_statements import (
     StatementBuildIssue,
     build_statement,
@@ -65,8 +65,35 @@ async def build(
         bool,
         typer.Option(help='Whether to install missing LaTeX packages.'),
     ] = False,
+    profile: Annotated[
+        Optional[str],
+        typer.Option(
+            '-p',
+            '--profile',
+            help='Timing profile to render statements against. Problems missing this profile are skipped with a warning.',
+        ),
+    ] = None,
 ):
     contest = find_contest_package_or_die()
+
+    eligible_problems: List[ContestProblem] = list(contest.problems)
+    if profile is not None:
+        eligible_problems = []
+        for problem in contest.problems:
+            saved = limits_info.get_saved_limits_profile(
+                profile, root=problem.get_path()
+            )
+            if saved is None:
+                console.console.print(
+                    f'[warning]Skipping problem [item]{problem.short_name}[/item]: timing profile [item]{profile}[/item] is not defined for it.[/warning]'
+                )
+                continue
+            eligible_problems.append(problem)
+        if not eligible_problems:
+            console.console.print(
+                f'[error]No problems in this contest define the timing profile [item]{profile}[/item].[/error]'
+            )
+            raise typer.Exit(1)
 
     candidate_languages = set(languages or [])
     candidate_names = set(names or [])
@@ -95,7 +122,7 @@ async def build(
         from rbx.box.testcase_sample_utils import build_samples
 
         problems_of_interest = []
-        for problem in contest.problems:
+        for problem in eligible_problems:
             console.console.print(
                 f'Processing problem [item]{problem.short_name}[/item]...'
             )
@@ -110,20 +137,26 @@ async def build(
                 except Exception:
                     issue_stack.add_issue(StatementBuildIssue(problem))
 
+    if profile is not None and problems_of_interest is None:
+        problems_of_interest = eligible_problems
+
     built_statements = []
 
-    for statement in valid_statements:
-        built_statements.append(
-            await build_statement(
-                statement,
-                contest,
-                problems_of_interest=problems_of_interest,
-                output_type=output,
-                use_samples=samples,
-                install_tex=install_tex,
-                custom_vars=expand_any_vars(annotations.parse_dictionary_items(vars)),
+    with limits_info.use_profile(profile):
+        for statement in valid_statements:
+            built_statements.append(
+                await build_statement(
+                    statement,
+                    contest,
+                    problems_of_interest=problems_of_interest,
+                    output_type=output,
+                    use_samples=samples,
+                    install_tex=install_tex,
+                    custom_vars=expand_any_vars(
+                        annotations.parse_dictionary_items(vars)
+                    ),
+                )
             )
-        )
 
     console.console.rule(title='Built statements')
     for statement, built_path in zip(valid_statements, built_statements):

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -142,7 +142,7 @@ async def build(
 
     built_statements = []
 
-    with limits_info.use_profile(profile):
+    with limits_info.use_profile(profile, when=lambda: profile is not None):
         for statement in valid_statements:
             built_statements.append(
                 await build_statement(

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -445,7 +445,7 @@ async def execute_build(
     if profile is not None:
         limits_info.get_limits_profile(profile, fallback_to_package_profile=False)
 
-    with limits_info.use_profile(profile):
+    with limits_info.use_profile(profile, when=lambda: profile is not None):
         pkg = package.find_problem_package_or_die()
         candidate_languages = set(languages or [])
         candidate_names = set(names or [])

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -440,34 +440,39 @@ async def execute_build(
     samples: bool = True,
     vars: Optional[List[str]] = None,
     validate: bool = True,
+    profile: Optional[str] = None,
 ) -> None:
-    pkg = package.find_problem_package_or_die()
-    candidate_languages = set(languages or [])
-    candidate_names = set(names or [])
+    if profile is not None:
+        limits_info.get_limits_profile(profile, fallback_to_package_profile=False)
 
-    def should_process(st: Statement) -> bool:
-        if candidate_languages and st.language not in candidate_languages:
-            return False
-        if candidate_names and st.name not in candidate_names:
-            return False
-        return True
+    with limits_info.use_profile(profile):
+        pkg = package.find_problem_package_or_die()
+        candidate_languages = set(languages or [])
+        candidate_names = set(names or [])
 
-    valid_statements = [st for st in pkg.expanded_statements if should_process(st)]
+        def should_process(st: Statement) -> bool:
+            if candidate_languages and st.language not in candidate_languages:
+                return False
+            if candidate_names and st.name not in candidate_names:
+                return False
+            return True
 
-    if not valid_statements:
-        console.console.print(
-            '[error]No statement found according to the specified criteria.[/error]',
+        valid_statements = [st for st in pkg.expanded_statements if should_process(st)]
+
+        if not valid_statements:
+            console.console.print(
+                '[error]No statement found according to the specified criteria.[/error]',
+            )
+            raise typer.Exit(1)
+
+        await execute_build_on_statements(
+            valid_statements,
+            verification,
+            output=output,
+            samples=samples,
+            vars=vars,
+            validate=validate,
         )
-        raise typer.Exit(1)
-
-    await execute_build_on_statements(
-        valid_statements,
-        verification,
-        output=output,
-        samples=samples,
-        vars=vars,
-        validate=validate,
-    )
 
 
 @app.command('build, b', help='Build statements.')
@@ -509,8 +514,25 @@ async def build(
         bool,
         typer.Option(help='Whether to validate outputs for testcases or not.'),
     ] = True,
+    profile: Annotated[
+        Optional[str],
+        typer.Option(
+            '-p',
+            '--profile',
+            help='Timing profile to render the statement against. Must exist in this problem.',
+        ),
+    ] = None,
 ):
-    await execute_build(verification, names, languages, output, samples, vars, validate)
+    await execute_build(
+        verification,
+        names,
+        languages,
+        output,
+        samples,
+        vars,
+        validate,
+        profile=profile,
+    )
 
 
 @app.callback()

--- a/rbx/testdata/contests/two_problems/A/problem.rbx.yml
+++ b/rbx/testdata/contests/two_problems/A/problem.rbx.yml
@@ -1,0 +1,3 @@
+name: 'problem-a'
+timeLimit: 1000
+memoryLimit: 256

--- a/rbx/testdata/contests/two_problems/B/problem.rbx.yml
+++ b/rbx/testdata/contests/two_problems/B/problem.rbx.yml
@@ -1,0 +1,3 @@
+name: 'problem-b'
+timeLimit: 1000
+memoryLimit: 256

--- a/rbx/testdata/contests/two_problems/contest.rbx.yml
+++ b/rbx/testdata/contests/two_problems/contest.rbx.yml
@@ -1,0 +1,8 @@
+---
+name: 'two-problems'
+problems:
+  - short_name: 'A'
+  - short_name: 'B'
+statements:
+  - name: 'english'
+    language: 'en'

--- a/tests/e2e/testdata/with-statement/e2e.rbx.yml
+++ b/tests/e2e/testdata/with-statement/e2e.rbx.yml
@@ -11,3 +11,14 @@ scenarios:
         expect:
           files_exist:
             - "build/main.pdf"
+
+  - name: build-statement-missing-profile
+    description: >
+      Building with a non-existent timing profile must fail loudly so the
+      user does not silently ship a statement rendered against the package
+      defaults.
+    steps:
+      - cmd: st b -p does-not-exist
+        expect_exit: 1
+        expect:
+          stdout_contains: "Limits profile"

--- a/tests/rbx/box/contest/test_statements_profile.py
+++ b/tests/rbx/box/contest/test_statements_profile.py
@@ -1,0 +1,72 @@
+import pathlib
+
+import pytest
+import typer
+
+from rbx.box import limits_info
+from rbx.box.contest import statements as contest_statements_cli
+from rbx.box.statements.schema import StatementType
+
+
+def _async_build():
+    # `build` is decorated with @within_contest (sync wrapper) and @syncer.sync.
+    # Peel both layers to reach the underlying async coroutine function.
+    return contest_statements_cli.build.__wrapped__.__wrapped__
+
+
+@pytest.mark.test_pkg('contests/two_problems')
+async def test_contest_build_skips_problems_missing_profile(
+    cleandir_with_testdata, monkeypatch
+):
+    pathlib.Path('A/.limits').mkdir(parents=True, exist_ok=True)
+    pathlib.Path('A/.limits/icpc.yml').write_text('timeLimit: 5000\n')
+
+    built_for = []
+    seen_profiles = []
+
+    async def fake_build_statement(
+        statement, contest, *, problems_of_interest=None, **kwargs
+    ):
+        seen_profiles.append(limits_info.get_active_profile())
+        built_for.append([p.short_name for p in (problems_of_interest or [])])
+        return pathlib.Path('fake.pdf')
+
+    monkeypatch.setattr(
+        'rbx.box.contest.statements.build_statement',
+        fake_build_statement,
+    )
+
+    await _async_build()(
+        verification=0,
+        names=None,
+        languages=None,
+        validate=False,
+        output=StatementType.PDF,
+        samples=False,
+        vars=None,
+        install_tex=False,
+        profile='icpc',
+    )
+
+    assert built_for, 'expected at least one statement build call'
+    for problems in built_for:
+        assert 'A' in problems
+        assert 'B' not in problems
+    assert seen_profiles == ['icpc']
+
+
+@pytest.mark.test_pkg('contests/two_problems')
+async def test_contest_build_all_missing_profile_exits(cleandir_with_testdata):
+    with pytest.raises(typer.Exit) as exc_info:
+        await _async_build()(
+            verification=0,
+            names=None,
+            languages=None,
+            validate=False,
+            output=StatementType.PDF,
+            samples=False,
+            vars=None,
+            install_tex=False,
+            profile='nonexistent',
+        )
+    assert exc_info.value.exit_code == 1

--- a/tests/rbx/box/contest/test_statements_profile.py
+++ b/tests/rbx/box/contest/test_statements_profile.py
@@ -58,6 +58,48 @@ async def test_contest_build_skips_problems_missing_profile(
 
 
 @pytest.mark.test_pkg('contests/two_problems')
+async def test_contest_build_respects_global_profile_when_local_none(
+    cleandir_with_testdata, monkeypatch, capsys
+):
+    pathlib.Path('A/.limits').mkdir(parents=True, exist_ok=True)
+    pathlib.Path('A/.limits/icpc.yml').write_text('timeLimit: 5000\n')
+    pathlib.Path('B/.limits').mkdir(parents=True, exist_ok=True)
+    pathlib.Path('B/.limits/icpc.yml').write_text('timeLimit: 5000\n')
+
+    token = limits_info.profile_var.set('icpc')
+    try:
+        seen_profiles = []
+
+        async def fake_build_statement(
+            statement, contest, *, problems_of_interest=None, **kwargs
+        ):
+            seen_profiles.append(limits_info.get_active_profile())
+            return pathlib.Path('fake.pdf')
+
+        monkeypatch.setattr(
+            'rbx.box.contest.statements.build_statement',
+            fake_build_statement,
+        )
+
+        await _build_async(
+            verification=0,
+            names=None,
+            languages=None,
+            validate=False,
+            output=StatementType.PDF,
+            samples=False,
+            vars=None,
+            install_tex=False,
+            profile=None,
+        )
+
+        assert seen_profiles, 'expected at least one statement build call'
+        assert all(p == 'icpc' for p in seen_profiles), seen_profiles
+    finally:
+        limits_info.profile_var.reset(token)
+
+
+@pytest.mark.test_pkg('contests/two_problems')
 async def test_contest_build_all_missing_profile_exits(cleandir_with_testdata):
     with pytest.raises(typer.Exit) as exc_info:
         await _build_async(

--- a/tests/rbx/box/contest/test_statements_profile.py
+++ b/tests/rbx/box/contest/test_statements_profile.py
@@ -1,3 +1,4 @@
+import inspect
 import pathlib
 
 import pytest
@@ -7,16 +8,12 @@ from rbx.box import limits_info
 from rbx.box.contest import statements as contest_statements_cli
 from rbx.box.statements.schema import StatementType
 
-
-def _async_build():
-    # `build` is decorated with @within_contest (sync wrapper) and @syncer.sync.
-    # Peel both layers to reach the underlying async coroutine function.
-    return contest_statements_cli.build.__wrapped__.__wrapped__
+_build_async = inspect.unwrap(contest_statements_cli.build)
 
 
 @pytest.mark.test_pkg('contests/two_problems')
 async def test_contest_build_skips_problems_missing_profile(
-    cleandir_with_testdata, monkeypatch
+    cleandir_with_testdata, monkeypatch, capsys
 ):
     pathlib.Path('A/.limits').mkdir(parents=True, exist_ok=True)
     pathlib.Path('A/.limits/icpc.yml').write_text('timeLimit: 5000\n')
@@ -36,7 +33,7 @@ async def test_contest_build_skips_problems_missing_profile(
         fake_build_statement,
     )
 
-    await _async_build()(
+    await _build_async(
         verification=0,
         names=None,
         languages=None,
@@ -54,11 +51,16 @@ async def test_contest_build_skips_problems_missing_profile(
         assert 'B' not in problems
     assert seen_profiles == ['icpc']
 
+    out = capsys.readouterr().out
+    assert 'B' in out
+    assert 'icpc' in out
+    assert 'Skipping' in out or 'skipping' in out
+
 
 @pytest.mark.test_pkg('contests/two_problems')
 async def test_contest_build_all_missing_profile_exits(cleandir_with_testdata):
     with pytest.raises(typer.Exit) as exc_info:
-        await _async_build()(
+        await _build_async(
             verification=0,
             names=None,
             languages=None,

--- a/tests/rbx/box/statements/test_build_statements.py
+++ b/tests/rbx/box/statements/test_build_statements.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import pathlib
 from typing import List, cast
@@ -1014,39 +1013,9 @@ class TestExecuteBuildStrictProfile:
     """Tests for strict --profile validation in execute_build."""
 
     @pytest.mark.test_pkg('problems/box1')
-    def test_execute_build_strict_profile_missing_exits(self, pkg_from_testdata):
+    async def test_execute_build_strict_profile_missing_exits(self, pkg_from_testdata):
         with pytest.raises(typer.Exit) as exc_info:
-            asyncio.run(
-                execute_build(
-                    verification=0,
-                    names=None,
-                    languages=None,
-                    output=StatementType.PDF,
-                    samples=False,
-                    vars=None,
-                    validate=False,
-                    profile='does-not-exist',
-                )
-            )
-        assert exc_info.value.exit_code == 1
-
-    @pytest.mark.test_pkg('problems/box1')
-    def test_execute_build_strict_profile_applies(self, pkg_from_testdata, monkeypatch):
-        pathlib.Path('.limits').mkdir(exist_ok=True)
-        pathlib.Path('.limits/icpc.yml').write_text('timeLimit: 5000\n')
-
-        seen = {}
-
-        async def fake_execute_build_on_statements(statements, *args, **kwargs):
-            seen['profile'] = limits_info.get_active_profile()
-            return []
-
-        monkeypatch.setattr(
-            'rbx.box.statements.build_statements.execute_build_on_statements',
-            fake_execute_build_on_statements,
-        )
-        asyncio.run(
-            execute_build(
+            await execute_build(
                 verification=0,
                 names=None,
                 languages=None,
@@ -1054,7 +1023,35 @@ class TestExecuteBuildStrictProfile:
                 samples=False,
                 vars=None,
                 validate=False,
-                profile='icpc',
+                profile='does-not-exist',
             )
+        assert exc_info.value.exit_code == 1
+
+    @pytest.mark.test_pkg('problems/box1')
+    async def test_execute_build_strict_profile_applies(
+        self, pkg_from_testdata, monkeypatch
+    ):
+        pathlib.Path('.limits').mkdir(exist_ok=True)
+        pathlib.Path('.limits/icpc.yml').write_text('timeLimit: 5000\n')
+
+        seen = {}
+
+        async def fake_execute_build_on_statements(statements, *args, **kwargs):
+            seen['profile'] = limits_info.get_active_profile()
+            return
+
+        monkeypatch.setattr(
+            'rbx.box.statements.build_statements.execute_build_on_statements',
+            fake_execute_build_on_statements,
+        )
+        await execute_build(
+            verification=0,
+            names=None,
+            languages=None,
+            output=StatementType.PDF,
+            samples=False,
+            vars=None,
+            validate=False,
+            profile='icpc',
         )
         assert seen['profile'] == 'icpc'

--- a/tests/rbx/box/statements/test_build_statements.py
+++ b/tests/rbx/box/statements/test_build_statements.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import pathlib
 from typing import List, cast
@@ -6,12 +7,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 import typer
 
+from rbx.box import limits_info
 from rbx.box.contest.schema import ContestStatement
 from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
 from rbx.box.schema import Package, Statement, Testcase
 from rbx.box.statements.build_statements import (
     build_statement,
     build_statement_bytes,
+    execute_build,
     get_builder,
     get_builders,
     get_environment_languages_for_statement,
@@ -1005,3 +1008,53 @@ class TestNeedsSamples:
             return_value=mock_overrides,
         ):
             assert needs_samples(statement) is False
+
+
+class TestExecuteBuildStrictProfile:
+    """Tests for strict --profile validation in execute_build."""
+
+    @pytest.mark.test_pkg('problems/box1')
+    def test_execute_build_strict_profile_missing_exits(self, pkg_from_testdata):
+        with pytest.raises(typer.Exit) as exc_info:
+            asyncio.run(
+                execute_build(
+                    verification=0,
+                    names=None,
+                    languages=None,
+                    output=StatementType.PDF,
+                    samples=False,
+                    vars=None,
+                    validate=False,
+                    profile='does-not-exist',
+                )
+            )
+        assert exc_info.value.exit_code == 1
+
+    @pytest.mark.test_pkg('problems/box1')
+    def test_execute_build_strict_profile_applies(self, pkg_from_testdata, monkeypatch):
+        pathlib.Path('.limits').mkdir(exist_ok=True)
+        pathlib.Path('.limits/icpc.yml').write_text('timeLimit: 5000\n')
+
+        seen = {}
+
+        async def fake_execute_build_on_statements(statements, *args, **kwargs):
+            seen['profile'] = limits_info.get_active_profile()
+            return []
+
+        monkeypatch.setattr(
+            'rbx.box.statements.build_statements.execute_build_on_statements',
+            fake_execute_build_on_statements,
+        )
+        asyncio.run(
+            execute_build(
+                verification=0,
+                names=None,
+                languages=None,
+                output=StatementType.PDF,
+                samples=False,
+                vars=None,
+                validate=False,
+                profile='icpc',
+            )
+        )
+        assert seen['profile'] == 'icpc'

--- a/tests/rbx/box/statements/test_build_statements.py
+++ b/tests/rbx/box/statements/test_build_statements.py
@@ -1055,3 +1055,39 @@ class TestExecuteBuildStrictProfile:
             profile='icpc',
         )
         assert seen['profile'] == 'icpc'
+
+    @pytest.mark.test_pkg('problems/box1')
+    async def test_execute_build_respects_global_profile_when_local_none(
+        self, pkg_from_testdata, monkeypatch
+    ):
+        # Simulate the global `rbx -p icpc st b` callback by setting the contextvar
+        # before invoking execute_build with profile=None (no local override).
+        pathlib.Path('.limits').mkdir(exist_ok=True)
+        pathlib.Path('.limits/icpc.yml').write_text('timeLimit: 5000\n')
+
+        token = limits_info.profile_var.set('icpc')
+        try:
+            seen = {}
+
+            async def fake_execute_build_on_statements(statements, *args, **kwargs):
+                seen['profile'] = limits_info.get_active_profile()
+                return
+
+            monkeypatch.setattr(
+                'rbx.box.statements.build_statements.execute_build_on_statements',
+                fake_execute_build_on_statements,
+            )
+
+            await execute_build(
+                verification=0,
+                names=None,
+                languages=None,
+                output=StatementType.PDF,
+                samples=False,
+                vars=None,
+                validate=False,
+                profile=None,
+            )
+            assert seen['profile'] == 'icpc'
+        finally:
+            limits_info.profile_var.reset(token)


### PR DESCRIPTION
Closes #456.

## Summary

Adds `-p/--profile <name>` to `rbx st b` (problem-level) and `rbx contest st b` (contest-level), so statements render against a specific timing profile instead of the package defaults.

- **Problem level:** strict. Exits 1 if `.limits/<profile>.yml` is missing — no silent fallback to package limits.
- **Contest level:** lenient. Problems missing the profile are **skipped with a warning** and excluded from the assembled contest book. If no problem defines the profile, the command exits 1.
- **Composition:** the subcommand flag composes with the global `rbx -p <profile>` callback. Subcommand wins when both are passed; the global is preserved when the subcommand flag is unset.

## Approach

Reuses the existing `rbx.box.limits_info.use_profile` context manager and `profile_var` contextvar plumbing — `build_statement_bytes` already reads the active profile when assembling `StatementBuilderProblem.limits` and `profiles`. **No template, schema, or builder changes.**

The fix uses `use_profile(profile, when=lambda: profile is not None)` so an unset local flag doesn't clobber a globally-set profile (caught in code review).

## Test plan

- [x] `tests/rbx/box/statements/test_build_statements.py::TestExecuteBuildStrictProfile` — strict-fail on missing profile, contextvar applied on success, global profile preserved when local flag unset.
- [x] `tests/rbx/box/contest/test_statements_profile.py` — skip-with-warn (asserts warning text), all-missing exits 1, global profile preserved.
- [x] `tests/e2e/testdata/with-statement/e2e.rbx.yml::build-statement-missing-profile` — full Typer wiring, missing-profile failure exits 1.
- [x] `uv run pytest tests/rbx/box/statements tests/rbx/box/contest tests/rbx/box/test_timing.py tests/e2e/testdata/with-statement/` → 356 passed.
- [x] `uv run ruff check .` clean; `uv run ruff format --check .` clean.

## Design / plan docs

- Design: docs/plans/2026-05-15-statements-timing-profile-design.md
- Plan: docs/plans/2026-05-15-statements-timing-profile.md

## User docs

Cheatsheet, CLI reference, statements guide, and profiling guide all updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)