### PR TITLE
feat(linters): built-in linter framework + side_effect C++ linter

### DIFF
--- a/docs/plans/2026-05-23-linters-design.md
+++ b/docs/plans/2026-05-23-linters-design.md
@@ -1,0 +1,280 @@
+# Built-in Linters Design
+
+Date: 2026-05-23
+Issue: https://github.com/rsalesc/rbx/issues/476
+
+## Goal
+
+Add support for **built-in linters** in `rbx`: rbx-made linters distributed as
+Python code that analyze a problem's source files during compilation and surface
+warnings or errors. Ship the first linter, `side_effect`, a C++ linter built on
+`tree-sitter-cpp` that flags side-effecting calls used as arguments to other
+calls (where C++ leaves argument evaluation order unspecified).
+
+This is distinct from general-purpose code linting: linters here are first-class
+rbx components, configured per language in `env.rbx.yml`, run only during the
+compilation phase.
+
+## Scope decisions
+
+- **Severity (default):** `side_effect` emits **warnings**, routed to the warning
+  stack. The interface still supports errors (→ `RbxException`) for future
+  linters. No per-linter `severity` override field in v1.
+- **Asset classes:** introduce an explicit `AssetKind` enum rather than reusing
+  Pydantic class names.
+- **`side_effect` v1 detection:** **hardcoded side-effect family only** (the
+  `rnd.next` family from testlib/tgen/jngen). The `SIDE_EFFECT` macro and header
+  expansion described in the issue are deferred to a follow-up issue.
+- **Side-effect family location:** a maintained hardcoded constant in code (not
+  user-configurable in `env.rbx.yml`).
+
+## Architecture
+
+New package `rbx/box/linters/`:
+
+```
+rbx/box/linters/
+  linter.py        # Linter ABC, LinterMessage, LinterSeverity
+  registry.py      # name -> Linter registry + @register decorator
+  cpp/
+    side_effect.py # first linter
+```
+
+### Interface (`linters/linter.py`)
+
+```python
+class LinterSeverity(enum.Enum):
+    WARNING = 'warning'
+    ERROR = 'error'
+
+class LinterMessage(BaseModel):
+    severity: LinterSeverity
+    message: str
+    line: Optional[int] = None   # 1-based
+    col: Optional[int] = None    # 1-based
+
+class Linter(abc.ABC):
+    name: ClassVar[str]                    # lowercase, referenced in env.rbx.yml
+    languages: ClassVar[Set[str]]          # language families it supports, e.g. {'cpp'}
+    applies_to: ClassVar[Set[AssetKind]]   # interface restriction; empty == all kinds
+
+    @abc.abstractmethod
+    def lint(self, code: CodeItem, source: str) -> List[LinterMessage]: ...
+```
+
+`lint()` is synchronous and pure over `(code, source)`. It receives the **raw
+source text** of the file (no preprocessing / header expansion).
+
+### Registry (`linters/registry.py`)
+
+A closed, in-process registry — no setuptools entry points or external plugins,
+matching "rbx-made linters distributed as Python code".
+
+```python
+_REGISTRY: Dict[str, Linter] = {}
+
+def register(linter_cls):    # decorator; instantiates and registers by .name
+    ...
+
+def get_linter(name: str) -> Linter: ...   # raises RbxException on unknown name
+```
+
+Linter modules are imported once (e.g. from `linters/__init__.py`) so their
+`@register` side effects run.
+
+## Config schema (`env.rbx.yml`)
+
+Add `linters` to `EnvironmentLanguage` (`rbx/box/environment.py`), default empty:
+
+```yaml
+languages:
+  - name: cpp
+    linters:
+      - side_effect                                      # shorthand
+      - {name: side_effect, applies_to: [generators]}    # restricted form
+```
+
+New model:
+
+```python
+class LinterConfig(BaseModel):
+    name: str
+    applies_to: Optional[List[AssetKind]] = None  # None/empty == all kinds
+```
+
+A field validator on `EnvironmentLanguage.linters` coerces a bare string into
+`LinterConfig(name=...)`.
+
+**Effective scope** for a given linter + asset is the intersection of:
+- the linter interface's `applies_to` (empty == all), and
+- the config entry's `applies_to` (None/empty == all).
+
+A linter runs on an asset only if the asset's language family is in the linter's
+`languages` set and the asset's kind is within the effective scope.
+
+## AssetKind & kind resolution
+
+New enum:
+
+```python
+class AssetKind(enum.Enum):
+    GENERATOR = 'generator'
+    VALIDATOR = 'validator'
+    SOLUTION = 'solution'
+    CHECKER = 'checker'
+    INTERACTOR = 'interactor'
+    VISUALIZER = 'visualizer'
+```
+
+`Solution`, `Generator`, `Checker`, `Interactor`, `Visualizer` are distinct
+`CodeItem` subclasses, so their kind is inferable via `isinstance`. **Validators
+are plain `CodeItem`** (`schema.py`: `validator: Optional[CodeItem]`) with no
+dedicated class, so their kind cannot be inferred from type.
+
+Resolution strategy:
+- Add `kind: Optional[AssetKind] = None` to `compile_item()` in `rbx/box/code.py`.
+- Auto-derive from `isinstance` for the typed subclasses when `kind` is not given.
+- Call sites compiling a bare-`CodeItem` validator (`rbx/box/validators.py`) pass
+  `kind=AssetKind.VALIDATOR` explicitly.
+- When kind is unknown, kind-restricted linters skip; unrestricted linters run.
+
+## Compile-time integration
+
+Linting runs inside `compile_item()` — the compilation phase. Steps:
+
+1. Resolve the language family for `code`.
+2. Resolve `kind` (param or `isinstance`).
+3. From the language's `linters` config, resolve each `Linter` via the registry.
+4. Filter by language-family support and effective `applies_to` scope.
+5. Read the raw source file and run each applicable linter's `lint()`.
+6. Route messages:
+   - `WARNING` → warning stack (see below).
+   - `ERROR` → accumulate and raise a single `RbxException` (via its context
+     manager) listing all errors with file + location.
+
+### Warning stack integration
+
+`WarningStack` (`rbx/box/sanitizers/warning_stack.py`) currently keys warnings by
+code path with `List[PreprocessLog]`. Add a method to carry linter messages with
+text + location so they render alongside compiler warnings, e.g.:
+
+```python
+def add_linter_warning(self, code: CodeItem, messages: List[LinterMessage]): ...
+```
+
+and include them in `print_warning_stack_report()`.
+
+### Caching caveat (verify during implementation)
+
+The compiler invocation itself is cached via `steps_with_caching.compile()`, but
+`compile_item()`'s body re-runs on each call. Linting must run on every build, so
+it is placed in `compile_item()`'s body independent of the cached compile step.
+**To verify in the plan:** that there is no higher-level memoization of
+`compile_item` (e.g. an `alru_cache`) that would swallow repeat lint runs; if
+there is, lint outside that boundary or include lint output in the cache.
+
+## The `side_effect` linter (v1)
+
+`linters/cpp/side_effect.py`, built on `tree-sitter-cpp`.
+
+```python
+@register
+class SideEffectLinter(Linter):
+    name = 'side_effect'
+    languages = {'cpp'}
+    applies_to = set()   # all kinds, restrictable via config
+```
+
+### Side-effect family
+
+A maintained module-level constant, seeded with the `rnd.next` family. Modeled as
+`(object, method)` patterns to match `rnd.next(...)`:
+
+```python
+SIDE_EFFECT_CALLS = {('rnd', 'next')}  # extend as needed
+```
+
+### Detection algorithm
+
+1. Parse the source with `tree-sitter-cpp`.
+2. Query every `call_expression` node (the "outer" calls).
+3. For each outer call, look at its top-level argument expressions
+   (`argument_list` children).
+4. Count how many top-level arguments **contain** (anywhere in their subtree) a
+   call to a known side-effect function.
+5. If the count is **>= 2**, emit a `WARNING` at the outer call's start position.
+
+A "known side-effect call" is a `call_expression` whose callee is a
+`field_expression` matching `<obj>.<method>` against `SIDE_EFFECT_CALLS`.
+
+### Behavior on the issue's examples
+
+```cpp
+some_function(rnd.next(), rnd.next());          // WARN  (2 side-effect args)
+some_function(rnd.next(), 3);                   // OK    (1 side-effect arg)
+some_function(fn_with_side_effect(), rnd.next()); // OK in v1 (macro not detected)
+```
+
+The third case will warn once `SIDE_EFFECT`-macro detection lands (follow-up).
+
+### Covered / not covered
+
+- **Nested calls** are covered: every `call_expression` is scanned, so an inner
+  `g(rnd.next(), rnd.next())` warns even when wrapped in another call.
+- **`cout << rnd.next() << rnd.next()`** is *not* flagged: `<<` is a
+  `binary_expression`, not a `call_expression`, and operator operands are
+  sequenced. This matches the issue's scope.
+
+### Deferred (follow-up issue)
+
+- `SIDE_EFFECT` macro detection (`SIDE_EFFECT int fn();`).
+- Header expansion so macros/functions declared in included headers (tgen.h,
+  jngen.h, testlib.h) are visible. Left as `# TODO(#NNN)` in code.
+
+## Dependencies
+
+Add to `pyproject.toml` (prebuilt wheels, Python >=3.10 satisfied):
+
+- `tree-sitter`
+- `tree-sitter-cpp`
+
+Pin to a known-compatible pair (tree-sitter and the grammar package's ABI must
+match). Verify `Parser(Language(tree_sitter_cpp.language()))` constructs cleanly
+under the chosen versions.
+
+## Error handling
+
+- Unknown linter name in config → `RbxException` at config resolution time, with
+  the offending name and the language.
+- Unsupported language for a referenced linter → `RbxException` (misconfiguration)
+  rather than silent skip, so typos surface.
+- A linter raising unexpectedly → wrap in `RbxException` identifying the linter
+  and file; do not let it crash compilation opaquely.
+- Linter `ERROR` messages → a single aggregated `RbxException`.
+
+## Testing
+
+Unit (linter):
+- `side_effect` over C++ snippets: the three issue examples, nested calls,
+  single side-effect arg, three+ args, free-function vs method callee,
+  `cout <<` chains (no warning), and a clean file (no warnings).
+- Parse via the real linter; do not mock the parser.
+
+Framework:
+- Registry lookup + unknown-name error.
+- Shorthand string → `LinterConfig` coercion.
+- `applies_to` intersection (interface ∩ config) and language-family filtering.
+- Kind resolution: `isinstance`-derived kinds and explicit validator kind.
+- Warning-vs-error routing.
+
+Integration:
+- Compile a generator containing an offending `rnd.next(...)` call and assert the
+  warning lands on the stack and renders in the report.
+- Compile with `applies_to: [generators]` and confirm a solution with the same
+  pattern is *not* flagged.
+
+## Follow-ups
+
+- Open an issue for `SIDE_EFFECT` macro detection + header expansion, referenced
+  by the `# TODO` in `side_effect.py`.
+```

--- a/docs/plans/2026-05-23-linters.md
+++ b/docs/plans/2026-05-23-linters.md
@@ -1,0 +1,945 @@
+# Built-in Linters Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a built-in linter framework to `rbx` (configured per language in `env.rbx.yml`, run during compilation, producing warnings/errors) plus the first linter, `side_effect`, a C++ linter on `tree-sitter-cpp` that flags side-effecting calls passed as arguments to other calls.
+
+**Architecture:** A new `rbx/box/linters/` package defines a `Linter` ABC + a name→instance registry. `EnvironmentLanguage` gains a `linters` config list. `compile_item()` resolves the applicable linters for a code item (by language entry, asset kind, and `applies_to` scope), runs them on the raw source, routes `WARNING`s to the existing `WarningStack` and `ERROR`s to a `RbxException`. The `side_effect` linter parses C++ with tree-sitter and warns when a call passes ≥2 arguments that each contain a known side-effecting call (seed: `rnd.next`).
+
+**Tech Stack:** Python ≥3.10, Pydantic v2, `tree-sitter` + `tree-sitter-cpp`, pytest.
+
+**Design doc:** `docs/plans/2026-05-23-linters-design.md`
+
+**Conventions for every task:** single quotes, absolute imports only, run `uv run ruff format .` and `uv run ruff check --fix .` before committing, and commit with the `/commit` skill (conventional commits; co-author trailer). Run tests with `uv run pytest`.
+
+---
+
+## Task 1: Add tree-sitter dependencies
+
+**Files:**
+- Modify: `pyproject.toml` (dependencies list, ~lines 17-64)
+- Test: `tests/rbx/box/linters/test_treesitter_smoke.py` (create)
+
+**Step 1: Add dependencies**
+
+Add to the `dependencies` array in `pyproject.toml`:
+
+```toml
+"tree-sitter>=0.22.0",
+"tree-sitter-cpp>=0.22.0",
+```
+
+Then run:
+
+```bash
+uv sync
+```
+
+Expected: lockfile updates, both packages install.
+
+**Step 2: Write a smoke test that the parser constructs and parses**
+
+`tests/rbx/box/linters/test_treesitter_smoke.py`:
+
+```python
+import tree_sitter_cpp
+from tree_sitter import Language, Parser
+
+
+def test_cpp_parser_constructs_and_parses():
+    language = Language(tree_sitter_cpp.language())
+    parser = Parser(language)
+    tree = parser.parse(b'int main() { return 0; }')
+    assert tree.root_node.type == 'translation_unit'
+    assert not tree.root_node.has_error
+```
+
+**Step 3: Run it**
+
+Run: `uv run pytest tests/rbx/box/linters/test_treesitter_smoke.py -v`
+Expected: PASS. If `Parser(language)` raises (older API), the installed `tree-sitter` is <0.22 — verify the pinned versions resolved and adjust the floor.
+
+**Step 4: Commit**
+
+```bash
+uv run ruff format . && uv run ruff check --fix .
+git add pyproject.toml uv.lock tests/rbx/box/linters/test_treesitter_smoke.py
+# commit: build: add tree-sitter and tree-sitter-cpp dependencies
+```
+
+---
+
+## Task 2: AssetKind enum + kind resolution
+
+**Files:**
+- Create: `rbx/box/linters/__init__.py` (empty for now)
+- Create: `rbx/box/linters/asset_kind.py`
+- Test: `tests/rbx/box/linters/test_asset_kind.py`
+
+**Step 1: Write the failing test**
+
+`tests/rbx/box/linters/test_asset_kind.py`:
+
+```python
+from rbx.box.linters.asset_kind import AssetKind, infer_asset_kind
+from rbx.box.schema import Checker, CodeItem, Generator, Interactor, Solution
+
+
+def test_infer_asset_kind_for_typed_subclasses():
+    assert infer_asset_kind(Generator(path='g.cpp', name='gen')) is AssetKind.GENERATOR
+    assert infer_asset_kind(Checker(path='c.cpp')) is AssetKind.CHECKER
+    assert infer_asset_kind(Interactor(path='i.cpp')) is AssetKind.INTERACTOR
+    assert (
+        infer_asset_kind(Solution(path='s.cpp', outcome='accepted'))
+        is AssetKind.SOLUTION
+    )
+
+
+def test_infer_asset_kind_for_bare_codeitem_is_none():
+    # Validators are bare CodeItems; their kind is not inferable from type.
+    assert infer_asset_kind(CodeItem(path='v.cpp')) is None
+```
+
+(Check the exact required fields for `Checker`/`Interactor`/`Solution`/`Generator` in `rbx/box/schema.py` and adjust the constructor kwargs so the models validate.)
+
+**Step 2: Run it**
+
+Run: `uv run pytest tests/rbx/box/linters/test_asset_kind.py -v`
+Expected: FAIL (module does not exist).
+
+**Step 3: Implement**
+
+`rbx/box/linters/asset_kind.py`:
+
+```python
+import enum
+from typing import Optional
+
+from rbx.box.schema import (
+    Checker,
+    CodeItem,
+    Generator,
+    Interactor,
+    Solution,
+    Visualizer,
+)
+
+
+class AssetKind(enum.Enum):
+    GENERATOR = 'generator'
+    VALIDATOR = 'validator'
+    SOLUTION = 'solution'
+    CHECKER = 'checker'
+    INTERACTOR = 'interactor'
+    VISUALIZER = 'visualizer'
+
+
+# Order matters: check most-specific subclasses first.
+_TYPE_TO_KIND = [
+    (Solution, AssetKind.SOLUTION),
+    (Generator, AssetKind.GENERATOR),
+    (Checker, AssetKind.CHECKER),
+    (Interactor, AssetKind.INTERACTOR),
+    (Visualizer, AssetKind.VISUALIZER),
+]
+
+
+def infer_asset_kind(code: CodeItem) -> Optional[AssetKind]:
+    """Infer the asset kind from the CodeItem subclass.
+
+    Validators are plain CodeItems with no dedicated subclass, so they return
+    None here; callers that know the role pass the kind explicitly.
+    """
+    for cls, kind in _TYPE_TO_KIND:
+        if isinstance(code, cls):
+            return kind
+    return None
+```
+
+(Confirm `Visualizer` is importable from `rbx.box.schema`; if it lives elsewhere, fix the import.)
+
+**Step 4: Run it**
+
+Run: `uv run pytest tests/rbx/box/linters/test_asset_kind.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+uv run ruff format . && uv run ruff check --fix .
+git add rbx/box/linters/__init__.py rbx/box/linters/asset_kind.py tests/rbx/box/linters/test_asset_kind.py
+# commit: feat(linters): add AssetKind enum and kind inference
+```
+
+---
+
+## Task 3: Linter interface
+
+**Files:**
+- Create: `rbx/box/linters/linter.py`
+- Test: `tests/rbx/box/linters/test_linter_interface.py`
+
+**Step 1: Write the failing test**
+
+`tests/rbx/box/linters/test_linter_interface.py`:
+
+```python
+from rbx.box.linters.asset_kind import AssetKind
+from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
+from rbx.box.schema import CodeItem
+
+
+class _DummyLinter(Linter):
+    name = 'dummy'
+    languages = {'cpp'}
+    applies_to = {AssetKind.GENERATOR}
+
+    def lint(self, code, source):
+        return [LinterMessage(severity=LinterSeverity.WARNING, message='hi', line=1)]
+
+
+def test_linter_metadata_and_lint():
+    linter = _DummyLinter()
+    assert linter.name == 'dummy'
+    assert linter.languages == {'cpp'}
+    assert linter.applies_to == {AssetKind.GENERATOR}
+    msgs = linter.lint(CodeItem(path='g.cpp'), 'source')
+    assert msgs == [LinterMessage(severity=LinterSeverity.WARNING, message='hi', line=1)]
+```
+
+**Step 2: Run it** — Expected: FAIL (module missing).
+
+**Step 3: Implement**
+
+`rbx/box/linters/linter.py`:
+
+```python
+import abc
+import enum
+from typing import ClassVar, List, Optional, Set
+
+from pydantic import BaseModel
+
+from rbx.box.linters.asset_kind import AssetKind
+from rbx.box.schema import CodeItem
+
+
+class LinterSeverity(enum.Enum):
+    WARNING = 'warning'
+    ERROR = 'error'
+
+
+class LinterMessage(BaseModel):
+    severity: LinterSeverity
+    message: str
+    line: Optional[int] = None  # 1-based
+    col: Optional[int] = None  # 1-based
+
+
+class Linter(abc.ABC):
+    # Lowercase identifier referenced in env.rbx.yml.
+    name: ClassVar[str]
+    # Env language names this linter supports (e.g. {'cpp'}).
+    languages: ClassVar[Set[str]]
+    # Interface-level restriction; empty set means "all asset kinds".
+    applies_to: ClassVar[Set[AssetKind]] = set()
+
+    @abc.abstractmethod
+    def lint(self, code: CodeItem, source: str) -> List[LinterMessage]:
+        """Analyze raw source text and return messages. Pure, synchronous."""
+        ...
+```
+
+**Step 4: Run it** — Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+# commit: feat(linters): add Linter interface and message types
+```
+
+---
+
+## Task 4: Registry
+
+**Files:**
+- Create: `rbx/box/linters/registry.py`
+- Test: `tests/rbx/box/linters/test_registry.py`
+
+**Step 1: Write the failing test**
+
+`tests/rbx/box/linters/test_registry.py`:
+
+```python
+import pytest
+
+from rbx.box.exception import RbxException
+from rbx.box.linters import registry
+from rbx.box.linters.linter import Linter
+
+
+@registry.register
+class _RegLinter(Linter):
+    name = 'reg_test'
+    languages = {'cpp'}
+
+    def lint(self, code, source):
+        return []
+
+
+def test_register_and_get():
+    assert isinstance(registry.get_linter('reg_test'), _RegLinter)
+
+
+def test_get_unknown_raises():
+    with pytest.raises(RbxException):
+        registry.get_linter('does_not_exist')
+```
+
+**Step 2: Run it** — Expected: FAIL.
+
+**Step 3: Implement**
+
+`rbx/box/linters/registry.py`:
+
+```python
+from typing import Dict, Type
+
+from rbx.box.exception import RbxException
+from rbx.box.linters.linter import Linter
+
+_REGISTRY: Dict[str, Linter] = {}
+
+
+def register(linter_cls: Type[Linter]) -> Type[Linter]:
+    instance = linter_cls()
+    _REGISTRY[instance.name] = instance
+    return linter_cls
+
+
+def get_linter(name: str) -> Linter:
+    if name not in _REGISTRY:
+        with RbxException() as e:
+            e.print(f'[error]Unknown linter: [item]{name}[/item][/error]')
+            known = ', '.join(sorted(_REGISTRY)) or '(none)'
+            e.print(f'Known linters: {known}')
+    return _REGISTRY[name]
+```
+
+(Confirm the `RbxException` context-manager pattern from `rbx/box/exception.py`; if `with RbxException() as e: e.print(...)` raises on `__exit__`, the `return` line is unreachable on the error path — that is intended.)
+
+**Step 4: Run it** — Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+# commit: feat(linters): add linter registry
+```
+
+---
+
+## Task 5: Config schema (`EnvironmentLanguage.linters`)
+
+**Files:**
+- Modify: `rbx/box/environment.py` (`EnvironmentLanguage`, ~line 184)
+- Test: `tests/rbx/box/linters/test_linter_config.py`
+
+**Step 1: Write the failing test**
+
+`tests/rbx/box/linters/test_linter_config.py`:
+
+```python
+from rbx.box.environment import EnvironmentLanguage, ExecutionConfig, LinterConfig
+from rbx.box.linters.asset_kind import AssetKind
+
+
+def _lang(**kw):
+    return EnvironmentLanguage(
+        name='cpp', extension='cpp', execution=ExecutionConfig(), **kw
+    )
+
+
+def test_linters_default_empty():
+    assert _lang().linters == []
+
+
+def test_shorthand_string_coerced_to_config():
+    lang = _lang(linters=['side_effect'])
+    assert lang.linters == [LinterConfig(name='side_effect', applies_to=None)]
+
+
+def test_full_form_with_applies_to():
+    lang = _lang(linters=[{'name': 'side_effect', 'applies_to': ['generators']}])
+    assert lang.linters[0].name == 'side_effect'
+    assert lang.linters[0].applies_to == [AssetKind.GENERATOR]
+```
+
+Note the config uses **plural** value `generators`; map plural config tokens to `AssetKind`. Decide and document the token spelling: accept the `AssetKind` enum values plus their plural forms (`generator`/`generators`). Implement a small validator that normalizes both.
+
+**Step 2: Run it** — Expected: FAIL (`LinterConfig` and `linters` field missing).
+
+**Step 3: Implement**
+
+In `rbx/box/environment.py`, add near the other config models (import `AssetKind` from `rbx.box.linters.asset_kind` at module top — verify no import cycle; `asset_kind` imports from `schema`, not `environment`, so this is safe):
+
+```python
+class LinterConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    name: str = Field(description='Name of the linter to run (see registry).')
+    applies_to: Optional[List[AssetKind]] = Field(
+        default=None,
+        description='Asset kinds this linter applies to. None means all kinds.',
+    )
+
+    @field_validator('applies_to', mode='before')
+    @classmethod
+    def _normalize_applies_to(cls, v):
+        if v is None:
+            return None
+        out = []
+        for item in v:
+            if isinstance(item, AssetKind):
+                out.append(item)
+                continue
+            token = str(item).rstrip('s')  # 'generators' -> 'generator'
+            out.append(AssetKind(token))
+        return out
+```
+
+Add the field to `EnvironmentLanguage`:
+
+```python
+    linters: List[LinterConfig] = Field(
+        default_factory=list,
+        description="""Linters to run for this language during compilation.""",
+    )
+
+    @field_validator('linters', mode='before')
+    @classmethod
+    def _coerce_linter_shorthand(cls, v):
+        if v is None:
+            return []
+        return [{'name': item} if isinstance(item, str) else item for item in v]
+```
+
+(Ensure `field_validator`, `Optional`, `List` are imported in `environment.py`.)
+
+**Step 4: Run it** — Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+# commit: feat(linters): add per-language linters config to env schema
+```
+
+---
+
+## Task 6: The `side_effect` C++ linter
+
+**Files:**
+- Create: `rbx/box/linters/cpp/__init__.py`
+- Create: `rbx/box/linters/cpp/side_effect.py`
+- Test: `tests/rbx/box/linters/test_side_effect.py`
+
+**Step 1: Write the failing tests (the issue's examples + edges)**
+
+`tests/rbx/box/linters/test_side_effect.py`:
+
+```python
+from rbx.box.linters.cpp.side_effect import SideEffectLinter
+from rbx.box.linters.linter import LinterSeverity
+from rbx.box.schema import CodeItem
+
+
+def _lint(src: str):
+    return SideEffectLinter().lint(CodeItem(path='gen.cpp'), src)
+
+
+def _wrap(body: str) -> str:
+    return 'void f() {\n' + body + '\n}\n'
+
+
+def test_two_side_effect_args_warns():
+    msgs = _lint(_wrap('some_function(rnd.next(), rnd.next());'))
+    assert len(msgs) == 1
+    assert msgs[0].severity is LinterSeverity.WARNING
+
+
+def test_one_side_effect_arg_is_ok():
+    assert _lint(_wrap('some_function(rnd.next(), 3);')) == []
+
+
+def test_unknown_side_effect_func_not_flagged_v1():
+    # fn_with_side_effect uses the SIDE_EFFECT macro, deferred to a follow-up.
+    assert _lint(_wrap('some_function(fn_with_side_effect(), rnd.next());')) == []
+
+
+def test_nested_call_is_flagged():
+    msgs = _lint(_wrap('outer(g(rnd.next(), rnd.next()));'))
+    assert len(msgs) == 1
+
+
+def test_cout_chain_not_flagged():
+    assert _lint(_wrap('std::cout << rnd.next() << rnd.next();')) == []
+
+
+def test_clean_source_no_warnings():
+    assert _lint(_wrap('int x = 1; some_function(x, x);')) == []
+
+
+def test_message_has_location():
+    msgs = _lint(_wrap('some_function(rnd.next(), rnd.next());'))
+    assert msgs[0].line is not None and msgs[0].col is not None
+```
+
+**Step 2: Run it** — Expected: FAIL (module missing).
+
+**Step 3: Implement**
+
+`rbx/box/linters/cpp/side_effect.py`:
+
+```python
+from typing import List, Optional, Set, Tuple
+
+import tree_sitter_cpp
+from tree_sitter import Language, Node, Parser
+
+from rbx.box.linters import registry
+from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
+from rbx.box.schema import CodeItem
+
+# Known side-effecting calls, as (object, method) pairs matching `obj.method(...)`.
+# Seeded with the testlib/tgen/jngen `rnd.next` family. Extend as needed.
+# TODO(#NNN): detect SIDE_EFFECT-macro-annotated functions and expand headers
+# so side-effecting functions declared in tgen.h/jngen.h/testlib.h are seen.
+SIDE_EFFECT_CALLS: Set[Tuple[str, str]] = {
+    ('rnd', 'next'),
+}
+
+_LANGUAGE = Language(tree_sitter_cpp.language())
+
+
+def _parser() -> Parser:
+    return Parser(_LANGUAGE)
+
+
+def _text(node: Node) -> str:
+    return node.text.decode('utf8')
+
+
+def _is_side_effect_call(node: Node) -> bool:
+    """True if `node` is a call_expression to a known side-effecting function."""
+    if node.type != 'call_expression':
+        return False
+    fn = node.child_by_field_name('function')
+    if fn is None or fn.type != 'field_expression':
+        return False
+    obj = fn.child_by_field_name('argument')
+    field = fn.child_by_field_name('field')
+    if obj is None or field is None:
+        return False
+    return (_text(obj), _text(field)) in SIDE_EFFECT_CALLS
+
+
+def _contains_side_effect_call(node: Node) -> bool:
+    if _is_side_effect_call(node):
+        return True
+    return any(_contains_side_effect_call(child) for child in node.named_children)
+
+
+def _argument_nodes(call: Node) -> List[Node]:
+    args = call.child_by_field_name('arguments')
+    if args is None:
+        return []
+    return list(args.named_children)
+
+
+class SideEffectLinter(Linter):
+    name = 'side_effect'
+    languages = {'cpp'}
+    applies_to = set()  # all kinds; restrictable via env config
+
+    def lint(self, code: CodeItem, source: str) -> List[LinterMessage]:
+        tree = _parser().parse(bytes(source, 'utf8'))
+        messages: List[LinterMessage] = []
+        self._visit(tree.root_node, messages)
+        return messages
+
+    def _visit(self, node: Node, messages: List[LinterMessage]) -> None:
+        if node.type == 'call_expression':
+            side_effect_args = sum(
+                1
+                for arg in _argument_nodes(node)
+                if _contains_side_effect_call(arg)
+            )
+            if side_effect_args >= 2:
+                row, col = node.start_point
+                messages.append(
+                    LinterMessage(
+                        severity=LinterSeverity.WARNING,
+                        message=(
+                            'Call passes multiple side-effecting arguments '
+                            '(e.g. rnd.next()); C++ leaves argument evaluation '
+                            'order unspecified, so results may differ across '
+                            'compilers. Compute each value into a variable first.'
+                        ),
+                        line=row + 1,
+                        col=col + 1,
+                    )
+                )
+        for child in node.named_children:
+            self._visit(child, messages)
+
+
+registry.register(SideEffectLinter)
+```
+
+`rbx/box/linters/cpp/__init__.py`: empty.
+
+Notes for the implementer:
+- Verify field names against the installed grammar: dump `tree.root_node` for `some_function(rnd.next(), rnd.next());` and confirm `call_expression` has fields `function` and `arguments`, and `field_expression` has `argument`/`field`. If a node uses `arguments` differently, adapt `_argument_nodes`.
+- `Node.text` returns bytes in tree-sitter ≥0.22.
+
+**Step 4: Run it** — Expected: PASS for all cases. Debug node types if any fail.
+
+**Step 5: Commit**
+
+```bash
+# commit: feat(linters): add side_effect C++ linter
+```
+
+---
+
+## Task 7: Warning-stack rendering for linter messages
+
+**Files:**
+- Modify: `rbx/box/sanitizers/warning_stack.py`
+- Test: `tests/rbx/box/linters/test_warning_stack_linter.py`
+
+**Step 1: Write the failing test**
+
+`tests/rbx/box/linters/test_warning_stack_linter.py`:
+
+```python
+from rbx.box.linters.linter import LinterMessage, LinterSeverity
+from rbx.box.sanitizers.warning_stack import WarningStack
+from rbx.box.schema import CodeItem
+
+
+def test_add_linter_warning_records_messages(tmp_path):
+    stack = WarningStack(tmp_path)
+    code = CodeItem(path='gen.cpp')
+    stack.add_linter_warning(
+        code,
+        [LinterMessage(severity=LinterSeverity.WARNING, message='m', line=2, col=3)],
+    )
+    assert code.path in stack.warnings
+    assert stack.linter_warnings[code.path][0].message == 'm'
+```
+
+**Step 2: Run it** — Expected: FAIL (`add_linter_warning`/`linter_warnings` missing).
+
+**Step 3: Implement**
+
+In `WarningStack.__init__`, add:
+
+```python
+        self.linter_warnings: Dict[pathlib.Path, List['LinterMessage']] = {}
+```
+
+Add the method:
+
+```python
+    def add_linter_warning(self, code: CodeItem, messages):
+        if not messages:
+            return
+        self.warnings.add(code.path)
+        self.linter_warnings.setdefault(code.path, []).extend(messages)
+```
+
+Add `self.linter_warnings.clear()` to `clear()`.
+
+Extend `print_warning_stack_report()` so that, for each path, any `linter_warnings` are printed under the path with `line:col message` (mirror the existing per-path summary formatting). Use a lazy/`TYPE_CHECKING` import for `LinterMessage` to avoid an import cycle (`warning_stack` is imported widely).
+
+**Step 4: Run it** — Expected: PASS. Also run the existing warning_stack tests if any: `uv run pytest tests/rbx -k warning -v`.
+
+**Step 5: Commit**
+
+```bash
+# commit: feat(linters): render linter warnings in the warning stack report
+```
+
+---
+
+## Task 8: Wire linting into `compile_item`
+
+**Files:**
+- Create: `rbx/box/linters/runner.py`
+- Modify: `rbx/box/code.py` (`compile_item`, line 559; add `kind` param; run linters)
+- Modify: `rbx/box/validators.py` (line ~49: pass `kind=AssetKind.VALIDATOR`)
+- Modify: `rbx/box/linters/__init__.py` (import `cpp.side_effect` so it registers)
+- Test: `tests/rbx/box/linters/test_runner.py`
+
+**Step 1: Write the failing test (runner resolves + filters + routes)**
+
+`tests/rbx/box/linters/test_runner.py`:
+
+```python
+import pytest
+
+from rbx.box.environment import LinterConfig
+from rbx.box.exception import RbxException
+from rbx.box.linters import runner
+from rbx.box.linters.asset_kind import AssetKind
+from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
+
+
+class _WarnLinter(Linter):
+    name = 'w_test'
+    languages = {'cpp'}
+    applies_to = set()
+
+    def lint(self, code, source):
+        return [LinterMessage(severity=LinterSeverity.WARNING, message='w')]
+
+
+class _ErrLinter(Linter):
+    name = 'e_test'
+    languages = {'cpp'}
+    applies_to = {AssetKind.GENERATOR}
+
+    def lint(self, code, source):
+        return [LinterMessage(severity=LinterSeverity.ERROR, message='boom')]
+
+
+def test_applies_to_intersection_skips_out_of_scope():
+    # _ErrLinter only applies to generators; a solution-kind asset is skipped.
+    msgs = runner.run_linters_for_messages(
+        configs=[LinterConfig(name='e_test', applies_to=None)],
+        linters=[_ErrLinter()],
+        language_name='cpp',
+        kind=AssetKind.SOLUTION,
+        code=None,
+        source='x',
+    )
+    assert msgs == []
+
+
+def test_config_applies_to_further_restricts():
+    msgs = runner.run_linters_for_messages(
+        configs=[LinterConfig(name='w_test', applies_to=[AssetKind.GENERATOR])],
+        linters=[_WarnLinter()],
+        language_name='cpp',
+        kind=AssetKind.SOLUTION,
+        code=None,
+        source='x',
+    )
+    assert msgs == []
+```
+
+Shape the public API of `runner.py` to whatever is cleanest; the test above documents one possible split (a pure `run_linters_for_messages` that does resolution/filtering/running and returns messages, separate from the side-effecting routing into the warning stack / RbxException). Prefer keeping the pure part testable without touching global state.
+
+**Step 2: Run it** — Expected: FAIL.
+
+**Step 3: Implement `runner.py`**
+
+```python
+from typing import List, Optional
+
+from rbx.box.environment import LinterConfig
+from rbx.box.exception import RbxException
+from rbx.box.linters import registry
+from rbx.box.linters.asset_kind import AssetKind
+from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
+from rbx.box.sanitizers import warning_stack
+from rbx.box.schema import CodeItem
+
+
+def _in_scope(
+    linter: Linter, config: LinterConfig, kind: Optional[AssetKind]
+) -> bool:
+    interface = linter.applies_to  # empty == all
+    config_scope = set(config.applies_to) if config.applies_to else None
+    effective = interface
+    if config_scope is not None:
+        effective = (interface & config_scope) if interface else config_scope
+    if not effective:
+        return True  # applies to all kinds
+    if kind is None:
+        return False  # restricted, but kind unknown -> skip
+    return kind in effective
+
+
+def run_linters_for_messages(
+    configs: List[LinterConfig],
+    linters: List[Linter],
+    language_name: str,
+    kind: Optional[AssetKind],
+    code,
+    source: str,
+) -> List[LinterMessage]:
+    out: List[LinterMessage] = []
+    for config, linter in zip(configs, linters):
+        if language_name not in linter.languages:
+            with RbxException() as e:
+                e.print(
+                    f'[error]Linter [item]{linter.name}[/item] does not support '
+                    f'language [item]{language_name}[/item][/error]'
+                )
+        if not _in_scope(linter, config, kind):
+            continue
+        out.extend(linter.lint(code, source))
+    return out
+
+
+async def run_linters(code: CodeItem, kind: Optional[AssetKind]) -> None:
+    """Run configured linters for `code` and route results. Called from compile_item."""
+    from rbx.box import code as code_module  # avoid import cycle
+
+    language = code_module.find_language(code)
+    configs = language.linters
+    if not configs:
+        return
+    linters = [registry.get_linter(c.name) for c in configs]
+    source = code.path.read_text()
+    messages = run_linters_for_messages(
+        configs=configs,
+        linters=linters,
+        language_name=language.name,
+        kind=kind,
+        code=code,
+        source=source,
+    )
+    warnings = [m for m in messages if m.severity is LinterSeverity.WARNING]
+    errors = [m for m in messages if m.severity is LinterSeverity.ERROR]
+    if warnings:
+        warning_stack.get_warning_stack().add_linter_warning(code, warnings)
+    if errors:
+        with RbxException() as e:
+            e.print(f'[error]Linter errors in {code.href()}[/error]')
+            for m in errors:
+                loc = f'{m.line}:{m.col} ' if m.line else ''
+                e.print(f'- {loc}{m.message}')
+```
+
+(Resolve the cycle pragmatically: `runner` needs `find_language`; `code` needs `runner`. Lazy-import one direction, as shown.)
+
+**Step 4: Wire into `compile_item` (`rbx/box/code.py:559`)**
+
+- Add parameter: `kind: Optional['AssetKind'] = None` to `compile_item`.
+- Near the top of the function body (after the `compilable_path.is_file()` check at line 571, before/around language resolution), add:
+
+```python
+        from rbx.box.linters.asset_kind import infer_asset_kind
+        from rbx.box.linters.runner import run_linters
+
+        await run_linters(code, kind if kind is not None else infer_asset_kind(code))
+```
+
+Place it so it runs every build (it is in the function body, not behind the compile cache). **Verify** there is no `@alru_cache`/memoization wrapping `compile_item` itself that would skip the body on repeat calls; search for `compile_item` decorators and callers. If such caching exists, move the `run_linters` call to the nearest un-memoized caller, or include lint results in the cache key.
+
+**Step 5: Update the validator call site (`rbx/box/validators.py:49`)**
+
+```python
+from rbx.box.linters.asset_kind import AssetKind
+...
+digest = await compile_item(
+    validator, sanitized=SanitizationLevel.PREFER, kind=AssetKind.VALIDATOR
+)
+```
+
+**Step 6: Register the linter on import** — `rbx/box/linters/__init__.py`:
+
+```python
+from rbx.box.linters.cpp import side_effect  # noqa: F401  (registers SideEffectLinter)
+```
+
+Ensure `rbx.box.linters` is imported before linting runs (importing `runner` pulls `registry`; import `side_effect` from the package `__init__`, and import the package where `run_linters` is first reached — the lazy import in `compile_item` of `rbx.box.linters.runner` will trigger `rbx.box.linters/__init__.py`).
+
+**Step 7: Run tests**
+
+Run: `uv run pytest tests/rbx/box/linters -v`
+Expected: PASS.
+
+**Step 8: Commit**
+
+```bash
+# commit: feat(linters): run linters during compilation
+```
+
+---
+
+## Task 9: Integration test (compile a real generator)
+
+**Files:**
+- Test: `tests/rbx/box/linters/test_side_effect_integration.py`
+- Possibly add a testdata fixture package or reuse `tests/rbx/box/conftest.py` fixtures.
+
+**Step 1: Write the test**
+
+Use the existing package fixtures (`pkg_from_testdata` / `testing_pkg` — see `tests/rbx/box/conftest.py` and `CLAUDE.md` testing conventions). The test should:
+1. Set up a package whose `env.rbx.yml` cpp language has `linters: [side_effect]`.
+2. Add a generator `.cpp` containing `printf("%d %d", rnd.next(0,9), rnd.next(0,9));`.
+3. Call `compile_item(generator, kind=AssetKind.GENERATOR)` (or the higher-level generator compile path).
+4. Assert the warning landed: `warning_stack.get_warning_stack().linter_warnings` contains the generator path with a side_effect message.
+
+Then a negative variant: configure `linters: [{name: side_effect, applies_to: [solutions]}]` and assert the **generator** is not flagged.
+
+Mark `slow` if it actually compiles; if it only lints (no compiler run needed because linting precedes the compile step), keep it fast. Follow the local-machine caveat: C++ sandbox/compile tests may fail pre-existingly on this machine — if the compile step itself fails for environmental reasons, structure the assertion around the lint side effect, which runs before the compiler.
+
+**Step 2: Run it** — Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+# commit: test(linters): integration test for side_effect during compilation
+```
+
+---
+
+## Task 10: Docs + follow-up issue
+
+**Files:**
+- Modify: `rbx/box/CLAUDE.md` (note the linters package and the `compile_item` `kind` param) — keep it short.
+- Modify: user-facing docs if there is a schema/env reference page (search `docs/` for env.rbx.yml documentation). Document the `linters` field with both config forms.
+- Modify: `rbx/box/linters/cpp/side_effect.py` — replace `#NNN` in the TODO with the real follow-up issue number once created.
+
+**Step 1: Open the follow-up issue**
+
+```bash
+gh issue create --repo rsalesc/rbx \
+  --title "side_effect linter: SIDE_EFFECT macro detection and header expansion" \
+  --body "Follow-up to #476. Detect SIDE_EFFECT-annotated declarations and expand includes (tgen.h/jngen.h/testlib.h) so side-effecting functions declared in headers are seen by the side_effect linter."
+```
+
+(If `gh issue create` hits the classic-projects GraphQL error seen during research, create via `gh api repos/rsalesc/rbx/issues -f title=... -f body=...`.)
+
+**Step 2: Update the TODO and docs, then commit**
+
+```bash
+# commit: docs(linters): document linters config and reference follow-up issue
+```
+
+---
+
+## Final verification
+
+Run the whole linter suite plus a lint/format pass:
+
+```bash
+uv run ruff format . && uv run ruff check .
+uv run pytest tests/rbx/box/linters -v
+uv run pytest --ignore=tests/rbx/box/cli -n auto
+```
+
+Expected: linter tests pass; no new failures beyond the documented pre-existing local C++ sandbox/checker/validator failures on this machine.
+
+## Open verification points (carry into execution)
+
+1. **tree-sitter API/version:** confirm `Parser(Language(tree_sitter_cpp.language()))` works under the resolved versions; adjust the floor if the installed API differs.
+2. **Grammar node fields:** confirm `call_expression.function`/`arguments` and `field_expression.argument`/`field` against the installed `tree-sitter-cpp`.
+3. **compile_item caching:** confirm the function body (and thus `run_linters`) executes on every build; if memoized, relocate the call.
+4. **applies_to token spelling:** finalize singular vs plural (`generator`/`generators`) and document it.
+5. **Import cycles:** `environment` ↔ `linters.asset_kind` ↔ `schema`, and `code` ↔ `linters.runner` — keep lazy imports where noted.
+```

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -96,9 +96,9 @@ languages:
     execution:
       command: "./{executable}"
     linters:
-      - side_effect                                   # shorthand form
-      - name: side_effect                             # full form
-        applies_to: [generators, solutions]           # restrict to asset kinds
+      - testlib                                       # shorthand form
+      - name: testlib                                 # full form
+        applies_to: [generators]                      # restrict to asset kinds
 ```
 
 - The **shorthand form** is just the linter name; it applies to every asset
@@ -116,9 +116,10 @@ linter's own supported kinds and the `applies_to` you configure.
 
 ### Available linters
 
-- `side_effect` (C++): warns when a function call passes two or more arguments
-  that each contain a side-effecting call (e.g. `f(rnd.next(), rnd.next())`).
-  C++ leaves argument evaluation order unspecified, so such calls can produce
+- `testlib` (C++, generators): lints testlib/tgen/jngen-based generators. Its
+  current check warns when a function call passes two or more arguments that
+  each contain a side-effecting call (e.g. `f(rnd.next(), rnd.next())`). C++
+  leaves argument evaluation order unspecified, so such calls can produce
   different results across compilers.
 
 ## File mapping

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -80,6 +80,47 @@ languages:
    you can specify how files should be named when copied into the sandbox. Notice you can refer to these
    files by using the `{file}` placeholder in the `compilation` and `execution` fields.
 
+## Linters
+
+Each language can configure built-in linters that {{rbx}} runs during the
+compilation phase. Linters analyze the raw source of your code items
+(generators, validators, solutions, checkers, etc.) and surface warnings or
+errors. Warnings are routed to the warning stack; errors abort the build.
+
+Add linters to a language with the `linters` field. There are two forms:
+
+```yaml
+languages:
+  - name: "cpp"
+    extension: "cpp"
+    execution:
+      command: "./{executable}"
+    linters:
+      - side_effect                                   # shorthand form
+      - name: side_effect                             # full form
+        applies_to: [generators, solutions]           # restrict to asset kinds
+```
+
+- The **shorthand form** is just the linter name; it applies to every asset
+  kind the linter supports.
+- The **full form** is an object with `name` and an optional `applies_to`
+  list. `applies_to` restricts the linter to specific asset kinds. When it is
+  omitted (or `null`), the linter applies to all kinds.
+
+The valid `applies_to` tokens are the asset kinds: `generator`, `validator`,
+`solution`, `checker`, `interactor`, and `visualizer`. Plural spellings
+(`generators`, `solutions`, ...) are also accepted.
+
+The effective scope for a linter on a given asset is the intersection of the
+linter's own supported kinds and the `applies_to` you configure.
+
+### Available linters
+
+- `side_effect` (C++): warns when a function call passes two or more arguments
+  that each contain a side-effecting call (e.g. `f(rnd.next(), rnd.next())`).
+  C++ leaves argument evaluation order unspecified, so such calls can produce
+  different results across compilers.
+
 ## File mapping
 
 The `fileMapping` field is a [`FileMapping`][rbx.box.environment.FileMapping] object where

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dependencies = [
   "openai-agents>=0.3.0",
   "packaging>=25.0",
   "texsoup>=0.3.1",
+  "tree-sitter>=0.22.0",
+  "tree-sitter-cpp>=0.22.0",
 ]
 
 [project.scripts]

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -155,13 +155,13 @@ Bridge between box-level code items and the grading engine:
 ## Linters (`linters/`)
 
 Per-language built-in linters, configured under `EnvironmentLanguage.linters` in `env.rbx.yml` and run during `compile_item()`. Structure:
-- `linter.py` -- `Linter` ABC (with `name`, `languages`, `applies_to`), `LinterMessage`, `LinterSeverity`.
+- `linter.py` -- `Linter` ABC (with `name`, `applies_to`), `LinterMessage`, `LinterSeverity`. Linters run for whatever language entry they're configured under in `env.rbx.yml`.
 - `registry.py` -- name→instance registry (`@register` decorator, `get_linter`).
 - `asset_kind.py` -- `AssetKind` enum + `infer_asset_kind(code)`.
 - `runner.py` -- `run_linters()` (routes WARNINGs to the warning stack, ERRORs to a `RbxException`) and the pure `run_linters_for_messages()`.
-- `cpp/side_effect.py` -- first linter (tree-sitter-cpp); flags calls passing 2+ side-effecting arguments (e.g. `f(rnd.next(), rnd.next())`).
+- `cpp/testlib.py` -- first linter (tree-sitter-cpp); `TestlibLinter` (`name='testlib'`, generators only) flags calls passing 2+ side-effecting arguments (e.g. `f(rnd.next(), rnd.next())`).
 
-Lazy imports break the `code` ↔ `linters.runner` cycle; `__init__.py` imports `cpp.side_effect` so it self-registers.
+Lazy imports break the `code` ↔ `linters.runner` cycle; `__init__.py` imports `cpp.testlib` so it self-registers.
 
 ## Global State (`global_package.py`)
 

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -148,9 +148,20 @@ Manages language configurations from `env.rbx.yml`:
 ## Code Compilation (`code.py`)
 
 Bridge between box-level code items and the grading engine:
-- `compile_item()` -- Resolves language, builds compilation command, calls `grading/steps.compile_item()`
+- `compile_item()` -- Resolves language, builds compilation command, calls `grading/steps.compile_item()`. Takes an optional `kind: AssetKind` param; when omitted it is inferred from the `CodeItem` subclass (validators are bare `CodeItem`s, so their kind is passed explicitly by `validators.py`). Runs configured linters (see below) on the raw source before compiling, on every build.
 - `run_item()` -- Resolves limits, calls `grading/steps.run_item()`
 - Language detection from file extension or explicit configuration
+
+## Linters (`linters/`)
+
+Per-language built-in linters, configured under `EnvironmentLanguage.linters` in `env.rbx.yml` and run during `compile_item()`. Structure:
+- `linter.py` -- `Linter` ABC (with `name`, `languages`, `applies_to`), `LinterMessage`, `LinterSeverity`.
+- `registry.py` -- name→instance registry (`@register` decorator, `get_linter`).
+- `asset_kind.py` -- `AssetKind` enum + `infer_asset_kind(code)`.
+- `runner.py` -- `run_linters()` (routes WARNINGs to the warning stack, ERRORs to a `RbxException`) and the pure `run_linters_for_messages()`.
+- `cpp/side_effect.py` -- first linter (tree-sitter-cpp); flags calls passing 2+ side-effecting arguments (e.g. `f(rnd.next(), rnd.next())`).
+
+Lazy imports break the `code` ↔ `linters.runner` cycle; `__init__.py` imports `cpp.side_effect` so it self-registers.
 
 ## Global State (`global_package.py`)
 

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -6,7 +6,7 @@ import shlex
 import sys
 from enum import Enum
 from pathlib import PosixPath
-from typing import Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import rich
 import rich.text
@@ -52,6 +52,9 @@ from rbx.grading.steps import (
     maybe_get_bits_stdcpp_for_commands,
 )
 from rbx.utils import is_arm
+
+if TYPE_CHECKING:
+    from rbx.box.linters.asset_kind import AssetKind
 
 MERGED_CAPTURE_FILENAME = 'merged_capture.pio'
 
@@ -562,6 +565,7 @@ async def compile_item(
     force_warnings: bool = False,
     verbose: bool = False,
     precompile: bool = True,
+    kind: Optional['AssetKind'] = None,
 ) -> str:
     with package.get_new_sandbox() as sandbox:
         _check_stack_limit()
@@ -573,6 +577,11 @@ async def compile_item(
                 f'[error]Compilation file not found: [item]{compilable_path}[/item][/error]'
             )
             raise typer.Exit(1)
+
+        from rbx.box.linters.asset_kind import infer_asset_kind
+        from rbx.box.linters.runner import run_linters
+
+        await run_linters(code, kind if kind is not None else infer_asset_kind(code))
 
         language = find_language_name(code)
         compilation_options = get_compilation_config(

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -4,11 +4,12 @@ from enum import Enum
 from typing import Annotated, Any, Dict, List, Optional, Type, TypeVar, Union
 
 import typer
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from rbx import config, console
 from rbx.box import presets, safeeval
 from rbx.box.extensions import Extensions, LanguageExtensions
+from rbx.box.linters.asset_kind import AssetKind
 from rbx.box.yaml_validation import load_yaml_model
 from rbx.grading.judge.sandbox import SandboxBase, SandboxParams
 from rbx.grading.judge.sandboxes.stupid_sandbox import StupidSandbox
@@ -181,6 +182,30 @@ class ExecutionConfig(BaseExecutionConfig):
     )
 
 
+class LinterConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    name: str = Field(description='Name of the linter to run (see registry).')
+    applies_to: Optional[List[AssetKind]] = Field(
+        default=None,
+        description='Asset kinds this linter applies to. None means all kinds.',
+    )
+
+    @field_validator('applies_to', mode='before')
+    @classmethod
+    def _normalize_applies_to(cls, v):
+        if v is None:
+            return None
+        out = []
+        for item in v:
+            if isinstance(item, AssetKind):
+                out.append(item)
+                continue
+            token = str(item).rstrip('s')  # 'generators' -> 'generator'
+            out.append(AssetKind(token))
+        return out
+
+
 class EnvironmentLanguage(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
@@ -224,6 +249,18 @@ for the environment will be used.""",
         default=None,
         description="""Extensions to apply for this language.""",
     )
+
+    linters: List[LinterConfig] = Field(
+        default_factory=list,
+        description="""Linters to run for this language during compilation.""",
+    )
+
+    @field_validator('linters', mode='before')
+    @classmethod
+    def _coerce_linter_shorthand(cls, v):
+        if v is None:
+            return []
+        return [{'name': item} if isinstance(item, str) else item for item in v]
 
     def get_extension(self, name: str, _: Type[T]) -> Optional[T]:
         if self.extensions is None:

--- a/rbx/box/linters/__init__.py
+++ b/rbx/box/linters/__init__.py
@@ -1,0 +1,1 @@
+from rbx.box.linters.cpp import side_effect  # noqa: F401  (registers SideEffectLinter)

--- a/rbx/box/linters/__init__.py
+++ b/rbx/box/linters/__init__.py
@@ -1,1 +1,1 @@
-from rbx.box.linters.cpp import side_effect  # noqa: F401  (registers SideEffectLinter)
+from rbx.box.linters.cpp import testlib  # noqa: F401  (registers TestlibLinter)

--- a/rbx/box/linters/asset_kind.py
+++ b/rbx/box/linters/asset_kind.py
@@ -1,0 +1,42 @@
+import enum
+from typing import Optional
+
+from rbx.box.schema import (
+    Checker,
+    CodeItem,
+    Generator,
+    Interactor,
+    Solution,
+    Visualizer,
+)
+
+
+class AssetKind(enum.Enum):
+    GENERATOR = 'generator'
+    VALIDATOR = 'validator'
+    SOLUTION = 'solution'
+    CHECKER = 'checker'
+    INTERACTOR = 'interactor'
+    VISUALIZER = 'visualizer'
+
+
+# Order matters: check most-specific subclasses first.
+_TYPE_TO_KIND = [
+    (Solution, AssetKind.SOLUTION),
+    (Generator, AssetKind.GENERATOR),
+    (Checker, AssetKind.CHECKER),
+    (Interactor, AssetKind.INTERACTOR),
+    (Visualizer, AssetKind.VISUALIZER),
+]
+
+
+def infer_asset_kind(code: CodeItem) -> Optional[AssetKind]:
+    """Infer the asset kind from the CodeItem subclass.
+
+    Validators are plain CodeItems with no dedicated subclass, so they return
+    None here; callers that know the role pass the kind explicitly.
+    """
+    for cls, kind in _TYPE_TO_KIND:
+        if isinstance(code, cls):
+            return kind
+    return None

--- a/rbx/box/linters/cpp/side_effect.py
+++ b/rbx/box/linters/cpp/side_effect.py
@@ -1,0 +1,92 @@
+from typing import List, Set, Tuple
+
+import tree_sitter_cpp
+from tree_sitter import Language, Node, Parser
+
+from rbx.box.linters import registry
+from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
+from rbx.box.schema import CodeItem
+
+# Known side-effecting calls, as (object, method) pairs matching `obj.method(...)`.
+# Seeded with the testlib/tgen/jngen `rnd.next` family. Extend as needed.
+# TODO: SIDE_EFFECT macro detection + header expansion (follow-up to #476)
+# Detect SIDE_EFFECT-macro-annotated functions and expand headers so
+# side-effecting functions declared in tgen.h/jngen.h/testlib.h are seen.
+SIDE_EFFECT_CALLS: Set[Tuple[str, str]] = {
+    ('rnd', 'next'),
+}
+
+_LANGUAGE = Language(tree_sitter_cpp.language())
+
+
+def _parser() -> Parser:
+    return Parser(_LANGUAGE)
+
+
+def _text(node: Node) -> str:
+    return node.text.decode('utf8')
+
+
+def _is_side_effect_call(node: Node) -> bool:
+    """True if `node` is a call_expression to a known side-effecting function."""
+    if node.type != 'call_expression':
+        return False
+    fn = node.child_by_field_name('function')
+    if fn is None or fn.type != 'field_expression':
+        return False
+    obj = fn.child_by_field_name('argument')
+    field = fn.child_by_field_name('field')
+    if obj is None or field is None:
+        return False
+    return (_text(obj), _text(field)) in SIDE_EFFECT_CALLS
+
+
+def _contains_side_effect_call(node: Node) -> bool:
+    if _is_side_effect_call(node):
+        return True
+    return any(_contains_side_effect_call(child) for child in node.named_children)
+
+
+def _argument_nodes(call: Node) -> List[Node]:
+    args = call.child_by_field_name('arguments')
+    if args is None:
+        return []
+    return list(args.named_children)
+
+
+class SideEffectLinter(Linter):
+    name = 'side_effect'
+    languages = {'cpp'}
+    applies_to = set()  # all kinds; restrictable via env config
+
+    def lint(self, code: CodeItem, source: str) -> List[LinterMessage]:
+        tree = _parser().parse(bytes(source, 'utf8'))
+        messages: List[LinterMessage] = []
+        self._visit(tree.root_node, messages)
+        return messages
+
+    def _visit(self, node: Node, messages: List[LinterMessage]) -> None:
+        if node.type == 'call_expression':
+            side_effect_args = sum(
+                1 for arg in _argument_nodes(node) if _contains_side_effect_call(arg)
+            )
+            if side_effect_args >= 2:
+                row, col = node.start_point
+                messages.append(
+                    LinterMessage(
+                        severity=LinterSeverity.WARNING,
+                        message=(
+                            'Call passes multiple side-effecting arguments '
+                            '(e.g. rnd.next()); C++ leaves argument evaluation '
+                            'order unspecified, so results may differ across '
+                            'compilers. Compute each value into a variable first.'
+                        ),
+                        line=row + 1,
+                        col=col + 1,
+                    )
+                )
+        for child in node.named_children:
+            self._visit(child, messages)
+
+
+registry.register(SideEffectLinter)

--- a/rbx/box/linters/cpp/testlib.py
+++ b/rbx/box/linters/cpp/testlib.py
@@ -4,6 +4,7 @@ import tree_sitter_cpp
 from tree_sitter import Language, Node, Parser
 
 from rbx.box.linters import registry
+from rbx.box.linters.asset_kind import AssetKind
 from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
 from rbx.box.schema import CodeItem
 
@@ -54,10 +55,15 @@ def _argument_nodes(call: Node) -> List[Node]:
     return list(args.named_children)
 
 
-class SideEffectLinter(Linter):
-    name = 'side_effect'
-    languages = {'cpp'}
-    applies_to = set()  # all kinds; restrictable via env config
+class TestlibLinter(Linter):
+    """Lints testlib/tgen/jngen-based C++ code.
+
+    Its first check flags side-effecting `rnd.next()` calls passed as multiple
+    arguments to the same call; more testlib-specific checks may be added later.
+    """
+
+    name = 'testlib'
+    applies_to = {AssetKind.GENERATOR}
 
     def lint(self, code: CodeItem, source: str) -> List[LinterMessage]:
         tree = _parser().parse(bytes(source, 'utf8'))
@@ -89,4 +95,4 @@ class SideEffectLinter(Linter):
             self._visit(child, messages)
 
 
-registry.register(SideEffectLinter)
+registry.register(TestlibLinter)

--- a/rbx/box/linters/linter.py
+++ b/rbx/box/linters/linter.py
@@ -21,10 +21,10 @@ class LinterMessage(BaseModel):
 
 
 class Linter(abc.ABC):
-    # Lowercase identifier referenced in env.rbx.yml.
+    # Lowercase identifier referenced in env.rbx.yml. A linter runs for whatever
+    # language entry it is configured under in env.rbx.yml; it is the user's
+    # responsibility to add it under languages where it makes sense.
     name: ClassVar[str]
-    # Env language names this linter supports (e.g. {'cpp'}).
-    languages: ClassVar[Set[str]]
     # Interface-level restriction; empty set means "all asset kinds".
     applies_to: ClassVar[Set[AssetKind]] = set()
 

--- a/rbx/box/linters/linter.py
+++ b/rbx/box/linters/linter.py
@@ -1,0 +1,34 @@
+import abc
+import enum
+from typing import ClassVar, List, Optional, Set
+
+from pydantic import BaseModel
+
+from rbx.box.linters.asset_kind import AssetKind
+from rbx.box.schema import CodeItem
+
+
+class LinterSeverity(enum.Enum):
+    WARNING = 'warning'
+    ERROR = 'error'
+
+
+class LinterMessage(BaseModel):
+    severity: LinterSeverity
+    message: str
+    line: Optional[int] = None  # 1-based
+    col: Optional[int] = None  # 1-based
+
+
+class Linter(abc.ABC):
+    # Lowercase identifier referenced in env.rbx.yml.
+    name: ClassVar[str]
+    # Env language names this linter supports (e.g. {'cpp'}).
+    languages: ClassVar[Set[str]]
+    # Interface-level restriction; empty set means "all asset kinds".
+    applies_to: ClassVar[Set[AssetKind]] = set()
+
+    @abc.abstractmethod
+    def lint(self, code: CodeItem, source: str) -> List[LinterMessage]:
+        """Analyze raw source text and return messages. Pure, synchronous."""
+        ...

--- a/rbx/box/linters/registry.py
+++ b/rbx/box/linters/registry.py
@@ -1,0 +1,21 @@
+from typing import Dict, Type
+
+from rbx.box.exception import RbxException
+from rbx.box.linters.linter import Linter
+
+_REGISTRY: Dict[str, Linter] = {}
+
+
+def register(linter_cls: Type[Linter]) -> Type[Linter]:
+    instance = linter_cls()
+    _REGISTRY[instance.name] = instance
+    return linter_cls
+
+
+def get_linter(name: str) -> Linter:
+    if name not in _REGISTRY:
+        with RbxException() as e:
+            e.print(f'[error]Unknown linter: [item]{name}[/item][/error]')
+            known = ', '.join(sorted(_REGISTRY)) or '(none)'
+            e.print(f'Known linters: {known}')
+    return _REGISTRY[name]

--- a/rbx/box/linters/runner.py
+++ b/rbx/box/linters/runner.py
@@ -1,0 +1,77 @@
+from typing import List, Optional
+
+from rbx.box.environment import LinterConfig
+from rbx.box.exception import RbxException
+from rbx.box.linters import registry
+from rbx.box.linters.asset_kind import AssetKind
+from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
+from rbx.box.sanitizers import warning_stack
+from rbx.box.schema import CodeItem
+
+
+def _in_scope(linter: Linter, config: LinterConfig, kind: Optional[AssetKind]) -> bool:
+    interface = linter.applies_to  # empty == all
+    config_scope = set(config.applies_to) if config.applies_to else None
+    effective = interface
+    if config_scope is not None:
+        effective = (interface & config_scope) if interface else config_scope
+    if not effective:
+        return True  # applies to all kinds
+    if kind is None:
+        return False  # restricted, but kind unknown -> skip
+    return kind in effective
+
+
+def run_linters_for_messages(
+    configs: List[LinterConfig],
+    linters: List[Linter],
+    language_name: str,
+    kind: Optional[AssetKind],
+    code,
+    source: str,
+) -> List[LinterMessage]:
+    out: List[LinterMessage] = []
+    for config, linter in zip(configs, linters):
+        if language_name not in linter.languages:
+            with RbxException() as e:
+                e.print(
+                    f'[error]Linter [item]{linter.name}[/item] does not support '
+                    f'language [item]{language_name}[/item][/error]'
+                )
+        if not _in_scope(linter, config, kind):
+            continue
+        out.extend(linter.lint(code, source))
+    return out
+
+
+async def run_linters(code: CodeItem, kind: Optional[AssetKind]) -> None:
+    """Run configured linters for `code` and route results.
+
+    Called from compile_item.
+    """
+    from rbx.box import code as code_module  # avoid import cycle
+
+    language = code_module.find_language(code)
+    configs = language.linters
+    if not configs:
+        return
+    linters = [registry.get_linter(c.name) for c in configs]
+    source = code.path.read_text()
+    messages = run_linters_for_messages(
+        configs=configs,
+        linters=linters,
+        language_name=language.name,
+        kind=kind,
+        code=code,
+        source=source,
+    )
+    warnings = [m for m in messages if m.severity is LinterSeverity.WARNING]
+    errors = [m for m in messages if m.severity is LinterSeverity.ERROR]
+    if warnings:
+        warning_stack.get_warning_stack().add_linter_warning(code, warnings)
+    if errors:
+        with RbxException() as e:
+            e.print(f'[error]Linter errors in {code.href()}[/error]')
+            for m in errors:
+                loc = f'{m.line}:{m.col} ' if m.line else ''
+                e.print(f'- {loc}{m.message}')

--- a/rbx/box/linters/runner.py
+++ b/rbx/box/linters/runner.py
@@ -10,13 +10,21 @@ from rbx.box.schema import CodeItem
 
 
 def _in_scope(linter: Linter, config: LinterConfig, kind: Optional[AssetKind]) -> bool:
-    interface = linter.applies_to  # empty == all
+    # An empty `applies_to` (interface or config) means "no restriction".
+    interface = linter.applies_to or None
     config_scope = set(config.applies_to) if config.applies_to else None
-    effective = interface
-    if config_scope is not None:
-        effective = (interface & config_scope) if interface else config_scope
+    if interface is None and config_scope is None:
+        return True  # unrestricted on both sides -> applies to all kinds
+    if interface is None:
+        effective = config_scope
+    elif config_scope is None:
+        effective = interface
+    else:
+        # Both restrict: the linter only applies to the intersection, which may
+        # be empty (disjoint scopes) -> the linter never applies.
+        effective = interface & config_scope
     if not effective:
-        return True  # applies to all kinds
+        return False
     if kind is None:
         return False  # restricted, but kind unknown -> skip
     return kind in effective
@@ -25,19 +33,12 @@ def _in_scope(linter: Linter, config: LinterConfig, kind: Optional[AssetKind]) -
 def run_linters_for_messages(
     configs: List[LinterConfig],
     linters: List[Linter],
-    language_name: str,
     kind: Optional[AssetKind],
     code,
     source: str,
 ) -> List[LinterMessage]:
     out: List[LinterMessage] = []
     for config, linter in zip(configs, linters):
-        if language_name not in linter.languages:
-            with RbxException() as e:
-                e.print(
-                    f'[error]Linter [item]{linter.name}[/item] does not support '
-                    f'language [item]{language_name}[/item][/error]'
-                )
         if not _in_scope(linter, config, kind):
             continue
         out.extend(linter.lint(code, source))
@@ -60,7 +61,6 @@ async def run_linters(code: CodeItem, kind: Optional[AssetKind]) -> None:
     messages = run_linters_for_messages(
         configs=configs,
         linters=linters,
-        language_name=language.name,
         kind=kind,
         code=code,
         source=source,

--- a/rbx/box/sanitizers/warning_stack.py
+++ b/rbx/box/sanitizers/warning_stack.py
@@ -1,13 +1,16 @@
 import functools
 import pathlib
 import shutil
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from rbx import console, utils
 from rbx.box.formatting import href
 from rbx.box.schema import CodeItem
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.steps import GradingFileOutput, PreprocessLog
+
+if TYPE_CHECKING:
+    from rbx.box.linters.linter import LinterMessage
 
 
 class WarningStack:
@@ -16,6 +19,7 @@ class WarningStack:
         self.warnings = set()
         self.warning_logs: Dict[pathlib.Path, List[PreprocessLog]] = {}
         self.sanitizer_warnings = {}
+        self.linter_warnings: Dict[pathlib.Path, List['LinterMessage']] = {}
 
     def add_warning(self, code: CodeItem, logs: Optional[List[PreprocessLog]] = None):
         self.warnings.add(code.path)
@@ -39,10 +43,19 @@ class WarningStack:
                 shutil.copyfileobj(f, fout)
         self.sanitizer_warnings[code.path] = dest_path
 
+    def add_linter_warning(
+        self, code: CodeItem, messages: List['LinterMessage']
+    ) -> None:
+        if not messages:
+            return
+        self.warnings.add(code.path)
+        self.linter_warnings.setdefault(code.path, []).extend(messages)
+
     def clear(self):
         self.warnings.clear()
         self.warning_logs.clear()
         self.sanitizer_warnings.clear()
+        self.linter_warnings.clear()
 
 
 @functools.cache
@@ -102,6 +115,15 @@ def print_warning_stack_report():
             summary = _summarize_warnings_for(path, stack, compilation_warnings)
             suffix = f' [warning]({summary})[/warning]' if summary else ''
             console.console.print(f'- {href(path)}{suffix}')
+            for message in stack.linter_warnings.get(path, []):
+                loc = ''
+                if message.line is not None:
+                    loc = (
+                        f'{message.line}:{message.col} '
+                        if message.col
+                        else (f'{message.line} ')
+                    )
+                console.console.print(f'    [warning]{loc}{message.message}[/warning]')
         console.console.print()
 
     if stack.sanitizer_warnings:

--- a/rbx/box/validators.py
+++ b/rbx/box/validators.py
@@ -10,6 +10,7 @@ from rbx import console
 from rbx.box import checkers, package, setter_config
 from rbx.box.code import SanitizationLevel, compile_item, run_item
 from rbx.box.fields import Primitive
+from rbx.box.linters.asset_kind import AssetKind
 from rbx.box.schema import CodeItem
 from rbx.box.testcase_extractors import (
     GenerationMetadata,
@@ -46,7 +47,9 @@ class TestcaseValidationInfo(BaseModel):
 
 async def _compile_validator(validator: CodeItem) -> str:
     try:
-        digest = await compile_item(validator, sanitized=SanitizationLevel.PREFER)
+        digest = await compile_item(
+            validator, sanitized=SanitizationLevel.PREFER, kind=AssetKind.VALIDATOR
+        )
     except Exception:
         console.console.print(
             f'[error]Failed compiling validator {validator.href()}.[/error]'

--- a/tests/rbx/box/linters/test_asset_kind.py
+++ b/tests/rbx/box/linters/test_asset_kind.py
@@ -1,0 +1,17 @@
+from rbx.box.linters.asset_kind import AssetKind, infer_asset_kind
+from rbx.box.schema import Checker, CodeItem, Generator, Interactor, Solution
+
+
+def test_infer_asset_kind_for_typed_subclasses():
+    assert infer_asset_kind(Generator(path='g.cpp', name='gen')) is AssetKind.GENERATOR
+    assert infer_asset_kind(Checker(path='c.cpp')) is AssetKind.CHECKER
+    assert infer_asset_kind(Interactor(path='i.cpp')) is AssetKind.INTERACTOR
+    assert (
+        infer_asset_kind(Solution(path='s.cpp', outcome='accepted'))
+        is AssetKind.SOLUTION
+    )
+
+
+def test_infer_asset_kind_for_bare_codeitem_is_none():
+    # Validators are bare CodeItems; their kind is not inferable from type.
+    assert infer_asset_kind(CodeItem(path='v.cpp')) is None

--- a/tests/rbx/box/linters/test_linter_config.py
+++ b/tests/rbx/box/linters/test_linter_config.py
@@ -1,0 +1,28 @@
+from rbx.box.environment import EnvironmentLanguage, ExecutionConfig, LinterConfig
+from rbx.box.linters.asset_kind import AssetKind
+
+
+def _lang(**kw):
+    return EnvironmentLanguage(
+        name='cpp', extension='cpp', execution=ExecutionConfig(), **kw
+    )
+
+
+def test_linters_default_empty():
+    assert _lang().linters == []
+
+
+def test_shorthand_string_coerced_to_config():
+    lang = _lang(linters=['side_effect'])
+    assert lang.linters == [LinterConfig(name='side_effect', applies_to=None)]
+
+
+def test_full_form_with_applies_to():
+    lang = _lang(linters=[{'name': 'side_effect', 'applies_to': ['generators']}])
+    assert lang.linters[0].name == 'side_effect'
+    assert lang.linters[0].applies_to == [AssetKind.GENERATOR]
+
+
+def test_singular_applies_to_token_accepted():
+    lang = _lang(linters=[{'name': 'side_effect', 'applies_to': ['generator']}])
+    assert lang.linters[0].applies_to == [AssetKind.GENERATOR]

--- a/tests/rbx/box/linters/test_linter_config.py
+++ b/tests/rbx/box/linters/test_linter_config.py
@@ -13,16 +13,16 @@ def test_linters_default_empty():
 
 
 def test_shorthand_string_coerced_to_config():
-    lang = _lang(linters=['side_effect'])
-    assert lang.linters == [LinterConfig(name='side_effect', applies_to=None)]
+    lang = _lang(linters=['testlib'])
+    assert lang.linters == [LinterConfig(name='testlib', applies_to=None)]
 
 
 def test_full_form_with_applies_to():
-    lang = _lang(linters=[{'name': 'side_effect', 'applies_to': ['generators']}])
-    assert lang.linters[0].name == 'side_effect'
+    lang = _lang(linters=[{'name': 'testlib', 'applies_to': ['generators']}])
+    assert lang.linters[0].name == 'testlib'
     assert lang.linters[0].applies_to == [AssetKind.GENERATOR]
 
 
 def test_singular_applies_to_token_accepted():
-    lang = _lang(linters=[{'name': 'side_effect', 'applies_to': ['generator']}])
+    lang = _lang(linters=[{'name': 'testlib', 'applies_to': ['generator']}])
     assert lang.linters[0].applies_to == [AssetKind.GENERATOR]

--- a/tests/rbx/box/linters/test_linter_interface.py
+++ b/tests/rbx/box/linters/test_linter_interface.py
@@ -5,7 +5,6 @@ from rbx.box.schema import CodeItem
 
 class _DummyLinter(Linter):
     name = 'dummy'
-    languages = {'cpp'}
     applies_to = {AssetKind.GENERATOR}
 
     def lint(self, code, source):
@@ -15,7 +14,6 @@ class _DummyLinter(Linter):
 def test_linter_metadata_and_lint():
     linter = _DummyLinter()
     assert linter.name == 'dummy'
-    assert linter.languages == {'cpp'}
     assert linter.applies_to == {AssetKind.GENERATOR}
     msgs = linter.lint(CodeItem(path='g.cpp'), 'source')
     assert msgs == [

--- a/tests/rbx/box/linters/test_linter_interface.py
+++ b/tests/rbx/box/linters/test_linter_interface.py
@@ -1,0 +1,23 @@
+from rbx.box.linters.asset_kind import AssetKind
+from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
+from rbx.box.schema import CodeItem
+
+
+class _DummyLinter(Linter):
+    name = 'dummy'
+    languages = {'cpp'}
+    applies_to = {AssetKind.GENERATOR}
+
+    def lint(self, code, source):
+        return [LinterMessage(severity=LinterSeverity.WARNING, message='hi', line=1)]
+
+
+def test_linter_metadata_and_lint():
+    linter = _DummyLinter()
+    assert linter.name == 'dummy'
+    assert linter.languages == {'cpp'}
+    assert linter.applies_to == {AssetKind.GENERATOR}
+    msgs = linter.lint(CodeItem(path='g.cpp'), 'source')
+    assert msgs == [
+        LinterMessage(severity=LinterSeverity.WARNING, message='hi', line=1)
+    ]

--- a/tests/rbx/box/linters/test_registry.py
+++ b/tests/rbx/box/linters/test_registry.py
@@ -1,0 +1,23 @@
+import pytest
+
+from rbx.box.exception import RbxException
+from rbx.box.linters import registry
+from rbx.box.linters.linter import Linter
+
+
+@registry.register
+class _RegLinter(Linter):
+    name = 'reg_test'
+    languages = {'cpp'}
+
+    def lint(self, code, source):
+        return []
+
+
+def test_register_and_get():
+    assert isinstance(registry.get_linter('reg_test'), _RegLinter)
+
+
+def test_get_unknown_raises():
+    with pytest.raises(RbxException):
+        registry.get_linter('does_not_exist')

--- a/tests/rbx/box/linters/test_registry.py
+++ b/tests/rbx/box/linters/test_registry.py
@@ -8,7 +8,6 @@ from rbx.box.linters.linter import Linter
 @registry.register
 class _RegLinter(Linter):
     name = 'reg_test'
-    languages = {'cpp'}
 
     def lint(self, code, source):
         return []

--- a/tests/rbx/box/linters/test_runner.py
+++ b/tests/rbx/box/linters/test_runner.py
@@ -6,7 +6,6 @@ from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
 
 class _WarnLinter(Linter):
     name = 'w_test'
-    languages = {'cpp'}
     applies_to = set()
 
     def lint(self, code, source):
@@ -15,7 +14,6 @@ class _WarnLinter(Linter):
 
 class _ErrLinter(Linter):
     name = 'e_test'
-    languages = {'cpp'}
     applies_to = {AssetKind.GENERATOR}
 
     def lint(self, code, source):
@@ -27,7 +25,6 @@ def test_applies_to_intersection_skips_out_of_scope():
     msgs = runner.run_linters_for_messages(
         configs=[LinterConfig(name='e_test', applies_to=None)],
         linters=[_ErrLinter()],
-        language_name='cpp',
         kind=AssetKind.SOLUTION,
         code=None,
         source='x',
@@ -39,8 +36,20 @@ def test_config_applies_to_further_restricts():
     msgs = runner.run_linters_for_messages(
         configs=[LinterConfig(name='w_test', applies_to=[AssetKind.GENERATOR])],
         linters=[_WarnLinter()],
-        language_name='cpp',
         kind=AssetKind.SOLUTION,
+        code=None,
+        source='x',
+    )
+    assert msgs == []
+
+
+def test_disjoint_interface_and_config_scopes_never_apply():
+    # Interface restricts to generators, config restricts to solutions: the
+    # intersection is empty, so the linter must not run even on a generator.
+    msgs = runner.run_linters_for_messages(
+        configs=[LinterConfig(name='e_test', applies_to=[AssetKind.SOLUTION])],
+        linters=[_ErrLinter()],
+        kind=AssetKind.GENERATOR,
         code=None,
         source='x',
     )
@@ -51,7 +60,6 @@ def test_in_scope_linter_runs():
     msgs = runner.run_linters_for_messages(
         configs=[LinterConfig(name='w_test', applies_to=None)],
         linters=[_WarnLinter()],
-        language_name='cpp',
         kind=AssetKind.SOLUTION,
         code=None,
         source='x',

--- a/tests/rbx/box/linters/test_runner.py
+++ b/tests/rbx/box/linters/test_runner.py
@@ -1,0 +1,60 @@
+from rbx.box.environment import LinterConfig
+from rbx.box.linters import runner
+from rbx.box.linters.asset_kind import AssetKind
+from rbx.box.linters.linter import Linter, LinterMessage, LinterSeverity
+
+
+class _WarnLinter(Linter):
+    name = 'w_test'
+    languages = {'cpp'}
+    applies_to = set()
+
+    def lint(self, code, source):
+        return [LinterMessage(severity=LinterSeverity.WARNING, message='w')]
+
+
+class _ErrLinter(Linter):
+    name = 'e_test'
+    languages = {'cpp'}
+    applies_to = {AssetKind.GENERATOR}
+
+    def lint(self, code, source):
+        return [LinterMessage(severity=LinterSeverity.ERROR, message='boom')]
+
+
+def test_applies_to_intersection_skips_out_of_scope():
+    # _ErrLinter only applies to generators; a solution-kind asset is skipped.
+    msgs = runner.run_linters_for_messages(
+        configs=[LinterConfig(name='e_test', applies_to=None)],
+        linters=[_ErrLinter()],
+        language_name='cpp',
+        kind=AssetKind.SOLUTION,
+        code=None,
+        source='x',
+    )
+    assert msgs == []
+
+
+def test_config_applies_to_further_restricts():
+    msgs = runner.run_linters_for_messages(
+        configs=[LinterConfig(name='w_test', applies_to=[AssetKind.GENERATOR])],
+        linters=[_WarnLinter()],
+        language_name='cpp',
+        kind=AssetKind.SOLUTION,
+        code=None,
+        source='x',
+    )
+    assert msgs == []
+
+
+def test_in_scope_linter_runs():
+    msgs = runner.run_linters_for_messages(
+        configs=[LinterConfig(name='w_test', applies_to=None)],
+        linters=[_WarnLinter()],
+        language_name='cpp',
+        kind=AssetKind.SOLUTION,
+        code=None,
+        source='x',
+    )
+    assert len(msgs) == 1
+    assert msgs[0].message == 'w'

--- a/tests/rbx/box/linters/test_side_effect.py
+++ b/tests/rbx/box/linters/test_side_effect.py
@@ -1,0 +1,44 @@
+from rbx.box.linters.cpp.side_effect import SideEffectLinter
+from rbx.box.linters.linter import LinterSeverity
+from rbx.box.schema import CodeItem
+
+
+def _lint(src: str):
+    return SideEffectLinter().lint(CodeItem(path='gen.cpp'), src)
+
+
+def _wrap(body: str) -> str:
+    return 'void f() {\n' + body + '\n}\n'
+
+
+def test_two_side_effect_args_warns():
+    msgs = _lint(_wrap('some_function(rnd.next(), rnd.next());'))
+    assert len(msgs) == 1
+    assert msgs[0].severity is LinterSeverity.WARNING
+
+
+def test_one_side_effect_arg_is_ok():
+    assert _lint(_wrap('some_function(rnd.next(), 3);')) == []
+
+
+def test_unknown_side_effect_func_not_flagged_v1():
+    # fn_with_side_effect uses the SIDE_EFFECT macro, deferred to a follow-up.
+    assert _lint(_wrap('some_function(fn_with_side_effect(), rnd.next());')) == []
+
+
+def test_nested_call_is_flagged():
+    msgs = _lint(_wrap('outer(g(rnd.next(), rnd.next()));'))
+    assert len(msgs) == 1
+
+
+def test_cout_chain_not_flagged():
+    assert _lint(_wrap('std::cout << rnd.next() << rnd.next();')) == []
+
+
+def test_clean_source_no_warnings():
+    assert _lint(_wrap('int x = 1; some_function(x, x);')) == []
+
+
+def test_message_has_location():
+    msgs = _lint(_wrap('some_function(rnd.next(), rnd.next());'))
+    assert msgs[0].line is not None and msgs[0].col is not None

--- a/tests/rbx/box/linters/test_side_effect_integration.py
+++ b/tests/rbx/box/linters/test_side_effect_integration.py
@@ -1,0 +1,71 @@
+from rbx.box import code
+from rbx.box.environment import LinterConfig
+from rbx.box.linters.asset_kind import AssetKind
+from rbx.box.sanitizers import warning_stack
+from rbx.box.schema import CodeItem
+from rbx.box.testing import testing_package
+
+_OFFENDING_GENERATOR = """#include <cstdio>
+int rnd_next() { return 0; }
+struct Rnd { int next(int a, int b) { return a; } } rnd;
+int main() {
+    printf("%d %d", rnd.next(0, 9), rnd.next(0, 9));
+    return 0;
+}
+"""
+
+
+def _cpp_language_with_linters(configs):
+    """Return a copy of the cpp env language with the given linters set."""
+    base = code.find_language(CodeItem(path='x.cpp', language='cpp'))
+    return base.model_copy(update={'linters': configs})
+
+
+async def _compile_lenient(code_item, **kwargs):
+    """Compile, tolerating compiler/sandbox failures (lint runs first)."""
+    try:
+        await code.compile_item(code_item, **kwargs)
+    except Exception:
+        # The lint step runs before the compiler in compile_item; even if the
+        # actual compile/sandbox step fails on this machine, the lint warnings
+        # were already recorded on the warning stack.
+        pass
+
+
+async def test_side_effect_warning_lands_on_generator(
+    testing_pkg: testing_package.TestingPackage, monkeypatch
+):
+    cpp_file = testing_pkg.add_file('gen.cpp')
+    cpp_file.write_text(_OFFENDING_GENERATOR)
+    code_item = CodeItem(path=cpp_file, language='cpp')
+
+    language = _cpp_language_with_linters([LinterConfig(name='side_effect')])
+    monkeypatch.setattr('rbx.box.code.find_language', lambda _: language)
+
+    warning_stack.get_warning_stack().clear()
+    await _compile_lenient(code_item, kind=AssetKind.GENERATOR)
+
+    stack = warning_stack.get_warning_stack()
+    assert code_item.path in stack.linter_warnings
+    messages = stack.linter_warnings[code_item.path]
+    assert len(messages) == 1
+    assert 'side-effecting' in messages[0].message
+
+
+async def test_side_effect_not_flagged_when_scoped_to_solutions(
+    testing_pkg: testing_package.TestingPackage, monkeypatch
+):
+    cpp_file = testing_pkg.add_file('gen.cpp')
+    cpp_file.write_text(_OFFENDING_GENERATOR)
+    code_item = CodeItem(path=cpp_file, language='cpp')
+
+    language = _cpp_language_with_linters(
+        [LinterConfig(name='side_effect', applies_to=[AssetKind.SOLUTION])]
+    )
+    monkeypatch.setattr('rbx.box.code.find_language', lambda _: language)
+
+    warning_stack.get_warning_stack().clear()
+    await _compile_lenient(code_item, kind=AssetKind.GENERATOR)
+
+    stack = warning_stack.get_warning_stack()
+    assert code_item.path not in stack.linter_warnings

--- a/tests/rbx/box/linters/test_testlib.py
+++ b/tests/rbx/box/linters/test_testlib.py
@@ -1,10 +1,10 @@
-from rbx.box.linters.cpp.side_effect import SideEffectLinter
+from rbx.box.linters.cpp.testlib import TestlibLinter
 from rbx.box.linters.linter import LinterSeverity
 from rbx.box.schema import CodeItem
 
 
 def _lint(src: str):
-    return SideEffectLinter().lint(CodeItem(path='gen.cpp'), src)
+    return TestlibLinter().lint(CodeItem(path='gen.cpp'), src)
 
 
 def _wrap(body: str) -> str:

--- a/tests/rbx/box/linters/test_testlib_integration.py
+++ b/tests/rbx/box/linters/test_testlib_integration.py
@@ -32,14 +32,14 @@ async def _compile_lenient(code_item, **kwargs):
         pass
 
 
-async def test_side_effect_warning_lands_on_generator(
+async def test_testlib_warning_lands_on_generator(
     testing_pkg: testing_package.TestingPackage, monkeypatch
 ):
     cpp_file = testing_pkg.add_file('gen.cpp')
     cpp_file.write_text(_OFFENDING_GENERATOR)
     code_item = CodeItem(path=cpp_file, language='cpp')
 
-    language = _cpp_language_with_linters([LinterConfig(name='side_effect')])
+    language = _cpp_language_with_linters([LinterConfig(name='testlib')])
     monkeypatch.setattr('rbx.box.code.find_language', lambda _: language)
 
     warning_stack.get_warning_stack().clear()
@@ -52,15 +52,17 @@ async def test_side_effect_warning_lands_on_generator(
     assert 'side-effecting' in messages[0].message
 
 
-async def test_side_effect_not_flagged_when_scoped_to_solutions(
+async def test_testlib_not_flagged_when_scoped_to_solutions(
     testing_pkg: testing_package.TestingPackage, monkeypatch
 ):
     cpp_file = testing_pkg.add_file('gen.cpp')
     cpp_file.write_text(_OFFENDING_GENERATOR)
     code_item = CodeItem(path=cpp_file, language='cpp')
 
+    # Interface restricts to generators; config restricts to solutions. The
+    # disjoint intersection means the linter must not run on this generator.
     language = _cpp_language_with_linters(
-        [LinterConfig(name='side_effect', applies_to=[AssetKind.SOLUTION])]
+        [LinterConfig(name='testlib', applies_to=[AssetKind.SOLUTION])]
     )
     monkeypatch.setattr('rbx.box.code.find_language', lambda _: language)
 

--- a/tests/rbx/box/linters/test_treesitter_smoke.py
+++ b/tests/rbx/box/linters/test_treesitter_smoke.py
@@ -1,0 +1,10 @@
+import tree_sitter_cpp
+from tree_sitter import Language, Parser
+
+
+def test_cpp_parser_constructs_and_parses():
+    language = Language(tree_sitter_cpp.language())
+    parser = Parser(language)
+    tree = parser.parse(b'int main() { return 0; }')
+    assert tree.root_node.type == 'translation_unit'
+    assert not tree.root_node.has_error

--- a/tests/rbx/box/linters/test_warning_stack_linter.py
+++ b/tests/rbx/box/linters/test_warning_stack_linter.py
@@ -1,0 +1,14 @@
+from rbx.box.linters.linter import LinterMessage, LinterSeverity
+from rbx.box.sanitizers.warning_stack import WarningStack
+from rbx.box.schema import CodeItem
+
+
+def test_add_linter_warning_records_messages(tmp_path):
+    stack = WarningStack(tmp_path)
+    code = CodeItem(path='gen.cpp')
+    stack.add_linter_warning(
+        code,
+        [LinterMessage(severity=LinterSeverity.WARNING, message='m', line=2, col=3)],
+    )
+    assert code.path in stack.warnings
+    assert stack.linter_warnings[code.path][0].message == 'm'

--- a/uv.lock
+++ b/uv.lock
@@ -2762,6 +2762,8 @@ dependencies = [
     { name = "textual" },
     { name = "textual-serve" },
     { name = "throttlex" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-cpp" },
     { name = "typer" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
@@ -2832,6 +2834,8 @@ requires-dist = [
     { name = "textual", specifier = ">=8.0" },
     { name = "textual-serve", specifier = ">=1.1.2" },
     { name = "throttlex", specifier = ">=1.0.0" },
+    { name = "tree-sitter", specifier = ">=0.22.0" },
+    { name = "tree-sitter-cpp", specifier = ">=0.22.0" },
     { name = "typer", specifier = ">=0.15.1" },
     { name = "typing-extensions", specifier = ">=4.14.1" },
     { name = "uvicorn", specifier = ">=0.35.1" },
@@ -3464,6 +3468,64 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20", size = 177961, upload-time = "2025-09-25T17:37:59.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/d4/f7ffb855cb039b7568aba4911fbe42e4c39c0e4398387c8e0d8251489992/tree_sitter-0.25.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72a510931c3c25f134aac2daf4eb4feca99ffe37a35896d7150e50ac3eee06c7", size = 146749, upload-time = "2025-09-25T17:37:16.475Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/58/f8a107f9f89700c0ab2930f1315e63bdedccbb5fd1b10fcbc5ebadd54ac8/tree_sitter-0.25.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44488e0e78146f87baaa009736886516779253d6d6bac3ef636ede72bc6a8234", size = 137766, upload-time = "2025-09-25T17:37:18.138Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fb/357158d39f01699faea466e8fd5a849f5a30252c68414bddc20357a9ac79/tree_sitter-0.25.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2f8e7d6b2f8489d4a9885e3adcaef4bc5ff0a275acd990f120e29c4ab3395c5", size = 599809, upload-time = "2025-09-25T17:37:19.169Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/68ae301626f2393a62119481cb660eb93504a524fc741a6f1528a4568cf6/tree_sitter-0.25.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20b570690f87f1da424cd690e51cc56728d21d63f4abd4b326d382a30353acc7", size = 627676, upload-time = "2025-09-25T17:37:20.715Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fe/4c1bef37db5ca8b17ca0b3070f2dff509468a50b3af18f17665adcab42b9/tree_sitter-0.25.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a0ec41b895da717bc218a42a3a7a0bfcfe9a213d7afaa4255353901e0e21f696", size = 624281, upload-time = "2025-09-25T17:37:21.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/3283cb7fa251cae2a0bf8661658021a789810db3ab1b0569482d4a3671fd/tree_sitter-0.25.2-cp310-cp310-win_amd64.whl", hash = "sha256:7712335855b2307a21ae86efe949c76be36c6068d76df34faa27ce9ee40ff444", size = 127295, upload-time = "2025-09-25T17:37:22.977Z" },
+    { url = "https://files.pythonhosted.org/packages/88/90/ceb05e6de281aebe82b68662890619580d4ffe09283ebd2ceabcf5df7b4a/tree_sitter-0.25.2-cp310-cp310-win_arm64.whl", hash = "sha256:a925364eb7fbb9cdce55a9868f7525a1905af512a559303bd54ef468fd88cb37", size = 113991, upload-time = "2025-09-25T17:37:23.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/22/88a1e00b906d26fa8a075dd19c6c3116997cb884bf1b3c023deb065a344d/tree_sitter-0.25.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8ca72d841215b6573ed0655b3a5cd1133f9b69a6fa561aecad40dca9029d75b", size = 146752, upload-time = "2025-09-25T17:37:24.775Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1c/22cc14f3910017b7a76d7358df5cd315a84fe0c7f6f7b443b49db2e2790d/tree_sitter-0.25.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cc0351cfe5022cec5a77645f647f92a936b38850346ed3f6d6babfbeeeca4d26", size = 137765, upload-time = "2025-09-25T17:37:26.103Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0c/d0de46ded7d5b34631e0f630d9866dab22d3183195bf0f3b81de406d6622/tree_sitter-0.25.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1799609636c0193e16c38f366bda5af15b1ce476df79ddaae7dd274df9e44266", size = 604643, upload-time = "2025-09-25T17:37:27.398Z" },
+    { url = "https://files.pythonhosted.org/packages/34/38/b735a58c1c2f60a168a678ca27b4c1a9df725d0bf2d1a8a1c571c033111e/tree_sitter-0.25.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e65ae456ad0d210ee71a89ee112ac7e72e6c2e5aac1b95846ecc7afa68a194c", size = 632229, upload-time = "2025-09-25T17:37:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f6/cda1e1e6cbff5e28d8433578e2556d7ba0b0209d95a796128155b97e7693/tree_sitter-0.25.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:49ee3c348caa459244ec437ccc7ff3831f35977d143f65311572b8ba0a5f265f", size = 629861, upload-time = "2025-09-25T17:37:29.593Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/19/427e5943b276a0dd74c2a1f1d7a7393443f13d1ee47dedb3f8127903c080/tree_sitter-0.25.2-cp311-cp311-win_amd64.whl", hash = "sha256:56ac6602c7d09c2c507c55e58dc7026b8988e0475bd0002f8a386cce5e8e8adc", size = 127304, upload-time = "2025-09-25T17:37:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d9/eef856dc15f784d85d1397a17f3ee0f82df7778efce9e1961203abfe376a/tree_sitter-0.25.2-cp311-cp311-win_arm64.whl", hash = "sha256:b3d11a3a3ac89bb8a2543d75597f905a9926f9c806f40fcca8242922d1cc6ad5", size = 113990, upload-time = "2025-09-25T17:37:31.852Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/9e/20c2a00a862f1c2897a436b17edb774e831b22218083b459d0d081c9db33/tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960", size = 146941, upload-time = "2025-09-25T17:37:34.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/8512e2062e652a1016e840ce36ba1cc33258b0dcc4e500d8089b4054afec/tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c", size = 137699, upload-time = "2025-09-25T17:37:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8a/d48c0414db19307b0fb3bb10d76a3a0cbe275bb293f145ee7fba2abd668e/tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99", size = 607125, upload-time = "2025-09-25T17:37:37.725Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/b95f545e9fc5001b8a78636ef942a4e4e536580caa6a99e73dd0a02e87aa/tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9", size = 635418, upload-time = "2025-09-25T17:37:38.922Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/b734bde3fb6f3513a010fa91f1f2875442cdc0382d6a949005cd84563d8f/tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac", size = 631250, upload-time = "2025-09-25T17:37:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/5f654994f36d10c64d50a192239599fcae46677491c8dd53e7579c35a3e3/tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897", size = 127156, upload-time = "2025-09-25T17:37:41.132Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/148c468d410efcf0a9535272d81c258d840c27b34781d625f1f627e2e27d/tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5", size = 113984, upload-time = "2025-09-25T17:37:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/67492014ce32729b63d7ef318a19f9cfedd855d677de5773476caf771e96/tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd", size = 146926, upload-time = "2025-09-25T17:37:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/a278b15e6b263e86c5e301c82a60923fa7c59d44f78d7a110a89a413e640/tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601", size = 137712, upload-time = "2025-09-25T17:37:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/423bba15d2bf6473ba67846ba5244b988cd97a4b1ea2b146822162256794/tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053", size = 607873, upload-time = "2025-09-25T17:37:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/b430d2cb43f8badfb3a3fa9d6cd7c8247698187b5674008c9d67b2a90c8e/tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614", size = 636313, upload-time = "2025-09-25T17:37:46.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/5f97098dbba807331d666a0997662e82d066e84b17d92efab575d283822f/tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae", size = 631370, upload-time = "2025-09-25T17:37:47.993Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/87caaed663fabc35e18dc704cd0e9800a0ee2f22bd18b9cbe7c10799895d/tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b", size = 127157, upload-time = "2025-09-25T17:37:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/23/f8467b408b7988aff4ea40946a4bd1a2c1a73d17156a9d039bbaff1e2ceb/tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8", size = 113975, upload-time = "2025-09-25T17:37:49.922Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0", size = 146776, upload-time = "2025-09-25T17:37:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87", size = 137732, upload-time = "2025-09-25T17:37:51.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab", size = 609456, upload-time = "2025-09-25T17:37:52.925Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358", size = 636772, upload-time = "2025-09-25T17:37:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/2c/4dd63d705a8933543cad9b92ff31be849b164fec91a6eb63475ebc9ce668/tree_sitter_cpp-0.23.4.tar.gz", hash = "sha256:6a59c4cebb1ad1dc2e8d586cf8a72b39d21b8108b7b139d089719e81a339e41d", size = 940358, upload-time = "2024-11-11T06:59:24.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/ac/11d56670f7b048362db872ca866fd00ba2002a322ab179f047b7c0fb2910/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aacb1759f0efd9dbc25bd8ee88184a340483018869f75412d9c3bc32c039a520", size = 287861, upload-time = "2024-11-11T06:59:15.005Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1c/0337c016bdc00a77a3326d12f10ee836401dd28f27db6fd5b7734bfb21ed/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc3c404d9f0cbd87951213a85440afbf4c31e718f8d907fa9ee12bea4b8d276f", size = 315513, upload-time = "2024-11-11T06:59:16.679Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7b/dd38c049b10ed7fda118b903a1d28a8b55a36b98c30606ef90e8f374c6de/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccc43ddf1279d5d5a4ef190373f4cb16522801bec4492bcd4754edf2aeba2b7b", size = 334813, upload-time = "2024-11-11T06:59:18.253Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4d/23e390234d2acd351f5563b1079c515d7c1fe13ddb7392cee543be74dda3/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:773d2cafc08bbc0f998687fa33f42f378c1a371cdb582870c4d13abb06092706", size = 316110, upload-time = "2024-11-11T06:59:19.823Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c7/b94a7e0e803af9d3bd4608fb4f0cfb2e9e233abaf0a38c928bfb0b1a025d/tree_sitter_cpp-0.23.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:247d127f0eb6574b0f6b30c0151e0bd0774e2e7acf9c558bdf9fbb8adc2e80c0", size = 308242, upload-time = "2024-11-11T06:59:21.466Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7e/909e52b3dec09c475140b0e175511e275d0d00ba2dbd7c68102d377ae0f6/tree_sitter_cpp-0.23.4-cp39-abi3-win_amd64.whl", hash = "sha256:68606a45bea92669d155399e1239f771a7767d8683cd8f8e30e7d813107030ca", size = 290997, upload-time = "2024-11-11T06:59:22.432Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6a/65435d4d1f4c735be7ffe52d7c2e7b8a7f7c2790343a2719c60c548611c8/tree_sitter_cpp-0.23.4-cp39-abi3-win_arm64.whl", hash = "sha256:712f84f18be94cbe2a148fa4fdf40fcf4a8c25a8f7670efb9f8a47ddec2fc281", size = 288203, upload-time = "2024-11-11T06:59:23.404Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #476.

## Summary

Adds a built-in **linter framework** to rbx plus the first linter, `side_effect`.

- **Framework** (`rbx/box/linters/`): a `Linter` ABC + name→instance registry. Linters are configured **per language** in `env.rbx.yml` via a new `linters` field, run during the **compilation phase** (inside `compile_item`), and produce messages routed by severity — `WARNING` → the existing warning stack, `ERROR` → `RbxException`.
- **Asset scoping**: a new `AssetKind` enum (`generator`, `validator`, `solution`, `checker`, `interactor`, `visualizer`). Kind is inferred from the `CodeItem` subclass where possible; validators are bare `CodeItem`s, so `compile_item` takes an explicit `kind` argument that `validators.py` passes. Linters can be restricted both in the interface (`applies_to`) and in config; the effective scope is their intersection.
- **Config forms** (both supported):
  ```yaml
  languages:
    - name: cpp
      linters:
        - side_effect                                   # shorthand
        - {name: side_effect, applies_to: [generators]} # restricted
  ```
- **`side_effect` linter** (`tree-sitter-cpp`): warns when a call passes **≥2 arguments** that each contain a known side-effecting call. C++ leaves argument evaluation order unspecified, which silently reordered `println(rnd.next(...), rnd.next(...))` under some compilers. v1 detects the hardcoded `rnd.next` family (testlib/tgen/jngen).

## Scope decisions (from the design doc)
- `side_effect` emits **warnings** by default; the interface still supports errors for future linters.
- v1 is **hardcoded `rnd.next` only**. The `SIDE_EFFECT` macro + header expansion described in the issue are **deferred** (TODO in `side_effect.py`); a follow-up issue should be opened.

Design and plan: `docs/plans/2026-05-23-linters-design.md`, `docs/plans/2026-05-23-linters.md`.

## Behavior on the issue's examples
```cpp
some_function(rnd.next(), rnd.next());            // WARN  (2 side-effect args)
some_function(rnd.next(), 3);                     // OK    (1 side-effect arg)
some_function(fn_with_side_effect(), rnd.next()); // OK in v1 (macro not yet detected)
```
`cout << rnd.next() << rnd.next()` is not flagged (`<<` operands are sequenced). Nested calls are covered.

## Dependencies
Adds `tree-sitter` and `tree-sitter-cpp` (resolved to 0.25.2 / 0.23.4).

## Testing
- 23 new tests in `tests/rbx/box/linters/` — all pass.
- `ruff format`/`ruff check` clean.
- The default env ships **no** `linters` config, so `run_linters` returns immediately on existing code paths (verified no-op).
- Full suite: pre-existing C++ compile/sandbox/checker/validator/docker failures on the local machine are unrelated to this change; no new failures introduced.

## Follow-up
Open an issue for `SIDE_EFFECT` macro detection + header expansion (referenced by the TODO in `side_effect.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)