### PR TITLE
fix: clear error when a solution's run command is missing (#454)

### DIFF
--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -41,6 +41,10 @@ class TooMuchStderrIssue(Issue):
 
 
 def _check_stderr(solution: CodeItem, stderr_path: pathlib.Path):
+    # The stderr file is absent when the program failed to even start (e.g. a
+    # missing interpreter/runtime), in which case there is no stderr to inspect.
+    if not stderr_path.is_file():
+        return
     if stderr_path.stat().st_size > STDERR_THRESHOLD_IN_BYTES:
         add_issue(TooMuchStderrIssue(solution))
 

--- a/tests/rbx/box/tasks_test.py
+++ b/tests/rbx/box/tasks_test.py
@@ -1,8 +1,36 @@
+import textwrap
+
+from rbx import testing_utils
 from rbx.box import code, tasks
 from rbx.box.environment import VerificationLevel
 from rbx.box.schema import CodeItem, Testcase
 from rbx.box.testing import testing_package
 from rbx.grading.judge.sandbox import SandboxBase
+from rbx.grading.steps import Outcome
+
+_ENV_WITH_MISSING_PY_INTERPRETER = textwrap.dedent("""\
+    ---
+    sandbox: "stupid"
+    defaultCompilation:
+      sandbox:
+        maxProcesses: 1000
+        timeLimit: 50000
+        wallTimeLimit: 50000
+        memoryLimit: 1024
+    defaultExecution:
+      sandbox:
+        timeLimit: 50000
+        wallTimeLimit: 50000
+        memoryLimit: 1024
+    languages:
+      - name: "py"
+        readableName: "Python3"
+        extension: "py"
+        execution:
+          command: "rbx-not-a-real-interpreter {executable}"
+        fileMapping:
+          executable: "{compilable}"
+""")
 
 
 class TestRunSolutionOnTestcase:
@@ -169,6 +197,48 @@ class TestRunSolutionOnTestcase:
         assert evaluation.log is not None
         assert evaluation.log.exitcode == 0
         assert evaluation.log.exitstatus == SandboxBase.EXIT_OK
+
+    async def test_run_solution_with_missing_interpreter_reports_clear_error(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        """A solution whose execution command points at a non-existent binary
+        should yield an informative INTERNAL_ERROR verdict instead of crashing
+        with a cryptic FileNotFoundError (regression test for issue #454)."""
+        # Point the python execution command at a non-existent interpreter.
+        env_path = testing_pkg.preset.path('env.rbx.yml')
+        env_path.write_text(_ENV_WITH_MISSING_PY_INTERPRETER)
+        testing_utils.clear_all_functools_cache()
+
+        py_file = testing_pkg.add_file(
+            'solution.py', src='program_test/simple_hello.py'
+        )
+        solution = CodeItem(path=py_file, language='py')
+        compiled_digest = await code.compile_item(solution)
+
+        input_file = testing_pkg.add_file('test.in')
+        input_file.write_text('')
+        output_file = testing_pkg.path('test.ans')
+        output_file.write_text('Hello, World!\n')
+        testcase = Testcase(inputPath=input_file, outputPath=output_file)
+
+        output_dir = testing_pkg.path('outputs')
+        output_dir.mkdir(exist_ok=True)
+
+        # Should not raise; the missing interpreter must be surfaced as a verdict.
+        evaluation = await tasks.run_solution_on_testcase(
+            solution=solution,
+            compiled_digest=compiled_digest,
+            checker_digest=None,
+            testcase=testcase,
+            output_dir=output_dir,
+            verification=VerificationLevel.NONE,
+            use_retries=False,
+        )
+
+        assert evaluation is not None
+        assert evaluation.result.outcome == Outcome.INTERNAL_ERROR
+        assert 'not found' in evaluation.result.message.lower()
+        assert 'rbx-not-a-real-interpreter' in evaluation.result.message
 
 
 class TestRunCommunicationSolutionOnTestcase:


### PR DESCRIPTION
Closes #454.

## What

When a language's `execution.command` references a non-existent interpreter/runtime (e.g. editing python's command to `python3x {executable}`), running a solution crashed with a cryptic `FileNotFoundError: .../000.err` traceback instead of the informative "executable not found" message we already show for the compilation case.

## Root cause

`#451` taught `rbx/grading/judge/program.py` to convert a missing-binary `FileNotFoundError` into a `ProgramNotFoundError`. `steps.run()` catches it and builds an `EXIT_SANDBOX_ERROR` `RunLog` (carrying the actionable message in `run_log.sandbox`) — but it skips `_process_output_artifacts`, so the `.err` stderr file is **never materialized** because the process never started.

`tasks._check_stderr()` then did an unconditional `stderr_path.stat()`, raising `FileNotFoundError` before the prepared message could surface. This affected both the output-generation path and the solution-judging path (both call `_check_stderr`).

## Fix

Guard `_check_stderr` to no-op when the stderr file is absent — a missing file legitimately means the program produced no stderr (here, because it never ran). With the crash gone, the existing `#451` machinery surfaces the informative verdict:

```
Failed generating output for tests/main/000.in
Summary: FAILED with exit code 1 and sandbox status sandbox error (time: 0.0s, memory: 0MB)
Reason: Executable 'python3x' was not found — is it installed and on your PATH?
Verdict: internal-error
Message: Executable 'python3x' was not found — is it installed and on your PATH?
```

## Testing

Added `test_run_solution_with_missing_interpreter_reports_clear_error` in `tests/rbx/box/tasks_test.py`, which overrides the env's python execution command to a non-existent binary and asserts the run yields an `INTERNAL_ERROR` verdict carrying the "not found" message instead of crashing. It fails (with the original `FileNotFoundError`) before the fix and passes after.

Ran `tasks_test.py`, `steps_run_test.py`, `steps_compile_test.py`, `checkers_test.py`, `solutions_test.py`, `judge/test_program.py` → 152 passed, 1 skipped. `ruff check`/`format` clean. Also verified the end-to-end CLI output manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)