### PR TITLE
feat(statements): multi-language sample explanations via .rbx.tex blocks

### DIFF
--- a/docs/plans/2026-05-19-multilang-sample-explanations-design.md
+++ b/docs/plans/2026-05-19-multilang-sample-explanations-design.md
@@ -1,0 +1,103 @@
+# Multi-language sample explanations — design
+
+## Problem
+
+Sample explanations exist in two flavors today:
+
+1. **Statement-level blocks** — `%- block explanation_N` inside the statement
+   `.rbx.tex`. These are inherently language-specific because each statement is
+   built per language.
+2. **Per-sample files** — a plain `<sample>.tex` (or `<sample>.md` for Markdown
+   statements) living alongside the sample `.in`. These are language-agnostic:
+   nothing ties the file to a language, so the same text is used for every
+   language.
+
+We want a third option that keeps the convenience of per-sample files but is
+language-aware: a `<sample>.rbx.tex` file alongside the `.in` that contains
+language-keyed JinjaTeX blocks.
+
+## Desired file format
+
+```latex
+%- block en
+This is the english explanation.
+%- endblock
+
+%- block pt
+Esta é a explicação em português.
+%- endblock
+```
+
+- Content **outside** any block is ignored.
+- The file receives all the same Jinja parameters the existing `.tex` file
+  receives.
+- Generalizes to Markdown statements via `<sample>.rbx.md`.
+
+## Resolution & priority
+
+For a given sample, the explanation is resolved as:
+
+1. Statement-level `explanation_N` block — highest priority (unchanged).
+2. Per-sample `<sample>.rbx.<ext>` — new, language-specific.
+3. Per-sample `<sample>.<ext>` — existing, language-agnostic.
+
+Where `<ext>` is the builder's plain explanation suffix (`.tex` for the
+rbxTeX/JinjaTeX/TeX2PDF builders, `.md` for the rbxMarkdownToTeX builder), and
+the blocks file suffix is `.rbx` + that suffix.
+
+Edge cases:
+
+- If **both** `<sample>.rbx.<ext>` and `<sample>.<ext>` exist → **error**,
+  asking the setter to remove one of the two (avoids silent ambiguity).
+- If the `.rbx.<ext>` file exists but has **no block for the statement's
+  language** → **warn and render no explanation** for that sample/language.
+
+## Implementation
+
+### `rbx/box/testcase_sample_utils.py`
+
+- Add `explanationFromBlocks: bool = False` to `StatementSample`.
+- Replace the inline explanation lookup inside `_get_statement_sample_from_entry`
+  with a helper that, given an input path and the plain suffix, returns
+  `(explanation_path, from_blocks)`:
+  - Prefers `<input>.rbx<suffix>` (sets `from_blocks=True`).
+  - Falls back to `<input><suffix>`.
+  - Raises `typer.Exit(1)` with a clear message if both exist.
+- The public `get_statement_samples(explanation_suffix=...)` signature is
+  unchanged — `explanation_suffix` remains the *plain* suffix and the blocks
+  suffix is derived, so `.rbx.md` support comes for free.
+
+### `rbx/box/statements/builders.py`
+
+- `ExplainedStatementSample` inherits the new field; no change to
+  `from_statement_sample` (it still reads the raw file text).
+- In `get_rbxtex_blocks`, the per-sample loop branches on
+  `sample.explanationFromBlocks`:
+  - If set: render the raw text via `render_jinja_blocks` (same kwargs as the
+    plain path, passing the statement language) and pick
+    `blocks.get(context.lang)`. If missing, print a warning and clear the
+    explanation.
+  - Otherwise: the existing `render_jinja` path.
+
+### Default preset
+
+Add `manual_tests/samples/000.rbx.tex` containing an `en` block, and reference
+it so the default preset demonstrates `.rbx.tex` as the default explanation
+method.
+
+### Docs
+
+Update `docs/setters/statements/formats/rbxtex.md` to document per-sample
+`.rbx.tex` / `.rbx.md` language-block explanations as the recommended method,
+alongside the existing `explanation_N` block and plain `.tex` options.
+
+## Testing
+
+- `tests/rbx/box/test_testcase_sample_utils.py`:
+  - resolution prefers `.rbx.tex` over `.tex`;
+  - falls back to `.tex` when only it exists;
+  - errors when both exist.
+- `tests/rbx/box/statements/test_builders.py`:
+  - `get_rbxtex_blocks` selects the block matching the statement language;
+  - a missing language block warns and yields no explanation;
+  - statement-level `explanation_N` block still overrides the per-sample file.

