### PR TITLE
feat(linters): group repeated linter warnings by message

### DIFF
--- a/rbx/box/sanitizers/warning_stack.py
+++ b/rbx/box/sanitizers/warning_stack.py
@@ -1,7 +1,7 @@
 import functools
 import pathlib
 import shutil
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from rbx import console, utils
 from rbx.box.formatting import href
@@ -83,6 +83,32 @@ def get_warning_stack() -> WarningStack:
     return _get_warning_stack(current_root)
 
 
+def _format_linter_location(message: 'LinterMessage') -> str:
+    if message.line is None:
+        return ''
+    if message.col:
+        return f'{message.line}:{message.col}'
+    return str(message.line)
+
+
+def group_linter_messages(
+    messages: List['LinterMessage'],
+) -> List[Tuple[str, List[str]]]:
+    """Group linter messages by identical text, collecting their locations.
+
+    Returns a list of ``(message, locations)`` pairs in first-seen order.
+    Locations are formatted as ``line:col`` (or ``line``) strings, deduped
+    while preserving order; messages with no location yield an empty list.
+    """
+    grouped: Dict[str, List[str]] = {}
+    for message in messages:
+        locations = grouped.setdefault(message.message, [])
+        loc = _format_linter_location(message)
+        if loc and loc not in locations:
+            locations.append(loc)
+    return list(grouped.items())
+
+
 def _summarize_warnings_for(path, stack, compilation_warnings) -> Optional[str]:
     logs = stack.warning_logs.get(path, [])
     warning_logs = [log for log in logs if log.warnings]
@@ -115,15 +141,16 @@ def print_warning_stack_report():
             summary = _summarize_warnings_for(path, stack, compilation_warnings)
             suffix = f' [warning]({summary})[/warning]' if summary else ''
             console.console.print(f'- {href(path)}{suffix}')
-            for message in stack.linter_warnings.get(path, []):
-                loc = ''
-                if message.line is not None:
-                    loc = (
-                        f'{message.line}:{message.col} '
-                        if message.col
-                        else (f'{message.line} ')
-                    )
-                console.console.print(f'    [warning]{loc}{message.message}[/warning]')
+            for message, locations in group_linter_messages(
+                stack.linter_warnings.get(path, [])
+            ):
+                if not locations:
+                    prefix = ''
+                elif len(locations) == 1:
+                    prefix = f'{locations[0]} '
+                else:
+                    prefix = f'lines {", ".join(locations)}: '
+                console.console.print(f'    [warning]{prefix}{message}[/warning]')
         console.console.print()
 
     if stack.sanitizer_warnings:

--- a/tests/rbx/box/sanitizers/test_warning_stack_report.py
+++ b/tests/rbx/box/sanitizers/test_warning_stack_report.py
@@ -2,6 +2,7 @@ import pathlib
 
 from rbx import console as rconsole
 from rbx import utils
+from rbx.box.linters.linter import LinterMessage, LinterSeverity
 from rbx.box.sanitizers import warning_stack
 from rbx.box.schema import CodeItem
 from rbx.grading.steps import PreprocessLog
@@ -32,6 +33,30 @@ def test_report_includes_per_file_warning_summary():
 
     assert 'sols/a.cpp' in out
     assert '2× -Wunused-variable' in out
+    stack.clear()
+
+
+def _linter_warning(message: str, line: int, col: int) -> LinterMessage:
+    return LinterMessage(
+        severity=LinterSeverity.WARNING, message=message, line=line, col=col
+    )
+
+
+def test_report_groups_repeated_linter_warnings_on_one_line():
+    stack = warning_stack.get_warning_stack()
+    stack.clear()
+    code = CodeItem(path=pathlib.Path('gens/gen.cpp'), language='cpp')
+    msg = 'multiple side-effecting arguments'
+    stack.add_linter_warning(
+        code,
+        [_linter_warning(msg, 2, 3), _linter_warning(msg, 5, 7)],
+    )
+
+    out = _capture_print(warning_stack.print_warning_stack_report)
+
+    # The two occurrences collapse into a single grouped line listing both.
+    assert f'lines 2:3, 5:7: {msg}' in out
+    assert out.count(msg) == 1
     stack.clear()
 
 

--- a/tests/rbx/box/sanitizers/warning_stack_test.py
+++ b/tests/rbx/box/sanitizers/warning_stack_test.py
@@ -1,8 +1,15 @@
 import pathlib
 
-from rbx.box.sanitizers.warning_stack import WarningStack
+from rbx.box.linters.linter import LinterMessage, LinterSeverity
+from rbx.box.sanitizers.warning_stack import WarningStack, group_linter_messages
 from rbx.box.schema import CodeItem
 from rbx.grading.steps import PreprocessLog
+
+
+def _warning(message: str, line=None, col=None) -> LinterMessage:
+    return LinterMessage(
+        severity=LinterSeverity.WARNING, message=message, line=line, col=col
+    )
 
 
 def _log(warnings: bool) -> PreprocessLog:
@@ -30,6 +37,46 @@ def test_add_warning_without_logs_still_records_path(tmp_path: pathlib.Path):
 
     assert code.path in stack.warnings
     assert stack.warning_logs.get(code.path) in (None, [])
+
+
+def test_group_linter_messages_groups_identical_by_message():
+    messages = [
+        _warning('same message', line=2, col=3),
+        _warning('same message', line=5, col=7),
+    ]
+
+    grouped = group_linter_messages(messages)
+
+    assert grouped == [('same message', ['2:3', '5:7'])]
+
+
+def test_group_linter_messages_keeps_distinct_messages_in_first_seen_order():
+    messages = [
+        _warning('first', line=1),
+        _warning('second', line=2),
+        _warning('first', line=3),
+    ]
+
+    grouped = group_linter_messages(messages)
+
+    assert grouped == [('first', ['1', '3']), ('second', ['2'])]
+
+
+def test_group_linter_messages_dedupes_repeated_locations():
+    messages = [
+        _warning('msg', line=4, col=1),
+        _warning('msg', line=4, col=1),
+    ]
+
+    grouped = group_linter_messages(messages)
+
+    assert grouped == [('msg', ['4:1'])]
+
+
+def test_group_linter_messages_handles_missing_location():
+    grouped = group_linter_messages([_warning('no location')])
+
+    assert grouped == [('no location', [])]
 
 
 def test_clear_resets_warning_logs(tmp_path: pathlib.Path):


### PR DESCRIPTION
## Summary

Closes #478.

Linter warnings (such as the `testlib` side-effect check) were rendered in the warning stack once per occurrence, so the same message repeated for every offending line. This groups identical messages within a file and lists all their locations together.

Before:
```
- gens/gen.cpp
    2:3 Call passes multiple side-effecting arguments ...
    5:7 Call passes multiple side-effecting arguments ...
```

After:
```
- gens/gen.cpp
    lines 2:3, 5:7: Call passes multiple side-effecting arguments ...
```

A single occurrence still renders as `<loc> <message>`; messages without a location render the bare message.

## Implementation

- Add `group_linter_messages()` in `rbx/box/sanitizers/warning_stack.py` — a pure helper that groups messages by text (first-seen order), collecting deduped `line:col` locations.
- Use it in `print_warning_stack_report()` for rendering.

## Testing

- Unit tests for `group_linter_messages` (grouping, ordering, dedupe, missing location).
- Rendering test asserting repeated warnings collapse onto a single grouped line.
- `uv run pytest tests/rbx/box/linters tests/rbx/box/sanitizers` → 64 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)