### PR TITLE
feat(ui): Vim-style hjkl navigation in rbx ui

### DIFF
--- a/docs/plans/2026-05-20-vim-navigation-ui-design.md
+++ b/docs/plans/2026-05-20-vim-navigation-ui-design.md
@@ -1,0 +1,126 @@
+# Vim-style (hjkl) navigation in `rbx ui`
+
+**Date:** 2026-05-20
+**Status:** Approved design — ready for implementation plan
+
+## Problem
+
+The Textual TUI launched by `rbx ui` only supports arrow-key navigation. Competitive
+programming users overwhelmingly favor Vim, and want `h/j/k/l` to navigate menus,
+lists, tables, and scrollable viewers.
+
+## Decisions (locked)
+
+- **Key scope:** `j`=down, `k`=up everywhere. `h`/`l` move left/right *only where
+  horizontal movement exists* (DataTable cells, horizontally-scrollable viewers). In
+  plain lists/menus, `h`/`l` are no-ops.
+- **Implementation:** Centralized app-level remap dispatched onto the focused widget's
+  existing actions, with a `check_action` guard that disables the keys when a text
+  field is focused.
+- **Motions:** `hjkl` only. No `gg`/`G`/`ctrl+d`/`ctrl+u`.
+
+### Non-goals (YAGNI)
+
+- No ranger-style `l`=select / `h`=back semantics.
+- No `gg`/`G`/half-page motions.
+- No footer hints (arrows remain the documented default; the Vim keys are hidden).
+- No config toggle — the feature is purely additive and never shadows typing.
+
+## Core idea
+
+The navigable widgets already expose every action we need:
+
+- `action_cursor_up/down/left/right` on `OptionList`, `ListView` (`Menu`), `DataTable`.
+- `action_scroll_up/down/left/right` on `ScrollView`-based viewers (`LogDisplay`,
+  `FileLog`, `CodeBox`).
+
+So we do **not** rewrite or subclass any widget. We add a thin **app-level binding
+layer** that maps `h/j/k/l` onto whatever the *focused* widget already supports, and
+steps aside when a text field is focused.
+
+## Component: `VimNavMixin`
+
+New mixin (`rbx/box/ui/vim_nav.py`) inherited by `rbxBaseApp` in `main.py`. Since
+`rbxBaseApp` is the parent of `rbxApp`, `rbxDifferApp`, and `rbxCommandApp`, this single
+placement covers all three navigable apps. `rbxReviewApp` (a standalone y/n confirm
+dialog) does not inherit `rbxBaseApp` and is intentionally excluded.
+
+### 1. Bindings (hidden from footer)
+
+```python
+BINDINGS = [
+    Binding('j', 'vim_move("down")',  'Down',  show=False),
+    Binding('k', 'vim_move("up")',    'Up',    show=False),
+    Binding('h', 'vim_move("left")',  'Left',  show=False),
+    Binding('l', 'vim_move("right")', 'Right', show=False),
+]
+```
+
+App-level bindings are the **last link in Textual's binding chain**, so any
+widget/screen that already binds those letters wins (none currently do). The Vim keys
+act purely as a fallback.
+
+### 2. Dispatch — `action_vim_move(direction)`
+
+Look at `self.focused`; for the direction, try the **cursor** action first, then fall
+back to **scroll**:
+
+| key | try first             | fall back to          |
+|-----|-----------------------|-----------------------|
+| j   | `action_cursor_down`  | `action_scroll_down`  |
+| k   | `action_cursor_up`    | `action_scroll_up`    |
+| h   | `action_cursor_left`  | `action_scroll_left`  |
+| l   | `action_cursor_right` | `action_scroll_right` |
+
+Resolve via `getattr(self.focused, name, None)` and invoke if present. This yields the
+agreed semantics automatically, per widget type:
+
+- `OptionList` / `ListView` (`Menu`): have `cursor_up/down` only → **j/k navigate; h/l
+  no-op** (their `scroll_left/right` fallback does nothing without horizontal overflow).
+- `DataTable`: has all four cursor actions → **full hjkl cell movement**.
+- `LogDisplay` / `FileLog` / `CodeBox` (scroll views): no cursor actions → **hjkl all
+  scroll**, horizontal included.
+
+### 3. Text-input guard — `check_action`
+
+When `self.focused` is an `Input` or `TextArea` (or `None`), return `None` for the
+`vim_move` action so the keystroke passes straight through and types normally.
+Textual's `Input` already consumes printable keys before app bindings resolve;
+`check_action` makes this explicit, version-robust, and keeps the footer honest.
+
+## Data flow
+
+```
+keypress
+  -> focused-widget / screen bindings (none match hjkl)
+  -> bubbles to app VimNavMixin binding
+  -> check_action gate (skip -> pass through if text field / no focus)
+  -> action_vim_move(direction)
+  -> getattr(focused, 'action_cursor_*' or 'action_scroll_*')()
+```
+
+No synthetic key events, no per-call-site changes.
+
+## Edge cases
+
+- No focused widget, or focused widget supports neither action for the direction →
+  no-op (guarded by `getattr(..., None)`).
+- `rbxReviewApp` excluded — nothing to navigate.
+- `Select` widget: collapsed → harmless no-op; expanded → its overlay `OptionList` is
+  focused, so `j`/`k` navigate options as expected.
+- If an action method returns an awaitable, schedule/await it (most cursor/scroll
+  actions are synchronous; handle the coroutine case defensively).
+
+## Testing (fast, Pilot-based — no docker/CLI)
+
+Using Textual's `App.run_test()` / `Pilot`:
+
+1. `OptionList` focused: `press('j')` advances `highlighted`, `press('k')` retreats;
+   `press('h'/'l')` is a no-op.
+2. `DataTable` focused: `h`/`l` move the column cursor, `j`/`k` move rows.
+3. **`Input` focused: `press('j')` ⇒ `input.value == 'j'`** — the critical regression
+   guard.
+4. Scroll viewer with overflowing content: `j` increases `scroll_y`, `l` increases
+   `scroll_x`.
+
+Check `tests/rbx/box/ui/` for an existing Pilot harness and match its conventions.

