### PR TITLE
feat(grading): guide macOS users when C/C++ compiler is not found (#408)

### DIFF
--- a/docs/plans/2026-05-24-cxx-not-found-macos-guidance-design.md
+++ b/docs/plans/2026-05-24-cxx-not-found-macos-guidance-design.md
@@ -1,0 +1,61 @@
+# C/C++ compiler-not-found guidance on macOS — Design
+
+Closes #408.
+
+## Problem
+
+When the C/C++ compiler isn't found, `rbx` prints a generic message:
+
+```
+FAILED The compiler/interpreter 'g++' was not found while running [...]
+Is it installed and on your PATH?
+```
+
+(added in #451, which closed #374). Issue #408 asks for more: when the missing
+executable is a C/C++ compiler — and especially on macOS — point the user at the
+known fix. macOS doesn't bundle GNU GCC, and the common setup is to install it via
+Homebrew and configure `command_substitutions` (e.g. `g++ -> g++-14`). If that
+version isn't installed, the compile fails with the generic message and no hint.
+
+There is already a docs page describing the whole fix: `docs/cpp-on-macos.md`,
+served at <https://rbx.rsalesc.dev/cpp-on-macos/>.
+
+## Design
+
+In the compile path's existing `ProgramNotFoundError` catch block
+(`rbx/grading/steps.py`), after the generic lines, add a conditional branch:
+
+```python
+if is_cxx_command(e.executable) and sys.platform == 'darwin':
+    # print macOS C/C++ guidance + link to the cpp-on-macos doc
+```
+
+- `is_cxx_command()` (same module) already detects the C/C++ family
+  (`gcc`/`g++`/`clang`/`clang++`).
+- Gated on `sys.platform == 'darwin'`: the doc is macOS-specific, so Linux/Windows
+  users keep the existing generic message.
+- C/C++ "not found" only surfaces at compile time (the run command is the compiled
+  binary, not the compiler), so this single site is sufficient.
+
+### Message (macOS + cxx)
+
+```
+On macOS the GNU compiler isn't bundled — install it with 'brew install gcc',
+then point rbx at the exact version via 'rbx config edit' (command_substitutions).
+See https://rbx.rsalesc.dev/cpp-on-macos/ for the full guide.
+```
+
+## Scope (YAGNI)
+
+- Compile path only; no change to `ProgramNotFoundError` (keeps the low-level
+  grading layer ignorant of cxx/docs concerns).
+- No new config and no docs changes — the doc already exists.
+
+## Testing
+
+`tests/rbx/grading/steps_compile_test.py`:
+
+1. cxx executable + `sys.platform` patched to `'darwin'` → message contains the doc
+   URL and brew guidance.
+2. cxx executable on non-darwin → generic message only, no doc URL.
+3. non-cxx executable on darwin → no C/C++ guidance, no doc URL.

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -770,6 +770,17 @@ async def compile(
                         utils.highlight_json_obj(cmd),
                     )
                     err.print('[warning]Is it installed and on your PATH?[/warning]')
+                    if is_cxx_command(e.executable) and sys.platform == 'darwin':
+                        err.print(
+                            '[warning]On macOS the GNU compiler is not bundled — '
+                            "install it with '[item]brew install gcc[/item]', then "
+                            "point rbx at the exact version via '[item]rbx config "
+                            "edit[/item]' (command_substitutions).[/warning]"
+                        )
+                        err.print(
+                            '[warning]See [item]https://rbx.rsalesc.dev/cpp-on-macos/[/item] '
+                            'for the full guide.[/warning]'
+                        )
                 else:
                     err.print(
                         '[error]FAILED[/error] Preprocessing failed with command',

--- a/tests/rbx/grading/steps_compile_test.py
+++ b/tests/rbx/grading/steps_compile_test.py
@@ -885,3 +885,59 @@ InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault
         message = ' '.join(plain.split()).lower()
         assert 'definitely-not-a-real-compiler-xyz' in message
         assert 'not found' in message
+
+    async def test_compile_missing_cxx_on_macos_links_doc(
+        self, sandbox: SandboxBase, cleandir: pathlib.Path
+    ):
+        """On macOS, a missing C/C++ compiler points the user at the macOS guide."""
+        artifacts = GradingArtifacts(root=cleandir)
+        params = SandboxParams()
+        with patch('rbx.grading.steps.sys.platform', 'darwin'):
+            with pytest.raises(steps.CompilationError) as exc_info:
+                await steps.compile(
+                    ['g++-14 src.cpp -o exe'],
+                    params,
+                    sandbox,
+                    artifacts,
+                )
+        plain = re.sub(r'\x1b\[[0-9;]*m', '', str(exc_info.value))
+        message = ' '.join(plain.split())
+        assert 'https://rbx.rsalesc.dev/cpp-on-macos/' in message
+        assert 'brew install gcc' in message
+
+    async def test_compile_missing_cxx_off_macos_is_generic(
+        self, sandbox: SandboxBase, cleandir: pathlib.Path
+    ):
+        """Off macOS, a missing C/C++ compiler keeps the generic message only."""
+        artifacts = GradingArtifacts(root=cleandir)
+        params = SandboxParams()
+        with patch('rbx.grading.steps.sys.platform', 'linux'):
+            with pytest.raises(steps.CompilationError) as exc_info:
+                await steps.compile(
+                    ['g++-14 src.cpp -o exe'],
+                    params,
+                    sandbox,
+                    artifacts,
+                )
+        plain = re.sub(r'\x1b\[[0-9;]*m', '', str(exc_info.value))
+        message = ' '.join(plain.split())
+        assert 'cpp-on-macos' not in message
+        assert 'not found' in message.lower()
+
+    async def test_compile_missing_non_cxx_on_macos_is_generic(
+        self, sandbox: SandboxBase, cleandir: pathlib.Path
+    ):
+        """A missing non-C/C++ tool on macOS gets no C/C++ guidance."""
+        artifacts = GradingArtifacts(root=cleandir)
+        params = SandboxParams()
+        with patch('rbx.grading.steps.sys.platform', 'darwin'):
+            with pytest.raises(steps.CompilationError) as exc_info:
+                await steps.compile(
+                    ['definitely-not-a-real-compiler-xyz src.py'],
+                    params,
+                    sandbox,
+                    artifacts,
+                )
+        plain = re.sub(r'\x1b\[[0-9;]*m', '', str(exc_info.value))
+        message = ' '.join(plain.split())
+        assert 'cpp-on-macos' not in message


### PR DESCRIPTION
Closes #408.

## What

When a C/C++ compiler (`gcc`/`g++`/`clang`/`clang++`) can't be found **at compile time on macOS**, `rbx` now appends targeted guidance after the existing generic "not found / on your PATH?" message:

```
FAILED The compiler/interpreter 'g++-14' was not found while running [...]
Is it installed and on your PATH?
On macOS the GNU compiler is not bundled — install it with 'brew install gcc',
then point rbx at the exact version via 'rbx config edit' (command_substitutions).
See https://rbx.rsalesc.dev/cpp-on-macos/ for the full guide.
```

This is the gap #408 asked for: the generic message added in #451 (which closed #374) identifies the executable but gives no macOS-specific direction. macOS doesn't bundle GNU GCC, so the common setup is `brew install gcc` + `command_substitutions` (e.g. `g++ -> g++-14`); if that version isn't installed, the compile fails with no hint.

## How

- Hooked into the existing `ProgramNotFoundError` catch in `rbx/grading/steps.py`'s compile path, gated on `is_cxx_command(e.executable) and sys.platform == 'darwin'`.
- Reuses the existing `is_cxx_command()` helper (covers `gcc`/`g++`/`clang`/`clang++`) and the existing `docs/cpp-on-macos.md` page (served at the linked URL) — no docs changes needed.
- C/C++ "not found" only surfaces at compile time (the run command is the compiled binary, not the compiler), so this single site is sufficient.
- No change to `ProgramNotFoundError` itself — the low-level grading layer stays ignorant of cxx/docs concerns. Linux/Windows users and non-compiler tools keep the current generic message.

## Scope

Compile path only; no new config; no docs changes.

Design: `docs/plans/2026-05-24-cxx-not-found-macos-guidance-design.md`.

## Testing

Added 3 tests to `tests/rbx/grading/steps_compile_test.py` covering: macOS + cxx → doc URL + brew guidance present; non-macOS + cxx → generic only; macOS + non-cxx → no C/C++ guidance. Full `steps_compile_test.py` → 28 passed. `ruff check`/`ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)