### PR TITLE
feat(linters): add per-file linter suppression directive

### DIFF
--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -122,6 +122,19 @@ linter's own supported kinds and the `applies_to` you configure.
   leaves argument evaluation order unspecified, so such calls can produce
   different results across compilers.
 
+### Suppressing a linter in a file
+
+If a linter flags something you intend to keep, you can disable it for an entire
+file with a comment directive of the form `<linter-name>-linter: disable`. For
+the `testlib` linter:
+
+```cpp
+// testlib-linter: disable
+```
+
+The directive must appear in a comment (a `//` or `#` comment marker). It
+disables only that linter; other linters configured for the language still run.
+
 ## File mapping
 
 The `fileMapping` field is a [`FileMapping`][rbx.box.environment.FileMapping] object where

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -158,7 +158,7 @@ Per-language built-in linters, configured under `EnvironmentLanguage.linters` in
 - `linter.py` -- `Linter` ABC (with `name`, `applies_to`), `LinterMessage`, `LinterSeverity`. Linters run for whatever language entry they're configured under in `env.rbx.yml`.
 - `registry.py` -- name→instance registry (`@register` decorator, `get_linter`).
 - `asset_kind.py` -- `AssetKind` enum + `infer_asset_kind(code)`.
-- `runner.py` -- `run_linters()` (routes WARNINGs to the warning stack, ERRORs to a `RbxException`) and the pure `run_linters_for_messages()`.
+- `runner.py` -- `run_linters()` (routes WARNINGs to the warning stack, ERRORs to a `RbxException`) and the pure `run_linters_for_messages()`. `is_linter_suppressed(name, source)` lets a file opt out of a linter via a `// <name>-linter: disable` comment directive (e.g. `// testlib-linter: disable`).
 - `cpp/testlib.py` -- first linter (tree-sitter-cpp); `TestlibLinter` (`name='testlib'`, generators only) flags calls passing 2+ side-effecting arguments (e.g. `f(rnd.next(), rnd.next())`).
 
 Lazy imports break the `code` ↔ `linters.runner` cycle; `__init__.py` imports `cpp.testlib` so it self-registers.

--- a/rbx/box/linters/runner.py
+++ b/rbx/box/linters/runner.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Optional
 
 from rbx.box.environment import LinterConfig
@@ -30,6 +31,21 @@ def _in_scope(linter: Linter, config: LinterConfig, kind: Optional[AssetKind]) -
     return kind in effective
 
 