--- a/docs/plans/2026-05-20-vim-navigation-ui.md
+++ b/docs/plans/2026-05-20-vim-navigation-ui.md
@@ -1,0 +1,483 @@
+# Vim-style (hjkl) Navigation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Vim-style `h/j/k/l` navigation to the `rbx ui` Textual TUI without breaking text entry.
+
+**Architecture:** A single `VimNavMixin` mixed into `rbxBaseApp` registers app-level `h/j/k/l` bindings. Each binding dispatches to the *focused* widget's existing `cursor_*`/`scroll_*` action (cursor first, scroll fallback). A `check_action` guard disables the keys when an `Input`/`TextArea` is focused so typing still works. No widget is subclassed and no call site changes.
+
+**Tech Stack:** Python, Textual 8.0, pytest + pytest-asyncio (`asyncio_mode = auto`), Textual `App.run_test()` / `Pilot` for tests.
+
+**Design doc:** `docs/plans/2026-05-20-vim-navigation-ui-design.md`
+
+**Conventions:** Single quotes (ruff-enforced), absolute imports only. Run tests with `uv run pytest`. Commit with the project's conventional-commits format (see `.claude/skills/commit.md`), appending `Co-Authored-By: Claude <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `VimNavMixin` — j/k cursor movement on a list
+
+**Files:**
+- Create: `rbx/box/ui/vim_nav.py`
+- Test: `tests/rbx/box/ui/test_vim_nav.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/rbx/box/ui/test_vim_nav.py`:
+
+```python
+"""Tests for Vim-style hjkl navigation in the Textual TUI (rbx.box.ui.vim_nav)."""
+
+from textual.app import App, ComposeResult
+from textual.widgets import OptionList
+
+from rbx.box.ui.vim_nav import VimNavMixin
+
+
+class _ListApp(VimNavMixin, App):
+    def compose(self) -> ComposeResult:
+        yield OptionList('a', 'b', 'c')
+
+    def on_mount(self) -> None:
+        self.query_one(OptionList).focus()
+
+
+async def test_j_moves_down_and_k_moves_up():
+    app = _ListApp()
+    async with app.run_test() as pilot:
+        option_list = app.query_one(OptionList)
+        start = option_list.highlighted or 0
+
+        await pilot.press('j')
+        assert option_list.highlighted == start + 1
+
+        await pilot.press('j')
+        assert option_list.highlighted == start + 2
+
+        await pilot.press('k')
+        assert option_list.highlighted == start + 1
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/ui/test_vim_nav.py::test_j_moves_down_and_k_moves_up -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'rbx.box.ui.vim_nav'`.
+
+**Step 3: Write minimal implementation**
+
+Create `rbx/box/ui/vim_nav.py`:
+
+```python
+from __future__ import annotations
+
+import inspect
+from typing import Optional
+
+from textual.binding import Binding
+from textual.widgets import Input, TextArea
+
+# Maps a logical direction to (cursor action, scroll fallback action).
+_DIRECTION_ACTIONS = {
+    'down': ('cursor_down', 'scroll_down'),
+    'up': ('cursor_up', 'scroll_up'),
+    'left': ('cursor_left', 'scroll_left'),
+    'right': ('cursor_right', 'scroll_right'),
+}
+
+
+class VimNavMixin:
+    """Adds Vim-style hjkl navigation as an app-level fallback.
+
+    Maps h/j/k/l onto the focused widget's existing ``cursor_*`` actions, falling
+    back to ``scroll_*``. The bindings live at the app level (the last link in
+    Textual's binding chain), so any widget that binds these letters wins. They are
+    disabled while a text-editing widget is focused, so typing is never hijacked.
+    """
+
+    BINDINGS = [
+        Binding('j', 'vim_move("down")', 'Down', show=False),
+        Binding('k', 'vim_move("up")', 'Up', show=False),
+        Binding('h', 'vim_move("left")', 'Left', show=False),
+        Binding('l', 'vim_move("right")', 'Right', show=False),
+    ]
+
+    def check_action(self, action: str, parameters: tuple) -> Optional[bool]:
+        if action == 'vim_move':
+            focused = self.focused
+            if focused is None or isinstance(focused, (Input, TextArea)):
+                # Returning None disables the binding and lets the key fall through
+                # (e.g. so it types into a focused Input).
+                return None
+        return super().check_action(action, parameters)
+
+    async def action_vim_move(self, direction: str) -> None:
+        focused = self.focused
+        if focused is None:
+            return
+        cursor_action, scroll_action = _DIRECTION_ACTIONS[direction]
+        method = getattr(focused, f'action_{cursor_action}', None)
+        if method is None:
+            method = getattr(focused, f'action_{scroll_action}', None)
+        if method is None:
+            return
+        result = method()
+        if inspect.isawaitable(result):
+            await result
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/ui/test_vim_nav.py::test_j_moves_down_and_k_moves_up -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/ui/vim_nav.py tests/rbx/box/ui/test_vim_nav.py
+git commit -m "$(cat <<'EOF'
+feat(ui): add VimNavMixin for hjkl list navigation
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `h`/`l` are no-ops on a plain list
+
+This pins the agreed semantics: horizontal keys do nothing where there is no horizontal movement.
+
+**Files:**
+- Test: `tests/rbx/box/ui/test_vim_nav.py` (add to existing file)
+
+**Step 1: Write the failing test**
+
+Append to `tests/rbx/box/ui/test_vim_nav.py`:
+
+```python
+async def test_h_and_l_are_noops_on_plain_list():
+    app = _ListApp()
+    async with app.run_test() as pilot:
+        option_list = app.query_one(OptionList)
+        await pilot.press('j')  # move off the first row first
+        before = option_list.highlighted
+
+        await pilot.press('l')
+        assert option_list.highlighted == before
+
+        await pilot.press('h')
+        assert option_list.highlighted == before
+```
+
+**Step 2: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/ui/test_vim_nav.py::test_h_and_l_are_noops_on_plain_list -v`
+Expected: PASS (OptionList has no `action_cursor_left/right`; its `scroll_left/right` fallback is a no-op with no horizontal overflow). This is a behavior-locking test for code already written in Task 1.
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/box/ui/test_vim_nav.py
+git commit -m "$(cat <<'EOF'
+test(ui): lock h/l no-op behavior on plain lists
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Text input is never hijacked (critical regression guard)
+
+**Files:**
+- Test: `tests/rbx/box/ui/test_vim_nav.py` (add)
+
+**Step 1: Write the failing test**
+
+Add the import `from textual.widgets import Input` (extend the existing import line to `from textual.widgets import Input, OptionList`) and append:
+
+```python
+class _InputApp(VimNavMixin, App):
+    def compose(self) -> ComposeResult:
+        yield Input()
+
+    def on_mount(self) -> None:
+        self.query_one(Input).focus()
+
+
+async def test_typing_hjkl_into_input_is_not_hijacked():
+    app = _InputApp()
+    async with app.run_test() as pilot:
+        await pilot.press('h', 'j', 'k', 'l')
+        assert app.query_one(Input).value == 'hjkl'
+```
+
+**Step 2: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/ui/test_vim_nav.py::test_typing_hjkl_into_input_is_not_hijacked -v`
+Expected: PASS — `check_action` returns `None` while the `Input` is focused, so the keys reach the Input and type normally.
+
+> If this FAILS with `value` empty or missing characters, the binding is shadowing the Input. Confirm the `check_action` `isinstance(focused, (Input, TextArea))` branch is reached (add a temporary `print`/`textual.log`). Do NOT "fix" it by removing the bindings — debug the guard.
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/box/ui/test_vim_nav.py
+git commit -m "$(cat <<'EOF'
+test(ui): guard text input against hjkl hijacking
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Full hjkl on `DataTable` (cell cursor)
+
+**Files:**
+- Test: `tests/rbx/box/ui/test_vim_nav.py` (add)
+
+**Step 1: Write the failing test**
+
+Extend the import to include `DataTable` (`from textual.widgets import DataTable, Input, OptionList`) and append:
+
+```python
+class _TableApp(VimNavMixin, App):
+    def compose(self) -> ComposeResult:
+        yield DataTable()
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.cursor_type = 'cell'
+        table.add_columns('x', 'y')
+        table.add_rows([('1', '2'), ('3', '4')])
+        table.focus()
+
+
+async def test_datatable_hjkl_moves_cell_cursor():
+    app = _TableApp()
+    async with app.run_test() as pilot:
+        table = app.query_one(DataTable)
+        assert table.cursor_coordinate == (0, 0)
+
+        await pilot.press('l')
+        assert table.cursor_coordinate == (0, 1)
+
+        await pilot.press('h')
+        assert table.cursor_coordinate == (0, 0)
+
+        await pilot.press('j')
+        assert table.cursor_coordinate == (1, 0)
+
+        await pilot.press('k')
+        assert table.cursor_coordinate == (0, 0)
+```
+
+**Step 2: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/ui/test_vim_nav.py::test_datatable_hjkl_moves_cell_cursor -v`
+Expected: PASS — `DataTable` defines all four `action_cursor_*` methods, so hjkl maps to full cell movement.
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/box/ui/test_vim_nav.py
+git commit -m "$(cat <<'EOF'
+test(ui): verify hjkl moves DataTable cell cursor
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: `j`/`l` scroll a scroll container
+
+**Files:**
+- Test: `tests/rbx/box/ui/test_vim_nav.py` (add)
+
+**Step 1: Write the failing test**
+
+Add imports `from textual.containers import VerticalScroll` and `from textual.widgets import Static` (alongside the existing widget import), then append:
+
+```python
+class _ScrollApp(VimNavMixin, App):
+    def compose(self) -> ComposeResult:
+        with VerticalScroll():
+            # Content larger than the test viewport in both dimensions.
+            wide_line = 'x' * 200
+            yield Static('\n'.join(wide_line for _ in range(200)))
+
+    def on_mount(self) -> None:
+        self.query_one(VerticalScroll).focus()
+
+
+async def test_j_and_l_scroll_a_scroll_container():
+    app = _ScrollApp()
+    async with app.run_test(size=(20, 10)) as pilot:
+        container = app.query_one(VerticalScroll)
+        assert container.scroll_offset == (0, 0)
+
+        for _ in range(5):
+            await pilot.press('j')
+        await pilot.pause()
+        assert container.scroll_offset.y > 0
+
+        for _ in range(5):
+            await pilot.press('l')
+        await pilot.pause()
+        assert container.scroll_offset.x > 0
+```
+
+**Step 2: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/ui/test_vim_nav.py::test_j_and_l_scroll_a_scroll_container -v`
+Expected: PASS — `VerticalScroll` has no `cursor_*` actions, so hjkl falls back to `scroll_*`.
+
+> If `scroll_offset` does not change: scrolling is animated/throttled. The `await pilot.pause()` after the presses should settle it; if still flaky, assert after a single larger movement or compare `>=`/use `pilot.pause()` between presses. The container must be focusable and actually overflow — keep `size=(20, 10)` small relative to content.
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/box/ui/test_vim_nav.py
+git commit -m "$(cat <<'EOF'
+test(ui): verify j/l scroll a scroll container via fallback
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Wire `VimNavMixin` into the real apps + integration test
+
+**Files:**
+- Modify: `rbx/box/ui/main.py:25` (`rbxBaseApp` class definition + import)
+- Test: `tests/rbx/box/ui/test_vim_nav.py` (add)
+
+**Step 1: Write the failing test**
+
+Append an integration test exercising the actual main-menu app:
+
+```python
+async def test_main_menu_app_supports_vim_nav():
+    from rbx.box.ui.main import rbxApp
+
+    async with rbxApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList)
+        start = option_list.highlighted or 0
+
+        await pilot.press('j')
+        assert option_list.highlighted == start + 1
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/ui/test_vim_nav.py::test_main_menu_app_supports_vim_nav -v`
+Expected: FAIL — `rbxApp` does not yet inherit `VimNavMixin`, so `j` does nothing and `highlighted` stays at `start`.
+
+**Step 3: Wire the mixin into `rbxBaseApp`**
+
+In `rbx/box/ui/main.py`, add the import near the other `rbx.box.ui` imports:
+
+```python
+from rbx.box.ui.vim_nav import VimNavMixin
+```
+
+Change the base app declaration (currently `class rbxBaseApp(App):`) to:
+
+```python
+class rbxBaseApp(VimNavMixin, App):
+```
+
+The mixin MUST come before `App` in the MRO so its `BINDINGS` merge in and its `check_action` overrides the default. No other changes are needed — `rbxApp`, `rbxDifferApp`, and `rbxCommandApp` all inherit from `rbxBaseApp`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/ui/test_vim_nav.py::test_main_menu_app_supports_vim_nav -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/ui/main.py tests/rbx/box/ui/test_vim_nav.py
+git commit -m "$(cat <<'EOF'
+feat(ui): enable vim hjkl navigation across rbx ui apps
+
+Mix VimNavMixin into rbxBaseApp so the main menu, differ, and command
+apps all gain hjkl navigation.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Document the feature
+
+**Files:**
+- Modify: `rbx/box/ui/CLAUDE.md`
+
+**Step 1: Add a short section**
+
+Add a brief subsection (e.g. under a new "Keybindings" heading) to `rbx/box/ui/CLAUDE.md` describing Vim navigation:
+
+```markdown
+## Keybindings
+
+- Vim navigation lives in `vim_nav.py` (`VimNavMixin`, mixed into `rbxBaseApp`).
+  App-level `h/j/k/l` bindings dispatch to the focused widget's existing
+  `cursor_*` action (falling back to `scroll_*`): `j`/`k` move down/up everywhere;
+  `h`/`l` move left/right only where horizontal movement exists (DataTable cells,
+  scroll viewers). `check_action` disables them while an `Input`/`TextArea` is
+  focused, so typing is never hijacked.
+```
+
+**Step 2: Commit**
+
+```bash
+git add rbx/box/ui/CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(ui): document vim hjkl navigation
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Full verification
+
+**Step 1: Run the full Vim-nav test file**
+
+Run: `uv run pytest tests/rbx/box/ui/test_vim_nav.py -v`
+Expected: all tests PASS.
+
+**Step 2: Run the broader UI test suite for regressions**
+
+Run: `uv run pytest tests/rbx/box/ui -v`
+Expected: PASS (no regressions in `test_run_ui.py` / `test_task_queue.py`).
+
+**Step 3: Lint and format**
+
+Run: `uv run ruff check rbx/box/ui/vim_nav.py rbx/box/ui/main.py tests/rbx/box/ui/test_vim_nav.py && uv run ruff format --check rbx/box/ui/vim_nav.py rbx/box/ui/main.py tests/rbx/box/ui/test_vim_nav.py`
+Expected: no errors. If `ruff format --check` reports changes, run `uv run ruff format <files>` and commit with `style(ui): format vim nav code`.
+
+**Step 4: Manual smoke test (optional, requires a problem package)**
+
+In a problem directory: `uv run rbx ui`, then use `j`/`k` to move through the main menu, `Enter` to open a flow, and confirm `h`/`l` move columns in the run report `DataTable`. Confirm typing into the limits-editor inputs still works.
+
+---
+
+## Notes for the implementer
+
+- **MRO matters:** `VimNavMixin` must be listed *before* `App`. Textual merges `BINDINGS` across the MRO and resolves `check_action`/`action_vim_move` on the app instance.
+- **Why app-level, not per-widget:** app bindings are the last fallback in Textual's binding chain, so they never shadow a widget/screen binding and require zero call-site changes.
+- **Don't widen scope:** no `gg`/`G`/`ctrl+d`, no ranger-style `l`=select/`h`=back, no footer hints, no config toggle (see design doc non-goals).
+```

--- a/rbx/box/ui/CLAUDE.md
+++ b/rbx/box/ui/CLAUDE.md
@@ -81,6 +81,10 @@ Helper functions that load run results from disk:
 - **`self.watch(widget, 'index', callback)`** -- Test explorer screens watch `ListView.index` to react to selection changes.
 - **CSS** in `css/app.tcss` uses Textual's TCSS syntax with `$`-prefixed theme variables.
 
+## Keybindings
+
+Vim navigation lives in `vim_nav.py` (`VimNavMixin`, mixed into `rbxBaseApp` in `main.py`, ahead of `App` in the MRO). It registers app-level `h/j/k/l` bindings that dispatch to the focused widget's existing `cursor_*` action, falling back to `scroll_*`: `j`/`k` move down/up everywhere; `h`/`l` move left/right only where horizontal movement exists (e.g. `DataTable` cells, scroll viewers). `check_action` disables the keys while an `Input`/`TextArea` is focused, so typing is never hijacked. The mixin subclasses `DOMNode` so Textual merges its `BINDINGS`.
+
 ## Core Dependencies
 
 - `rbx.box.solutions` -- `SolutionReportSkeleton`, `SolutionSkeleton`, verdict formatting

--- a/rbx/box/ui/main.py
+++ b/rbx/box/ui/main.py
@@ -14,6 +14,7 @@ from rbx.box.ui.screens.differ import DifferScreen
 from rbx.box.ui.screens.limits_editor import LimitsEditorScreen
 from rbx.box.ui.screens.run_explorer import RunExplorerScreen
 from rbx.box.ui.screens.test_explorer import TestExplorerScreen
+from rbx.box.ui.vim_nav import VimNavMixin
 
 SCREEN_OPTIONS = [
     ('Explore tests built by `rbx build`', TestExplorerScreen),
@@ -22,7 +23,7 @@ SCREEN_OPTIONS = [
 ]
 
 
-class rbxBaseApp(App):
+class rbxBaseApp(VimNavMixin, App):
     def run(self, *args, **kwargs):
         console.console.begin_capture()
         super().run(*args, **kwargs)

--- a/rbx/box/ui/vim_nav.py
+++ b/rbx/box/ui/vim_nav.py
@@ -36,7 +36,9 @@ class VimNavMixin(DOMNode):
         Binding('l', 'vim_move("right")', 'Right', show=False),
     ]
 
-    def check_action(self, action: str, parameters: tuple) -> Optional[bool]:
+    def check_action(
+        self, action: str, parameters: tuple[object, ...]
+    ) -> Optional[bool]:
         if action == 'vim_move':
             focused = self.focused
             if focused is None or isinstance(focused, (Input, TextArea)):
@@ -47,6 +49,7 @@ class VimNavMixin(DOMNode):
 
     async def action_vim_move(self, direction: str) -> None:
         focused = self.focused
+        # Defensive: check_action normally gates this, but guard direct/edge invocations.
         if focused is None:
             return
         cursor_action, scroll_action = _DIRECTION_ACTIONS[direction]

--- a/rbx/box/ui/vim_nav.py
+++ b/rbx/box/ui/vim_nav.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import inspect
+from typing import Optional
+
+from textual.binding import Binding
+from textual.dom import DOMNode
+from textual.widgets import Input, TextArea
+
+# Maps a logical direction to (cursor action, scroll fallback action).
+_DIRECTION_ACTIONS = {
+    'down': ('cursor_down', 'scroll_down'),
+    'up': ('cursor_up', 'scroll_up'),
+    'left': ('cursor_left', 'scroll_left'),
+    'right': ('cursor_right', 'scroll_right'),
+}
+
+
+class VimNavMixin(DOMNode):
+    """Adds Vim-style hjkl navigation as an app-level fallback.
+
+    Maps h/j/k/l onto the focused widget's existing ``cursor_*`` actions, falling
+    back to ``scroll_*``. The bindings live at the app level (the last link in
+    Textual's binding chain), so any widget that binds these letters wins. They are
+    disabled while a text-editing widget is focused, so typing is never hijacked.
+
+    Subclasses ``DOMNode`` so Textual's ``_merge_bindings`` (which only collects
+    ``BINDINGS`` from ``DOMNode`` subclasses in the MRO) picks up the hjkl bindings
+    when the mixin is combined with an ``App`` or ``Screen``.
+    """
+
+    BINDINGS = [
+        Binding('j', 'vim_move("down")', 'Down', show=False),
+        Binding('k', 'vim_move("up")', 'Up', show=False),
+        Binding('h', 'vim_move("left")', 'Left', show=False),
+        Binding('l', 'vim_move("right")', 'Right', show=False),
+    ]
+
+    def check_action(self, action: str, parameters: tuple) -> Optional[bool]:
+        if action == 'vim_move':
+            focused = self.focused
+            if focused is None or isinstance(focused, (Input, TextArea)):
+                # Returning None disables the binding and lets the key fall through
+                # (e.g. so it types into a focused Input).
+                return None
+        return super().check_action(action, parameters)
+
+    async def action_vim_move(self, direction: str) -> None:
+        focused = self.focused
+        if focused is None:
+            return
+        cursor_action, scroll_action = _DIRECTION_ACTIONS[direction]
+        method = getattr(focused, f'action_{cursor_action}', None)
+        if method is None:
+            method = getattr(focused, f'action_{scroll_action}', None)
+        if method is None:
+            return
+        result = method()
+        if inspect.isawaitable(result):
+            await result

--- a/tests/rbx/box/ui/test_vim_nav.py
+++ b/tests/rbx/box/ui/test_vim_nav.py
@@ -1,0 +1,125 @@
+"""Tests for Vim-style hjkl navigation in the Textual TUI (rbx.box.ui.vim_nav)."""
+
+from textual.app import App, ComposeResult
+from textual.containers import ScrollableContainer
+from textual.widgets import DataTable, Input, OptionList, Static
+
+from rbx.box.ui.vim_nav import VimNavMixin
+
+
+class _ListApp(VimNavMixin, App):
+    def compose(self) -> ComposeResult:
+        yield OptionList('a', 'b', 'c')
+
+    def on_mount(self) -> None:
+        self.query_one(OptionList).focus()
+
+
+async def test_j_moves_down_and_k_moves_up():
+    app = _ListApp()
+    async with app.run_test() as pilot:
+        option_list = app.query_one(OptionList)
+        start = option_list.highlighted or 0
+
+        await pilot.press('j')
+        assert option_list.highlighted == start + 1
+
+        await pilot.press('j')
+        assert option_list.highlighted == start + 2
+
+        await pilot.press('k')
+        assert option_list.highlighted == start + 1
+
+
+async def test_h_and_l_are_noops_on_plain_list():
+    app = _ListApp()
+    async with app.run_test() as pilot:
+        option_list = app.query_one(OptionList)
+        await pilot.press('j')  # move off the first row first
+        before = option_list.highlighted
+
+        await pilot.press('l')
+        assert option_list.highlighted == before
+
+        await pilot.press('h')
+        assert option_list.highlighted == before
+
+
+class _InputApp(VimNavMixin, App):
+    def compose(self) -> ComposeResult:
+        yield Input()
+
+    def on_mount(self) -> None:
+        self.query_one(Input).focus()
+
+
+async def test_typing_hjkl_into_input_is_not_hijacked():
+    app = _InputApp()
+    async with app.run_test() as pilot:
+        await pilot.press('h', 'j', 'k', 'l')
+        assert app.query_one(Input).value == 'hjkl'
+
+
+class _TableApp(VimNavMixin, App):
+    def compose(self) -> ComposeResult:
+        yield DataTable()
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.cursor_type = 'cell'
+        table.add_columns('x', 'y')
+        table.add_rows([('1', '2'), ('3', '4')])
+        table.focus()
+
+
+async def test_datatable_hjkl_moves_cell_cursor():
+    app = _TableApp()
+    async with app.run_test() as pilot:
+        table = app.query_one(DataTable)
+        assert table.cursor_coordinate == (0, 0)
+
+        await pilot.press('l')
+        assert table.cursor_coordinate == (0, 1)
+
+        await pilot.press('h')
+        assert table.cursor_coordinate == (0, 0)
+
+        await pilot.press('j')
+        assert table.cursor_coordinate == (1, 0)
+
+        await pilot.press('k')
+        assert table.cursor_coordinate == (0, 0)
+
+
+class _ScrollApp(VimNavMixin, App):
+    def compose(self) -> ComposeResult:
+        # ScrollableContainer scrolls on both axes (VerticalScroll forces
+        # overflow-x: hidden, so horizontal scrolling is impossible there). The
+        # child is sized larger than the viewport on both axes so there is real
+        # content to scroll into.
+        with ScrollableContainer():
+            wide_line = 'x' * 200
+            content = Static('\n'.join(wide_line for _ in range(200)))
+            content.styles.width = 200
+            content.styles.height = 200
+            yield content
+
+    def on_mount(self) -> None:
+        self.query_one(ScrollableContainer).focus()
+
+
+async def test_j_and_l_scroll_a_scroll_container():
+    app = _ScrollApp()
+    async with app.run_test(size=(20, 10)) as pilot:
+        container = app.query_one(ScrollableContainer)
+        assert container.scroll_offset == (0, 0)
+
+        for _ in range(5):
+            await pilot.press('j')
+        await pilot.pause()
+        assert container.scroll_offset.y > 0
+
+        for _ in range(5):
+            await pilot.press('l')
+        await pilot.pause()
+        assert container.scroll_offset.x > 0

--- a/tests/rbx/box/ui/test_vim_nav.py
+++ b/tests/rbx/box/ui/test_vim_nav.py
@@ -123,3 +123,14 @@ async def test_j_and_l_scroll_a_scroll_container():
             await pilot.press('l')
         await pilot.pause()
         assert container.scroll_offset.x > 0
+
+
+async def test_main_menu_app_supports_vim_nav():
+    from rbx.box.ui.main import rbxApp
+
+    async with rbxApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList)
+        start = option_list.highlighted or 0
+
+        await pilot.press('j')
+        assert option_list.highlighted == start + 1

--- a/tests/rbx/box/ui/test_vim_nav.py
+++ b/tests/rbx/box/ui/test_vim_nav.py
@@ -2,7 +2,7 @@
 
 from textual.app import App, ComposeResult
 from textual.containers import ScrollableContainer
-from textual.widgets import DataTable, Input, OptionList, Static
+from textual.widgets import DataTable, Input, OptionList, Select, Static
 
 from rbx.box.ui.vim_nav import VimNavMixin
 
@@ -134,3 +134,26 @@ async def test_main_menu_app_supports_vim_nav():
 
         await pilot.press('j')
         assert option_list.highlighted == start + 1
+
+
+class _SelectApp(VimNavMixin, App):
+    def compose(self) -> ComposeResult:
+        yield Select([('one', 1), ('two', 2), ('three', 3)])
+
+    def on_mount(self) -> None:
+        self.query_one(Select).focus()
+
+
+async def test_jk_on_collapsed_select_does_not_change_value():
+    app = _SelectApp()
+    async with app.run_test() as pilot:
+        select = app.query_one(Select)
+        before = select.value  # collapsed; no selection by default
+
+        await pilot.press('j')
+        await pilot.press('k')
+
+        # Collapsed Select must not change its value from hjkl navigation.
+        assert select.value == before
+        # And it should still be collapsed (j/k did not open the overlay).
+        assert select.expanded is False


### PR DESCRIPTION
## Summary

Adds Vim-style `h/j/k/l` navigation to the `rbx ui` Textual TUI, so menus, lists, tables, and scrollable viewers can be navigated without arrow keys.

- New `VimNavMixin` (`rbx/box/ui/vim_nav.py`) registers **app-level** `h/j/k/l` bindings that dispatch onto the *focused* widget's existing actions — `cursor_*` first, `scroll_*` as fallback. No widget is subclassed and no call site changes.
- Mixed into `rbxBaseApp` (`rbx/box/ui/main.py`, ahead of `App` in the MRO), so the main menu, differ, and command apps all gain it.
- A `check_action` guard disables the keys while an `Input`/`TextArea` is focused, so typing is never hijacked.

### Behavior
- `j`/`k` move down/up everywhere.
- `h`/`l` move left/right only where horizontal movement exists (`DataTable` cells, scroll viewers); they are no-ops on plain lists.
- hjkl only — no `gg`/`G`/`ctrl+d`, no ranger-style select/back, no footer hints, no config toggle (deliberate non-goals).

Design and plan: `docs/plans/2026-05-20-vim-navigation-ui-design.md`, `docs/plans/2026-05-20-vim-navigation-ui.md`.

## Test Plan
- [x] `uv run pytest tests/rbx/box/ui/test_vim_nav.py` — 7 passed (OptionList j/k, h/l no-op on list, Input not hijacked, DataTable cell hjkl, scroll-container j/l, main-menu integration, collapsed-Select no-op)
- [x] `uv run pytest tests/rbx/box/ui` — 32 passed, no regressions
- [x] `uv run ruff check` / `ruff format --check` clean on changed files
- [ ] Manual smoke: `rbx ui` → `j`/`k` through main menu, `Enter` into a flow, `h`/`l` move columns in the run-report `DataTable`, typing in the limits-editor inputs still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)