--- a/docs/plans/2026-05-19-multilang-sample-explanations.md
+++ b/docs/plans/2026-05-19-multilang-sample-explanations.md
@@ -1,0 +1,444 @@
+# Multi-language Sample Explanations Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Support per-sample `<sample>.rbx.tex` / `.rbx.md` explanation files containing language-keyed JinjaTeX blocks, selecting the block matching the statement's language.
+
+**Architecture:** Explanation-path resolution in `testcase_sample_utils.py` learns to prefer a `.rbx<suffix>` "blocks" file over the plain `<suffix>` file (erroring if both exist) and records `explanationFromBlocks` on the sample. The per-sample rendering loop in `builders.get_rbxtex_blocks` branches on that flag: blocks files are rendered via the existing `render_jinja_blocks` and the block matching `context.lang` is selected (warning if absent). The default preset and docs are updated to make `.rbx.tex` the demonstrated default.
+
+**Tech Stack:** Python 3.10+, Pydantic v2, Jinja2 (LaTeX/Markdown flavored), Typer, pytest.
+
+---
+
+### Task 1: Resolve `.rbx.tex` blocks file in sample explanation lookup
+
+**Files:**
+- Modify: `rbx/box/testcase_sample_utils.py` (`StatementSample` model ~line 36; `_get_statement_sample_from_entry` ~lines 68-164)
+- Test: `tests/rbx/box/test_testcase_sample_utils.py`
+
+**Step 1: Write failing tests**
+
+Add to `tests/rbx/box/test_testcase_sample_utils.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_get_statement_samples_explanation_prefers_blocks(
+    tmp_path, mock_extract_generation_testcases_from_groups
+):
+    """A .rbx.<suffix> blocks file is preferred and flagged as from-blocks."""
+    dest_input = tmp_path / 'dest.in'
+    blocks_expl = tmp_path / 'dest.rbx.desc'
+    blocks_expl.touch()
+
+    entry = create_entry(
+        TestcaseEntry(group='samples', index=0),
+        copied_to_input=dest_input,
+    )
+    mock_extract_generation_testcases_from_groups.return_value = [entry]
+
+    samples = await testcase_sample_utils.get_statement_samples(
+        explanation_suffix='.desc'
+    )
+    sample = list(samples)[0]
+    assert sample.explanationPath.resolve() == blocks_expl.resolve()
+    assert sample.explanationFromBlocks is True
+
+
+@pytest.mark.asyncio
+async def test_get_statement_samples_explanation_plain_fallback(
+    tmp_path, mock_extract_generation_testcases_from_groups
+):
+    """With only the plain file, it is used and not flagged as from-blocks."""
+    dest_input = tmp_path / 'dest.in'
+    plain_expl = tmp_path / 'dest.desc'
+    plain_expl.touch()
+
+    entry = create_entry(
+        TestcaseEntry(group='samples', index=0),
+        copied_to_input=dest_input,
+    )
+    mock_extract_generation_testcases_from_groups.return_value = [entry]
+
+    samples = await testcase_sample_utils.get_statement_samples(
+        explanation_suffix='.desc'
+    )
+    sample = list(samples)[0]
+    assert sample.explanationPath.resolve() == plain_expl.resolve()
+    assert sample.explanationFromBlocks is False
+
+
+@pytest.mark.asyncio
+async def test_get_statement_samples_explanation_conflict_errors(
+    tmp_path, mock_extract_generation_testcases_from_groups
+):
+    """Both a blocks and a plain explanation file is an error."""
+    dest_input = tmp_path / 'dest.in'
+    (tmp_path / 'dest.desc').touch()
+    (tmp_path / 'dest.rbx.desc').touch()
+
+    entry = create_entry(
+        TestcaseEntry(group='samples', index=0),
+        copied_to_input=dest_input,
+    )
+    mock_extract_generation_testcases_from_groups.return_value = [entry]
+
+    import typer
+
+    with pytest.raises(typer.Exit):
+        await testcase_sample_utils.get_statement_samples(explanation_suffix='.desc')
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_testcase_sample_utils.py -k "prefers_blocks or plain_fallback or conflict_errors" -v`
+Expected: FAIL (`explanationFromBlocks` attribute missing; conflict not raised).
+
+**Step 3: Implement**
+
+In `rbx/box/testcase_sample_utils.py`, add the field to `StatementSample`:
+
+```python
+class StatementSample(BaseModel):
+    entry: GenerationTestcaseEntry
+    inputPath: pathlib.Path
+    outputPath: pathlib.Path
+    answerPath: Optional[pathlib.Path] = None
+    explanationPath: Optional[pathlib.Path] = None
+    explanationFromBlocks: bool = False
+    hasOutput: bool = True
+    checkOutput: bool = False
+    interaction: Optional[SampleTestcaseInteraction] = None
+```
+
+Add a module-level helper (above `_get_statement_sample_from_entry`):
+
+```python
+def _resolve_explanation_path(
+    input_path: pathlib.Path, explanation_suffix: Optional[str]
+) -> Tuple[Optional[pathlib.Path], bool]:
+    """Resolve the explanation file for a sample input.
+
+    Prefers a language-block `.rbx<suffix>` file over the plain `<suffix>` file,
+    returning whether the resolved file is a blocks file. Errors if both exist.
+    """
+    if explanation_suffix is None:
+        return None, False
+    plain_path = input_path.with_suffix(explanation_suffix)
+    blocks_path = input_path.with_suffix('.rbx' + explanation_suffix)
+    plain_exists = plain_path.is_file()
+    blocks_exists = blocks_path.is_file()
+    if plain_exists and blocks_exists:
+        console.console.print(
+            f'[error]Both [item]{utils.relcwd(blocks_path)}[/item] and '
+            f'[item]{utils.relcwd(plain_path)}[/item] exist for the same sample.[/error]'
+        )
+        console.console.print(
+            f'[error]Use either the language-specific [item].rbx{explanation_suffix}[/item] '
+            f'explanation or the language-agnostic [item]{explanation_suffix}[/item] '
+            'explanation, but not both.[/error]'
+        )
+        raise typer.Exit(1)
+    if blocks_exists:
+        return blocks_path, True
+    if plain_exists:
+        return plain_path, False
+    return None, False
+```
+
+Add `Tuple` to the `typing` import at the top:
+`from typing import List, Optional, Tuple`
+
+In `_get_statement_sample_from_entry`, add `explanation_from_blocks: bool = False`
+next to the other locals (~line 74), and replace the explanation block inside
+`process_additional_files` (~lines 97-100):
+
+```python
+    def process_additional_files(testcase: Testcase):
+        nonlocal input_path, output_path, explanation_path
+        nonlocal explanation_from_blocks, interaction
+        explanation_path, explanation_from_blocks = _resolve_explanation_path(
+            testcase.inputPath, explanation_suffix
+        )
+        ...  # pin_path / pout_path / interaction logic unchanged
+```
+
+Finally pass the flag into the returned model (~line 153):
+
+```python
+    return StatementSample(
+        entry=entry,
+        inputPath=input_path,
+        outputPath=output_path,
+        answerPath=answer_path,
+        hasOutput=output_path is not None,
+        checkOutput=should_check_output,
+        interaction=_build_sample_interaction(entry, interaction)
+        if interaction is not None
+        else None,
+        explanationPath=explanation_path,
+        explanationFromBlocks=explanation_from_blocks,
+    )
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_testcase_sample_utils.py -v`
+Expected: PASS (new tests + existing explanation tests still green).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/testcase_sample_utils.py tests/rbx/box/test_testcase_sample_utils.py
+git commit -m "feat(statements): resolve per-sample .rbx.tex blocks explanations"
+```
+
+---
+
+### Task 2: Select the language block when rendering blocks explanations
+
+**Files:**
+- Modify: `rbx/box/statements/builders.py` (`get_rbxtex_blocks` per-sample loop ~lines 296-311)
+- Test: `tests/rbx/box/statements/test_builders.py`
+
+**Step 1: Write failing tests**
+
+Add to `tests/rbx/box/statements/test_builders.py` inside `class TestGetRbxTexBlocks`:
+
+```python
+    def test_get_rbxtex_blocks_selects_language_block(self, context, tmp_path):
+        """A from-blocks explanation selects the block for context.lang."""
+        package = Package(name='test-problem', timeLimit=1000, memoryLimit=256)
+        statement = Statement(
+            name='statement', path=pathlib.Path('stmt.tex'), type=StatementType.JinjaTeX
+        )
+        limits = LimitsProfile(timeLimit=1000, memoryLimit=256)
+
+        explanation_file = tmp_path / '1.rbx.tex'
+        explanation_file.write_text(
+            'Ignored preamble.\n'
+            '%- block en\nEnglish explanation.\n%- endblock\n'
+            '%- block pt\nPortuguese explanation.\n%- endblock\n'
+        )
+
+        samples = [
+            StatementSample(
+                entry=create_dummy_entry(),
+                inputPath=tmp_path / '1.in',
+                outputPath=tmp_path / '1.out',
+                explanationPath=explanation_file,
+                explanationFromBlocks=True,
+            )
+        ]
+        problem = StatementBuilderProblem(
+            package=package, statement=statement, limits=limits, samples=samples
+        )
+
+        _, kwargs = get_rbxtex_blocks(b'', context, problem)
+        explanation = kwargs['problem']['samples'][0].explanation
+        assert 'English explanation.' in explanation
+        assert 'Portuguese' not in explanation
+        assert 'Ignored preamble' not in explanation
+
+    def test_get_rbxtex_blocks_missing_language_block_warns(
+        self, context, tmp_path, capsys
+    ):
+        """A from-blocks explanation without the language block yields no explanation."""
+        package = Package(name='test-problem', timeLimit=1000, memoryLimit=256)
+        statement = Statement(
+            name='statement', path=pathlib.Path('stmt.tex'), type=StatementType.JinjaTeX
+        )
+        limits = LimitsProfile(timeLimit=1000, memoryLimit=256)
+
+        explanation_file = tmp_path / '1.rbx.tex'
+        explanation_file.write_text('%- block pt\nSó português.\n%- endblock\n')
+
+        samples = [
+            StatementSample(
+                entry=create_dummy_entry(),
+                inputPath=tmp_path / '1.in',
+                outputPath=tmp_path / '1.out',
+                explanationPath=explanation_file,
+                explanationFromBlocks=True,
+            )
+        ]
+        problem = StatementBuilderProblem(
+            package=package, statement=statement, limits=limits, samples=samples
+        )
+
+        # context.lang == 'en', file only has 'pt'
+        _, kwargs = get_rbxtex_blocks(b'', context, problem)
+        assert kwargs['problem']['samples'][0].explanation is None
+```
+
+Note: the existing `test_get_rbxtex_blocks_block_overrides_explanation_path`
+uses a plain (non-blocks) explanation file and must remain green — it verifies
+the statement-level `explanation_0` block still wins over a per-sample file.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/statements/test_builders.py -k "selects_language_block or missing_language_block" -v`
+Expected: FAIL (the whole `.rbx.tex` body is rendered verbatim instead of the `en` block).
+
+**Step 3: Implement**
+
+In `rbx/box/statements/builders.py`, inside `get_rbxtex_blocks`, replace the
+per-sample loop body (~lines 297-311) so it branches on the flag:
+
+```python
+        for i, sample in enumerate(item_kwargs['problem']['samples']):
+            if i in statement_blocks.explanations:
+                # Sample will come from a block, not from the file.
+                sample.explanation = statement_blocks.explanations[i]
+                continue
+            if sample.explanation is None:
+                # No explanation provided.
+                continue
+            if sample.explanationFromBlocks:
+                # Language-specific explanation: render blocks and pick the one
+                # matching the statement language. Content outside blocks is
+                # ignored. Receives the same Jinja kwargs as a plain explanation.
+                sample_blocks = render_jinja_blocks(
+                    context.root,
+                    sample.explanation.encode(),
+                    mode=mode,
+                    **item.build_inner_jinja_kwargs(),
+                )
+                selected = sample_blocks.blocks.get(context.lang)
+                if selected is None:
+                    console.console.print(
+                        f'[warning]Sample explanation for testcase [item]{i}[/item] '
+                        f'has no block for language [item]{context.lang}[/item]; '
+                        'no explanation will be shown for this sample.[/warning]'
+                    )
+                sample.explanation = selected
+                continue
+            # Render samples.
+            sample.explanation = render_jinja(
+                context.root,
+                sample.explanation.encode(),
+                mode=mode,
+                **item.build_inner_jinja_kwargs(),
+            ).decode()
+```
+
+(`render_jinja_blocks` and `console` are already imported in this module.)
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/statements/test_builders.py -v`
+Expected: PASS (new tests + existing explanation/externalize tests green).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/statements/builders.py tests/rbx/box/statements/test_builders.py
+git commit -m "feat(statements): select language block for .rbx.tex sample explanations"
+```
+
+---
+
+### Task 3: Make `.rbx.tex` the default explanation in the default preset
+
+**Files:**
+- Create: `rbx/resources/presets/default/problem/manual_tests/samples/000.rbx.tex`
+
+**Step 1: Create the explanation file**
+
+`rbx/resources/presets/default/problem/manual_tests/samples/000.rbx.tex`:
+
+```latex
+%- block en
+The sum of the two integers in the first sample is $\VAR{1 + 2}$.
+%- endblock
+```
+
+(The default preset's only statement language is `en`; see
+`problem.rbx.yml` `statements[0].language`. Use a literal explanation if the
+arithmetic VAR feels too cute — the goal is simply to demonstrate the
+`%- block <lang>` format.)
+
+**Step 2: Verify it builds**
+
+Run (from a throwaway copy of the preset, or rely on the e2e/preset tests in
+Task 5):
+`uv run pytest tests/rbx/box -k "preset" -v` (sanity that nothing breaks).
+Expected: PASS / no new failures.
+
+**Step 3: Commit**
+
+```bash
+git add rbx/resources/presets/default/problem/manual_tests/samples/000.rbx.tex
+git commit -m "feat(preset): demonstrate .rbx.tex sample explanation in default preset"
+```
+
+---
+
+### Task 4: Document per-sample language-block explanations
+
+**Files:**
+- Modify: `docs/setters/statements/formats/rbxtex.md`
+
+**Step 1: Add a "Sample explanations" section**
+
+After the "Default blocks" section (after line ~123), add documentation covering
+the three explanation options in priority order:
+
+1. Statement-level `%- block explanation_N` (language-specific, in the statement file).
+2. Per-sample `<sample>.rbx.tex` (recommended; language-specific blocks alongside the `.in`):
+
+   ```latex
+   %- block en
+   This is the english explanation.
+   %- endblock
+
+   %- block pt
+   Esta é a explicação em português.
+   %- endblock
+   ```
+
+   - Content outside blocks is ignored.
+   - Receives the same Jinja variables as the rest of the statement.
+   - For Markdown statements the file is `<sample>.rbx.md`.
+3. Per-sample `<sample>.tex` (language-agnostic, the same text for every language).
+
+Note the rules: `.rbx.tex` is the recommended/default method; a sample may not
+have both a `.rbx.tex` and a `.tex` file (it is an error); a `.rbx.tex` with no
+block for the statement's language renders no explanation for that language.
+
+**Step 2: Verify docs reference is consistent**
+
+Run: `grep -n "explanation" docs/setters/statements/formats/rbxtex.md`
+Expected: new section present, existing `explanation_N` table row intact.
+
+**Step 3: Commit**
+
+```bash
+git add docs/setters/statements/formats/rbxtex.md
+git commit -m "docs(statements): document per-sample language-block explanations"
+```
+
+---
+
+### Task 5: Full verification
+
+**Step 1: Run the affected test suites**
+
+Run:
+```bash
+uv run pytest tests/rbx/box/test_testcase_sample_utils.py tests/rbx/box/statements -v
+```
+Expected: all PASS.
+
+**Step 2: Lint & format**
+
+Run:
+```bash
+uv run ruff check rbx/box/testcase_sample_utils.py rbx/box/statements/builders.py
+uv run ruff format --check rbx/box/testcase_sample_utils.py rbx/box/statements/builders.py
+```
+Expected: clean (run `ruff format` if needed and amend via a new commit).
+
+**Step 3: Broad sanity run**
+
+Run: `uv run pytest --ignore=tests/rbx/box/cli -n auto -q`
+Expected: no new failures relative to `main`.