+def is_linter_suppressed(name: str, source: str) -> bool:
+    """Whether `source` disables the linter `name` for the whole file.
+
+    A line comment of the form ``<name>-linter: disable`` (using either the
+    ``//`` or ``#`` comment marker, with flexible spacing) suppresses that
+    linter across the entire file. The marker is required so the directive is
+    not matched inside string literals or other code.
+    """
+    pattern = re.compile(
+        rf'(?://|#)\s*{re.escape(name)}-linter:\s*disable\b',
+        re.IGNORECASE,
+    )
+    return pattern.search(source) is not None
+
+
 def run_linters_for_messages(
     configs: List[LinterConfig],
     linters: List[Linter],
@@ -40,6 +56,8 @@ def run_linters_for_messages(
     out: List[LinterMessage] = []
     for config, linter in zip(configs, linters):
         if not _in_scope(linter, config, kind):
+            continue
+        if is_linter_suppressed(linter.name, source):
             continue
         out.extend(linter.lint(code, source))
     return out

--- a/tests/rbx/box/linters/test_runner.py
+++ b/tests/rbx/box/linters/test_runner.py
@@ -66,3 +66,48 @@ def test_in_scope_linter_runs():
     )
     assert len(msgs) == 1
     assert msgs[0].message == 'w'
+
+
+def test_suppression_directive_disables_linter():
+    msgs = runner.run_linters_for_messages(
+        configs=[LinterConfig(name='w_test', applies_to=None)],
+        linters=[_WarnLinter()],
+        kind=AssetKind.SOLUTION,
+        code=None,
+        source='// w_test-linter: disable\nint main() {}',
+    )
+    assert msgs == []
+
+
+def test_suppression_directive_is_per_linter():
+    # Disabling w_test must not silence e_test.
+    msgs = runner.run_linters_for_messages(
+        configs=[
+            LinterConfig(name='w_test', applies_to=None),
+            LinterConfig(name='e_test', applies_to=None),
+        ],
+        linters=[_WarnLinter(), _ErrLinter()],
+        kind=AssetKind.GENERATOR,
+        code=None,
+        source='// w_test-linter: disable\nint main() {}',
+    )
+    assert [m.message for m in msgs] == ['boom']
+
+
+def test_suppression_requires_a_comment_marker():
+    # A bare occurrence outside a comment must not disable the linter.
+    msgs = runner.run_linters_for_messages(
+        configs=[LinterConfig(name='w_test', applies_to=None)],
+        linters=[_WarnLinter()],
+        kind=AssetKind.SOLUTION,
+        code=None,
+        source='const char* s = "w_test-linter: disable";',
+    )
+    assert len(msgs) == 1
+
+
+def test_is_linter_suppressed_accepts_hash_comments_and_spacing():
+    assert runner.is_linter_suppressed('w_test', '#  w_test-linter:disable')
+    assert runner.is_linter_suppressed('w_test', '   // w_test-linter:   disable')
+    assert not runner.is_linter_suppressed('w_test', '// other-linter: disable')
+    assert not runner.is_linter_suppressed('w_test', 'no directive here')

--- a/tests/rbx/box/linters/test_testlib_integration.py
+++ b/tests/rbx/box/linters/test_testlib_integration.py
@@ -52,6 +52,23 @@ async def test_testlib_warning_lands_on_generator(
     assert 'side-effecting' in messages[0].message
 
 
+async def test_testlib_suppressed_by_disable_directive(
+    testing_pkg: testing_package.TestingPackage, monkeypatch
+):
+    cpp_file = testing_pkg.add_file('gen.cpp')
+    cpp_file.write_text('// testlib-linter: disable\n' + _OFFENDING_GENERATOR)
+    code_item = CodeItem(path=cpp_file, language='cpp')
+
+    language = _cpp_language_with_linters([LinterConfig(name='testlib')])
+    monkeypatch.setattr('rbx.box.code.find_language', lambda _: language)
+
+    warning_stack.get_warning_stack().clear()
+    await _compile_lenient(code_item, kind=AssetKind.GENERATOR)
+
+    stack = warning_stack.get_warning_stack()
+    assert code_item.path not in stack.linter_warnings
+
+
 async def test_testlib_not_flagged_when_scoped_to_solutions(
     testing_pkg: testing_package.TestingPackage, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Closes #479.

Adds a suppression mechanism so a file can opt out of a specific linter, as requested in the issue. A comment directive of the form `<linter-name>-linter: disable` disables that linter for the **whole file**. For the `testlib` linter:

```cpp
// testlib-linter: disable
```

- The directive must live in a comment (`//` or `#` marker), so it won't be triggered by a matching string literal in code.
- Suppression is **per-linter** and generic across the framework (keyed by `linter.name`): disabling one linter leaves the others configured for the language running.
- Matching is case-insensitive and tolerant of spacing (`// testlib-linter:disable`, `#  testlib-linter:   disable`, ...).

## Implementation

- `is_linter_suppressed(name, source)` in `rbx/box/linters/runner.py` — pure helper matching the directive.
- `run_linters_for_messages()` skips any linter suppressed by the source.
- Docs: documented the directive in the environment reference; noted the helper in `rbx/box/CLAUDE.md`.

## Testing

- Unit tests in `test_runner.py`: directive disables the linter, per-linter scoping, comment-marker requirement, and `is_linter_suppressed` spacing/marker cases.
- Integration test in `test_testlib_integration.py`: an offending generator with `// testlib-linter: disable` produces no warning during compilation.
- `uv run pytest tests/rbx/box/linters` → 29 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)