--- a/docs/setters/statements/formats/rbxtex.md
+++ b/docs/setters/statements/formats/rbxtex.md
@@ -122,6 +122,45 @@ These can be specified in the main file, and will be rendered in the default tem
 It is a good practice to reuse these commonly defined blocks in your own templates as well, since they're
 semantically meaningful, and have a special treatment for {{polygon}} packages.
 
+## Sample explanations
+
+There are three ways to attach an explanation to a sample, listed here in
+descending priority (a higher-priority source overrides the ones below it for
+the same sample):
+
+1. **An `explanation_N` block in the statement file** — language-specific (the
+   statement file is already built per language), as described in the table
+   above.
+
+2. **A `<sample>.rbx.tex` file next to the sample input** *(recommended)* — a
+   per-sample file living alongside the `.in` file (e.g. `000.rbx.tex` next to
+   `000.in`). It holds one block per language, keyed by the language code:
+
+    ```latex
+    %- block en
+    In the first sample, the answer is $A + B = 10$.
+    %- endblock
+
+    %- block pt
+    No primeiro exemplo, a resposta é $A + B = 10$.
+    %- endblock
+    ```
+
+    Only the block matching the statement's language is rendered; any content
+    outside a block is ignored. The file receives the same Jinja variables as
+    the rest of the statement. For Markdown statements, use `<sample>.rbx.md`
+    instead.
+
+3. **A `<sample>.tex` file next to the sample input** — a per-sample file that
+   is *language-agnostic*: the same text is used for every language. (For
+   Markdown statements, `<sample>.md`.)
+
+!!! warning
+    A single sample may not have **both** a `<sample>.rbx.tex` and a
+    `<sample>.tex` file — that is an error. Choose one. If a `<sample>.rbx.tex`
+    file has no block for the statement's language, no explanation is shown for
+    that sample in that language (and {{rbx}} warns you).
+
 ## Example
 
 Here is a barebones example of a problem statement written in rbxTeX.

--- a/rbx/box/statements/builders.py
+++ b/rbx/box/statements/builders.py
@@ -302,6 +302,26 @@ def get_rbxtex_blocks(
             if sample.explanation is None:
                 # No explanation provided.
                 continue
+            if sample.explanationFromBlocks:
+                # Language-specific explanation: render the language blocks and
+                # pick the one matching the statement language. Content outside
+                # blocks is ignored. Receives the same Jinja kwargs as a plain
+                # per-sample explanation.
+                sample_blocks = render_jinja_blocks(
+                    context.root,
+                    sample.explanation.encode(),
+                    mode=mode,
+                    **item.build_inner_jinja_kwargs(),
+                )
+                selected = sample_blocks.blocks.get(context.lang)
+                if selected is None:
+                    console.console.print(
+                        f'[warning]Sample explanation for testcase [item]{i}[/item] '
+                        f'has no block for language [item]{context.lang}[/item]; '
+                        'no explanation will be shown for this sample.[/warning]'
+                    )
+                sample.explanation = selected
+                continue
             # Render samples.
             sample.explanation = render_jinja(
                 context.root,

--- a/rbx/box/testcase_sample_utils.py
+++ b/rbx/box/testcase_sample_utils.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import typer
 from pydantic import BaseModel
@@ -39,6 +39,7 @@ class StatementSample(BaseModel):
     outputPath: pathlib.Path
     answerPath: Optional[pathlib.Path] = None
     explanationPath: Optional[pathlib.Path] = None
+    explanationFromBlocks: bool = False
     hasOutput: bool = True
     checkOutput: bool = False
     interaction: Optional[SampleTestcaseInteraction] = None
@@ -65,6 +66,39 @@ def _build_sample_interaction(
     return SampleTestcaseInteraction(entries=interaction.entries, chunks=chunks)
 
 
+def _resolve_explanation_path(
+    input_path: pathlib.Path, explanation_suffix: Optional[str]
+) -> Tuple[Optional[pathlib.Path], bool]:
+    """Resolve the explanation file for a sample input.
+
+    Prefers a language-block ``.rbx<suffix>`` file over the plain ``<suffix>``
+    file, returning whether the resolved file is a blocks file. Errors if both
+    exist for the same sample.
+    """
+    if explanation_suffix is None:
+        return None, False
+    plain_path = input_path.with_suffix(explanation_suffix)
+    blocks_path = input_path.with_suffix('.rbx' + explanation_suffix)
+    plain_exists = plain_path.is_file()
+    blocks_exists = blocks_path.is_file()
+    if plain_exists and blocks_exists:
+        console.console.print(
+            f'[error]Both [item]{utils.abspath(blocks_path)}[/item] and '
+            f'[item]{utils.abspath(plain_path)}[/item] exist for the same sample.[/error]'
+        )
+        console.console.print(
+            f'[error]Use either the language-specific [item].rbx{explanation_suffix}[/item] '
+            f'explanation or the language-agnostic [item]{explanation_suffix}[/item] '
+            'explanation, but not both.[/error]'
+        )
+        raise typer.Exit(1)
+    if blocks_exists:
+        return blocks_path, True
+    if plain_exists:
+        return plain_path, False
+    return None, False
+
+
 def _get_statement_sample_from_entry(
     entry: GenerationTestcaseEntry, explanation_suffix: Optional[str] = None
 ) -> StatementSample:
@@ -72,6 +106,7 @@ def _get_statement_sample_from_entry(
     output_path: pathlib.Path = utils.get_empty_sentinel_path()
     answer_path: Optional[pathlib.Path] = None
     explanation_path: Optional[pathlib.Path] = None
+    explanation_from_blocks: bool = False
     interaction: Optional[TestcaseInteraction] = None
 
     # Process manually provided files.
@@ -93,11 +128,11 @@ def _get_statement_sample_from_entry(
         answer_path = testcase.outputPath
 
     def process_additional_files(testcase: Testcase):
-        nonlocal input_path, output_path, explanation_path, interaction
-        if explanation_suffix is not None:
-            explanation_path = testcase.inputPath.with_suffix(explanation_suffix)
-            if explanation_path.is_file():
-                explanation_path = explanation_path
+        nonlocal input_path, output_path, explanation_path
+        nonlocal explanation_from_blocks, interaction
+        explanation_path, explanation_from_blocks = _resolve_explanation_path(
+            testcase.inputPath, explanation_suffix
+        )
 
         pin_path = testcase.inputPath.with_suffix('.pin')
         pout_path = testcase.inputPath.with_suffix('.pout')
@@ -161,6 +196,7 @@ def _get_statement_sample_from_entry(
         if interaction is not None
         else None,
         explanationPath=explanation_path,
+        explanationFromBlocks=explanation_from_blocks,
     )
 
 

--- a/rbx/resources/presets/default/problem/manual_tests/samples/000.rbx.tex
+++ b/rbx/resources/presets/default/problem/manual_tests/samples/000.rbx.tex
@@ -1,0 +1,3 @@
+%- block en
+In the first sample, $A = 3$ and $B = 7$, so the answer is $A + B = 10$.
+%- endblock

--- a/tests/rbx/box/statements/test_build_statements.py
+++ b/tests/rbx/box/statements/test_build_statements.py
@@ -29,6 +29,7 @@ from rbx.box.statements.schema import (
     TexToPDF,
     rbxToTeX,
 )
+from rbx.box.testcase_sample_utils import StatementSample
 from rbx.box.testcase_schema import TestcaseEntry
 from rbx.box.testing import testing_package
 
@@ -515,6 +516,77 @@ class TestBuildStatementBytesExtended:
             assert output_type == StatementType.TeX
             # get_samples should NOT be called when use_samples=False based on the conditional logic
             mock_get_samples.assert_not_called()
+
+    async def test_build_rbxtex_with_language_block_explanation(
+        self, sample_package, chdir_tmp_path, mock_limits
+    ):
+        """End-to-end: an rbxTeX statement renders the .rbx.tex sample explanation
+        block matching the statement language and drops the others."""
+        statement_file = chdir_tmp_path / 'statement.rbx.tex'
+        statement_file.write_text('%- block legend\nLegend.\n%- endblock\n')
+
+        template_file = chdir_tmp_path / 'template.rbx.tex'
+        template_file.write_text(
+            '\\documentclass{article}\n'
+            '\\begin{document}\n'
+            '\\VAR{problem.blocks.legend}\n'
+            '%- for sample in problem.samples\n'
+            '%- if sample.explanation\n'
+            'EXPLANATION: \\VAR{sample.explanation}\n'
+            '%- endif\n'
+            '%- endfor\n'
+            '\\end{document}\n'
+        )
+
+        explanation_file = chdir_tmp_path / '000.rbx.tex'
+        explanation_file.write_text(
+            '%- block en\nEnglish explanation.\n%- endblock\n'
+            '%- block pt\nPortuguese explanation.\n%- endblock\n'
+        )
+
+        sample = StatementSample(
+            entry=GenerationTestcaseEntry(
+                group_entry=TestcaseEntry(group='samples', index=0),
+                subgroup_entry=TestcaseEntry(group='samples', index=0),
+                metadata=GenerationMetadata(
+                    copied_to=Testcase(inputPath=chdir_tmp_path / '000.in')
+                ),
+            ),
+            inputPath=chdir_tmp_path / '000.in',
+            outputPath=chdir_tmp_path / '000.out',
+            explanationPath=explanation_file,
+            explanationFromBlocks=True,
+        )
+
+        statement = Statement(
+            name='test-statement',
+            language='en',
+            title='Test Problem',
+            path=statement_file,
+            type=StatementType.rbxTeX,
+            configure=[
+                rbxToTeX(
+                    type=ConversionType.rbxToTex,
+                    template=pathlib.Path('template.rbx.tex'),
+                )
+            ],
+            assets=[],
+        )
+
+        with patch(
+            'rbx.box.statements.build_statements.get_statement_samples'
+        ) as mock_get_samples:
+            mock_get_samples.return_value = [sample]
+
+            content, output_type = await build_statement_bytes(
+                statement=statement,
+                pkg=sample_package,
+                output_type=StatementType.TeX,
+            )
+
+        assert output_type == StatementType.TeX
+        assert b'English explanation.' in content
+        assert b'Portuguese explanation.' not in content
 
     async def test_build_with_combined_overrides(
         self, sample_package, sample_statement, mock_samples, tmp_path, mock_limits

--- a/tests/rbx/box/statements/test_builders.py
+++ b/tests/rbx/box/statements/test_builders.py
@@ -522,6 +522,68 @@ Explanation from block.
         # kwargs samples should also use the block-based explanation
         assert 'Explanation from block.' in kwargs['problem']['samples'][0].explanation
 
+    def test_get_rbxtex_blocks_selects_language_block(self, context, tmp_path):
+        """A from-blocks explanation selects the block for context.lang."""
+        package = Package(name='test-problem', timeLimit=1000, memoryLimit=256)
+        statement = Statement(
+            name='statement', path=pathlib.Path('stmt.tex'), type=StatementType.JinjaTeX
+        )
+        limits = LimitsProfile(timeLimit=1000, memoryLimit=256)
+
+        explanation_file = tmp_path / '1.rbx.tex'
+        explanation_file.write_text(
+            'Ignored preamble.\n'
+            '%- block en\nEnglish explanation.\n%- endblock\n'
+            '%- block pt\nPortuguese explanation.\n%- endblock\n'
+        )
+
+        samples = [
+            StatementSample(
+                entry=create_dummy_entry(),
+                inputPath=tmp_path / '1.in',
+                outputPath=tmp_path / '1.out',
+                explanationPath=explanation_file,
+                explanationFromBlocks=True,
+            )
+        ]
+        problem = StatementBuilderProblem(
+            package=package, statement=statement, limits=limits, samples=samples
+        )
+
+        _, kwargs = get_rbxtex_blocks(b'', context, problem)
+        explanation = kwargs['problem']['samples'][0].explanation
+        assert 'English explanation.' in explanation
+        assert 'Portuguese' not in explanation
+        assert 'Ignored preamble' not in explanation
+
+    def test_get_rbxtex_blocks_missing_language_block_warns(self, context, tmp_path):
+        """A from-blocks explanation without the language block yields no explanation."""
+        package = Package(name='test-problem', timeLimit=1000, memoryLimit=256)
+        statement = Statement(
+            name='statement', path=pathlib.Path('stmt.tex'), type=StatementType.JinjaTeX
+        )
+        limits = LimitsProfile(timeLimit=1000, memoryLimit=256)
+
+        explanation_file = tmp_path / '1.rbx.tex'
+        explanation_file.write_text('%- block pt\nSo portugues.\n%- endblock\n')
+
+        samples = [
+            StatementSample(
+                entry=create_dummy_entry(),
+                inputPath=tmp_path / '1.in',
+                outputPath=tmp_path / '1.out',
+                explanationPath=explanation_file,
+                explanationFromBlocks=True,
+            )
+        ]
+        problem = StatementBuilderProblem(
+            package=package, statement=statement, limits=limits, samples=samples
+        )
+
+        # context.lang == 'en', file only has 'pt'
+        _, kwargs = get_rbxtex_blocks(b'', context, problem)
+        assert kwargs['problem']['samples'][0].explanation is None
+
     def test_get_rbxtex_blocks_externalize(self, context, tmp_path):
         """Test get_rbxtex_blocks with externalize=True."""
         package = Package(name='test-problem', timeLimit=1000, memoryLimit=256)

--- a/tests/rbx/box/test_testcase_sample_utils.py
+++ b/tests/rbx/box/test_testcase_sample_utils.py
@@ -3,6 +3,7 @@ from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import typer
 
 from rbx.box import testcase_sample_utils
 from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
@@ -252,6 +253,71 @@ async def test_get_statement_samples_explanation_priority(
         explanation_suffix='.desc'
     )
     assert list(samples)[0].explanationPath.resolve() == src_expl.resolve()
+
+
+@pytest.mark.asyncio
+async def test_get_statement_samples_explanation_prefers_blocks(
+    tmp_path, mock_extract_generation_testcases_from_groups
+):
+    """A .rbx.<suffix> blocks file is preferred and flagged as from-blocks."""
+    dest_input = tmp_path / 'dest.in'
+    blocks_expl = tmp_path / 'dest.rbx.desc'
+    blocks_expl.touch()
+
+    entry = create_entry(
+        TestcaseEntry(group='samples', index=0),
+        copied_to_input=dest_input,
+    )
+    mock_extract_generation_testcases_from_groups.return_value = [entry]
+
+    samples = await testcase_sample_utils.get_statement_samples(
+        explanation_suffix='.desc'
+    )
+    sample = list(samples)[0]
+    assert sample.explanationPath.resolve() == blocks_expl.resolve()
+    assert sample.explanationFromBlocks is True
+
+
+@pytest.mark.asyncio
+async def test_get_statement_samples_explanation_plain_fallback(
+    tmp_path, mock_extract_generation_testcases_from_groups
+):
+    """With only the plain file, it is used and not flagged as from-blocks."""
+    dest_input = tmp_path / 'dest.in'
+    plain_expl = tmp_path / 'dest.desc'
+    plain_expl.touch()
+
+    entry = create_entry(
+        TestcaseEntry(group='samples', index=0),
+        copied_to_input=dest_input,
+    )
+    mock_extract_generation_testcases_from_groups.return_value = [entry]
+
+    samples = await testcase_sample_utils.get_statement_samples(
+        explanation_suffix='.desc'
+    )
+    sample = list(samples)[0]
+    assert sample.explanationPath.resolve() == plain_expl.resolve()
+    assert sample.explanationFromBlocks is False
+
+
+@pytest.mark.asyncio
+async def test_get_statement_samples_explanation_conflict_errors(
+    tmp_path, mock_extract_generation_testcases_from_groups
+):
+    """Both a blocks and a plain explanation file is an error."""
+    dest_input = tmp_path / 'dest.in'
+    (tmp_path / 'dest.desc').touch()
+    (tmp_path / 'dest.rbx.desc').touch()
+
+    entry = create_entry(
+        TestcaseEntry(group='samples', index=0),
+        copied_to_input=dest_input,
+    )
+    mock_extract_generation_testcases_from_groups.return_value = [entry]
+
+    with pytest.raises(typer.Exit):
+        await testcase_sample_utils.get_statement_samples(explanation_suffix='.desc')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #444.

## What

Adds a third way to attach a sample explanation: a `<sample>.rbx.tex` file living alongside the sample `.in`, containing language-keyed JinjaTeX blocks. Only the block matching the statement's language is rendered.

```latex
%- block en
This is the english explanation.
%- endblock

%- block pt
Esta é a explicação em português.
%- endblock
```

This complements the existing options without removing them:

1. `explanation_N` block in the statement file (language-specific) — highest priority.
2. **`<sample>.rbx.tex` (new, recommended)** — language-specific blocks alongside the `.in`.
3. `<sample>.tex` (existing) — language-agnostic.

Content outside blocks is ignored, and the file receives the same Jinja variables as the rest of the statement. The mechanism generalizes to Markdown statements via `<sample>.rbx.md`.

### Behavior decisions
- **Conflict:** a sample may not have both a `.rbx.tex` and a `.tex` file — that's an error (avoids silent ambiguity).
- **Missing language block:** if the `.rbx.tex` has no block for the statement's language, no explanation is shown for that sample and rbx warns.

## How

- `testcase_sample_utils.py`: `_resolve_explanation_path` prefers the `.rbx<suffix>` blocks file over the plain `<suffix>` file (erroring if both exist) and records `explanationFromBlocks` on the `StatementSample`.
- `statements/builders.py`: in `get_rbxtex_blocks`, a from-blocks explanation is rendered via the existing `render_jinja_blocks` and the block matching `context.lang` is selected (warning if absent).
- Default preset: `manual_tests/samples/000.rbx.tex` demonstrates `.rbx.tex` as the default explanation method.
- Docs: `rbxtex.md` documents the three explanation options and the new recommended one.

## Testing

- Unit tests for path resolution (prefers `.rbx.tex`, falls back to `.tex`, errors on conflict).
- Unit tests for block selection (picks the language block; missing language → no explanation).
- End-to-end `build_statement_bytes` test rendering an rbxTeX statement with a `.rbx.tex` explanation, asserting the `en` block renders and `pt` is dropped.

All tests in the affected areas pass; ruff check/format are clean. (Unrelated local C++/sandbox-dependent test failures are pre-existing and reproduce on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)