### PR TITLE
BocaNext Layer 2: Python judge-side runtime (rbx_boca)

### DIFF
--- a/docs/plans/2026-05-29-boca-next-layer2-runtime.md
+++ b/docs/plans/2026-05-29-boca-next-layer2-runtime.md
@@ -1,0 +1,1182 @@
+# BocaNext Layer 2 Runtime (`rbx_boca`) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the judge-side Python runtime library (`rbx_boca`) that BocaNext bundles into each `.pyz` to compile, run, and judge BOCA submissions — replacing the duplicated bash scripts with one tested, composable, stdlib-only package.
+
+**Architecture:** `rbx_boca` is a standalone, stdlib-only Python package authored in the rbx source tree and (later, by Layer 1 — issue #489) zipapp-bundled into each `compile/run/compare/limits/tests` script. This plan builds Layer 2 ONLY. It is structured bottom-up: pure logic first (verdicts, manifest, language engine, safeexec argv), then side-effecting units behind injectable seams (sandbox/asset executors, tasks), then the entrypoint dispatcher and a `zipapp`-based integration harness with a stub `safeexec`. Layer 1 (env→spec resolution, real bundling, CLI) is out of scope.
+
+**Tech Stack:** Python 3.8+ stdlib only (`dataclasses`, `pathlib`, `subprocess`, `hashlib`, `zipapp`, `resource`, `signal`), pytest. No third-party runtime deps — the bundle must run on a bare BOCA judge.
+
+**Design reference:** `docs/plans/2026-05-29-boca-next-python-packager-design.md`. Source of truth for current behavior: `rbx/resources/packagers/boca/` (esp. `interactor_run.sh`, `compare.sh`, `pipe.c`, `safeexec.c`, `run/*`, `compile/*`).
+
+**Conventions:**
+- Project enforces Conventional Commits via commitizen. Use the `/commit` skill workflow for each commit step; the messages below are the intended subjects.
+- Absolute imports only (ruff `TID`). Inside `rbx_boca`, import as `rbx_boca.<module>` so imports are identical in-repo and in-bundle.
+- Single quotes (ruff format). Run `uv run ruff format .` and `uv run ruff check --fix .` before each commit.
+- Run tests with `uv run pytest tests/rbx/box/packaging/boca_next/ -v`.
+
+---
+
+## Phase 0 — Scaffolding
+
+### Task 0.1: Create the runtime package and make it importable in tests
+
+**Files:**
+- Create: `rbx/resources/packagers/boca_next/runtime/rbx_boca/__init__.py` (empty)
+- Create: `tests/rbx/box/packaging/boca_next/__init__.py` (empty)
+- Create: `tests/rbx/box/packaging/boca_next/conftest.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_import.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/packaging/boca_next/test_import.py
+def test_rbx_boca_importable():
+    import rbx_boca  # noqa: F401
+```
+
+**Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca_next/test_import.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'rbx_boca'`
+
+**Step 3: Make it importable**
+
+Create the empty `__init__.py` files above, then the conftest that puts the runtime dir on `sys.path` exactly as the `.pyz` does on the judge:
+
+```python
+# tests/rbx/box/packaging/boca_next/conftest.py
+import sys
+from pathlib import Path
+
+_RUNTIME = (
+    Path(__file__).resolve().parents[4]
+    / 'rbx'
+    / 'resources'
+    / 'packagers'
+    / 'boca_next'
+    / 'runtime'
+)
+if str(_RUNTIME) not in sys.path:
+    sys.path.insert(0, str(_RUNTIME))
+```
+
+> Verify `parents[4]` resolves to the repo root from
+> `tests/rbx/box/packaging/boca_next/conftest.py` (4 levels up). Adjust the index
+> if the test fails to find the runtime.
+
+**Step 4: Run it to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca_next/test_import.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+`chore: scaffold rbx_boca runtime package and test harness`
+
+---
+
+## Phase 1 — `verdicts.py` (pure exit-code logic)
+
+This is the highest-value, fully-pure module. Behavior verified against
+`rbx/resources/packagers/boca/compare.sh` and `interactor_run.sh`.
+
+### Task 1.1: `PipeLog` parser
+
+**Files:**
+- Create: `rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_verdicts.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/packaging/boca_next/test_verdicts.py
+import pytest
+from rbx_boca import verdicts
+
+
+def test_pipelog_parses_three_lines():
+    log = verdicts.PipeLog.parse('2\n0\n1\n')
+    assert log == verdicts.PipeLog(first_tag=2, solution_status=0, interactor_status=1)
+
+
+def test_pipelog_tolerates_whitespace():
+    log = verdicts.PipeLog.parse(' 1 \n 139 \n 0 \n')
+    assert log == verdicts.PipeLog(first_tag=1, solution_status=139, interactor_status=0)
+
+
+def test_pipelog_rejects_short_log():
+    with pytest.raises(ValueError):
+        verdicts.PipeLog.parse('1\n0\n')
+```
+
+**Step 2: Run to verify it fails** — `ModuleNotFoundError`/`AttributeError`.
+
+**Step 3: Implement**
+
+```python
+# rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class PipeLog:
+    """Parsed pipe.log: see rbx/resources/packagers/boca/pipe.c lines 359-362."""
+
+    first_tag: int  # 1 = solution exited first, 2 = interactor exited first
+    solution_status: int  # bash-like: 0-255, or 128+signal
+    interactor_status: int
+
+    @staticmethod
+    def parse(text: str) -> 'PipeLog':
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip() != '']
+        if len(lines) < 3:
+            raise ValueError(f'pipe.log must have 3 numeric lines, got: {text!r}')
+        return PipeLog(int(lines[0]), int(lines[1]), int(lines[2]))
+```
+
+**Step 4: Run to verify it passes.**
+
+**Step 5: Commit** — `feat: add PipeLog parser to rbx_boca verdicts`
+
+### Task 1.2: `batch_run_exit` mapper
+
+**Step 1: Write the failing test** (append to `test_verdicts.py`)
+
+```python
+@pytest.mark.parametrize(
+    'safeexec_exit,expected',
+    [
+        (0, 0),     # OK
+        (3, 3),     # TLE
+        (7, 7),     # MLE
+        (2, 2),     # RTE (signal)
+        (9, 9),     # RTE (abnormal)
+        (10, 10),   # boundary: not remapped
+        (11, 9),    # child nonzero (1+10) -> RTE
+        (52, 9),    # child nonzero (42+10) -> RTE
+    ],
+)
+def test_batch_run_exit(safeexec_exit, expected):
+    assert verdicts.batch_run_exit(safeexec_exit) == expected
+```
+
+**Step 2: Run to verify it fails.**
+
+**Step 3: Implement** (append to `verdicts.py`)
+
+```python
+def batch_run_exit(safeexec_exit: int) -> int:
+    """Map safeexec's exit code to the run-script exit code BOCA expects.
+
+    Mirrors rbx/resources/packagers/boca/run/* : codes > 10 (child exited with
+    nonzero N, reported as N+10) collapse to 9 (runtime error).
+    """
+    return 9 if safeexec_exit > 10 else safeexec_exit
+```
+
+**Step 4: Run to verify it passes. Step 5: Commit** — `feat: add batch_run_exit mapper`
+
+### Task 1.3: `compare_verdict` mapper
+
+**Step 1: Write the failing test**
+
+```python
+# testlib branch (interactor wrote 'testlib exitcode N'): 1,2->WA 3->43 else->47
+@pytest.mark.parametrize(
+    'testlib,expected', [(1, 6), (2, 6), (3, 43), (4, 47), (5, 47)]
+)
+def test_compare_verdict_testlib(testlib, expected):
+    assert verdicts.compare_verdict(testlib_code=testlib, checker_exit=None) == expected
+
+
+# checker branch: 0->AC 1,2->WA 3->43 else->47
+@pytest.mark.parametrize(
+    'checker,expected', [(0, 4), (1, 6), (2, 6), (3, 43), (4, 47), (9, 47)]
+)
+def test_compare_verdict_checker(checker, expected):
+    assert verdicts.compare_verdict(testlib_code=None, checker_exit=checker) == expected
+```
+
+**Step 2: Run to verify it fails.**
+
+**Step 3: Implement** (append). Maps verified against `compare.sh:7-48`.
+
+```python
+def compare_verdict(
+    testlib_code: Optional[int], checker_exit: Optional[int]
+) -> int:
+    """BOCA compare exit code. See rbx/resources/packagers/boca/compare.sh.
+
+    AC=4, WA=6, JUDGE_ERROR=43, OTHER_ERROR=47.
+    """
+    if testlib_code is not None:
+        if testlib_code in (1, 2):
+            return 6
+        if testlib_code == 3:
+            return 43
+        return 47
+    if checker_exit == 0:
+        return 4
+    if checker_exit in (1, 2):
+        return 6
+    if checker_exit == 3:
+        return 43
+    return 47
+```
+
+**Step 4: Run. Step 5: Commit** — `feat: add compare_verdict mapper`
+
+### Task 1.4: `interactive_run_decision` — the 6-level priority logic
+
+**Step 1: Write the failing test.** Cases below are derived directly from
+`interactor_run.sh:108-157` (`first_tag` 1=solution, 2=interactor).
+
+```python
+D = verdicts.RunDecision
+
+@pytest.mark.parametrize(
+    'first_tag,ecsf,ecint,expected',
+    [
+        # L1: interactor first, crashed (ecint not in 0..4) -> judge error 4
+        (2, 0, 139, D(run_exit=4, testlib_code=None)),
+        (2, 0, 5, D(run_exit=4, testlib_code=None)),
+        # L2: solution TLE/MLE beats everything below
+        (1, 3, 0, D(run_exit=3, testlib_code=None)),
+        (1, 7, 0, D(run_exit=7, testlib_code=None)),
+        (2, 3, 1, D(run_exit=3, testlib_code=None)),  # even if interactor said WA
+        # L3: interactor first with testlib verdict 1..4 -> run_exit 0 + code
+        (2, 0, 1, D(run_exit=0, testlib_code=1)),
+        (2, 0, 2, D(run_exit=0, testlib_code=2)),
+        (2, 0, 3, D(run_exit=0, testlib_code=3)),
+        (2, 0, 4, D(run_exit=0, testlib_code=4)),
+        # L3: interactor first, ecint 0 -> fall through (solution ok) -> success
+        (2, 0, 0, D(run_exit=0, testlib_code=None)),
+        # L4: solution nonzero (RTE), interactor not first / ecint 0
+        (1, 11, 0, D(run_exit=11, testlib_code=None)),
+        # L5: solution first ok, interactor reported error afterwards
+        (1, 0, 1, D(run_exit=0, testlib_code=1)),
+        (1, 0, 5, D(run_exit=4, testlib_code=None)),
+        # L6: all clean
+        (1, 0, 0, D(run_exit=0, testlib_code=None)),
+    ],
+)
+def test_interactive_run_decision(first_tag, ecsf, ecint, expected):
+    assert verdicts.interactive_run_decision(first_tag, ecsf, ecint) == expected
+```
+
+**Step 2: Run to verify it fails.**
+
+**Step 3: Implement** (append). `check_interactor` mirrors `interactor_run.sh:118-131`.
+
+```python
+@dataclass(frozen=True)
+class RunDecision:
+    run_exit: int
+    testlib_code: Optional[int]
+
+
+def _check_interactor(ecint: int) -> Optional['RunDecision']:
+    """interactor_run.sh check_interactor: 0->pass(None); 1..4->emit code, exit 0;
+    else->judge error (exit 4)."""
+    if ecint == 0:
+        return None
+    if 1 <= ecint <= 4:
+        return RunDecision(run_exit=0, testlib_code=ecint)
+    return RunDecision(run_exit=4, testlib_code=None)
+
+
+def interactive_run_decision(
+    first_tag: int, ecsf: int, ecint: int
+) -> RunDecision:
+    """Ordered priority logic from interactor_run.sh:133-157.
+
+    Ordering IS the spec: resource limits (TLE/MLE) beat the interactor verdict,
+    which beats a solution RTE.
+    """
+    interactor_first = first_tag == 2
+    is_testlib = 0 <= ecint <= 4
+
+    # 1. interactor crashed before solution
+    if interactor_first and not is_testlib:
+        return _check_interactor(ecint)  # -> run_exit 4
+
+    # 2. solution TLE (3) / MLE (7)
+    if ecsf in (3, 7):
+        return RunDecision(run_exit=ecsf, testlib_code=None)
+
+    # 3. interactor finished first -> its verdict
+    if interactor_first:
+        decided = _check_interactor(ecint)
+        if decided is not None:
+            return decided  # ecint==0 falls through
+
+    # 4. solution error
+    if ecsf != 0:
+        return RunDecision(run_exit=ecsf, testlib_code=None)
+
+    # 5. interactor error regardless of order
+    decided = _check_interactor(ecint)
+    if decided is not None:
+        return decided
+
+    # 6. success -> compare decides
+    return RunDecision(run_exit=0, testlib_code=None)
+```
+
+**Step 4: Run. Step 5: Commit** — `feat: add interactive_run_decision priority logic`
+
+---
+
+## Phase 2 — `manifest.py` (config dataclasses)
+
+### Task 2.1: `LanguageSpec`, `LimitsConfig`, `TaskConfig`, `LanguageManifest`
+
+**Files:**
+- Create: `rbx/resources/packagers/boca_next/runtime/rbx_boca/manifest.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_manifest.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/packaging/boca_next/test_manifest.py
+from rbx_boca import manifest
+
+TASK_JSON = '{"task_type": "interactive", "output_kb": 65536}'
+LANG_JSON = '''
+{
+  "language": {
+    "id": "cpp",
+    "kind": "compiled_static",
+    "compiler_argv": ["g++", "{flags}", "-o", "{exe}", "{src}"],
+    "compiler_fallbacks": ["/usr/bin/g++"],
+    "flags": "-std=c++20 -O2 -lm -static",
+    "run_argv": ["{exe}"]
+  },
+  "limits": {"time_sec": 3, "runs": 2, "memory_mb": 256}
+}
+'''
+
+
+def test_task_config_parses():
+    t = manifest.TaskConfig.from_json(TASK_JSON)
+    assert t.task_type == 'interactive'
+    assert t.output_kb == 65536
+
+
+def test_language_manifest_parses():
+    m = manifest.LanguageManifest.from_json(LANG_JSON)
+    assert m.language.id == 'cpp'
+    assert m.language.kind == 'compiled_static'
+    assert m.language.run_argv == ['{exe}']
+    assert m.language.build is None
+    assert m.language.syntax_check is False
+    assert m.language.sandbox_overrides == {}
+    assert m.limits.runs == 2
+
+
+def test_language_spec_optional_fields():
+    spec = manifest.LanguageSpec.from_dict(
+        {
+            'id': 'java',
+            'kind': 'jvm_jar',
+            'compiler_argv': ['javac', '{src}'],
+            'compiler_fallbacks': [],
+            'flags': '',
+            'run_argv': ['java', '-jar', '{jar}', '{jvm_flags}'],
+            'build': 'javac_then_jar',
+        }
+    )
+    assert spec.build == 'javac_then_jar'
+```
+
+**Step 2: Run to verify it fails.**
+
+**Step 3: Implement**
+
+```python
+# rbx/resources/packagers/boca_next/runtime/rbx_boca/manifest.py
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class LanguageSpec:
+    id: str
+    kind: str  # 'compiled_static' | 'jvm_jar' | 'interpreted'
+    compiler_argv: List[str]
+    compiler_fallbacks: List[str]
+    flags: str
+    run_argv: List[str]
+    build: Optional[str] = None  # jvm: 'javac_then_jar' | 'kotlinc_include_runtime'
+    syntax_check: bool = False  # interpreted (py3) py_compile pre-check
+    sandbox_overrides: Dict[str, Any] = field(default_factory=dict)
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> 'LanguageSpec':
+        return LanguageSpec(
+            id=d['id'],
+            kind=d['kind'],
+            compiler_argv=list(d['compiler_argv']),
+            compiler_fallbacks=list(d.get('compiler_fallbacks', [])),
+            flags=d.get('flags', ''),
+            run_argv=list(d['run_argv']),
+            build=d.get('build'),
+            syntax_check=bool(d.get('syntax_check', False)),
+            sandbox_overrides=dict(d.get('sandbox_overrides', {})),
+        )
+
+
+@dataclass(frozen=True)
+class LimitsConfig:
+    time_sec: int
+    runs: int
+    memory_mb: int
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> 'LimitsConfig':
+        return LimitsConfig(
+            time_sec=int(d['time_sec']),
+            runs=int(d['runs']),
+            memory_mb=int(d['memory_mb']),
+        )
+
+
+@dataclass(frozen=True)
+class TaskConfig:
+    task_type: str  # 'batch' | 'interactive'
+    output_kb: int
+
+    @staticmethod
+    def from_json(text: str) -> 'TaskConfig':
+        d = json.loads(text)
+        return TaskConfig(task_type=d['task_type'], output_kb=int(d['output_kb']))
+
+
+@dataclass(frozen=True)
+class LanguageManifest:
+    language: LanguageSpec
+    limits: LimitsConfig
+
+    @staticmethod
+    def from_json(text: str) -> 'LanguageManifest':
+        d = json.loads(text)
+        return LanguageManifest(
+            language=LanguageSpec.from_dict(d['language']),
+            limits=LimitsConfig.from_dict(d['limits']),
+        )
+```
+
+**Step 4: Run. Step 5: Commit** — `feat: add rbx_boca manifest dataclasses`
+
+---
+
+## Phase 3 — `languages.py` (kind engine)
+
+### Task 3.1: `render_argv` template helper
+
+**Files:**
+- Create: `rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_languages.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/packaging/boca_next/test_languages.py
+from rbx_boca import languages
+
+
+def test_render_argv_string_substitution():
+    out = languages.render_argv(
+        ['g++', '{flags}', '-o', '{exe}', '{src}'],
+        flags='-O2 -static',
+        exe='run.exe',
+        src='sol.cpp',
+    )
+    # '{flags}' is a lone token whose value contains spaces -> split into args
+    assert out == ['g++', '-O2', '-static', '-o', 'run.exe', 'sol.cpp']
+
+
+def test_render_argv_list_splice():
+    out = languages.render_argv(
+        ['java', '{jvm_flags}', '-jar', '{jar}'],
+        jvm_flags=['-Xmx256000K', '-Xss25600K'],
+        jar='run.jar',
+    )
+    assert out == ['java', '-Xmx256000K', '-Xss25600K', '-jar', 'run.jar']
+
+
+def test_render_argv_empty_token_dropped():
+    out = languages.render_argv(['cc', '{flags}', '{src}'], flags='', src='a.c')
+    assert out == ['cc', 'a.c']
+```
+
+**Step 2: Run to verify it fails.**
+
+**Step 3: Implement**
+
+```python
+# rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py
+from typing import Any, Dict, List
+
+from rbx_boca.manifest import LanguageSpec
+
+
+def render_argv(template: List[str], **subst: Any) -> List[str]:
+    """Expand a {token} argv template.
+
+    - A lone token '{name}' whose value is a list splices the list in.
+    - A lone token '{name}' whose value is a str is shlex-style split on
+      whitespace (so '-O2 -static' becomes two args); an empty value is dropped.
+    - Tokens embedded in larger strings are str-replaced (no splitting).
+    """
+    out: List[str] = []
+    for tok in template:
+        if tok.startswith('{') and tok.endswith('}') and tok.count('{') == 1:
+            key = tok[1:-1]
+            val = subst.get(key, '')
+            if isinstance(val, list):
+                out.extend(str(v) for v in val)
+            else:
+                out.extend(str(val).split())
+        else:
+            rendered = tok
+            for key, val in subst.items():
+                if not isinstance(val, list):
+                    rendered = rendered.replace('{' + key + '}', str(val))
+            out.append(rendered)
+    return out
+```
+
+**Step 4: Run. Step 5: Commit** — `feat: add render_argv template helper`
+
+### Task 3.2: `resolve_compiler` — binary resolution with fallbacks
+
+**Step 1: Write the failing test**
+
+```python
+def test_resolve_compiler_prefers_path(tmp_path, monkeypatch):
+    # primary binary present on PATH -> used as-is
+    spec = languages.LanguageSpec.from_dict(
+        {
+            'id': 'cpp', 'kind': 'compiled_static',
+            'compiler_argv': ['g++', '{src}'], 'compiler_fallbacks': ['/opt/g++'],
+            'flags': '', 'run_argv': ['{exe}'],
+        }
+    )
+    monkeypatch.setattr(languages.shutil, 'which', lambda name: '/usr/bin/g++')
+    assert languages.resolve_compiler(spec) == '/usr/bin/g++'
+
+
+def test_resolve_compiler_uses_fallback(monkeypatch, tmp_path):
+    fallback = tmp_path / 'kotlinc'
+    fallback.write_text('#!/bin/sh\n')
+    fallback.chmod(0o755)
+    spec = languages.LanguageSpec.from_dict(
+        {
+            'id': 'kt', 'kind': 'jvm_jar',
+            'compiler_argv': ['kotlinc', '{src}'],
+            'compiler_fallbacks': [str(fallback)],
+            'flags': '', 'run_argv': ['java', '-jar', '{jar}'],
+            'build': 'kotlinc_include_runtime',
+        }
+    )
+    monkeypatch.setattr(languages.shutil, 'which', lambda name: None)
+    assert languages.resolve_compiler(spec) == str(fallback)
+```
+
+**Step 2: Run to verify it fails.**
+
+**Step 3: Implement** (append to `languages.py`)
+
+```python
+import shutil
+from pathlib import Path
+
+
+def resolve_compiler(spec: LanguageSpec) -> str:
+    """Resolve the compiler/interpreter binary: PATH lookup of compiler_argv[0],
+    then the first executable fallback. Mirrors `which X || X=/usr/bin/X` in the
+    bash compile templates."""
+    primary = spec.compiler_argv[0]
+    found = shutil.which(primary)
+    if found:
+        return found
+    for cand in spec.compiler_fallbacks:
+        p = Path(cand)
+        if p.is_file() and os.access(cand, os.X_OK):
+            return cand
+    raise FileNotFoundError(f'compiler not found for {spec.id}: {primary}')
+```
+
+> Add `import os` at the top with the other imports.
+
+**Step 4: Run. Step 5: Commit** — `feat: add resolve_compiler with fallbacks`
+
+### Task 3.3: Kind handlers — `build_compile_plan` and `build_run_argv`
+
+This is the core dedup. Each `kind` produces (a) a compile plan and (b) a run
+argv, parameterized by the `LanguageSpec`. Behavior verified against
+`compile/*` and `run/*`. JVM `{jvm_flags}` = `['-XX:+UseSerialGC',
+'-Xmx{mem}K', '-Xss{mem/10}K', '-Xms{mem}K']`; static-link check belongs to
+`compiled_static`; `nruns` policy and sandbox profiles live in Phase 4/6 but the
+*kind* string drives them.
+
+**Step 1: Write the failing test**
+
+```python
+def test_compiled_static_run_argv():
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    assert languages.build_run_argv(spec, exe='run.exe', memory_mb=256) == ['run.exe']
+
+
+def test_jvm_run_argv_injects_jvm_flags():
+    spec = _spec(
+        'java', 'jvm_jar',
+        run_argv=['java', '-jar', '{jar}', '{jvm_flags}'], build='javac_then_jar',
+    )
+    out = languages.build_run_argv(spec, exe='run.jar', memory_mb=256)
+    assert out == [
+        'java', '-jar', 'run.jar',
+        '-XX:+UseSerialGC', '-Xmx256000K', '-Xss25600K', '-Xms256000K',
+    ]
+
+
+def test_kotlin_run_argv_uses_classpath_mainkt():
+    spec = _spec(
+        'kt', 'jvm_jar',
+        run_argv=['java', '-cp', '{jar}', '{jvm_flags}', 'MainKt'],
+        build='kotlinc_include_runtime',
+    )
+    out = languages.build_run_argv(spec, exe='run.jar', memory_mb=256)
+    assert out[:4] == ['java', '-cp', 'run.jar', '-XX:+UseSerialGC']
+    assert out[-1] == 'MainKt'
+
+
+def test_interpreted_run_argv():
+    spec = _spec('py3', 'interpreted', run_argv=['{interp}', '{src}'])
+    out = languages.build_run_argv(spec, exe='run.exe', memory_mb=256, interp='python3', src='sol.py')
+    assert out == ['python3', 'sol.py']
+```
+
+Add a `_spec` helper at the top of the test file:
+
+```python
+def _spec(id, kind, run_argv, build=None):
+    return languages.LanguageSpec.from_dict(
+        {
+            'id': id, 'kind': kind, 'compiler_argv': ['cc', '{src}'],
+            'compiler_fallbacks': [], 'flags': '', 'run_argv': run_argv,
+            'build': build,
+        }
+    )
+```
+
+**Step 2: Run to verify it fails.**
+
+**Step 3: Implement** (append). `build_compile_plan` is covered in Task 3.4.
+
+```python
+KINDS = ('compiled_static', 'jvm_jar', 'interpreted')
+
+
+def jvm_flags(memory_mb: int) -> List[str]:
+    """JVM memory flags from run/java, run/kt: heap=memory, stack=heap/10."""
+    heap_kb = memory_mb * 1000
+    stack_kb = heap_kb // 10
+    return [
+        '-XX:+UseSerialGC',
+        f'-Xmx{heap_kb}K',
+        f'-Xss{stack_kb}K',
+        f'-Xms{heap_kb}K',
+    ]
+
+
+def build_run_argv(spec: LanguageSpec, *, exe: str, memory_mb: int, **extra: Any) -> List[str]:
+    if spec.kind not in KINDS:
+        raise ValueError(f'unknown kind: {spec.kind}')
+    subst: Dict[str, Any] = {'exe': exe, 'jar': exe}
+    subst.update(extra)
+    if spec.kind == 'jvm_jar':
+        subst['jvm_flags'] = jvm_flags(memory_mb)
+    return render_argv(spec.run_argv, **subst)
+```
+
+**Step 4: Run. Step 5: Commit** — `feat: add kind-driven build_run_argv`
+
+### Task 3.4: `build_compile_plan` per kind
+
+A compile plan is an ordered list of argv steps plus post-checks, executed by the
+`compile` entrypoint (Phase 6). Verified against `compile/*`.
+
+- `compiled_static`: one step `render_argv(compiler_argv, flags=..., exe=..., src=...)`; post-check `static_link`.
+- `jvm_jar` + `build=javac_then_jar`: compile each `*.java`, then `jar cfm <jar> Manifest.txt *` with a generated `Main-Class` manifest (class name from basename).
+- `jvm_jar` + `build=kotlinc_include_runtime`: rename source to `Main.kt`, then `kotlinc -d <jar> -include-runtime Main.kt`.
+- `interpreted`: optional `py_compile` syntax check (if `syntax_check`), then write `#!<interp>\n` + source to `<exe>`, `chmod 755`.
+
+**Step 1: Write the failing test**
+
+```python
+def test_compile_plan_compiled_static():
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    object.__setattr__(spec, 'flags', '-O2 -static')
+    plan = languages.build_compile_plan(spec, src='sol.cpp', exe='run.exe', basename='run')
+    assert plan.steps[0] == ['cc', 'sol.cpp']  # from compiler_argv in _spec
+    assert plan.static_link_check is True
+
+
+def test_compile_plan_interpreted_writes_shebang_script():
+    spec = _spec('py3', 'interpreted', run_argv=['{interp}', '{src}'])
+    object.__setattr__(spec, 'syntax_check', True)
+    plan = languages.build_compile_plan(
+        spec, src='sol.py', exe='run.exe', basename='run', interp='python3'
+    )
+    assert plan.shebang == '#!python3'
+    assert plan.write_script == ('sol.py', 'run.exe')
+    assert plan.static_link_check is False
+```
+
+> These tests pin the *shape* of `CompilePlan`. Keep the dataclass minimal —
+> only fields the `compile` entrypoint consumes. Refine field names while red, but
+> keep them stable once green.
+
+**Step 2: Run to verify it fails.**
+
+**Step 3: Implement** a `CompilePlan` dataclass and `build_compile_plan(spec, *, src, exe, basename, **extra)` that branches on `spec.kind`/`spec.build` to populate it. Include the JVM manifest-class derivation and the Kotlin `Main.kt` rename as plan fields. (Author the dataclass to match the asserted fields; add `jar`/`manifest_class` fields for the jvm branch and assert them in added tests.)
+
+**Step 4: Run. Step 5: Commit** — `feat: add build_compile_plan kind handlers`
+
+---
+
+## Phase 4 — `sandbox.py` (safeexec)
+
+### Task 4.1: `SafeExecSpec` + `build_safeexec_argv` (pure)
+
+**Files:**
+- Create: `rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_sandbox.py`
+
+Fields/flags verified against `run/*` and `compile/*`:
+`-r<runs> -t<cpu> -T<wall> -d<mem_kb> -m<mem_kb> -f<out_kb> -F<fds> [-u<procs>]
+-U<uid> -G<gid> -n<n> -C<chdir> [-R<chroot>] -istdin0 -ostdout0 -estderr0`.
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/packaging/boca_next/test_sandbox.py
+from rbx_boca import sandbox
+
+
+def test_build_safeexec_argv_compiled_run_profile():
+    spec = sandbox.SafeExecSpec(
+        runs=2, cpu_sec=3, wall_sec=12, mem_kb=256000, out_kb=65536,
+        fds=10, procs=None, uid=65534, gid=65534, chdir='.', chroot=None,
+        stdin='stdin0', stdout='stdout0', stderr='stderr0',
+    )
+    argv = sandbox.build_safeexec_argv(spec, program=['./run.exe'])
+    assert argv[0].endswith('safeexec') or argv[0] == 'safeexec'
+    body = argv[1:]
+    assert '-r2' in body and '-t3' in body and '-T12' in body
+    assert '-d256000' in body and '-m256000' in body
+    assert '-f65536' in body and '-F10' in body
+    assert '-U65534' in body and '-G65534' in body
+    assert '-C.' in body and '-istdin0' in body
+    assert '-ostdout0' in body and '-estderr0' in body
+    assert '-u' not in ''.join(body)  # procs None -> no -u flag
+    assert body[-1] == './run.exe'
+
+
+def test_build_safeexec_argv_includes_procs_and_chroot():
+    spec = sandbox.SafeExecSpec(
+        runs=1, cpu_sec=2, wall_sec=8, mem_kb=512000, out_kb=1024,
+        fds=256, procs=256, uid=1, gid=1, chdir='.', chroot='/jail',
+        stdin='stdin0', stdout='stdout0', stderr='stderr0',
+    )
+    argv = sandbox.build_safeexec_argv(spec, program=['java', '-jar', 'run.jar'])
+    assert '-u256' in argv and '-R/jail' in argv
+    assert argv[-3:] == ['java', '-jar', 'run.jar']
+```
+
+**Step 2: Run to verify it fails.**
+
+**Step 3: Implement**
+
+```python
+# rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class SafeExecSpec:
+    runs: int
+    cpu_sec: int
+    wall_sec: int
+    mem_kb: int
+    out_kb: int
+    fds: int
+    procs: Optional[int]
+    uid: int
+    gid: int
+    chdir: str
+    chroot: Optional[str]
+    stdin: Optional[str]
+    stdout: str
+    stderr: str
+
+
+def build_safeexec_argv(
+    spec: SafeExecSpec, program: List[str], *, safeexec: str = 'safeexec'
+) -> List[str]:
+    argv = [safeexec, f'-r{spec.runs}', f'-t{spec.cpu_sec}', f'-T{spec.wall_sec}']
+    argv += [f'-d{spec.mem_kb}', f'-m{spec.mem_kb}', f'-f{spec.out_kb}']
+    argv += [f'-F{spec.fds}']
+    if spec.procs is not None:
+        argv.append(f'-u{spec.procs}')
+    argv += [f'-U{spec.uid}', f'-G{spec.gid}', f'-C{spec.chdir}']
+    if spec.chroot is not None:
+        argv.append(f'-R{spec.chroot}')
+    if spec.stdin is not None:
+        argv.append(f'-i{spec.stdin}')
+    argv += [f'-o{spec.stdout}', f'-e{spec.stderr}']
+    argv += list(program)
+    return argv
+```
+
+**Step 4: Run. Step 5: Commit** — `feat: add build_safeexec_argv`
+
+### Task 4.2: Per-kind safeexec profiles
+
+A pure factory mapping `(kind, phase, limits, overrides)` → `SafeExecSpec`,
+encoding the kind defaults (fds 10 vs 256, JVM fixed-large memory, `nruns`
+policy: `compiled_static` honors `runs`, others force 1). Apply
+`sandbox_overrides` last.
+
+**Step 1: Write the failing test** — assert: compiled_static run profile uses
+`fds=10`, `mem_kb=memory*1000`, `runs=limits.runs`; jvm_jar run profile uses
+`fds=256`, `procs=256`, fixed large `mem_kb` (e.g. `20000000`), `runs=1`;
+interpreted run profile uses `fds=256`, real memory, `runs=1`; and that
+`sandbox_overrides={'fds': 99}` wins.
+
+**Step 2–4:** Implement `profile_for(kind, phase, limits, overrides) -> SafeExecSpec` with the constants from `run/*` and `compile/*`; TDD each assertion.
+
+**Step 5: Commit** — `feat: add per-kind safeexec profiles`
+
+### Task 4.3: `SafeExec` executor with injectable `Runner`
+
+**Step 1: Write the failing test**
+
+```python
+def test_safeexec_run_invokes_runner_and_returns_exit():
+    calls = []
+
+    def fake_runner(argv, **kw):
+        calls.append(argv)
+        return 7  # MLE
+
+    ex = sandbox.SafeExec(path='/usr/bin/safeexec', runner=fake_runner)
+    spec = _minimal_spec()  # helper building a SafeExecSpec
+    code = ex.run(spec, program=['./run.exe'])
+    assert code == 7
+    assert calls[0][0] == '/usr/bin/safeexec'
+```
+
+**Step 2–4:** Implement `SafeExec(path, runner)` where `runner` defaults to a
+thin `subprocess.call` wrapper; `.run()` builds argv via `build_safeexec_argv`
+and delegates. (Locating/compiling `safeexec.c` is handled by `NativeAsset` in
+Phase 5; `SafeExec.path` is supplied by the caller.)
+
+**Step 5: Commit** — `feat: add SafeExec executor with injectable runner`
+
+---
+
+## Phase 5 — `assets.py` (`NativeAsset` compile cache)
+
+### Task 5.1: cache-key composition
+
+**Files:**
+- Create: `rbx/resources/packagers/boca_next/runtime/rbx_boca/assets.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_assets.py`
+
+**Step 1: Write the failing test**
+
+```python
+from rbx_boca import assets
+
+
+def test_cache_key_depends_on_source_and_flags():
+    a = assets.NativeAsset(name='checker', source=b'int main(){}', compile_argv=['g++', '-O2'])
+    b = assets.NativeAsset(name='checker', source=b'int main(){}', compile_argv=['g++', '-O3'])
+    c = assets.NativeAsset(name='checker', source=b'int main(){ }', compile_argv=['g++', '-O2'])
+    assert a.cache_key() != b.cache_key()  # flags differ
+    assert a.cache_key() != c.cache_key()  # source differs
+    assert a.cache_key() == assets.NativeAsset('checker', b'int main(){}', ['g++', '-O2']).cache_key()
+```
+
+**Step 2–4:** Implement `NativeAsset` dataclass with
+`cache_key()` = `hashlib.md5(source + b'\0' + '\0'.join(compile_argv))`.hexdigest().
+
+**Step 5: Commit** — `feat: add NativeAsset cache key`
+
+### Task 5.2: `.ensure()` cache hit/miss with injectable runner + cache dir
+
+**Step 1: Write the failing test**
+
+```python
+def test_ensure_compiles_on_miss_then_caches(tmp_path):
+    compiled = []
+
+    def fake_runner(argv, **kw):
+        # emulate compiler: create the output file (last token after -o)
+        out = argv[argv.index('-o') + 1]
+        (tmp_path / out).write_bytes(b'ELF')
+        compiled.append(argv)
+        return 0
+
+    a = assets.NativeAsset(name='checker', source=b'src', compile_argv=['g++', '-O2', '-o', '{out}', '{src}'])
+    out1 = a.ensure(cache_dir=tmp_path, runner=fake_runner)
+    out2 = a.ensure(cache_dir=tmp_path, runner=fake_runner)
+    assert out1 == out2
+    assert out1.exists()
+    assert len(compiled) == 1  # second call is a cache hit, no recompile
+```
+
+**Step 2–4:** Implement `.ensure(cache_dir, runner)`:
+- target = `cache_dir / f'{name}-{cache_key()}'`
+- if target exists and is non-empty → return it (cache hit)
+- else write source to a temp `.cpp`/`.c`, render `{src}`/`{out}` in `compile_argv` (point `{out}` at a temp path), run; on success atomically move to `target` (`os.replace`) and return it; raise on nonzero.
+
+> Note for executor: the bash uses `/tmp/boca-cache`. The default `cache_dir`
+> will be wired in Phase 6 from a module constant; keep it a parameter here for
+> testability.
+
+**Step 5: Commit** — `feat: add NativeAsset.ensure with compile cache`
+
+### Task 5.3: concurrency safety (atomic publish)
+
+**Step 1: Write a test** simulating two `.ensure()` calls racing on the same key
+(call the compile twice writing to distinct temp paths, then `os.replace` to the
+same target) and assert the final target is valid and no partial file is ever
+observed. **Implement** by compiling to a unique temp name and `os.replace` onto
+the final path (atomic on POSIX). **Commit** — `feat: make asset cache publish atomic`
+
+---
+
+## Phase 6 — `tasks.py` (Batch/Interactive orchestration)
+
+### Task 6.1: `RunContext` + `BatchTask.compile`
+
+**Files:**
+- Create: `rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_tasks.py`
+
+`RunContext` bundles the parsed manifests, cwd, an injected `runner`, the
+resolved asset paths, and the safeexec path — everything the tasks need, all
+injectable for tests.
+
+**Step 1: Write the failing test** — a `BatchTask.compile(ctx, src, exe, basename)`
+that, given a `compiled_static` spec, calls the runner with the compiler argv
+from `build_compile_plan` and (on success) returns 0; assert the runner saw
+`g++ ... -o <exe> <src>` and that a non-statically-linked binary triggers the
+static-link failure path (stub the `file` check).
+
+**Step 2–4:** Implement `BatchTask.compile` by executing the `CompilePlan`
+steps via `ctx.runner` and running post-checks. Reuse `languages.build_compile_plan`.
+
+**Step 5: Commit** — `feat: add BatchTask.compile`
+
+### Task 6.2: `BatchTask.run`
+
+**Step 1: Write the failing test** — `BatchTask.run(ctx, args)` builds the
+safeexec argv (via `sandbox.profile_for('compiled_static','run',...)` +
+`build_run_argv`), invokes `ctx.safeexec.run(...)` (fake returns 11), and returns
+`verdicts.batch_run_exit(11) == 9`.
+
+**Step 2–4:** Implement. Parse the BOCA run args (`basename input timelimit
+repetitions memory outputsize_kb`), copy input to `stdin0` (via injected fs ops),
+run, map exit.
+
+**Step 5: Commit** — `feat: add BatchTask.run`
+
+### Task 6.3: `BatchTask.compare` + `InteractiveTask.compare`
+
+**Step 1: Write the failing test** — `compare(ctx, args)` for batch runs the
+checker (fake returns 1) → `compare_verdict(None, 1) == 6`; for interactive,
+when `stdout0` contains `testlib exitcode 3`, returns `compare_verdict(3, None)
+== 43` *without* invoking the checker.
+
+**Step 2–4:** Implement a shared `compare` that first greps the team-output file
+for `^testlib exitcode` (mirrors `compare.sh:7`), else runs the checker via
+`ctx.runner`, then `verdicts.compare_verdict`.
+
+**Step 5: Commit** — `feat: add compare for batch and interactive tasks`
+
+### Task 6.4: `InteractiveTask.run` (fifo + pipe.exe orchestration)
+
+**Step 1: Write the failing test** — with a fake runner that, when invoked with
+the `pipe.exe` argv, writes a known `pipe.log` (`2\n0\n1\n`) to cwd and returns 0,
+assert `InteractiveTask.run` parses it, applies `interactive_run_decision(2,0,1)`
+→ `RunDecision(run_exit=0, testlib_code=1)`, writes `testlib exitcode 1` to
+`stdout0`, and returns `0`.
+
+**Step 2–4:** Implement: create fifos (guard with a flag so tests can stub
+`os.mkfifo`), build the `pipe.exe` argv (solution-under-safeexec `=`
+interactor-launcher command — the launcher command is the re-entrant `.pyz`
+sentinel; see Phase 7/8), run via `ctx.runner`, parse `pipe.log`, apply the
+decision, emit the testlib line when present, return `run_exit`.
+
+**Step 5: Commit** — `feat: add InteractiveTask.run orchestration`
+
+---
+
+## Phase 7 — `interactor_launcher.py`
+
+### Task 7.1: pure helpers (rlimit, timeout, fd plan)
+
+**Files:**
+- Create: `rbx/resources/packagers/boca_next/runtime/rbx_boca/interactor_launcher.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_interactor_launcher.py`
+
+**Step 1: Write the failing test** — `address_space_limit() == 1024000 * 1024`
+(bytes; bash `ulimit -v 1024000` is KiB), and `watchdog_timeout(wall_sec)` returns
+`(term_after=wall_sec, kill_after=5)`.
+
+**Step 2–4:** Implement the pure helpers only.
+
+**Step 5: Commit** — `feat: add interactor launcher pure helpers`
+
+### Task 7.2: `launch()` (integration-covered)
+
+**Step 1:** Implement `launch(argv, *, ittime, notify_fd)`:
+- `resource.setrlimit(resource.RLIMIT_AS, (limit, limit))`
+- fork a watchdog child that **closes `notify_fd`** (the `exec {fd}>&-` analogue),
+  `sleep(ittime)`, `os.killpg(0, SIGTERM)`, `sleep(5)`, `os.killpg(0, SIGKILL)`
+- parent `os.execv(argv[0], argv)` (which preserves `notify_fd` open until exit)
+
+> **Risk (from design doc):** the watchdog must NOT inherit `notify_fd`, else
+> `pipe.exe` never sees EPOLLHUP and hangs. This is covered by the Phase 9
+> integration test, not a unit test (it is pure syscall/exec behavior).
+
+**Step 2:** Defer verification to Phase 9. **Commit** — `feat: add interactor launch()`
+
+---
+
+## Phase 8 — `entrypoints.py` + `__main__`
+
+### Task 8.1: argv parsing + dispatch
+
+**Files:**
+- Create: `rbx/resources/packagers/boca_next/runtime/rbx_boca/entrypoints.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_entrypoints.py`
+
+**Step 1: Write the failing test** — `entrypoints.main(['compile', 'sol.cpp',
+'run', '3', '256'], context_factory=fake)` routes to `Task.compile` with parsed
+args; `['run', 'run', 'in', '3', '2', '256', '65536']` routes to `Task.run`;
+`['limits']` prints the 4 numbers (`time_sec runs memory_mb output_kb`, one per
+line) and returns 0; `['tests']` returns 0; `['__interactor_launcher__', ...]`
+routes to `interactor_launcher.launch`. Use a fake `context_factory` and capture
+stdout.
+
+**Step 2–4:** Implement `main(argv, context_factory=...)` that selects the entry
+by `argv[0]`, builds the `RunContext` (reading `task.json`/`language.json` from
+the bundle via `importlib.resources`/`__loader__`), selects `BatchTask` vs
+`InteractiveTask` by `task_type`, and dispatches. Keep it thin.
+
+**Step 5: Commit** — `feat: add entrypoints.main dispatcher`
+
+### Task 8.2: `__main__.py` + per-entry generated stubs
+
+`__main__.py` (in the package root of the bundle) calls
+`entrypoints.main(sys.argv[1:])`. The per-file `__main__` that Layer 1 generates
+will pass the fixed entry name; for Layer 2, ship a single
+`rbx_boca/__main__.py` that reads the entry from `argv` so the integration
+harness can drive it. (Layer 1 wires the filename→entry mapping.)
+
+**Step 1: Write a test** that runs `python -m rbx_boca limits` in a subprocess
+with `PYTHONPATH` set to the runtime dir and a temp cwd containing `task.json`
++ `language.json`, asserting the 4 echoed numbers.
+
+**Step 2–4:** Implement `rbx_boca/__main__.py`.
+
+**Step 5: Commit** — `feat: add rbx_boca __main__ entry`
+
+---
+
+## Phase 9 — Integration harness (zipapp + stub safeexec)
+
+### Task 9.1: bundle builder test helper
+
+**Files:**
+- Create: `tests/rbx/box/packaging/boca_next/_bundle.py`
+- Test: `tests/rbx/box/packaging/boca_next/test_integration.py`
+
+**Step 1:** Implement `_bundle.build_pyz(dest, task_json, language_json, assets)` using
+stdlib `zipapp.create_archive` over a temp dir containing a copy of `rbx_boca/`,
+the two JSON files, and an `assets/` dir; shebang `/usr/bin/env python3`. This is a
+*test-only* stand-in for Layer 1.
+
+**Step 2:** Write `test_pyz_limits_end_to_end`: build a `.pyz`, run it with
+`['limits']`, assert it echoes the 4 numbers. This proves zipimport + manifest
+reading works from a real archive.
+
+**Step 5: Commit** — `test: add zipapp bundle integration harness`
+
+### Task 9.2: stub `safeexec` end-to-end batch run
+
+**Step 1:** Add a stub `safeexec` shell script (written to a temp dir, made
+executable) that ignores its flags, runs the trailing program, and exits with a
+controllable code. Build a batch `.pyz` and drive `compile` then `run` then
+`compare` against a trivial "echo" solution + `wcmp`-style stub checker. Assert
+the final compare exit code is `4` (AC) for matching output and `6` (WA) for
+mismatched.
+
+> If compiling a real checker is too heavy for CI, stub the checker as a
+> `NativeAsset` whose `compile_argv` is a no-op script copy. Mark the test
+> `@pytest.mark.slow` if it invokes a real compiler.
+
+**Step 5: Commit** — `test: add batch end-to-end run via stub safeexec`
+
+### Task 9.3: interactive end-to-end (the fd-inheritance risk)
+
+**Step 1:** Build an interactive `.pyz`. Provide a stub `pipe.exe` (a small
+compiled C from the real `pipe.c`, or — if compilation is unavailable in CI — a
+Python stub that mimics its fifo/epoll/`pipe.log` contract) plus a stub
+interactor that exits with a chosen testlib code. Drive `run` and assert:
+(a) the run completes without hanging (proves the launcher drops `notify_fd`),
+(b) `interactive_run_decision` produces the expected `run_exit`/testlib line,
+(c) `compare` yields the expected BOCA code.
+
+> Mark `@pytest.mark.slow`/`@pytest.mark.docker` if it needs a compiler/sandbox.
+> This is the only coverage for the fd-inheritance/`killpg` risk flagged in the
+> design — do not skip it.
+
+**Step 5: Commit** — `test: add interactive end-to-end with launcher fd check`
+
+---
+
+## Phase 10 — Wrap-up
+
+### Task 10.1: module docs + CLAUDE.md pointer
+
+**Step 1:** Add a short `rbx/box/packaging/boca_next/CLAUDE.md` (or a section in
+the packaging `CLAUDE.md`) describing the two-layer split, that `rbx_boca` is
+stdlib-only and importable via the test conftest, and linking the design doc and
+issue #489 (Layer 1). **Commit** — `docs: document rbx_boca runtime`
+
+### Task 10.2: full suite + lint
+
+**Step 1:** Run `uv run pytest tests/rbx/box/packaging/boca_next/ -v` (and
+`-m 'not slow and not docker'` for the fast subset), `uv run ruff check .`,
+`uv run ruff format --check .`. Fix anything red. **Commit** — `chore: finalize rbx_boca runtime`
+
+---
+
+## Out of scope (Layer 1 — issue #489)
+
+env-config → `LanguageSpec` resolution; package-time limits/`nruns` computation;
+real `.pyz` assembly + directory layout; `rbx package boca-next` CLI; embedding
+real asset sources (`checker.cpp`, `testlib.h`, `rbx.h`, `interactor.cpp`,
+`safeexec.c`, `pipe.c`); deprecating the bash packager.

--- a/docs/plans/2026-05-29-boca-next-python-packager-design.md
+++ b/docs/plans/2026-05-29-boca-next-python-packager-design.md
@@ -324,3 +324,36 @@ arrive as argv from BOCA. `tests` is a trivial validation hook (`exit 0`).
   follow-up issue.
 - Migrating or deprecating the existing bash packager.
 - Polygon/BOCA upload integration changes.
+
+## Implementation corrections (as-built)
+
+The earlier prose above was written from slightly incorrect research. The
+following points are the authoritative description of the Layer 2 runtime as
+actually built; where they conflict with text above, these win.
+
+- **`nruns` is honored for ALL kinds in the batch run phase.** The earlier kind
+  table claimed `nruns` is forced to `1` for JVM/interpreted runs. That is WRONG
+  versus the bash: `run/cpp`, `run/java`, and `run/py3` all pass `-r$nruns`.
+  Forcing to `1` happens only in Layer 1's limits computation and for
+  interactive tasks — never in the per-language run profiles. So
+  `sandbox.profile_for` honors the passed `nruns` for `compiled_static`,
+  `jvm_jar`, AND `interpreted` in the run phase.
+- **safeexec argv includes `-n` (process limit) and a `--` separator.**
+  `build_safeexec_argv` emits `-n{n}` (`1` for `compiled_static`; `0` for JVM,
+  interpreted, and compile) and a literal `--` before the program, so JVM /
+  interpreter dash-args are not parsed by safeexec. The compile phase uses
+  cpu = wall = 2× the timelimit (bash `-t$ttime -T$ttime`, `ttime = time*2`);
+  the run phase uses cpu = 1× and wall = 4×.
+- **Manifests are read via `pkgutil.get_data('rbx_boca', name)` from INSIDE the
+  `rbx_boca` package** (not the zip root), with an `RBX_BOCA_BUNDLE_DIR` env
+  override for testing. (The design originally sketched manifests at the zip
+  root; bundling them inside the package is what makes zip-safe reading work via
+  `pkgutil`.)
+- **The interactor launcher's `RLIMIT_AS` is best-effort** — clamped to the hard
+  limit and with errors swallowed — so it works on non-Linux dev machines.
+  Production Linux still applies the ~1GB cap.
+- **Interactive testing scope:** a full real-`pipe.exe` / SUID-`safeexec`
+  interactive run needs gcc + root and is out of scope for hermetic CI. The risk
+  (a leaked notify fd → `pipe.exe` hang) is instead covered by the
+  interactor-launcher fd-inheritance + watchdog integration tests, plus a
+  `build_pipe_argv` shape test that structurally matches `interactor_run.sh`.

--- a/docs/plans/2026-05-29-boca-next-python-packager-design.md
+++ b/docs/plans/2026-05-29-boca-next-python-packager-design.md
@@ -60,6 +60,7 @@ run/cpp  (a .pyz)
  │   ├─ languages.py     # generic LanguageSpec engine + kind handlers
  │   ├─ tasks.py         # BatchTask / InteractiveTask orchestration
  │   ├─ verdicts.py      # exit-code -> BOCA-code pure mappers
+ │   ├─ interactor_launcher.py  # re-entrant mode: setrlimit + watchdog + execv
  │   └─ entrypoints.py   # compile/run/compare/limits/tests glue
  ├─ task.json            # language-agnostic config (task_type, output_kb)
  ├─ language.json        # this bundle's LanguageSpec + per-language limits
@@ -225,9 +226,67 @@ A future execution method is a new `Task` subclass — nothing else changes.
 
 ### 6. `verdicts.py` (pure)
 
-`safeexec_outcome(code)`, `checker_outcome(code)`, and the interactive
-**6-level priority logic** rewritten as a pure function over a parsed `pipe.log`
-structure -> BOCA exit code. Fully tested, no IO.
+The exit-code translations, rewritten as pure functions over parsed data — the
+surface that is impossible to test in today's bash. There are **two BOCA code
+spaces** (the run script's exit code, interpreted by the autojudge, and the
+compare script's `4/6/43/47`), so three mappers:
+
+- `batch_run_exit(safeexec_exit) -> run_exit` — incl. the `>10 -> 9` RTE remap.
+- `interactive_run_decision(first_tag, ecsf, ecint) -> (run_exit, testlib_code?)`
+  — the 6-level priority logic, de-duplicated into ordered rules (table below).
+- `compare_verdict(testlib_code?, checker_exit?) -> boca_code` — shared by both
+  task types.
+
+All three are pure, with table-driven tests over every code combination.
+
+See **Interactive execution** below for the priority table.
+
+### Interactive execution
+
+Coordination is split native-vs-Python at clean seams:
+
+- **`pipe.exe` (`pipe.c`) and `safeexec` stay `NativeAsset`s.** `pipe.exe`
+  launches the two children, wires their stdin/stdout over `fifo.in`/`fifo.out`,
+  uses `epoll` on per-child notify pipes to detect which exits first, and writes
+  a **3-line `pipe.log`**: `first_tag` (1=solution, 2=interactor),
+  `solution_status`, `interactor_status` (bash-like: `0-255`, or `128+signal`).
+  Kept *as-is* — it is a clean contract with no bug to fix.
+- **`InteractiveTask` (Python) replaces `interactor_run.sh`**: create the fifos,
+  build the `pipe.exe` argv (solution-under-safeexec `=` interactor-under-
+  launcher), invoke it, parse `pipe.log`, then apply
+  `interactive_run_decision`.
+
+**Interactor launcher (Python).** The interactor runs *unsandboxed* (trusted
+judge code that needs the fifos + notify fd), so it goes through a thin launcher
+instead of safeexec. `pipe.exe` execs the **same `.pyz` re-entrantly** with a
+sentinel argv (`<pyz> __interactor_launcher__ <ittime> ./interactor.exe ...`);
+`__main__` dispatches to `rbx_boca/interactor_launcher.py`, which does
+`resource.setrlimit(RLIMIT_AS, 1GB)`, arms a process-group watchdog
+(`SIGTERM` after the budget, `SIGKILL` +5s), then `os.execv`s the interactor.
+
+> **Implementation risk to verify:** the bash watchdog does `exec {fd}>&-` so it
+> drops its copy of `pipe.exe`'s notify fd — otherwise the pipe never `HUP`s and
+> first-exit detection hangs. The Python launcher must replicate this exactly:
+> the watchdog child must **not inherit** the notify fd, and the main interactor
+> process must hold it open until exit. fd-inheritance / close-on-exec / `killpg`
+> semantics get **integration coverage** (real `.pyz` + stub interactor); the
+> pure parts (rlimit value, timeout computation) are extracted as tested helpers.
+
+**6-level priority logic** (`interactive_run_decision`). The ordering *is* the
+spec — resource limits beat the interactor verdict, which beats solution RTE:
+
+| # | Condition | Result |
+|---|-----------|--------|
+| 1 | interactor-first & `ecint ∉ {0,1,2,3,4}` (interactor crashed) | `run_exit=4` (judge error) |
+| 2 | `ecsf ∈ {3,7}` | `run_exit=ecsf` (TLE / MLE) |
+| 3 | interactor-first | `ecint∈{1..4}` → emit testlib code, `run_exit=0`; `0` → fall through; else `run_exit=4` |
+| 4 | `ecsf ≠ 0` | `run_exit=ecsf` (solution RTE) |
+| 5 | (always) re-check interactor | as #3 |
+| 6 | otherwise | `run_exit=0` (success → compare decides) |
+
+`compare_verdict` then reads the emitted `testlib exitcode` line if present
+(`1,2 → WA(6)`, `3 → 43`, else `47`); otherwise it runs the checker
+(`0 → AC(4)`, `1,2 → WA(6)`, `3 → 43`, else `47`).
 
 ### 7. `entrypoints.py` (thin glue)
 

--- a/docs/plans/2026-05-29-boca-next-python-packager-design.md
+++ b/docs/plans/2026-05-29-boca-next-python-packager-design.md
@@ -1,0 +1,219 @@
+# BocaNext: a Python-based BOCA packager
+
+Date: 2026-05-29
+Issue: https://github.com/rsalesc/rbx/issues/488
+
+## Motivation
+
+The current BOCA packager (`rbx/box/packaging/boca/`) emits per-language **bash**
+scripts from templates in `rbx/resources/packagers/boca/`. There are 7 `compile`
+scripts (130–1200 lines each), 7 `run`, 7 `interactive`, plus shared
+`compare.sh`, `checker.sh`, `interactor_*.sh`, `safeexec_compile.sh`,
+`pipe_compile.sh`. ~80% of the compile/run/interactive content is duplicated
+boilerplate (bocajail user detection, safeexec parameter assembly, chroot
+mount/unmount, MD5 compile caching). It is hard to read, hard to test, and
+hard to extend.
+
+BOCA does not require these scripts to be bash. `autojudging.php` runs each
+script **by path with its executable bit** (`chmod 0700` then `system()`), so
+the shebang chooses the interpreter — Python works. Scripts receive only
+file-path arguments, run under user `nobody` in a working directory, and may
+run inside a `bocajail` chroot.
+
+This document designs **BocaNext**: a *new, separate* packager (the existing
+bash packager is left untouched and can be deprecated later once BocaNext is
+proven). The goals are (1) maintainability and code reuse and (3) room to
+redesign the execution model — not a 1:1 port.
+
+## Two layers
+
+BocaNext splits into two bodies of code with different lifecycles and test
+strategies:
+
+- **Layer 1 — rbx-side packager** (`rbx/box/packaging/boca_next/`). Runs at
+  `rbx package` time. Reuses `BocaExtension`, limits resolution, and
+  language-mapping utilities. Its only new job is to **assemble `.pyz` bundles**
+  and lay them out in the directory shape BOCA expects
+  (`compile/<lang>`, `run/<lang>`, `compare/<lang>`, `limits/<lang>`,
+  `tests/<lang>`). **Tracked in a follow-up issue — out of scope for this
+  design.**
+
+- **Layer 2 — judge-side runtime library** (`rbx/resources/packagers/boca_next/runtime/`).
+  The reusable code that actually runs on the judge. Authored as a clean,
+  stdlib-only, importable Python package and **zipapp-bundled into every
+  `.pyz`**. Because it is a real package in the source tree, it is directly
+  unit-testable in rbx's own test suite — no shell, no judge required.
+  **This document designs Layer 2.**
+
+## Delivery form
+
+Each emitted file (e.g. `run/cpp`) is a **`.pyz`** (PEP 441 zipapp) with a
+`#!/usr/bin/env python3` shebang. BOCA selects scripts by *filename*, not by
+argument, so the entrypoint and language are frozen per file.
+
+```
+run/cpp  (a .pyz)
+ ├─ __main__.py          # generated: from rbx_boca import run; run.main()
+ ├─ rbx_boca/            # Layer 2 runtime library (identical in every bundle)
+ │   ├─ sandbox.py       # safeexec argv builder + executor
+ │   ├─ assets.py        # native-asset compile + MD5 cache
+ │   ├─ languages.py     # generic LanguageSpec engine + kind handlers
+ │   ├─ tasks.py         # BatchTask / InteractiveTask orchestration
+ │   ├─ verdicts.py      # exit-code -> BOCA-code pure mappers
+ │   └─ entrypoints.py   # compile/run/compare/limits/tests glue
+ ├─ manifest.json        # problem-specific config, baked at package time
+ └─ assets/              # embedded sources: checker.cpp, testlib.h, rbx.h,
+                         #   interactor.cpp, safeexec.c, pipe.c
+```
+
+`zipimport` loads pure-Python modules straight from the zip (no extraction);
+embedded asset sources are read via the zip loader. The result is a single
+self-contained file that survives the `bocajail` chroot, exactly like the
+inline-heredoc bash approach does today.
+
+### Runtime requirement
+
+`.pyz` execution requires a `python3` interpreter (>= 3.8, stdlib only)
+reachable wherever the script runs — the BOCA host and inside `bocajail` if
+used. The current bash approach only needs `/bin/sh`, so this is a **new,
+documented deployment requirement** of BocaNext.
+
+## Layer 2 interfaces
+
+The issue's three configuration axes map onto three abstractions, plus a
+strategy for execution method and a pure verdict layer.
+
+### Design rule: behavior in code, data in the manifest
+
+Behavior (how to compile cpp, how to assemble safeexec flags, the interactive
+verdict priority) lives in the runtime library **code**. The manifest carries
+**only** values that cannot be known until package time. Combined with the
+fact that each `.pyz` is per-(entrypoint, language) — so its manifest needs
+config for *one* language only — the manifest collapses to a small flat record:
+
+```json
+{
+  "task_type": "batch",
+  "limits": { "time_ms": 1000, "memory_mb": 256, "max_runs": 10, "max_time_error": 0.2 },
+  "policy": { "use_bocajail": true, "fallback_user": "nobody" },
+  "language": { "...one LanguageSpec..." : true }
+}
+```
+
+Asset *sources* are embedded zip files, not manifest fields; the manifest at
+most names which assets are required (and the `Task` can derive even that).
+
+### 1. `Manifest` (pure data)
+
+A frozen dataclass parsed from `manifest.json`. Read by everything downstream;
+no globals. Trivially unit-tested via parse round-trips.
+
+### 2. `LanguageSpec` + generic engine (axis 3 — per-language compile/exec)
+
+A `LanguageSpec` is **data**, not a hardcoded class or enum:
+
+```json
+{
+  "id": "cpp",
+  "kind": "compiled_static",
+  "compile_argv": ["g++", "{flags}", "-o", "{exe}", "{src}"],
+  "run_argv": ["{exe}"],
+  "flags": "-std=c++20 -O2 -lm -static",
+  "limit_modifiers": { "time_mult": 1.0, "memory_add_mb": 0 }
+}
+```
+
+The runtime library contains **one generic engine** that interprets a
+`LanguageSpec`, parameterized by its `kind`. This collapses the 7×130–1200-line
+compile scripts into a single code path — the largest dedup win.
+
+**`kind` + templates (hybrid) model.** A `LanguageSpec` carries a `kind` from a
+small fixed set of **kind handlers** in the runtime:
+
+- `compiled_static` — compile to a statically linked exe; verify static linkage
+  (C/C++/cc).
+- `jvm_jar` — compile to a JAR; emit a launcher; JVM memory/time defaults
+  (Java/Kotlin, incl. Kotlin `Main.kt` handling).
+- `interpreted` — syntax-check; prepend shebang; pypy3/python3 switch
+  (py2/py3).
+
+Adding a language by **reusing an existing kind** is pure config (no runtime
+code) and covers the overwhelming majority of cases. A genuinely novel
+execution model requires adding a new `kind` to the runtime library — a
+deliberate, rare extension point. rbx ships default `LanguageSpec`s; users
+extend/override via the `env.rbx.yml` extension mechanism (Layer 1 resolves and
+bakes the spec for this bundle's language).
+
+### 3. `SafeExecSpec` + `build_safeexec_argv(spec) -> list[str]` (axis 3 — sandbox params)
+
+A **pure function** mapping resource limits + policy to safeexec argv
+(`-r -t -T -d -m -f -F -U -G -R -C -o -e`). Asserted directly in tests. The
+`SafeExec` *executor* wraps it with `.locate_or_build()` (compile `safeexec.c`,
+cached) and `.run(...)`. The actual subprocess call sits behind an **injectable
+`Runner`** so tests use a fake.
+
+### 4. `NativeAsset` (axis 2 — which assets to build)
+
+Represents a compiled-on-judge artifact: name, embedded source, compiler argv,
+MD5 cache key, output path. `.ensure(runner) -> Path` performs the
+`/tmp/boca-cache` check-or-compile **once**, tested once. Instances: `checker`,
+`interactor`, `safeexec`, `pipe`. Caching behavior matches today's bash
+scripts (MD5 of source + flags).
+
+### 5. `Task` strategy (axis 1 — execution method)
+
+`BatchTask` / `InteractiveTask`, selected by `manifest.task_type`. Each
+implements:
+
+- `required_assets()` — which `NativeAsset`s to build (axis 2 in action).
+  Batch: `checker`, `safeexec`. Interactive: also `interactor`, `pipe`.
+- `compile(ctx)` — build the solution (via the `LanguageSpec` engine) plus
+  required assets.
+- `run(ctx, args)` — batch: direct safeexec; interactive: pipe-coordinated
+  (`pipe.exe` + `interactor.exe` over fifos).
+- `compare(ctx, args)` — both run the checker; interactive also reads the
+  testlib exit code from the pipe log.
+
+A future execution method is a new `Task` subclass — nothing else changes.
+
+### 6. `verdicts.py` (pure)
+
+`safeexec_outcome(code)`, `checker_outcome(code)`, and the interactive
+**6-level priority logic** rewritten as a pure function over a parsed `pipe.log`
+structure -> BOCA exit code. Fully tested, no IO.
+
+### 7. `entrypoints.py` (thin glue)
+
+`compile / run / compare / limits / tests` each: parse argv -> build a
+`RunContext` from manifest + cwd -> call the `Task` method -> translate the
+result to an exit code + stderr details. Deliberately thin; all logic lives in
+the tested units above. `limits` emits resolved limits; `tests` is a trivial
+validation hook (`exit 0`).
+
+## Argument contract (from `autojudging.php`)
+
+| Entrypoint | Arguments |
+|------------|-----------|
+| `limits`   | (none) |
+| `compile`  | `sourcename basename timelimit memory` |
+| `run`      | `basename inputfile timelimit repetitions memory outputsize_kb` |
+| `compare`  | `team_output expected_output input_file` |
+| `tests`    | (none) |
+
+## Testability
+
+- **Pure units** (argv builders, verdict mappers, cache keys, manifest /
+  LanguageSpec parsing) — tested directly by asserting return values.
+- **Side-effecting units** (compile, run) — take an injectable `Runner` /
+  filesystem so tests substitute fakes; no real subprocess or sandbox needed.
+- **Integration** — a few tests build a real `.pyz` and run it against a **stub
+  `safeexec`** that emits canned exit codes, exercising the full entrypoint ->
+  task -> verdict path end to end.
+
+## Explicitly out of scope (this session)
+
+- **Layer 1** (the rbx-side bundler, env-config -> `LanguageSpec` resolution,
+  `.pyz` assembly, directory layout, `rbx package boca-next` CLI wiring) —
+  follow-up issue.
+- Migrating or deprecating the existing bash packager.
+- Polygon/BOCA upload integration changes.

--- a/docs/plans/2026-05-29-boca-next-python-packager-design.md
+++ b/docs/plans/2026-05-29-boca-next-python-packager-design.md
@@ -61,7 +61,8 @@ run/cpp  (a .pyz)
  │   ├─ tasks.py         # BatchTask / InteractiveTask orchestration
  │   ├─ verdicts.py      # exit-code -> BOCA-code pure mappers
  │   └─ entrypoints.py   # compile/run/compare/limits/tests glue
- ├─ manifest.json        # problem-specific config, baked at package time
+ ├─ task.json            # language-agnostic config (task_type, output_kb)
+ ├─ language.json        # this bundle's LanguageSpec + per-language limits
  └─ assets/              # embedded sources: checker.cpp, testlib.h, rbx.h,
                          #   interactor.cpp, safeexec.c, pipe.c
 ```
@@ -87,62 +88,108 @@ strategy for execution method and a pure verdict layer.
 
 Behavior (how to compile cpp, how to assemble safeexec flags, the interactive
 verdict priority) lives in the runtime library **code**. The manifest carries
-**only** values that cannot be known until package time. Combined with the
-fact that each `.pyz` is per-(entrypoint, language) — so its manifest needs
-config for *one* language only — the manifest collapses to a small flat record:
+**only** values that cannot be known until package time. Three forces shrink it
+to almost nothing:
 
-```json
+- **Behavior lives in the `kind` handlers** (how to compile cpp, assemble
+  safeexec flags, the interactive verdict priority) — never in data.
+- **Asset *sources* are embedded zip files**, not manifest fields; the `Task`
+  derives which assets it needs from `task_type`.
+- **The time-rounding / `nruns` computation is a package-time (Layer 1) job**,
+  not judge-side. `_get_limits` today computes the integer time limit and run
+  count on the packaging machine (using `maximumTimeError` / `_MAX_REPS`); the
+  `limits/<lang>` script just echoes four literal numbers, which BOCA then feeds
+  *back* as argv to `compile` / `run` / `compare`. So `maximumTimeError` and the
+  rounding logic never reach the judge, and `compile` / `run` / `compare` read
+  their effective limits from **argv**, not the manifest. `bocajail` is detected
+  at runtime (`id -u bocajail`) with a universal `nobody` fallback, so no policy
+  data is baked either.
+
+### 1. Two manifests, split by axis of variation
+
+Rather than one blob, BocaNext bakes **two** small JSON files, separated by
+*what varies*:
+
+**`task.json`** — language-agnostic, problem-level, identical in every bundle:
+
+```jsonc
+{ "task_type": "batch", "output_kb": 65536 }   // pkg.outputLimit is problem-wide
+```
+
+**`language.json`** — everything that varies per language; each `.pyz` carries
+the one for its own language:
+
+```jsonc
 {
-  "task_type": "batch",
-  "limits": { "time_ms": 1000, "memory_mb": 256, "max_runs": 10, "max_time_error": 0.2 },
-  "policy": { "use_bocajail": true, "fallback_user": "nobody" },
-  "language": { "...one LanguageSpec..." : true }
+  "language": { "...one LanguageSpec..." : true },
+  "limits":   { "time_sec": 3, "runs": 2, "memory_mb": 256 }
 }
 ```
 
-Asset *sources* are embedded zip files, not manifest fields; the manifest at
-most names which assets are required (and the `Task` can derive even that).
-
-### 1. `Manifest` (pure data)
-
-A frozen dataclass parsed from `manifest.json`. Read by everything downstream;
-no globals. Trivially unit-tested via parse round-trips.
+Consumption: `limits` reads `output_kb` (task) + `time_sec/runs/memory_mb`
+(language) and echoes the four numbers BOCA expects; `compile` / `run` read
+`language.json` + `task_type`; `compare` reads `task_type`. Both files parse
+into frozen dataclasses, read by everything downstream — no globals, trivially
+unit-tested via parse round-trips.
 
 ### 2. `LanguageSpec` + generic engine (axis 3 — per-language compile/exec)
 
-A `LanguageSpec` is **data**, not a hardcoded class or enum:
+The runtime library contains **one generic engine** that interprets a
+`LanguageSpec`, parameterized by its `kind`. This collapses the 7×130–1200-line
+compile scripts into a single code path — the largest dedup win. The crucial
+design decision is **where the data/code line falls**: research on the existing
+bash templates (compile + run + interactive, all 7 languages) showed that *most*
+of what "varies per language" is actually `kind`-level structure, not data.
 
-```json
+**The `kind` handler owns the structural behavior** (identical within a kind):
+
+| Behavior                         | `compiled_static` | `jvm_jar`                          | `interpreted`        |
+|----------------------------------|-------------------|------------------------------------|----------------------|
+| Artifact                         | static ELF        | `run.jar`                          | script + shebang     |
+| Static-link check                | required          | —                                  | —                    |
+| Sandbox fd limit                 | `-F10`            | `-F256 -u256`                      | `-F256 -u256`        |
+| Run memory → safeexec            | real (`-d/-m`)    | fixed large + `-Xmx`/`-Xss=heap/10`| real (`-d/-m`)       |
+| `nruns` (repeat timing)          | supported         | forced to 1                        | forced to 1          |
+| JVM flags (`-XX:+UseSerialGC` …) | —                 | generated                          | —                    |
+| Syntax pre-check                 | —                 | —                                  | py3 `py_compile`     |
+
+**The `LanguageSpec` (data) fills the small holes the kind leaves:**
+
+```jsonc
 {
   "id": "cpp",
   "kind": "compiled_static",
-  "compile_argv": ["g++", "{flags}", "-o", "{exe}", "{src}"],
-  "run_argv": ["{exe}"],
+  "compiler_argv": ["g++", "{flags}", "-o", "{exe}", "{src}"],  // C adds -lm via flags
+  "compiler_fallbacks": ["/usr/bin/g++"],
   "flags": "-std=c++20 -O2 -lm -static",
-  "limit_modifiers": { "time_mult": 1.0, "memory_add_mb": 0 }
+  "run_argv": ["{exe}"],          // kind injects computed holes like {jvm_flags}
+  "sandbox_overrides": {}          // optional escape hatch over kind defaults
 }
 ```
 
-The runtime library contains **one generic engine** that interprets a
-`LanguageSpec`, parameterized by its `kind`. This collapses the 7×130–1200-line
-compile scripts into a single code path — the largest dedup win.
-
-**`kind` + templates (hybrid) model.** A `LanguageSpec` carries a `kind` from a
-small fixed set of **kind handlers** in the runtime:
-
-- `compiled_static` — compile to a statically linked exe; verify static linkage
-  (C/C++/cc).
-- `jvm_jar` — compile to a JAR; emit a launcher; JVM memory/time defaults
-  (Java/Kotlin, incl. Kotlin `Main.kt` handling).
-- `interpreted` — syntax-check; prepend shebang; pypy3/python3 switch
-  (py2/py3).
+`jvm_jar` additionally carries a **`build` selector** in data
+(`javac_then_jar` vs `kotlinc_include_runtime`) and the `run_argv` form
+(`-jar {jar}` vs `-cp {jar} {jvm_flags} MainKt`), since those genuinely differ
+Java-vs-Kotlin but both stay inside one kind.
 
 Adding a language by **reusing an existing kind** is pure config (no runtime
-code) and covers the overwhelming majority of cases. A genuinely novel
-execution model requires adding a new `kind` to the runtime library — a
-deliberate, rare extension point. rbx ships default `LanguageSpec`s; users
-extend/override via the `env.rbx.yml` extension mechanism (Layer 1 resolves and
-bakes the spec for this bundle's language).
+code) and covers the overwhelming majority of cases. A genuinely novel execution
+model requires adding a new `kind` to the runtime library — a deliberate, rare
+extension point. rbx ships default `LanguageSpec`s; users extend/override via the
+`env.rbx.yml` extension mechanism (Layer 1 resolves and bakes the spec for this
+bundle's language).
+
+**Fidelity decisions** (from auditing the current bash). BocaNext *unifies* two
+genuine bugs/drift and *preserves* two semantically-meaningful behaviors as
+overridable `kind` defaults:
+
+- **Unify:** Kotlin compile currently skips the `bocajail`/chroot logic every
+  other language applies — apply it uniformly. Kotlin compile hardcodes
+  `-t20 -T32 -istdin0` unlike Java — derive its compile sandbox params from the
+  kind like Java's.
+- **Preserve:** the JVM's large fixed virtual-memory grant (it cannot start
+  otherwise; the real limit is enforced via `-Xmx`), and `nruns = 1` for
+  JVM/interpreted (startup variance makes repeated timing meaningless).
 
 ### 3. `SafeExecSpec` + `build_safeexec_argv(spec) -> list[str]` (axis 3 — sandbox params)
 
@@ -185,10 +232,11 @@ structure -> BOCA exit code. Fully tested, no IO.
 ### 7. `entrypoints.py` (thin glue)
 
 `compile / run / compare / limits / tests` each: parse argv -> build a
-`RunContext` from manifest + cwd -> call the `Task` method -> translate the
-result to an exit code + stderr details. Deliberately thin; all logic lives in
-the tested units above. `limits` emits resolved limits; `tests` is a trivial
-validation hook (`exit 0`).
+`RunContext` from `task.json` / `language.json` + cwd -> call the `Task` method
+-> translate the result to an exit code + stderr details. Deliberately thin; all
+logic lives in the tested units above. `limits` echoes the four pre-computed
+numbers (`time_sec`, `runs`, `memory_mb`, `output_kb`); effective per-run limits
+arrive as argv from BOCA. `tests` is a trivial validation hook (`exit 0`).
 
 ## Argument contract (from `autojudging.php`)
 

--- a/docs/plans/2026-05-29-boca-next-python-packager-design.md
+++ b/docs/plans/2026-05-29-boca-next-python-packager-design.md
@@ -123,7 +123,7 @@ the one for its own language:
 ```jsonc
 {
   "language": { "...one LanguageSpec..." : true },
-  "limits":   { "time_sec": 3, "runs": 2, "memory_mb": 256 }
+  "limits":   { "time_sec": 3, "runs": 2, "memory_mb": 256, "wall_time_sec": 12 }
 }
 ```
 
@@ -341,9 +341,19 @@ actually built; where they conflict with text above, these win.
 - **safeexec argv includes `-n` (process limit) and a `--` separator.**
   `build_safeexec_argv` emits `-n{n}` (`1` for `compiled_static`; `0` for JVM,
   interpreted, and compile) and a literal `--` before the program, so JVM /
-  interpreter dash-args are not parsed by safeexec. The compile phase uses
-  cpu = wall = 2× the timelimit (bash `-t$ttime -T$ttime`, `ttime = time*2`);
-  the run phase uses cpu = 1× and wall = 4×.
+  interpreter dash-args are not parsed by safeexec.
+- **Time limits are configured, not hardcoded multiples** (revises the original
+  `×4` run / `×2` compile sketch). `profile_for` is a dumb assembler taking
+  explicit `cpu_sec` and `wall_sec`; the caller supplies the policy:
+  - **Run wall TL** is an absolute `wall_time_sec` field on `LimitsConfig` (a
+    per-problem limit, hence in the limits). The run phase sets `cpu_sec` from
+    the BOCA run argv and `wall_sec = limits.wall_time_sec`.
+  - **Compile TL** is an absolute `compile_time_sec` field on `LanguageSpec`
+    (default `30`; a per-language property — JVM langs set it higher), used as
+    `cpu_sec == wall_sec == compile_time_sec` (TL == wall TL), fully decoupled
+    from the problem timelimit.
+  - Interactive `ittime` (the interactor watchdog budget) is `wall_time_sec + 1`
+    (`interactor_run.sh:13`, where `ttime` is the wall TL).
 - **Manifests are read via `pkgutil.get_data('rbx_boca', name)` from INSIDE the
   `rbx_boca` package** (not the zip root), with an `RBX_BOCA_BUNDLE_DIR` env
   override for testing. (The design originally sketched manifests at the zip

--- a/rbx/box/packaging/boca_next/CLAUDE.md
+++ b/rbx/box/packaging/boca_next/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md — BocaNext packager
+
+This guide covers **BocaNext**, a NEW, separate BOCA packager. It does not touch
+the existing bash-based `BocaPackager` in `rbx/box/packaging/boca/`, which
+remains the default and is left untouched.
+
+## Two layers
+
+BocaNext is split into two independent layers:
+
+- **Layer 1** — the rbx-side bundler: env-config → `LanguageSpec` resolution,
+  `.pyz` assembly, directory layout, and the `rbx package boca-next` CLI wiring.
+  **NOT yet implemented**; tracked in GitHub issue **#489**.
+- **Layer 2** — the judge-side runtime library `rbx_boca`. **IMPLEMENTED** at
+  `rbx/resources/packagers/boca_next/runtime/rbx_boca/`.
+
+## `rbx_boca` runtime
+
+`rbx_boca` is **stdlib-only** and targets **Python 3.8+** (the interpreter found
+on BOCA judges). It is authored as a normal Python package, and is intended to be
+zipapp-bundled (by the future Layer 1) into each of the BOCA scripts
+(`compile` / `run` / `compare` / `limits` / `tests`) as a `.pyz`.
+
+The five BOCA scripts dispatch into `rbx_boca` via its `__main__` / entrypoints
+based on the invoked command and the argv contract from `autojudging.php`.
+
+### Importability in tests
+
+`rbx_boca` is importable in tests via
+`tests/rbx/box/packaging/boca_next/conftest.py`, which inserts the runtime
+directory on `sys.path`, so `import rbx_boca` works exactly as it does on the
+judge (where the package lives inside the `.pyz`).
+
+## Module map
+
+- `manifest.py` — config dataclasses (parsed from bundled manifests).
+- `languages.py` — the kind engine (compiled_static / jvm_jar / interpreted).
+- `sandbox.py` — safeexec argv construction and per-phase/per-language profiles.
+- `assets.py` — `NativeAsset` compile cache.
+- `verdicts.py` — pure exit-code → verdict logic.
+- `interactor_launcher.py` — re-entrant interactor wrapper (fd inheritance,
+  watchdog, best-effort RLIMIT).
+- `tasks.py` — Batch / Interactive task orchestration (`BaseTask` shares the
+  compile/compare logic).
+- `entrypoints.py` + `__main__.py` — command dispatch.
+
+## Design + plan
+
+- Design doc: `docs/plans/2026-05-29-boca-next-python-packager-design.md`
+  (see the **Implementation corrections (as-built)** section for deviations
+  discovered during implementation).
+- Implementation plan: `docs/plans/2026-05-29-boca-next-layer2-runtime.md`.
+
+## Running tests
+
+```bash
+uv run pytest tests/rbx/box/packaging/boca_next/
+```
+
+The 2 slow launcher tests can be skipped with `-m "not slow"`.

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/__main__.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from rbx_boca import entrypoints
+
+if __name__ == '__main__':
+    sys.exit(entrypoints.main(sys.argv[1:]))

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/assets.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/assets.py
@@ -1,0 +1,17 @@
+import hashlib
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class NativeAsset:
+    name: str
+    source: bytes
+    compile_argv: List[str]  # template; may contain {src} and {out} tokens
+
+    def cache_key(self) -> str:
+        h = hashlib.md5()
+        h.update(self.source)
+        h.update(b'\0')
+        h.update('\0'.join(self.compile_argv).encode('utf-8'))
+        return h.hexdigest()

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/assets.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/assets.py
@@ -1,6 +1,9 @@
 import hashlib
+import os
+import tempfile
 from dataclasses import dataclass
-from typing import List
+from pathlib import Path
+from typing import Callable, List, Union
 
 
 @dataclass(frozen=True)
@@ -15,3 +18,44 @@ class NativeAsset:
         h.update(b'\0')
         h.update('\0'.join(self.compile_argv).encode('utf-8'))
         return h.hexdigest()
+
+    def ensure(
+        self, cache_dir: Union[str, 'os.PathLike[str]'], runner: Callable[..., int]
+    ) -> Path:
+        cache_dir = Path(cache_dir)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        target = cache_dir / '{}-{}'.format(self.name, self.cache_key())
+
+        # Cache hit: a non-empty published binary already exists.
+        if target.exists() and target.stat().st_size > 0:
+            return target
+
+        # Cache miss: compile to unique temp paths, then atomically publish.
+        src_fd, src_name = tempfile.mkstemp(dir=str(cache_dir), suffix='.src')
+        out_fd, out_name = tempfile.mkstemp(dir=str(cache_dir), suffix='.out')
+        os.close(out_fd)
+        # The unique temp output must not exist when the compiler runs, so it
+        # creates a fresh binary rather than appending to an empty placeholder.
+        os.unlink(out_name)
+        try:
+            with os.fdopen(src_fd, 'wb') as f:
+                f.write(self.source)
+
+            rendered_argv = [
+                arg.replace('{src}', src_name).replace('{out}', out_name)
+                for arg in self.compile_argv
+            ]
+            rc = runner(rendered_argv)
+            if rc != 0:
+                raise RuntimeError('failed to compile {}'.format(self.name))
+
+            # Atomic publish (os.replace is atomic on POSIX): concurrent judges
+            # never observe a partial binary at the final target path.
+            os.replace(out_name, str(target))
+            return target
+        finally:
+            for leftover in (src_name, out_name):
+                try:
+                    os.unlink(leftover)
+                except OSError:
+                    pass

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/entrypoints.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/entrypoints.py
@@ -1,0 +1,127 @@
+"""BOCA entry-point dispatcher for the Layer-2 runtime.
+
+BOCA invokes lifecycle scripts by filename (``compile``, ``run``, ``compare``,
+``limits``, ``tests``). In Layer 2 those filenames are thin wrappers that exec
+``python -m rbx_boca <entry> ...`` with the entry name passed as ``argv[0]``.
+This module maps that entry name to the right :mod:`rbx_boca.tasks` hook.
+
+A re-entrant ``__interactor_launcher__`` entry is also handled here: pipe.exe
+spawns the interactor through this same binary so the launcher can install the
+RLIMIT_AS cap and process-group watchdog before exec'ing the real interactor.
+
+The whole module is stdlib-only and Python 3.8 compatible. Every external
+effect lives behind ``load_context`` so the dispatcher itself is unit-testable
+with an injected ``context_factory``.
+"""
+
+import importlib.resources
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from rbx_boca import interactor_launcher, sandbox
+from rbx_boca.manifest import LanguageManifest, TaskConfig
+from rbx_boca.tasks import BatchTask, InteractiveTask, RunContext
+
+# Re-entrant sentinel entry name: pipe.exe execs this binary with the sentinel
+# as argv[0] so the interactor is launched under the watchdog/RLIMIT_AS cap.
+_INTERACTOR_LAUNCHER = '__interactor_launcher__'
+
+# Returned for an unrecognized BOCA entry name.
+_UNKNOWN_ENTRY = 2
+
+_TASK_JSON = 'task.json'
+_LANGUAGE_JSON = 'language.json'
+
+
+def _read_bundle_file(name: str) -> str:
+    """Read a bundled manifest file.
+
+    Honors ``RBX_BOCA_BUNDLE_DIR`` (used by tests and by the packaged layout
+    when the manifests sit beside the runtime). Otherwise falls back to the
+    manifests bundled inside the ``rbx_boca`` package (Layer 1 places them
+    there).
+    """
+    override = os.environ.get('RBX_BOCA_BUNDLE_DIR')
+    if override:
+        return (Path(override) / name).read_text()
+    return importlib.resources.read_text('rbx_boca', name)
+
+
+def _default_runner(argv: List[str], **kwargs) -> int:
+    return subprocess.call(argv, **kwargs)
+
+
+def _resolve_safeexec_path() -> str:
+    """Best-effort safeexec path. Phase 9 / Layer 1 wire the real NativeAsset
+    path; here we fall back to PATH lookup or the conventional location."""
+    return shutil.which('safeexec') or '/usr/bin/safeexec'
+
+
+def load_context() -> RunContext:
+    """Default ``context_factory``: parse the bundled manifests and build a real
+    :class:`RunContext`.
+
+    Asset paths (checker/interactor/pipe) and ``interactor_launch_argv`` are
+    left best-effort here; Phase 9 finalizes the interactive wiring. The unit
+    tests never exercise this -- they inject a fake ``context_factory``.
+    """
+    task = TaskConfig.from_json(_read_bundle_file(_TASK_JSON))
+    lang = LanguageManifest.from_json(_read_bundle_file(_LANGUAGE_JSON))
+    safeexec = sandbox.SafeExec(path=_resolve_safeexec_path(), runner=_default_runner)
+    return RunContext(
+        task=task,
+        lang=lang,
+        cwd=Path.cwd(),
+        runner=_default_runner,
+        safeexec=safeexec,
+    )
+
+
+def _dispatch_interactor_launcher(rest: List[str]) -> int:
+    ittime = int(rest[0])
+    notify_fd = int(rest[1])
+    if len(rest) < 3 or rest[2] != '--':
+        raise ValueError("expected '--' separator before interactor argv")
+    interactor_argv = rest[3:]
+    # launch() replaces this process via execv, so it never returns; the 0 below
+    # is only reached in tests that stub launch out.
+    interactor_launcher.launch(interactor_argv, ittime=ittime, notify_fd=notify_fd)
+    return 0
+
+
+def main(
+    argv: List[str], *, context_factory: Optional[Callable[[], RunContext]] = None
+) -> int:
+    entry = argv[0]
+    rest = argv[1:]
+
+    # Re-entrant interactor launcher: no manifests / context required.
+    if entry == _INTERACTOR_LAUNCHER:
+        return _dispatch_interactor_launcher(rest)
+
+    ctx = (context_factory or load_context)()
+    task = BatchTask() if ctx.task.task_type == 'batch' else InteractiveTask()
+
+    if entry == 'compile':
+        # BOCA: sourcename=rest[0], basename=rest[1]. Keep exe == basename for
+        # Layer 2. timelimit=rest[2] / memory=rest[3] are available but unused.
+        return task.compile(ctx, src=rest[0], exe=rest[1], basename=rest[1])
+    if entry == 'run':
+        return task.run(ctx, rest)
+    if entry == 'compare':
+        return task.compare(ctx, rest)
+    if entry == 'limits':
+        print(ctx.lang.limits.time_sec)
+        print(ctx.lang.limits.runs)
+        print(ctx.lang.limits.memory_mb)
+        print(ctx.task.output_kb)
+        return 0
+    if entry == 'tests':
+        return 0
+
+    print('unknown entry: {!r}'.format(entry), file=sys.stderr)
+    return _UNKNOWN_ENTRY

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/entrypoints.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/entrypoints.py
@@ -14,8 +14,8 @@ effect lives behind ``load_context`` so the dispatcher itself is unit-testable
 with an injected ``context_factory``.
 """
 
-import importlib.resources
 import os
+import pkgutil
 import shutil
 import subprocess
 import sys
@@ -44,11 +44,19 @@ def _read_bundle_file(name: str) -> str:
     when the manifests sit beside the runtime). Otherwise falls back to the
     manifests bundled inside the ``rbx_boca`` package (Layer 1 places them
     there).
+
+    Uses ``pkgutil.get_data`` for the package read: it is zip-safe (works when
+    ``rbx_boca`` is imported from a zipapp ``.pyz``) and, unlike
+    ``importlib.resources.read_text``, is not deprecated. Phase 9 verifies this
+    reads correctly from a real zipapp archive.
     """
     override = os.environ.get('RBX_BOCA_BUNDLE_DIR')
     if override:
         return (Path(override) / name).read_text()
-    return importlib.resources.read_text('rbx_boca', name)
+    data = pkgutil.get_data('rbx_boca', name)
+    if data is None:
+        raise FileNotFoundError('bundled manifest not found: {!r}'.format(name))
+    return data.decode('utf-8')
 
 
 def _default_runner(argv: List[str], **kwargs) -> int:
@@ -78,7 +86,23 @@ def load_context() -> RunContext:
         cwd=Path.cwd(),
         runner=_default_runner,
         safeexec=safeexec,
+        # Re-invoke THIS bundle for the interactor side. pipe.exe execs this
+        # prefix + ['__interactor_launcher__', ittime, __FD__, '--', interactor].
+        interactor_launch_argv=_interactor_launch_argv(),
     )
+
+
+def _interactor_launch_argv() -> List[str]:
+    """Prefix that re-invokes this runtime to reach the interactor launcher.
+
+    When packaged as a zipapp the launcher must be re-entered through the same
+    archive, so prefer ``RBX_BOCA_SELF`` (set by the packaged ``run`` wrapper to
+    the .pyz path). Otherwise fall back to ``python -m rbx_boca``.
+    """
+    self_path = os.environ.get('RBX_BOCA_SELF')
+    if self_path:
+        return [self_path]
+    return [sys.executable, '-m', 'rbx_boca']
 
 
 def _dispatch_interactor_launcher(rest: List[str]) -> int:

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/entrypoints.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/entrypoints.py
@@ -82,10 +82,10 @@ def load_context() -> RunContext:
 
 
 def _dispatch_interactor_launcher(rest: List[str]) -> int:
-    ittime = int(rest[0])
-    notify_fd = int(rest[1])
     if len(rest) < 3 or rest[2] != '--':
         raise ValueError("expected '--' separator before interactor argv")
+    ittime = int(rest[0])
+    notify_fd = int(rest[1])
     interactor_argv = rest[3:]
     # launch() replaces this process via execv, so it never returns; the 0 below
     # is only reached in tests that stub launch out.

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/interactor_launcher.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/interactor_launcher.py
@@ -35,7 +35,13 @@ def launch(interactor_argv: Sequence[str], *, ittime: int, notify_fd: int) -> No
     pure syscall behavior, not unit-testable).
     """
     limit = address_space_limit()
-    resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
+    soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+    if hard != resource.RLIM_INFINITY:
+        limit = min(limit, hard)
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (limit, hard))
+    except (ValueError, OSError):
+        pass  # address-space cap is best-effort hardening, not correctness-critical
 
     # Ensure notify_fd survives execv into the interactor: the interactor must
     # inherit it and hold the pipe open until it exits, so pipe.exe's epoll sees

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/interactor_launcher.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/interactor_launcher.py
@@ -1,0 +1,22 @@
+from typing import Tuple
+
+# bash `ulimit -v 1024000` caps virtual address space (RLIMIT_AS) at this many
+# KiB. Python's resource.setrlimit expects bytes, so we convert.
+_ADDRESS_SPACE_LIMIT_KIB = 1024000
+
+# After SIGTERM, the watchdog waits this many seconds before SIGKILL.
+_KILL_GRACE_SECONDS = 5
+
+
+def address_space_limit() -> int:
+    """Return the RLIMIT_AS cap in bytes (bash `ulimit -v 1024000`, in KiB)."""
+    return _ADDRESS_SPACE_LIMIT_KIB * 1024
+
+
+def watchdog_timeout(ittime: int) -> Tuple[int, int]:
+    """Return (term_after_seconds, kill_after_seconds) for the watchdog.
+
+    After ``ittime`` seconds send SIGTERM to the process group; ``_KILL_GRACE_SECONDS``
+    seconds later send SIGKILL.
+    """
+    return (ittime, _KILL_GRACE_SECONDS)

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/interactor_launcher.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/interactor_launcher.py
@@ -1,4 +1,9 @@
-from typing import Tuple
+import fcntl
+import os
+import resource
+import signal
+import time
+from typing import Sequence, Tuple
 
 # bash `ulimit -v 1024000` caps virtual address space (RLIMIT_AS) at this many
 # KiB. Python's resource.setrlimit expects bytes, so we convert.
@@ -20,3 +25,47 @@ def watchdog_timeout(ittime: int) -> Tuple[int, int]:
     seconds later send SIGKILL.
     """
     return (ittime, _KILL_GRACE_SECONDS)
+
+
+def launch(interactor_argv: Sequence[str], *, ittime: int, notify_fd: int) -> None:
+    """Replace this process with the interactor, under an RLIMIT_AS cap and a
+    process-group watchdog. Mirrors interactor_run.sh runit_wrapper.sh.
+
+    Verified by Phase 9 integration tests (fd-inheritance / killpg semantics are
+    pure syscall behavior, not unit-testable).
+    """
+    limit = address_space_limit()
+    resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
+
+    # Ensure notify_fd survives execv into the interactor: the interactor must
+    # inherit it and hold the pipe open until it exits, so pipe.exe's epoll sees
+    # HUP only when the interactor is done.
+    flags = fcntl.fcntl(notify_fd, fcntl.F_GETFD)
+    fcntl.fcntl(notify_fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
+
+    term_after, kill_after = watchdog_timeout(ittime)
+
+    if os.fork() == 0:
+        # Watchdog child. CLOSE its copy of notify_fd (the `exec {fd}>&-`
+        # analogue) — critical so the watchdog does not keep the pipe open and
+        # block pipe.exe's HUP detection.
+        try:
+            os.close(notify_fd)
+        except OSError:
+            pass
+        time.sleep(term_after)
+        try:
+            os.killpg(0, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        time.sleep(kill_after)
+        try:
+            os.killpg(0, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        os._exit(0)
+
+    # Parent: become the interactor. Same pid/pgid, so the watchdog's
+    # killpg(0, ...) targets this group. notify_fd (now non-cloexec) is inherited
+    # and stays open until the interactor exits.
+    os.execv(interactor_argv[0], list(interactor_argv))

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Any, List
+from typing import Any, Dict, List
 
 from rbx_boca.manifest import LanguageSpec
 
@@ -45,3 +45,30 @@ def resolve_compiler(spec: LanguageSpec) -> str:
         if p.is_file() and os.access(cand, os.X_OK):
             return cand
     raise FileNotFoundError(f'compiler not found for {spec.id}: {primary}')
+
+
+KINDS = ('compiled_static', 'jvm_jar', 'interpreted')
+
+
+def jvm_flags(memory_mb: int) -> List[str]:
+    """JVM memory flags from run/java, run/kt: heap=memory, stack=heap/10."""
+    heap_kb = memory_mb * 1000
+    stack_kb = heap_kb // 10
+    return [
+        '-XX:+UseSerialGC',
+        f'-Xmx{heap_kb}K',
+        f'-Xss{stack_kb}K',
+        f'-Xms{heap_kb}K',
+    ]
+
+
+def build_run_argv(
+    spec: LanguageSpec, *, exe: str, memory_mb: int, **extra: Any
+) -> List[str]:
+    if spec.kind not in KINDS:
+        raise ValueError(f'unknown kind: {spec.kind}')
+    subst: Dict[str, Any] = {'exe': exe, 'jar': exe}
+    subst.update(extra)
+    if spec.kind == 'jvm_jar':
+        subst['jvm_flags'] = jvm_flags(memory_mb)
+    return render_argv(spec.run_argv, **subst)

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py
@@ -1,7 +1,8 @@
 import os
 import shutil
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 from rbx_boca.manifest import LanguageSpec
 
@@ -72,3 +73,82 @@ def build_run_argv(
     if spec.kind == 'jvm_jar':
         subst['jvm_flags'] = jvm_flags(memory_mb)
     return render_argv(spec.run_argv, **subst)
+
+
+@dataclass(frozen=True)
+class CompilePlan:
+    """Pure description of how to build a submission. Contains NO IO; the
+    `compile` entrypoint (Phase 6) interprets these fields to perform the
+    steps. Mirrors the BOCA bash compile templates.
+
+    Fields:
+    - steps: ordered argv commands to run (compiler/jar invocations).
+    - artifact: 'exe' | 'jar' | 'script' -- what the build produces.
+    - static_link_check: post-compile `file ... | grep 'statically linked'`
+      (compiled_static only).
+    - rename: (from, to) source rename, e.g. ('sol.kt', 'Main.kt') for kotlin.
+    - manifest_class: jvm java Main-Class for the generated Manifest.txt.
+    - shebang: interpreted shebang line, e.g. '#!python3'.
+    - write_script: (source_path, exe_path) -- prepend shebang + chmod 755.
+    - syntax_check_argv: interpreted `py_compile` pre-check step, if enabled.
+    """
+
+    steps: List[List[str]] = field(default_factory=list)
+    artifact: str = 'exe'
+    static_link_check: bool = False
+    rename: Optional[Tuple[str, str]] = None
+    manifest_class: Optional[str] = None
+    shebang: Optional[str] = None
+    write_script: Optional[Tuple[str, str]] = None
+    syntax_check_argv: Optional[List[str]] = None
+
+
+def build_compile_plan(
+    spec: LanguageSpec,
+    *,
+    src: str,
+    exe: str,
+    basename: str,
+    **extra: Any,
+) -> CompilePlan:
+    """Build a CompilePlan describing how to compile `src` into `exe`,
+    branching on spec.kind / spec.build. Pure: performs no IO."""
+    if spec.kind not in KINDS:
+        raise ValueError(f'unknown kind: {spec.kind}')
+
+    if spec.kind == 'compiled_static':
+        step = render_argv(spec.compiler_argv, src=src, exe=exe, flags=spec.flags)
+        return CompilePlan(steps=[step], artifact='exe', static_link_check=True)
+
+    if spec.kind == 'interpreted':
+        interp = extra.get('interp', '')
+        syntax_check_argv = None
+        if spec.syntax_check:
+            syntax_check_argv = [interp, '-m', 'py_compile', src]
+        return CompilePlan(
+            steps=[],
+            artifact='script',
+            static_link_check=False,
+            shebang='#!' + interp,
+            write_script=(src, exe),
+            syntax_check_argv=syntax_check_argv,
+        )
+
+    # spec.kind == 'jvm_jar'
+    compiler = spec.compiler_argv[0]
+    if spec.build == 'javac_then_jar':
+        javac_step = render_argv(spec.compiler_argv, src=src, exe=exe, flags=spec.flags)
+        jar_step = ['jar', 'cfm', exe, 'Manifest.txt', '.']
+        return CompilePlan(
+            steps=[javac_step, jar_step],
+            artifact='jar',
+            manifest_class=basename,
+        )
+    if spec.build == 'kotlinc_include_runtime':
+        kotlinc_step = [compiler, '-d', exe, '-include-runtime', 'Main.kt']
+        return CompilePlan(
+            steps=[kotlinc_step],
+            artifact='jar',
+            rename=(src, 'Main.kt'),
+        )
+    raise ValueError(f'unknown jvm build variant: {spec.build}')

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py
@@ -1,0 +1,27 @@
+from typing import Any, List
+
+
+def render_argv(template: List[str], **subst: Any) -> List[str]:
+    """Expand a {token} argv template.
+
+    - A lone token '{name}' whose value is a list splices the list in.
+    - A lone token '{name}' whose value is a str is split on whitespace
+      (so '-O2 -static' becomes two args); an empty value is dropped.
+    - Tokens embedded in larger strings are str-replaced (no splitting).
+    """
+    out: List[str] = []
+    for tok in template:
+        if tok.startswith('{') and tok.endswith('}') and tok.count('{') == 1:
+            key = tok[1:-1]
+            val = subst.get(key, '')
+            if isinstance(val, list):
+                out.extend(str(v) for v in val)
+            else:
+                out.extend(str(val).split())
+        else:
+            rendered = tok
+            for key, val in subst.items():
+                if not isinstance(val, list):
+                    rendered = rendered.replace('{' + key + '}', str(val))
+            out.append(rendered)
+    return out

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/languages.py
@@ -1,4 +1,9 @@
+import os
+import shutil
+from pathlib import Path
 from typing import Any, List
+
+from rbx_boca.manifest import LanguageSpec
 
 
 def render_argv(template: List[str], **subst: Any) -> List[str]:
@@ -25,3 +30,18 @@ def render_argv(template: List[str], **subst: Any) -> List[str]:
                     rendered = rendered.replace('{' + key + '}', str(val))
             out.append(rendered)
     return out
+
+
+def resolve_compiler(spec: LanguageSpec) -> str:
+    """Resolve the compiler/interpreter binary: PATH lookup of compiler_argv[0],
+    then the first executable fallback. Mirrors `which X || X=/usr/bin/X` in the
+    bash compile templates."""
+    primary = spec.compiler_argv[0]
+    found = shutil.which(primary)
+    if found:
+        return found
+    for cand in spec.compiler_fallbacks:
+        p = Path(cand)
+        if p.is_file() and os.access(cand, os.X_OK):
+            return cand
+    raise FileNotFoundError(f'compiler not found for {spec.id}: {primary}')

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/manifest.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/manifest.py
@@ -14,6 +14,10 @@ class LanguageSpec:
     build: Optional[str] = None  # jvm: 'javac_then_jar' | 'kotlinc_include_runtime'
     syntax_check: bool = False  # interpreted (py3) py_compile pre-check
     sandbox_overrides: Dict[str, Any] = field(default_factory=dict)
+    # Absolute compile-phase time limit (seconds). Compile uses cpu == wall ==
+    # this value, decoupled from the problem timelimit (e.g. JVM langs set it
+    # higher). A per-language property, hence it lives on the spec.
+    compile_time_sec: int = 30
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> 'LanguageSpec':
@@ -27,6 +31,7 @@ class LanguageSpec:
             build=d.get('build'),
             syntax_check=bool(d.get('syntax_check', False)),
             sandbox_overrides=dict(d.get('sandbox_overrides', {})),
+            compile_time_sec=int(d.get('compile_time_sec', 30)),
         )
 
 
@@ -35,6 +40,10 @@ class LimitsConfig:
     time_sec: int
     runs: int
     memory_mb: int
+    # Absolute run-phase wall time limit (seconds), used directly as safeexec -T.
+    # A per-problem limit, hence it lives in the limits rather than being a
+    # hardcoded multiple of the cpu timelimit.
+    wall_time_sec: int
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> 'LimitsConfig':
@@ -42,6 +51,7 @@ class LimitsConfig:
             time_sec=int(d['time_sec']),
             runs=int(d['runs']),
             memory_mb=int(d['memory_mb']),
+            wall_time_sec=int(d['wall_time_sec']),
         )
 
 

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/manifest.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/manifest.py
@@ -1,0 +1,70 @@
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class LanguageSpec:
+    id: str
+    kind: str  # 'compiled_static' | 'jvm_jar' | 'interpreted'
+    compiler_argv: List[str]
+    compiler_fallbacks: List[str]
+    flags: str
+    run_argv: List[str]
+    build: Optional[str] = None  # jvm: 'javac_then_jar' | 'kotlinc_include_runtime'
+    syntax_check: bool = False  # interpreted (py3) py_compile pre-check
+    sandbox_overrides: Dict[str, Any] = field(default_factory=dict)
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> 'LanguageSpec':
+        return LanguageSpec(
+            id=d['id'],
+            kind=d['kind'],
+            compiler_argv=list(d['compiler_argv']),
+            compiler_fallbacks=list(d.get('compiler_fallbacks', [])),
+            flags=d.get('flags', ''),
+            run_argv=list(d['run_argv']),
+            build=d.get('build'),
+            syntax_check=bool(d.get('syntax_check', False)),
+            sandbox_overrides=dict(d.get('sandbox_overrides', {})),
+        )
+
+
+@dataclass(frozen=True)
+class LimitsConfig:
+    time_sec: int
+    runs: int
+    memory_mb: int
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> 'LimitsConfig':
+        return LimitsConfig(
+            time_sec=int(d['time_sec']),
+            runs=int(d['runs']),
+            memory_mb=int(d['memory_mb']),
+        )
+
+
+@dataclass(frozen=True)
+class TaskConfig:
+    task_type: str  # 'batch' | 'interactive'
+    output_kb: int
+
+    @staticmethod
+    def from_json(text: str) -> 'TaskConfig':
+        d = json.loads(text)
+        return TaskConfig(task_type=d['task_type'], output_kb=int(d['output_kb']))
+
+
+@dataclass(frozen=True)
+class LanguageManifest:
+    language: LanguageSpec
+    limits: LimitsConfig
+
+    @staticmethod
+    def from_json(text: str) -> 'LanguageManifest':
+        d = json.loads(text)
+        return LanguageManifest(
+            language=LanguageSpec.from_dict(d['language']),
+            limits=LimitsConfig.from_dict(d['limits']),
+        )

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
@@ -97,7 +97,7 @@ def profile_for(
             )
         elif kind == 'jvm_jar':
             spec = SafeExecSpec(
-                runs=1,
+                runs=nruns,
                 cpu_sec=cpu_sec,
                 wall_sec=wall_sec,
                 mem_kb=_JVM_MEM_KB,
@@ -115,7 +115,7 @@ def profile_for(
             )
         else:  # interpreted
             spec = SafeExecSpec(
-                runs=1,
+                runs=nruns,
                 cpu_sec=cpu_sec,
                 wall_sec=wall_sec,
                 mem_kb=mem_kb,

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
@@ -1,6 +1,7 @@
 import dataclasses
+import subprocess
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 
 @dataclass(frozen=True)
@@ -171,3 +172,21 @@ def profile_for(
     if overrides:
         spec = dataclasses.replace(spec, **overrides)
     return spec
+
+
+def _default_runner(argv: List[str], **kwargs) -> int:
+    return subprocess.call(argv, **kwargs)
+
+
+class SafeExec:
+    def __init__(
+        self,
+        path: str = 'safeexec',
+        runner: Optional[Callable[..., int]] = None,
+    ) -> None:
+        self.path = path
+        self.runner = runner if runner is not None else _default_runner
+
+    def run(self, spec: SafeExecSpec, program: List[str], **kwargs) -> int:
+        argv = build_safeexec_argv(spec, program, safeexec=self.path)
+        return self.runner(argv, **kwargs)

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
@@ -68,6 +68,7 @@ def profile_for(
     phase: str,
     *,
     cpu_sec: int,
+    wall_sec: int,
     memory_mb: int,
     nruns: int = 1,
     out_kb: int = 0,
@@ -88,7 +89,6 @@ def profile_for(
     mem_kb = memory_mb * 1000
 
     if phase == 'run':
-        wall_sec = cpu_sec * 4
         run_stdin = 'stdin0' if stdin is None else stdin
         if kind == 'compiled_static':
             spec = SafeExecSpec(
@@ -145,10 +145,9 @@ def profile_for(
                 stderr=stderr,
             )
     else:  # compile
-        # BOCA compile scripts set BOTH the CPU limit (-t) and the wall
-        # limit (-T) to 2x the timelimit (compile/cpp:96,132).
-        cpu_sec = cpu_sec * 2
-        wall_sec = cpu_sec
+        # Compile uses the caller-supplied cpu_sec/wall_sec as-is. The caller
+        # sets cpu_sec == wall_sec == spec.compile_time_sec (TL == wall TL),
+        # decoupled from the problem timelimit.
         if kind == 'jvm_jar':
             spec = SafeExecSpec(
                 runs=1,

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class SafeExecSpec:
+    runs: int
+    cpu_sec: int
+    wall_sec: int
+    mem_kb: int
+    out_kb: int
+    fds: int
+    n: int  # safeexec -n process limit (1 for compiled, 0 for jvm/interpreted/compile)
+    procs: Optional[int]  # safeexec -u procs-per-user (jvm/interpreted only)
+    uid: int
+    gid: int
+    chdir: str
+    chroot: Optional[str]
+    stdin: Optional[str]
+    stdout: str
+    stderr: str
+
+
+def build_safeexec_argv(
+    spec: SafeExecSpec, program: List[str], *, safeexec: str = 'safeexec'
+) -> List[str]:
+    argv = [safeexec, f'-r{spec.runs}', f'-t{spec.cpu_sec}', f'-T{spec.wall_sec}']
+    argv += [f'-d{spec.mem_kb}', f'-m{spec.mem_kb}', f'-f{spec.out_kb}']
+    argv += [f'-F{spec.fds}', f'-n{spec.n}']
+    if spec.procs is not None:
+        argv.append(f'-u{spec.procs}')
+    argv += [f'-U{spec.uid}', f'-G{spec.gid}', f'-C{spec.chdir}']
+    if spec.chroot is not None:
+        argv.append(f'-R{spec.chroot}')
+    if spec.stdin is not None:
+        argv.append(f'-i{spec.stdin}')
+    argv += [f'-o{spec.stdout}', f'-e{spec.stderr}']
+    argv += list(program)
+    return argv

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
@@ -1,3 +1,4 @@
+import dataclasses
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -37,3 +38,136 @@ def build_safeexec_argv(
     argv += [f'-o{spec.stdout}', f'-e{spec.stderr}']
     argv += list(program)
     return argv
+
+
+_KNOWN_KINDS = ('compiled_static', 'jvm_jar', 'interpreted')
+_KNOWN_PHASES = ('run', 'compile')
+
+_JVM_MEM_KB = 20000000
+_JVM_RUN_OUT_KB = 20000
+_COMPILE_OUT_KB = 50000
+
+
+def profile_for(
+    kind: str,
+    phase: str,
+    *,
+    cpu_sec: int,
+    memory_mb: int,
+    nruns: int = 1,
+    out_kb: int = 0,
+    uid: int,
+    gid: int,
+    chdir: str = '.',
+    chroot: Optional[str] = None,
+    stdin: Optional[str] = None,
+    stdout: str = 'stdout0',
+    stderr: str = 'stderr0',
+    overrides: Optional[dict] = None,
+) -> SafeExecSpec:
+    if kind not in _KNOWN_KINDS:
+        raise ValueError(f'unknown kind: {kind!r}')
+    if phase not in _KNOWN_PHASES:
+        raise ValueError(f'unknown phase: {phase!r}')
+
+    mem_kb = memory_mb * 1000
+
+    if phase == 'run':
+        wall_sec = cpu_sec * 4
+        run_stdin = 'stdin0' if stdin is None else stdin
+        if kind == 'compiled_static':
+            spec = SafeExecSpec(
+                runs=nruns,
+                cpu_sec=cpu_sec,
+                wall_sec=wall_sec,
+                mem_kb=mem_kb,
+                out_kb=out_kb,
+                fds=10,
+                n=1,
+                procs=None,
+                uid=uid,
+                gid=gid,
+                chdir=chdir,
+                chroot=chroot,
+                stdin=run_stdin,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        elif kind == 'jvm_jar':
+            spec = SafeExecSpec(
+                runs=1,
+                cpu_sec=cpu_sec,
+                wall_sec=wall_sec,
+                mem_kb=_JVM_MEM_KB,
+                out_kb=_JVM_RUN_OUT_KB,
+                fds=256,
+                n=0,
+                procs=256,
+                uid=uid,
+                gid=gid,
+                chdir=chdir,
+                chroot=chroot,
+                stdin=run_stdin,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        else:  # interpreted
+            spec = SafeExecSpec(
+                runs=1,
+                cpu_sec=cpu_sec,
+                wall_sec=wall_sec,
+                mem_kb=mem_kb,
+                out_kb=out_kb,
+                fds=256,
+                n=0,
+                procs=256,
+                uid=uid,
+                gid=gid,
+                chdir=chdir,
+                chroot=chroot,
+                stdin=run_stdin,
+                stdout=stdout,
+                stderr=stderr,
+            )
+    else:  # compile
+        wall_sec = cpu_sec * 2
+        if kind == 'jvm_jar':
+            spec = SafeExecSpec(
+                runs=1,
+                cpu_sec=cpu_sec,
+                wall_sec=wall_sec,
+                mem_kb=_JVM_MEM_KB,
+                out_kb=_COMPILE_OUT_KB,
+                fds=256,
+                n=0,
+                procs=256,
+                uid=uid,
+                gid=gid,
+                chdir=chdir,
+                chroot=chroot,
+                stdin=None,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        else:  # compiled_static & interpreted
+            spec = SafeExecSpec(
+                runs=1,
+                cpu_sec=cpu_sec,
+                wall_sec=wall_sec,
+                mem_kb=mem_kb,
+                out_kb=_COMPILE_OUT_KB,
+                fds=1000,
+                n=0,
+                procs=None,
+                uid=uid,
+                gid=gid,
+                chdir=chdir,
+                chroot=chroot,
+                stdin=None,
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+    if overrides:
+        spec = dataclasses.replace(spec, **overrides)
+    return spec

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
@@ -24,8 +24,19 @@ class SafeExecSpec:
 
 
 def build_safeexec_argv(
-    spec: SafeExecSpec, program: List[str], *, safeexec: str = 'safeexec'
+    spec: SafeExecSpec,
+    program: List[str],
+    *,
+    safeexec: str = 'safeexec',
+    notify: Optional[str] = None,
 ) -> List[str]:
+    """Build the safeexec argv for ``program``.
+
+    ``notify`` (interactive only) emits ``-D<notify>``: safeexec's notify-fd
+    option. The interactive runner passes the literal ``__FD__`` token here,
+    which pipe.exe substitutes with a real fd number at runtime (mirrors
+    interactor_run.sh:45 ``-D__FD__``). Do NOT substitute it yourself.
+    """
     argv = [safeexec, f'-r{spec.runs}', f'-t{spec.cpu_sec}', f'-T{spec.wall_sec}']
     argv += [f'-d{spec.mem_kb}', f'-m{spec.mem_kb}', f'-f{spec.out_kb}']
     argv += [f'-F{spec.fds}', f'-n{spec.n}']
@@ -37,6 +48,8 @@ def build_safeexec_argv(
     if spec.stdin is not None:
         argv.append(f'-i{spec.stdin}')
     argv += [f'-o{spec.stdout}', f'-e{spec.stderr}']
+    if notify is not None:
+        argv.append(f'-D{notify}')
     argv.append('--')
     argv += list(program)
     return argv

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/sandbox.py
@@ -37,6 +37,7 @@ def build_safeexec_argv(
     if spec.stdin is not None:
         argv.append(f'-i{spec.stdin}')
     argv += [f'-o{spec.stdout}', f'-e{spec.stderr}']
+    argv.append('--')
     argv += list(program)
     return argv
 
@@ -131,7 +132,10 @@ def profile_for(
                 stderr=stderr,
             )
     else:  # compile
-        wall_sec = cpu_sec * 2
+        # BOCA compile scripts set BOTH the CPU limit (-t) and the wall
+        # limit (-T) to 2x the timelimit (compile/cpp:96,132).
+        cpu_sec = cpu_sec * 2
+        wall_sec = cpu_sec
         if kind == 'jvm_jar':
             spec = SafeExecSpec(
                 runs=1,

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -323,6 +323,14 @@ class InteractiveTask(BaseTask):
         return pipe_argv
 
     def run(self, ctx: RunContext, args: List[str]) -> int:
+        # Copy the test input into stdin0 so the interactor (which is invoked
+        # with `stdin0 stdout0`) reads the actual test data. Mirrors the batch
+        # path's stdin0 population; the interactor argv passes the literal
+        # 'stdin0' filename (matching bash interactor_run.sh), so the file must
+        # exist with the real input contents.
+        inputfile = args[1]
+        (ctx.cwd / _STDIN).write_text(Path(inputfile).read_text())
+
         # Make the bidirectional fifos (stubbable for unit tests).
         make_fifos = (
             ctx.make_fifos

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -1,0 +1,125 @@
+"""Batch/Interactive orchestration: wires together the runtime modules.
+
+This is the Layer-2 glue. Each *task type* (batch, interactive) exposes the
+three BOCA lifecycle hooks -- ``compile``, ``run``, ``compare`` -- by composing
+the already-built, already-tested primitives in :mod:`rbx_boca.languages`,
+:mod:`rbx_boca.sandbox` and :mod:`rbx_boca.verdicts`.
+
+Everything a task needs is bundled in :class:`RunContext`, and every external
+effect (subprocess execution, safeexec, static-link checking, fifo creation) is
+injected so the orchestration can be unit-tested without real subprocesses.
+
+stdlib-only, Python 3.8 compatible.
+"""
+
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from rbx_boca import languages, sandbox
+from rbx_boca.manifest import LanguageManifest, TaskConfig
+
+# BOCA compile/other-error exit code, mirrors run/cpp aborting when a submission
+# is not statically linked (exit 47).
+_OTHER_ERROR = 47
+
+
+def _default_static_link_ok(exe: Path) -> bool:
+    """Run `file <exe>` and look for 'statically linked'. Mirrors the run-time
+    static-link guard in BOCA's run/cpp template."""
+    try:
+        out = subprocess.run(
+            ['file', str(exe)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        ).stdout.decode('utf-8', 'replace')
+    except OSError:
+        return False
+    return 'statically linked' in out
+
+
+@dataclass
+class RunContext:
+    """Everything the task orchestration needs, with all effects injectable.
+
+    Real runs build this from parsed manifests + resolved asset paths; unit
+    tests construct it directly with fake ``runner`` / ``safeexec`` /
+    ``static_link_ok`` / ``make_fifos`` callables so no subprocess ever runs.
+    """
+
+    task: TaskConfig
+    lang: LanguageManifest
+    cwd: Path
+    # Runs an argv, returns the process exit code. Used for compiler steps,
+    # the checker, syntax checks and (interactive) the pipe.exe orchestrator.
+    runner: Callable[..., int]
+    # Configured safeexec executor (its .path is already resolved).
+    safeexec: sandbox.SafeExec
+    uid: int = 65534
+    gid: int = 65534
+    chroot: Optional[str] = None
+    cache_dir: Path = field(default_factory=lambda: Path('.'))
+    # Already-resolved asset binaries (NativeAsset.ensure happens in Phase 9).
+    checker_path: Optional[Path] = None
+    interactor_path: Optional[Path] = None
+    pipe_path: Optional[Path] = None
+    # Re-entrant sentinel argv that launches the interactor under safeexec.
+    # Phase 7/8 wire the real value; injected directly in unit tests.
+    interactor_launch_argv: List[str] = field(default_factory=list)
+    # Injectable static-link checker (default: `file <exe>` grep).
+    static_link_ok: Callable[[Path], bool] = _default_static_link_ok
+    # Injectable fifo creator (default: os.mkfifo the two interactive fifos).
+    make_fifos: Optional[Callable[[], None]] = None
+
+    @property
+    def spec(self):
+        return self.lang.language
+
+
+class BatchTask:
+    """Standard batch task: compile a submission, run it once per test under
+    safeexec, compare its stdout against the expected output via a checker."""
+
+    def compile(self, ctx: RunContext, *, src: str, exe: str, basename: str) -> int:
+        spec = ctx.spec
+        interp = ''
+        if spec.kind == 'interpreted':
+            interp = languages.resolve_compiler(spec)
+        plan = languages.build_compile_plan(
+            spec, src=src, exe=exe, basename=basename, interp=interp
+        )
+
+        # Interpreted: write the shebang'd script + optional syntax pre-check.
+        # NOTE: Layer-2 placement choice -- compile steps run directly via
+        # ctx.runner (not wrapped in safeexec). The sandbox wrapping of the
+        # compiler is an integration concern (Phase 9); unit tests assert on
+        # the bare compiler argv.
+        if plan.write_script is not None:
+            source_path, exe_path = plan.write_script
+            contents = (ctx.cwd / source_path).read_text()
+            target = ctx.cwd / exe_path
+            target.write_text((plan.shebang or '') + '\n' + contents)
+            os.chmod(str(target), 0o755)
+
+        if plan.syntax_check_argv is not None:
+            rc = ctx.runner(plan.syntax_check_argv)
+            if rc != 0:
+                return rc
+
+        # Compiled / jvm: optional source rename, then each compiler step.
+        if plan.rename is not None:
+            src_from, src_to = plan.rename
+            os.replace(str(ctx.cwd / src_from), str(ctx.cwd / src_to))
+
+        for step in plan.steps:
+            rc = ctx.runner(step)
+            if rc != 0:
+                return rc
+
+        # Static-link guard (compiled_static): mirrors run/cpp aborting with 47.
+        if plan.static_link_check and not ctx.static_link_ok(ctx.cwd / exe):
+            return _OTHER_ERROR
+
+        return 0

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -15,6 +15,7 @@ stdlib-only, Python 3.8 compatible.
 import os
 import re
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional
@@ -121,6 +122,12 @@ def _compare(ctx: 'RunContext', args: List[str]) -> int:
     testlib_code = _read_testlib_code(Path(team_output))
     if testlib_code is not None:
         return verdicts.compare_verdict(testlib_code=testlib_code, checker_exit=None)
+
+    # No testlib marker: we are about to invoke the checker. If its path was
+    # never wired, fail loudly instead of exec'ing a program named "None".
+    if ctx.checker_path is None:
+        print('checker_path not configured', file=sys.stderr)
+        return _OTHER_ERROR
 
     checker_exit = ctx.runner(
         [str(ctx.checker_path), input_file, team_output, expected_output]
@@ -323,6 +330,12 @@ class InteractiveTask(BaseTask):
         return pipe_argv
 
     def run(self, ctx: RunContext, args: List[str]) -> int:
+        # Fail loudly if the interactive assets were never wired, instead of
+        # building a pipe argv that exec's a program named "None".
+        if ctx.interactor_path is None or ctx.pipe_path is None:
+            print('interactor_path/pipe_path not configured', file=sys.stderr)
+            return _JUDGE_ERROR
+
         # Copy the test input into stdin0 so the interactor (which is invoked
         # with `stdin0 stdout0`) reads the actual test data. Mirrors the batch
         # path's stdin0 population; the interactor argv passes the literal

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -13,6 +13,7 @@ stdlib-only, Python 3.8 compatible.
 """
 
 import os
+import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -27,6 +28,9 @@ _OTHER_ERROR = 47
 
 # Local filenames inside the sandbox cwd.
 _STDIN = 'stdin0'
+
+# First line of team output that carries an interactor (testlib) verdict.
+_TESTLIB_RE = re.compile(r'^testlib exitcode\s+(-?\d+)\s*$')
 
 
 def _default_static_link_ok(exe: Path) -> bool:
@@ -79,6 +83,41 @@ class RunContext:
     @property
     def spec(self):
         return self.lang.language
+
+
+def _read_testlib_code(path: Path) -> Optional[int]:
+    """Return the integer from the first `testlib exitcode N` line, or None."""
+    try:
+        text = path.read_text()
+    except OSError:
+        return None
+    for line in text.splitlines():
+        m = _TESTLIB_RE.match(line.strip())
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def _compare(ctx: 'RunContext', args: List[str]) -> int:
+    """Shared compare logic for batch and interactive tasks.
+
+    args = [team_output, expected_output, input_file].
+
+    If the team output carries a `testlib exitcode N` marker (written by
+    InteractiveTask.run), trust it directly and skip the checker. Otherwise
+    invoke the checker as `checker input team_output expected_output` and map
+    its exit. BatchTask never writes that marker, so it always runs the checker.
+    """
+    team_output, expected_output, input_file = args[0], args[1], args[2]
+
+    testlib_code = _read_testlib_code(Path(team_output))
+    if testlib_code is not None:
+        return verdicts.compare_verdict(testlib_code=testlib_code, checker_exit=None)
+
+    checker_exit = ctx.runner(
+        [str(ctx.checker_path), input_file, team_output, expected_output]
+    )
+    return verdicts.compare_verdict(testlib_code=None, checker_exit=checker_exit)
 
 
 class BatchTask:
@@ -163,3 +202,15 @@ class BatchTask:
         )
         raw = ctx.safeexec.run(spec_se, program)
         return verdicts.batch_run_exit(raw)
+
+    def compare(self, ctx: RunContext, args: List[str]) -> int:
+        return _compare(ctx, args)
+
+
+class InteractiveTask:
+    """Interactive task: solution and interactor talk over a pair of fifos,
+    bridged by pipe.exe. The interactor's verdict (testlib code) is recorded
+    into stdout0 so the (shared) compare step can read it without a checker."""
+
+    def compare(self, ctx: RunContext, args: List[str]) -> int:
+        return _compare(ctx, args)

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -128,9 +128,13 @@ def _compare(ctx: 'RunContext', args: List[str]) -> int:
     return verdicts.compare_verdict(testlib_code=None, checker_exit=checker_exit)
 
 
-class BatchTask:
-    """Standard batch task: compile a submission, run it once per test under
-    safeexec, compare its stdout against the expected output via a checker."""
+class BaseTask:
+    """Shared lifecycle hooks for every task type.
+
+    ``compile`` (build the submission) and ``compare`` (map a verdict) are
+    identical for batch and interactive problems, so they live here. Only
+    ``run`` differs, and each subclass provides its own implementation.
+    """
 
     def compile(self, ctx: RunContext, *, src: str, exe: str, basename: str) -> int:
         spec = ctx.spec
@@ -182,6 +186,14 @@ class BatchTask:
 
         return 0
 
+    def compare(self, ctx: RunContext, args: List[str]) -> int:
+        return _compare(ctx, args)
+
+
+class BatchTask(BaseTask):
+    """Standard batch task: compile a submission, run it once per test under
+    safeexec, compare its stdout against the expected output via a checker."""
+
     def run(self, ctx: RunContext, args: List[str]) -> int:
         # BOCA run argv: basename inputfile timelimit repetitions memory out_kb
         basename, inputfile, timelimit, repetitions, memory, outputsize_kb = (
@@ -219,11 +231,8 @@ class BatchTask:
         raw = ctx.safeexec.run(spec_se, program)
         return verdicts.batch_run_exit(raw)
 
-    def compare(self, ctx: RunContext, args: List[str]) -> int:
-        return _compare(ctx, args)
 
-
-class InteractiveTask:
+class InteractiveTask(BaseTask):
     """Interactive task: solution and interactor talk over a pair of fifos,
     bridged by pipe.exe. The interactor's verdict (testlib code) is recorded
     into stdout0 so the (shared) compare step can read it without a checker."""
@@ -324,6 +333,3 @@ class InteractiveTask:
             if path.exists():
                 path.unlink()
             os.mkfifo(str(path))
-
-    def compare(self, ctx: RunContext, args: List[str]) -> int:
-        return _compare(ctx, args)

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -28,6 +28,10 @@ _OTHER_ERROR = 47
 
 # Local filenames inside the sandbox cwd.
 _STDIN = 'stdin0'
+_STDOUT = 'stdout0'
+_FIFO_IN = 'fifo.in'
+_FIFO_OUT = 'fifo.out'
+_PIPE_LOG = 'pipe.log'
 
 # First line of team output that carries an interactor (testlib) verdict.
 _TESTLIB_RE = re.compile(r'^testlib exitcode\s+(-?\d+)\s*$')
@@ -211,6 +215,94 @@ class InteractiveTask:
     """Interactive task: solution and interactor talk over a pair of fifos,
     bridged by pipe.exe. The interactor's verdict (testlib code) is recorded
     into stdout0 so the (shared) compare step can read it without a checker."""
+
+    def run(self, ctx: RunContext, args: List[str]) -> int:
+        # BOCA run argv: basename inputfile timelimit repetitions memory out_kb
+        basename, inputfile, timelimit, repetitions, memory, outputsize_kb = (
+            args[0],
+            args[1],
+            int(args[2]),
+            int(args[3]),
+            int(args[4]),
+            int(args[5]),
+        )
+        spec = ctx.spec
+
+        # Make the bidirectional fifos (stubbable for unit tests).
+        make_fifos = (
+            ctx.make_fifos
+            if ctx.make_fifos is not None
+            else (lambda: self._default_make_fifos(ctx))
+        )
+        make_fifos()
+
+        # Build the safeexec-wrapped solution command.
+        run_extra = {}
+        if spec.kind == 'interpreted':
+            run_extra['interp'] = languages.resolve_compiler(spec)
+        program = languages.build_run_argv(
+            spec, exe=basename, memory_mb=memory, **run_extra
+        )
+        spec_se = sandbox.profile_for(
+            spec.kind,
+            'run',
+            cpu_sec=timelimit,
+            memory_mb=memory,
+            nruns=repetitions,
+            out_kb=outputsize_kb,
+            uid=ctx.uid,
+            gid=ctx.gid,
+            chroot=ctx.chroot,
+            overrides=spec.sandbox_overrides,
+        )
+        solution_cmd = sandbox.build_safeexec_argv(
+            spec_se, program, safeexec=ctx.safeexec.path
+        )
+
+        # pipe.exe -i fifo.in -o fifo.out -e <sol stderr> -E <int stderr>
+        #          -- <solution cmd> = <interactor launcher cmd>
+        pipe_argv = [
+            str(ctx.pipe_path),
+            '-i',
+            _FIFO_IN,
+            '-o',
+            _FIFO_OUT,
+            '-e',
+            spec_se.stderr,
+            '-E',
+            'interactor.stderr',
+            '--',
+        ]
+        pipe_argv += solution_cmd
+        pipe_argv += ['=']
+        # The interactor launcher receives the test input path ({input} token);
+        # testlib interactors read the input file from their argv.
+        pipe_argv += languages.render_argv(
+            list(ctx.interactor_launch_argv), input=inputfile
+        )
+
+        ctx.runner(pipe_argv)
+
+        # Parse pipe.log and apply the ordered interactive decision logic.
+        log = verdicts.PipeLog.parse((ctx.cwd / _PIPE_LOG).read_text())
+        decision = verdicts.interactive_run_decision(
+            log.first_tag, log.solution_status, log.interactor_status
+        )
+
+        # Record the interactor verdict for the compare step (no checker run).
+        if decision.testlib_code is not None:
+            (ctx.cwd / _STDOUT).write_text(
+                'testlib exitcode {}\n'.format(decision.testlib_code)
+            )
+
+        return decision.run_exit
+
+    def _default_make_fifos(self, ctx: RunContext) -> None:
+        for name in (_FIFO_IN, _FIFO_OUT):
+            path = ctx.cwd / name
+            if path.exists():
+                path.unlink()
+            os.mkfifo(str(path))
 
     def compare(self, ctx: RunContext, args: List[str]) -> int:
         return _compare(ctx, args)

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -26,6 +26,10 @@ from rbx_boca.manifest import LanguageManifest, TaskConfig
 # is not statically linked (exit 47).
 _OTHER_ERROR = 47
 
+# BOCA run-phase judge-error exit code (JUDGE_ERROR=4 in interactor_run.sh).
+# Used when pipe.exe fails or pipe.log is missing/malformed.
+_JUDGE_ERROR = 4
+
 # Local filenames inside the sandbox cwd.
 _STDIN = 'stdin0'
 _STDOUT = 'stdout0'
@@ -154,6 +158,14 @@ class BatchTask:
             if rc != 0:
                 return rc
 
+        # jvm jar: write the Main-Class manifest BEFORE the `jar cfm` step that
+        # references it. Mirrors BOCA run/java writing Manifest.txt with
+        # `Main-Class: <klass>` prior to invoking jar.
+        if plan.manifest_class is not None:
+            (ctx.cwd / 'Manifest.txt').write_text(
+                'Main-Class: {}\n'.format(plan.manifest_class)
+            )
+
         # Compiled / jvm: optional source rename, then each compiler step.
         if plan.rename is not None:
             src_from, src_to = plan.rename
@@ -281,10 +293,19 @@ class InteractiveTask:
             list(ctx.interactor_launch_argv), input=inputfile
         )
 
-        ctx.runner(pipe_argv)
+        # If pipe.exe itself fails, treat it as a judge error (mirrors BOCA's
+        # interactor_run.sh returning JUDGE_ERROR=4 on pipe.exe failure).
+        pipe_rc = ctx.runner(pipe_argv)
+        if pipe_rc != 0:
+            return _JUDGE_ERROR
 
-        # Parse pipe.log and apply the ordered interactive decision logic.
-        log = verdicts.PipeLog.parse((ctx.cwd / _PIPE_LOG).read_text())
+        # Parse pipe.log and apply the ordered interactive decision logic. A
+        # missing, short, or garbage log (which would crash PipeLog.parse) is
+        # also a judge error, matching interactor_run.sh's invalid-tag handling.
+        try:
+            log = verdicts.PipeLog.parse((ctx.cwd / _PIPE_LOG).read_text())
+        except (ValueError, OSError):
+            return _JUDGE_ERROR
         decision = verdicts.interactive_run_decision(
             log.first_tag, log.solution_status, log.interactor_status
         )

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -18,12 +18,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional
 
-from rbx_boca import languages, sandbox
+from rbx_boca import languages, sandbox, verdicts
 from rbx_boca.manifest import LanguageManifest, TaskConfig
 
 # BOCA compile/other-error exit code, mirrors run/cpp aborting when a submission
 # is not statically linked (exit 47).
 _OTHER_ERROR = 47
+
+# Local filenames inside the sandbox cwd.
+_STDIN = 'stdin0'
 
 
 def _default_static_link_ok(exe: Path) -> bool:
@@ -123,3 +126,40 @@ class BatchTask:
             return _OTHER_ERROR
 
         return 0
+
+    def run(self, ctx: RunContext, args: List[str]) -> int:
+        # BOCA run argv: basename inputfile timelimit repetitions memory out_kb
+        basename, inputfile, timelimit, repetitions, memory, outputsize_kb = (
+            args[0],
+            args[1],
+            int(args[2]),
+            int(args[3]),
+            int(args[4]),
+            int(args[5]),
+        )
+        spec = ctx.spec
+
+        # Point the sandbox stdin at the test input by copying it to stdin0.
+        (ctx.cwd / _STDIN).write_text(Path(inputfile).read_text())
+
+        run_extra = {}
+        if spec.kind == 'interpreted':
+            run_extra['interp'] = languages.resolve_compiler(spec)
+        program = languages.build_run_argv(
+            spec, exe=basename, memory_mb=memory, **run_extra
+        )
+
+        spec_se = sandbox.profile_for(
+            spec.kind,
+            'run',
+            cpu_sec=timelimit,
+            memory_mb=memory,
+            nruns=repetitions,
+            out_kb=outputsize_kb,
+            uid=ctx.uid,
+            gid=ctx.gid,
+            chroot=ctx.chroot,
+            overrides=spec.sandbox_overrides,
+        )
+        raw = ctx.safeexec.run(spec_se, program)
+        return verdicts.batch_run_exit(raw)

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -227,6 +227,7 @@ class BatchTask(BaseTask):
             spec.kind,
             'run',
             cpu_sec=timelimit,
+            wall_sec=ctx.lang.limits.wall_time_sec,
             memory_mb=memory,
             nruns=repetitions,
             out_kb=outputsize_kb,
@@ -278,10 +279,12 @@ class InteractiveTask(BaseTask):
         program = languages.build_run_argv(
             spec, exe=basename, memory_mb=memory, **run_extra
         )
+        wall_time_sec = ctx.lang.limits.wall_time_sec
         spec_se = sandbox.profile_for(
             spec.kind,
             'run',
             cpu_sec=timelimit,
+            wall_sec=wall_time_sec,
             memory_mb=memory,
             nruns=repetitions,
             out_kb=outputsize_kb,
@@ -300,8 +303,8 @@ class InteractiveTask(BaseTask):
         )
 
         # Interactor side: re-enter this bundle under the watchdog/RLIMIT_AS cap.
-        # ittime = wall TL + 1 (interactor_run.sh:13).
-        ittime = timelimit + 1
+        # ittime = wall TL + 1 (interactor_run.sh:13, where ttime is the wall TL).
+        ittime = wall_time_sec + 1
         interactor_cmd = list(ctx.interactor_launch_argv) + [
             '__interactor_launcher__',
             str(ittime),

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/tasks.py
@@ -237,9 +237,24 @@ class InteractiveTask(BaseTask):
     bridged by pipe.exe. The interactor's verdict (testlib code) is recorded
     into stdout0 so the (shared) compare step can read it without a checker."""
 
-    def run(self, ctx: RunContext, args: List[str]) -> int:
+    # Notify-fd token pipe.exe substitutes with a real fd at runtime
+    # (interactor_run.sh:45/47 `__FD__`). Emitted literally; never substituted.
+    _FD_TOKEN = '__FD__'
+
+    def build_pipe_argv(self, ctx: RunContext, args: List[str]) -> List[str]:
+        """Construct the pipe.exe argv for an interactive run.
+
+        Structurally mirrors rbx/resources/packagers/boca/interactor_run.sh:44-47:
+
+            pipe.exe -i fifo.in -o fifo.out -e <sol stderr> -E interactor.stderr --
+                <safeexec solution -ofifo.out -ififo.in -D__FD__ ...>
+                = <launch> __interactor_launcher__ <ittime> __FD__ -- <interactor> stdin0 stdout0
+
+        ``ittime = timelimit + 1`` (interactor_run.sh:13 adds 1s of wall slack).
+        pipe.exe substitutes the literal ``__FD__`` tokens with real fds.
+        """
         # BOCA run argv: basename inputfile timelimit repetitions memory out_kb
-        basename, inputfile, timelimit, repetitions, memory, outputsize_kb = (
+        basename, _inputfile, timelimit, repetitions, memory, outputsize_kb = (
             args[0],
             args[1],
             int(args[2]),
@@ -249,15 +264,7 @@ class InteractiveTask(BaseTask):
         )
         spec = ctx.spec
 
-        # Make the bidirectional fifos (stubbable for unit tests).
-        make_fifos = (
-            ctx.make_fifos
-            if ctx.make_fifos is not None
-            else (lambda: self._default_make_fifos(ctx))
-        )
-        make_fifos()
-
-        # Build the safeexec-wrapped solution command.
+        # Solution program, run under safeexec with fifo redirection + notify fd.
         run_extra = {}
         if spec.kind == 'interpreted':
             run_extra['interp'] = languages.resolve_compiler(spec)
@@ -274,14 +281,30 @@ class InteractiveTask(BaseTask):
             uid=ctx.uid,
             gid=ctx.gid,
             chroot=ctx.chroot,
+            stdin=_FIFO_IN,
+            stdout=_FIFO_OUT,
             overrides=spec.sandbox_overrides,
         )
         solution_cmd = sandbox.build_safeexec_argv(
-            spec_se, program, safeexec=ctx.safeexec.path
+            spec_se,
+            program,
+            safeexec=ctx.safeexec.path,
+            notify=self._FD_TOKEN,
         )
 
-        # pipe.exe -i fifo.in -o fifo.out -e <sol stderr> -E <int stderr>
-        #          -- <solution cmd> = <interactor launcher cmd>
+        # Interactor side: re-enter this bundle under the watchdog/RLIMIT_AS cap.
+        # ittime = wall TL + 1 (interactor_run.sh:13).
+        ittime = timelimit + 1
+        interactor_cmd = list(ctx.interactor_launch_argv) + [
+            '__interactor_launcher__',
+            str(ittime),
+            self._FD_TOKEN,
+            '--',
+            str(ctx.interactor_path),
+            _STDIN,
+            _STDOUT,
+        ]
+
         pipe_argv = [
             str(ctx.pipe_path),
             '-i',
@@ -296,11 +319,19 @@ class InteractiveTask(BaseTask):
         ]
         pipe_argv += solution_cmd
         pipe_argv += ['=']
-        # The interactor launcher receives the test input path ({input} token);
-        # testlib interactors read the input file from their argv.
-        pipe_argv += languages.render_argv(
-            list(ctx.interactor_launch_argv), input=inputfile
+        pipe_argv += interactor_cmd
+        return pipe_argv
+
+    def run(self, ctx: RunContext, args: List[str]) -> int:
+        # Make the bidirectional fifos (stubbable for unit tests).
+        make_fifos = (
+            ctx.make_fifos
+            if ctx.make_fifos is not None
+            else (lambda: self._default_make_fifos(ctx))
         )
+        make_fifos()
+
+        pipe_argv = self.build_pipe_argv(ctx, args)
 
         # If pipe.exe itself fails, treat it as a judge error (mirrors BOCA's
         # interactor_run.sh returning JUDGE_ERROR=4 on pipe.exe failure).

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
@@ -15,3 +15,12 @@ class PipeLog:
         if len(lines) < 3:
             raise ValueError(f'pipe.log must have 3 numeric lines, got: {text!r}')
         return PipeLog(int(lines[0]), int(lines[1]), int(lines[2]))
+
+
+def batch_run_exit(safeexec_exit: int) -> int:
+    """Map safeexec's exit code to the run-script exit code BOCA expects.
+
+    Mirrors rbx/resources/packagers/boca/run/* : codes > 10 (child exited with
+    nonzero N, reported as N+10) collapse to 9 (runtime error).
+    """
+    return 9 if safeexec_exit > 10 else safeexec_exit

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
@@ -1,6 +1,11 @@
 from dataclasses import dataclass
 from typing import Optional
 
+# Run-phase judge-error exit code. Mirrors JUDGE_ERROR=4 in
+# rbx/resources/packagers/boca_next/runtime/interactor_run.sh:101. Named to
+# disambiguate from the compare-phase AC=4 in compare_verdict, which is unrelated.
+_INTERACTOR_JUDGE_ERROR = 4
+
 
 @dataclass(frozen=True)
 class PipeLog:
@@ -60,7 +65,7 @@ def _check_interactor(ecint: int) -> Optional['RunDecision']:
         return None
     if 1 <= ecint <= 4:
         return RunDecision(run_exit=0, testlib_code=ecint)
-    return RunDecision(run_exit=4, testlib_code=None)
+    return RunDecision(run_exit=_INTERACTOR_JUDGE_ERROR, testlib_code=None)
 
 
 def interactive_run_decision(first_tag: int, ecsf: int, ecint: int) -> RunDecision:
@@ -74,7 +79,7 @@ def interactive_run_decision(first_tag: int, ecsf: int, ecint: int) -> RunDecisi
 
     # 1. interactor crashed before solution
     if interactor_first and not is_testlib:
-        return _check_interactor(ecint)  # -> run_exit 4
+        return _check_interactor(ecint)  # -> run_exit _INTERACTOR_JUDGE_ERROR
 
     # 2. solution TLE (3) / MLE (7)
     if ecsf in (3, 7):

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
@@ -45,3 +45,55 @@ def compare_verdict(testlib_code: Optional[int], checker_exit: Optional[int]) ->
     if checker_exit == 3:
         return 43
     return 47
+
+
+@dataclass(frozen=True)
+class RunDecision:
+    run_exit: int
+    testlib_code: Optional[int]
+
+
+def _check_interactor(ecint: int) -> Optional['RunDecision']:
+    """interactor_run.sh check_interactor: 0->pass(None); 1..4->emit code, exit 0;
+    else->judge error (exit 4)."""
+    if ecint == 0:
+        return None
+    if 1 <= ecint <= 4:
+        return RunDecision(run_exit=0, testlib_code=ecint)
+    return RunDecision(run_exit=4, testlib_code=None)
+
+
+def interactive_run_decision(first_tag: int, ecsf: int, ecint: int) -> RunDecision:
+    """Ordered priority logic from interactor_run.sh:133-157.
+
+    Ordering IS the spec: resource limits (TLE/MLE) beat the interactor verdict,
+    which beats a solution RTE.
+    """
+    interactor_first = first_tag == 2
+    is_testlib = 0 <= ecint <= 4
+
+    # 1. interactor crashed before solution
+    if interactor_first and not is_testlib:
+        return _check_interactor(ecint)  # -> run_exit 4
+
+    # 2. solution TLE (3) / MLE (7)
+    if ecsf in (3, 7):
+        return RunDecision(run_exit=ecsf, testlib_code=None)
+
+    # 3. interactor finished first -> its verdict
+    if interactor_first:
+        decided = _check_interactor(ecint)
+        if decided is not None:
+            return decided  # ecint==0 falls through
+
+    # 4. solution error
+    if ecsf != 0:
+        return RunDecision(run_exit=ecsf, testlib_code=None)
+
+    # 5. interactor error regardless of order
+    decided = _check_interactor(ecint)
+    if decided is not None:
+        return decided
+
+    # 6. success -> compare decides
+    return RunDecision(run_exit=0, testlib_code=None)

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PipeLog:
+    """Parsed pipe.log: see rbx/resources/packagers/boca/pipe.c lines 359-362."""
+
+    first_tag: int  # 1 = solution exited first, 2 = interactor exited first
+    solution_status: int  # bash-like: 0-255, or 128+signal
+    interactor_status: int
+
+    @staticmethod
+    def parse(text: str) -> 'PipeLog':
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip() != '']
+        if len(lines) < 3:
+            raise ValueError(f'pipe.log must have 3 numeric lines, got: {text!r}')
+        return PipeLog(int(lines[0]), int(lines[1]), int(lines[2]))

--- a/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
+++ b/rbx/resources/packagers/boca_next/runtime/rbx_boca/verdicts.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -24,3 +25,23 @@ def batch_run_exit(safeexec_exit: int) -> int:
     nonzero N, reported as N+10) collapse to 9 (runtime error).
     """
     return 9 if safeexec_exit > 10 else safeexec_exit
+
+
+def compare_verdict(testlib_code: Optional[int], checker_exit: Optional[int]) -> int:
+    """BOCA compare exit code. See rbx/resources/packagers/boca/compare.sh.
+
+    AC=4, WA=6, JUDGE_ERROR=43, OTHER_ERROR=47.
+    """
+    if testlib_code is not None:
+        if testlib_code in (1, 2):
+            return 6
+        if testlib_code == 3:
+            return 43
+        return 47
+    if checker_exit == 0:
+        return 4
+    if checker_exit in (1, 2):
+        return 6
+    if checker_exit == 3:
+        return 43
+    return 47

--- a/tests/rbx/box/packaging/boca_next/_bundle.py
+++ b/tests/rbx/box/packaging/boca_next/_bundle.py
@@ -1,0 +1,79 @@
+"""Test helper: build a real executable ``.pyz`` bundling the ``rbx_boca``
+runtime plus its manifests, mirroring the Layer-1 packaged layout.
+
+The produced archive is self-contained: ``importlib.resources`` /
+``pkgutil.get_data`` find ``task.json`` and ``language.json`` inside the zip,
+so the runtime reads them with NO ``RBX_BOCA_BUNDLE_DIR`` override -- exactly as
+it will in production.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import zipapp
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# rbx_boca runtime package dir: tests/rbx/box/packaging/boca_next -> repo root.
+_RUNTIME_PKG = (
+    Path(__file__).resolve().parents[5]
+    / 'rbx'
+    / 'resources'
+    / 'packagers'
+    / 'boca_next'
+    / 'runtime'
+    / 'rbx_boca'
+)
+
+_MAIN = (
+    'import sys\n'
+    'from rbx_boca import entrypoints\n'
+    'sys.exit(entrypoints.main(sys.argv[1:]))\n'
+)
+
+
+def build_pyz(
+    dest_dir: Path,
+    task_json: Dict[str, Any],
+    language_json: Dict[str, Any],
+    *,
+    assets: Optional[Dict[str, bytes]] = None,
+) -> Path:
+    """Build an executable ``app.pyz`` under ``dest_dir`` and return its path.
+
+    - ``task_json`` / ``language_json`` are written into ``rbx_boca/`` inside the
+      archive so the runtime reads them via ``pkgutil.get_data``.
+    - ``assets`` (name -> bytes) are written into ``rbx_boca/assets/``.
+    """
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    target = dest_dir / 'app.pyz'
+
+    staging = Path(tempfile.mkdtemp(prefix='rbx_boca_pyz_'))
+    try:
+        pkg = staging / 'rbx_boca'
+        # Copy the whole package, skipping bytecode caches.
+        shutil.copytree(
+            _RUNTIME_PKG, pkg, ignore=shutil.ignore_patterns('__pycache__', '*.pyc')
+        )
+
+        (pkg / 'task.json').write_text(json.dumps(task_json))
+        (pkg / 'language.json').write_text(json.dumps(language_json))
+
+        if assets:
+            assets_dir = pkg / 'assets'
+            assets_dir.mkdir(exist_ok=True)
+            for name, content in assets.items():
+                (assets_dir / name).write_bytes(content)
+
+        (staging / '__main__.py').write_text(_MAIN)
+
+        zipapp.create_archive(
+            str(staging), str(target), interpreter='/usr/bin/env python3'
+        )
+        os.chmod(str(target), 0o755)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+    return target

--- a/tests/rbx/box/packaging/boca_next/conftest.py
+++ b/tests/rbx/box/packaging/boca_next/conftest.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+_RUNTIME = (
+    Path(__file__).resolve().parents[5]
+    / 'rbx'
+    / 'resources'
+    / 'packagers'
+    / 'boca_next'
+    / 'runtime'
+)
+if str(_RUNTIME) not in sys.path:
+    sys.path.insert(0, str(_RUNTIME))

--- a/tests/rbx/box/packaging/boca_next/test_assets.py
+++ b/tests/rbx/box/packaging/boca_next/test_assets.py
@@ -40,3 +40,40 @@ def test_ensure_compiles_on_miss_then_caches(tmp_path):
     assert out1 == out2
     assert out1.exists()
     assert len(compiled) == 1  # second call is a cache hit, no recompile
+
+
+def test_ensure_atomic_publish_under_race(tmp_path):
+    # Two compiles writing distinct temp outputs, both publishing to the same key.
+    outputs = []
+
+    def fake_runner(argv, **kw):
+        out = argv[argv.index('-o') + 1]
+        Path(out).write_bytes(b'ELF-BINARY')
+        outputs.append(out)
+        return 0
+
+    a = assets.NativeAsset(
+        name='pipe', source=b'csrc', compile_argv=['gcc', '-O2', '-o', '{out}', '{src}']
+    )
+    # First ensure populates the cache; the temp out path is unique (not the final target)
+    target = a.ensure(cache_dir=tmp_path, runner=fake_runner)
+    assert target.read_bytes() == b'ELF-BINARY'
+    # The compiler wrote to a UNIQUE temp path, not directly to the final target
+    assert all(Path(o) != target for o in outputs)
+    # Final published file is the full binary (atomic os.replace, never partial)
+    assert target.stat().st_size == len(b'ELF-BINARY')
+
+
+def test_ensure_raises_on_compile_failure(tmp_path):
+    def fake_runner(argv, **kw):
+        return 1
+
+    a = assets.NativeAsset(
+        name='checker', source=b'bad', compile_argv=['g++', '-o', '{out}', '{src}']
+    )
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        a.ensure(cache_dir=tmp_path, runner=fake_runner)
+    # No partial published binary, and no leftover temp files.
+    assert list(tmp_path.iterdir()) == []

--- a/tests/rbx/box/packaging/boca_next/test_assets.py
+++ b/tests/rbx/box/packaging/boca_next/test_assets.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from rbx_boca import assets
 
 
@@ -17,3 +19,24 @@ def test_cache_key_depends_on_source_and_flags():
         a.cache_key()
         == assets.NativeAsset('checker', b'int main(){}', ['g++', '-O2']).cache_key()
     )
+
+
+def test_ensure_compiles_on_miss_then_caches(tmp_path):
+    compiled = []
+
+    def fake_runner(argv, **kw):
+        out = argv[argv.index('-o') + 1]
+        Path(out).write_bytes(b'ELF')  # emulate compiler producing the output binary
+        compiled.append(argv)
+        return 0
+
+    a = assets.NativeAsset(
+        name='checker',
+        source=b'src',
+        compile_argv=['g++', '-O2', '-o', '{out}', '{src}'],
+    )
+    out1 = a.ensure(cache_dir=tmp_path, runner=fake_runner)
+    out2 = a.ensure(cache_dir=tmp_path, runner=fake_runner)
+    assert out1 == out2
+    assert out1.exists()
+    assert len(compiled) == 1  # second call is a cache hit, no recompile

--- a/tests/rbx/box/packaging/boca_next/test_assets.py
+++ b/tests/rbx/box/packaging/boca_next/test_assets.py
@@ -1,0 +1,19 @@
+from rbx_boca import assets
+
+
+def test_cache_key_depends_on_source_and_flags():
+    a = assets.NativeAsset(
+        name='checker', source=b'int main(){}', compile_argv=['g++', '-O2']
+    )
+    b = assets.NativeAsset(
+        name='checker', source=b'int main(){}', compile_argv=['g++', '-O3']
+    )
+    c = assets.NativeAsset(
+        name='checker', source=b'int main(){ }', compile_argv=['g++', '-O2']
+    )
+    assert a.cache_key() != b.cache_key()  # flags differ
+    assert a.cache_key() != c.cache_key()  # source differs
+    assert (
+        a.cache_key()
+        == assets.NativeAsset('checker', b'int main(){}', ['g++', '-O2']).cache_key()
+    )

--- a/tests/rbx/box/packaging/boca_next/test_entrypoints.py
+++ b/tests/rbx/box/packaging/boca_next/test_entrypoints.py
@@ -1,0 +1,164 @@
+from dataclasses import dataclass, field
+from typing import Any, List
+
+from rbx_boca import entrypoints
+
+
+@dataclass
+class _FakeTask:
+    """Records calls to the BOCA lifecycle hooks and returns a canned code."""
+
+    code: int = 0
+    calls: List[Any] = field(default_factory=list)
+
+    def compile(self, ctx, *, src, exe, basename):
+        self.calls.append(('compile', src, exe, basename))
+        return self.code
+
+    def run(self, ctx, args):
+        self.calls.append(('run', list(args)))
+        return self.code
+
+    def compare(self, ctx, args):
+        self.calls.append(('compare', list(args)))
+        return self.code
+
+
+@dataclass
+class _FakeLimits:
+    time_sec: int
+    runs: int
+    memory_mb: int
+
+
+@dataclass
+class _FakeLang:
+    limits: _FakeLimits
+
+
+@dataclass
+class _FakeTaskConfig:
+    task_type: str
+    output_kb: int
+
+
+@dataclass
+class _FakeCtx:
+    task: _FakeTaskConfig
+    lang: _FakeLang
+
+
+def _fake_ctx(task_type='batch', output_kb=65536):
+    return _FakeCtx(
+        task=_FakeTaskConfig(task_type=task_type, output_kb=output_kb),
+        lang=_FakeLang(limits=_FakeLimits(time_sec=3, runs=2, memory_mb=256)),
+    )
+
+
+def _install_fakes(monkeypatch, code=0):
+    """Replace BatchTask/InteractiveTask with recording fakes; return them."""
+    batch = _FakeTask(code=code)
+    interactive = _FakeTask(code=code)
+    monkeypatch.setattr(entrypoints, 'BatchTask', lambda: batch)
+    monkeypatch.setattr(entrypoints, 'InteractiveTask', lambda: interactive)
+    return batch, interactive
+
+
+def test_dispatch_compile(monkeypatch):
+    batch, interactive = _install_fakes(monkeypatch, code=7)
+    ctx = _fake_ctx(task_type='batch')
+    rc = entrypoints.main(
+        ['compile', 'sol.cpp', 'run', '3', '256'], context_factory=lambda: ctx
+    )
+    assert rc == 7
+    assert batch.calls == [('compile', 'sol.cpp', 'run', 'run')]
+    assert interactive.calls == []
+
+
+def test_dispatch_run(monkeypatch):
+    batch, interactive = _install_fakes(monkeypatch, code=9)
+    ctx = _fake_ctx(task_type='batch')
+    rc = entrypoints.main(
+        ['run', 'run', 'in', '3', '2', '256', '65536'], context_factory=lambda: ctx
+    )
+    assert rc == 9
+    assert batch.calls == [('run', ['run', 'in', '3', '2', '256', '65536'])]
+
+
+def test_dispatch_compare(monkeypatch):
+    batch, interactive = _install_fakes(monkeypatch, code=6)
+    ctx = _fake_ctx(task_type='batch')
+    rc = entrypoints.main(
+        ['compare', 'team.out', 'exp.out', 'in.txt'], context_factory=lambda: ctx
+    )
+    assert rc == 6
+    assert batch.calls == [('compare', ['team.out', 'exp.out', 'in.txt'])]
+
+
+def test_dispatch_interactive_task_type_selects_interactive_task(monkeypatch):
+    batch, interactive = _install_fakes(monkeypatch, code=0)
+    ctx = _fake_ctx(task_type='interactive')
+    entrypoints.main(
+        ['run', 'run', 'in', '3', '1', '256', '65536'], context_factory=lambda: ctx
+    )
+    assert interactive.calls == [('run', ['run', 'in', '3', '1', '256', '65536'])]
+    assert batch.calls == []
+
+
+def test_dispatch_limits(capsys):
+    ctx = _fake_ctx(output_kb=65536)
+    rc = entrypoints.main(['limits'], context_factory=lambda: ctx)
+    assert rc == 0
+    out = capsys.readouterr().out.split()
+    assert out == ['3', '2', '256', '65536']
+
+
+def test_dispatch_tests():
+    ctx = _fake_ctx()
+    assert entrypoints.main(['tests'], context_factory=lambda: ctx) == 0
+
+
+def test_dispatch_unknown_entry_returns_nonzero():
+    ctx = _fake_ctx()
+    rc = entrypoints.main(['bogus'], context_factory=lambda: ctx)
+    assert rc != 0
+
+
+def test_dispatch_interactor_launcher(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        entrypoints.interactor_launcher,
+        'launch',
+        lambda argv, *, ittime, notify_fd: captured.update(
+            argv=argv, ittime=ittime, notify_fd=notify_fd
+        ),
+    )
+    rc = entrypoints.main(
+        [
+            '__interactor_launcher__',
+            '7',
+            '5',
+            '--',
+            './interactor.exe',
+            'stdin0',
+            'stdout0',
+        ]
+    )
+    assert rc == 0
+    assert captured['ittime'] == 7 and captured['notify_fd'] == 5
+    assert captured['argv'] == ['./interactor.exe', 'stdin0', 'stdout0']
+
+
+def test_interactor_launcher_does_not_require_context_factory(monkeypatch):
+    # No context_factory passed and load_context must NOT be invoked.
+    def _boom():
+        raise AssertionError('load_context should not be called')
+
+    monkeypatch.setattr(entrypoints, 'load_context', _boom)
+    monkeypatch.setattr(
+        entrypoints.interactor_launcher,
+        'launch',
+        lambda argv, *, ittime, notify_fd: None,
+    )
+    rc = entrypoints.main(['__interactor_launcher__', '1', '2', '--', './i.exe'])
+    assert rc == 0

--- a/tests/rbx/box/packaging/boca_next/test_entrypoints.py
+++ b/tests/rbx/box/packaging/boca_next/test_entrypoints.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List
 
+import pytest
 from rbx_boca import entrypoints
 
 _RUNTIME = (
@@ -175,6 +176,13 @@ def test_interactor_launcher_does_not_require_context_factory(monkeypatch):
     )
     rc = entrypoints.main(['__interactor_launcher__', '1', '2', '--', './i.exe'])
     assert rc == 0
+
+
+def test_interactor_launcher_too_few_args_raises_value_error():
+    # Length/`--` validation runs BEFORE indexing, so a clear ValueError is
+    # raised instead of a bare IndexError.
+    with pytest.raises(ValueError):
+        entrypoints.main(['__interactor_launcher__', '7'])
 
 
 # --- Task 8.2: python -m rbx_boca entry ---

--- a/tests/rbx/box/packaging/boca_next/test_entrypoints.py
+++ b/tests/rbx/box/packaging/boca_next/test_entrypoints.py
@@ -203,7 +203,12 @@ def test_main_module_limits_subprocess(tmp_path):
                     'compiler_argv': ['g++', '-o', '{exe}', '{src}'],
                     'run_argv': ['{exe}'],
                 },
-                'limits': {'time_sec': 3, 'runs': 2, 'memory_mb': 256},
+                'limits': {
+                    'time_sec': 3,
+                    'runs': 2,
+                    'memory_mb': 256,
+                    'wall_time_sec': 12,
+                },
             }
         )
     )

--- a/tests/rbx/box/packaging/boca_next/test_entrypoints.py
+++ b/tests/rbx/box/packaging/boca_next/test_entrypoints.py
@@ -1,7 +1,20 @@
+import json
+import subprocess
+import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, List
 
 from rbx_boca import entrypoints
+
+_RUNTIME = (
+    Path(__file__).resolve().parents[5]
+    / 'rbx'
+    / 'resources'
+    / 'packagers'
+    / 'boca_next'
+    / 'runtime'
+)
 
 
 @dataclass
@@ -162,3 +175,40 @@ def test_interactor_launcher_does_not_require_context_factory(monkeypatch):
     )
     rc = entrypoints.main(['__interactor_launcher__', '1', '2', '--', './i.exe'])
     assert rc == 0
+
+
+# --- Task 8.2: python -m rbx_boca entry ---
+
+
+def test_main_module_limits_subprocess(tmp_path):
+    bundle = tmp_path / 'bundle'
+    bundle.mkdir()
+    (bundle / 'task.json').write_text(
+        json.dumps({'task_type': 'batch', 'output_kb': 65536})
+    )
+    (bundle / 'language.json').write_text(
+        json.dumps(
+            {
+                'language': {
+                    'id': 'cpp',
+                    'kind': 'compiled_static',
+                    'compiler_argv': ['g++', '-o', '{exe}', '{src}'],
+                    'run_argv': ['{exe}'],
+                },
+                'limits': {'time_sec': 3, 'runs': 2, 'memory_mb': 256},
+            }
+        )
+    )
+    env = {
+        'PATH': '/usr/bin:/bin',
+        'PYTHONPATH': str(_RUNTIME),
+        'RBX_BOCA_BUNDLE_DIR': str(bundle),
+    }
+    result = subprocess.run(
+        [sys.executable, '-m', 'rbx_boca', 'limits'],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ['3', '2', '256', '65536']

--- a/tests/rbx/box/packaging/boca_next/test_import.py
+++ b/tests/rbx/box/packaging/boca_next/test_import.py
@@ -1,0 +1,2 @@
+def test_rbx_boca_importable():
+    import rbx_boca  # noqa: F401

--- a/tests/rbx/box/packaging/boca_next/test_integration.py
+++ b/tests/rbx/box/packaging/boca_next/test_integration.py
@@ -9,9 +9,91 @@ deprecated); verified by ``test_pyz_limits_end_to_end`` reading task.json /
 language.json from inside a real archive with NO env override.
 """
 
+import os
 import subprocess
+import sys
+from pathlib import Path
+
+from rbx_boca import entrypoints, manifest, sandbox, tasks
 
 from tests.rbx.box.packaging.boca_next import _bundle
+
+# --- stubs --------------------------------------------------------------------
+
+# A stub `safeexec`: skip its own -flags, find the program after `--`, honor
+# -i<file>/-o<file> redirection, exec the program, propagate its exit code.
+_STUB_SAFEEXEC = """#!{python}
+import os
+import sys
+
+argv = sys.argv[1:]
+stdin_path = None
+stdout_path = None
+prog = None
+i = 0
+while i < len(argv):
+    a = argv[i]
+    if a == '--':
+        prog = argv[i + 1:]
+        break
+    if a.startswith('-i'):
+        stdin_path = a[2:]
+    elif a.startswith('-o'):
+        stdout_path = a[2:]
+    # all other -flags are limits we ignore in the stub
+    i += 1
+
+if not prog:
+    sys.exit(2)
+
+if stdin_path:
+    fd = os.open(stdin_path, os.O_RDONLY)
+    os.dup2(fd, 0)
+if stdout_path:
+    fd = os.open(stdout_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    os.dup2(fd, 1)
+
+os.execv(prog[0], prog)
+"""
+
+# A stub checker: `checker <input> <team_out> <expected_out>`; exit 0 if the
+# team output equals the expected output, else 1 (mirrors a trivial diff checker).
+_STUB_CHECKER = """#!{python}
+import sys
+
+_input, team, expected = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(team) as f:
+    t = f.read().split()
+with open(expected) as f:
+    e = f.read().split()
+sys.exit(0 if t == e else 1)
+"""
+
+# A trivial solution: read an int from stdin, print it doubled.
+_SOLUTION = """import sys
+n = int(sys.stdin.read().split()[0])
+print(n * 2)
+"""
+
+
+def _write_exec(path: Path, text: str) -> Path:
+    path.write_text(text.format(python=sys.executable))
+    os.chmod(str(path), 0o755)
+    return path
+
+
+def _interpreted_language_json():
+    return {
+        'language': {
+            'id': 'py3',
+            'kind': 'interpreted',
+            'compiler_argv': ['python3'],
+            'run_argv': ['{interp}', '{exe}'],
+            'syntax_check': False,
+        },
+        'limits': {'time_sec': 3, 'runs': 1, 'memory_mb': 256},
+    }
+
 
 # --- Task 9.1: zipapp bundle + limits e2e -------------------------------------
 
@@ -40,3 +122,101 @@ def test_pyz_limits_end_to_end(tmp_path):
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.splitlines() == ['3', '2', '256', '65536']
+
+
+# --- Task 9.2: batch e2e via stub safeexec + interpreted solution -------------
+
+
+def test_pyz_batch_compile_and_run_end_to_end(tmp_path):
+    """compile -> run through the real .pyz under a stub safeexec, executing a
+    real python solution. Proves the .pyz actually runs a solution sandboxed."""
+    work = tmp_path / 'work'
+    work.mkdir()
+    bindir = tmp_path / 'bin'
+    bindir.mkdir()
+    _write_exec(bindir / 'safeexec', _STUB_SAFEEXEC)
+
+    pyz = _bundle.build_pyz(
+        tmp_path,
+        {'task_type': 'batch', 'output_kb': 65536},
+        _interpreted_language_json(),
+    )
+
+    (work / 'sol.py').write_text(_SOLUTION)
+    (work / 'in.txt').write_text('21\n')
+
+    env = dict(os.environ)
+    env['PATH'] = str(bindir) + os.pathsep + env.get('PATH', '')
+
+    # compile sol.py -> run (writes shebang script).
+    rc = subprocess.run(
+        [str(pyz), 'compile', 'sol.py', 'run', '3', '256'],
+        cwd=str(work),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert rc.returncode == 0, rc.stderr
+    assert (work / 'run').exists()
+
+    # run run in.txt 3 1 256 65536 (solution exits 0 -> batch run exit 0).
+    rc = subprocess.run(
+        [str(pyz), 'run', 'run', 'in.txt', '3', '1', '256', '65536'],
+        cwd=str(work),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert rc.returncode == 0, rc.stderr
+    # The solution wrote its doubled answer to stdout0 via stub safeexec -o.
+    assert (work / 'stdout0').read_text().split() == ['42']
+
+
+def test_compare_end_to_end_via_entrypoint(tmp_path):
+    """compare e2e at the entrypoints.main level with an injected context using a
+    real stub checker script. (Driven here rather than through the subprocess
+    because load_context leaves checker_path best-effort for Layer 2.)"""
+    checker = _write_exec(tmp_path / 'checker', _STUB_CHECKER)
+
+    (tmp_path / 'in.txt').write_text('21\n')
+    (tmp_path / 'team.out').write_text('42\n')
+    (tmp_path / 'exp.out').write_text('42\n')
+    (tmp_path / 'wrong.out').write_text('99\n')
+
+    def _factory():
+        lang = manifest.LanguageManifest(
+            language=manifest.LanguageSpec.from_dict(
+                _interpreted_language_json()['language']
+            ),
+            limits=manifest.LimitsConfig(time_sec=3, runs=1, memory_mb=256),
+        )
+        return tasks.RunContext(
+            task=manifest.TaskConfig(task_type='batch', output_kb=65536),
+            lang=lang,
+            cwd=tmp_path,
+            runner=lambda argv, **kw: subprocess.call(argv, **kw),
+            safeexec=sandbox.SafeExec(path='/usr/bin/safeexec'),
+            checker_path=checker,
+        )
+
+    ac = entrypoints.main(
+        [
+            'compare',
+            str(tmp_path / 'team.out'),
+            str(tmp_path / 'exp.out'),
+            str(tmp_path / 'in.txt'),
+        ],
+        context_factory=_factory,
+    )
+    assert ac == 4  # AC: team == expected
+
+    wa = entrypoints.main(
+        [
+            'compare',
+            str(tmp_path / 'team.out'),
+            str(tmp_path / 'wrong.out'),
+            str(tmp_path / 'in.txt'),
+        ],
+        context_factory=_factory,
+    )
+    assert wa == 6  # WA: team != expected

--- a/tests/rbx/box/packaging/boca_next/test_integration.py
+++ b/tests/rbx/box/packaging/boca_next/test_integration.py
@@ -320,3 +320,118 @@ def test_interactor_launcher_watchdog_kills_hanging_interactor(tmp_path):
                 os.waitpid(pid, 0)
             except OSError:
                 pass
+
+
+# --- Task 9.4: pipe.exe argv shape -------------------------------------------
+
+
+def _interactive_ctx(tmp_path):
+    spec = manifest.LanguageSpec.from_dict(
+        {
+            'id': 'cpp',
+            'kind': 'compiled_static',
+            'compiler_argv': ['g++', '-o', '{exe}', '{src}'],
+            'run_argv': ['{exe}'],
+        }
+    )
+    lang = manifest.LanguageManifest(
+        language=spec,
+        limits=manifest.LimitsConfig(time_sec=3, runs=1, memory_mb=256),
+    )
+    return tasks.RunContext(
+        task=manifest.TaskConfig(task_type='interactive', output_kb=65536),
+        lang=lang,
+        cwd=tmp_path,
+        runner=lambda argv, **kw: 0,
+        safeexec=sandbox.SafeExec(path='/usr/bin/safeexec'),
+        checker_path=Path('/bin/checker'),
+        interactor_path=Path('/box/interactor.exe'),
+        pipe_path=Path('/box/pipe.exe'),
+        interactor_launch_argv=[sys.executable, '-m', 'rbx_boca'],
+    )
+
+
+def test_build_pipe_argv_shape(tmp_path):
+    ctx = _interactive_ctx(tmp_path)
+    argv = tasks.InteractiveTask().build_pipe_argv(
+        ctx, ['run', 'in.txt', '3', '1', '256', '65536']
+    )
+
+    # pipe.exe prefix mirrors interactor_run.sh:44.
+    assert argv[:10] == [
+        '/box/pipe.exe',
+        '-i',
+        'fifo.in',
+        '-o',
+        'fifo.out',
+        '-e',
+        'stderr0',  # solution safeexec spec.stderr
+        '-E',
+        'interactor.stderr',
+        '--',
+    ]
+
+    # Exactly one `=` separator splitting solution side / interactor side.
+    assert argv.count('=') == 1
+    sep = argv.index('=')
+    solution_seg = argv[10:sep]
+    interactor_seg = argv[sep + 1 :]
+
+    # Solution side: safeexec with fifo redirection + notify fd (literal __FD__).
+    assert solution_seg[0] == '/usr/bin/safeexec'
+    assert '-ififo.in' in solution_seg
+    assert '-ofifo.out' in solution_seg
+    assert '-D__FD__' in solution_seg
+    # __FD__ must appear ONLY in the literal -D__FD__ token (never substituted).
+    assert [t for t in solution_seg if '__FD__' in t] == ['-D__FD__']
+
+    # Interactor side: re-enter the bundle under the launcher, ittime = wall+1.
+    assert interactor_seg == [
+        sys.executable,
+        '-m',
+        'rbx_boca',
+        '__interactor_launcher__',
+        '4',  # ittime = timelimit(3) + 1
+        '__FD__',
+        '--',
+        '/box/interactor.exe',
+        'stdin0',
+        'stdout0',
+    ]
+
+
+def test_interactive_run_still_parses_pipelog(tmp_path):
+    """The refactor preserves the Phase 6 flow: run() builds argv, runs the
+    (fake) pipe.exe, parses pipe.log, decides, emits testlib, returns."""
+
+    def runner(argv, **kw):
+        # emulate pipe.exe: interactor-first(2), sol ok(0), WA(1).
+        (tmp_path / 'pipe.log').write_text('2\n0\n1\n')
+        return 0
+
+    ctx = tasks.RunContext(
+        task=manifest.TaskConfig(task_type='interactive', output_kb=65536),
+        lang=manifest.LanguageManifest(
+            language=manifest.LanguageSpec.from_dict(
+                {
+                    'id': 'cpp',
+                    'kind': 'compiled_static',
+                    'compiler_argv': ['g++'],
+                    'run_argv': ['{exe}'],
+                }
+            ),
+            limits=manifest.LimitsConfig(time_sec=3, runs=1, memory_mb=256),
+        ),
+        cwd=tmp_path,
+        runner=runner,
+        safeexec=sandbox.SafeExec(path='/usr/bin/safeexec'),
+        interactor_path=Path('/box/interactor.exe'),
+        pipe_path=Path('/box/pipe.exe'),
+        interactor_launch_argv=[sys.executable, '-m', 'rbx_boca'],
+        make_fifos=lambda: None,
+    )
+    rc = tasks.InteractiveTask().run(
+        ctx, ['run', str(tmp_path / 'in.txt'), '3', '1', '256', '65536']
+    )
+    assert rc == 0
+    assert (tmp_path / 'stdout0').read_text().strip() == 'testlib exitcode 1'

--- a/tests/rbx/box/packaging/boca_next/test_integration.py
+++ b/tests/rbx/box/packaging/boca_next/test_integration.py
@@ -1,0 +1,42 @@
+"""Phase 9 integration harness for the rbx_boca Layer-2 runtime.
+
+These tests validate the runtime end-to-end. They are deliberately HERMETIC:
+no gcc, no root, no real SUID safeexec, no real pipe.exe (this machine cannot
+build/run SUID safeexec or compile C).
+
+Manifest reading from the .pyz uses ``pkgutil.get_data`` (zip-safe, not
+deprecated); verified by ``test_pyz_limits_end_to_end`` reading task.json /
+language.json from inside a real archive with NO env override.
+"""
+
+import subprocess
+
+from tests.rbx.box.packaging.boca_next import _bundle
+
+# --- Task 9.1: zipapp bundle + limits e2e -------------------------------------
+
+
+def test_pyz_limits_end_to_end(tmp_path):
+    """A real .pyz reads its bundled manifests (no env override) and prints the
+    limits. Proves zipimport + manifest reading works from a real archive."""
+    pyz = _bundle.build_pyz(
+        tmp_path,
+        task_json={'task_type': 'batch', 'output_kb': 65536},
+        language_json={
+            'language': {
+                'id': 'cpp',
+                'kind': 'compiled_static',
+                'compiler_argv': ['g++', '-o', '{exe}', '{src}'],
+                'run_argv': ['{exe}'],
+            },
+            'limits': {'time_sec': 3, 'runs': 2, 'memory_mb': 256},
+        },
+    )
+    result = subprocess.run(
+        [str(pyz), 'limits'],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ['3', '2', '256', '65536']

--- a/tests/rbx/box/packaging/boca_next/test_integration.py
+++ b/tests/rbx/box/packaging/boca_next/test_integration.py
@@ -10,11 +10,14 @@ language.json from inside a real archive with NO env override.
 """
 
 import os
+import select
+import signal
 import subprocess
 import sys
 from pathlib import Path
 
-from rbx_boca import entrypoints, manifest, sandbox, tasks
+import pytest
+from rbx_boca import entrypoints, interactor_launcher, manifest, sandbox, tasks
 
 from tests.rbx.box.packaging.boca_next import _bundle
 
@@ -220,3 +223,100 @@ def test_compare_end_to_end_via_entrypoint(tmp_path):
         context_factory=_factory,
     )
     assert wa == 6  # WA: team != expected
+
+
+# --- Task 9.3: interactor launcher fd-inheritance + watchdog ------------------
+
+
+def _fork_launch(interactor_argv, ittime, notify_fd):
+    """Fork; in the child run launch() (which execv's, never returns). Returns
+    the child pid in the parent."""
+    pid = os.fork()
+    if pid == 0:  # child
+        try:
+            interactor_launcher.launch(
+                interactor_argv, ittime=ittime, notify_fd=notify_fd
+            )
+        except BaseException:
+            os._exit(127)
+        os._exit(0)  # unreachable if execv succeeds
+    return pid
+
+
+@pytest.mark.slow
+def test_interactor_launcher_fd_closes_when_interactor_exits(tmp_path):
+    """The notify pipe must reach EOF PROMPTLY after the interactor exits.
+
+    Proves: launch() cleared CLOEXEC so the interactor inherited the fd AND the
+    watchdog child closed its own copy. If the watchdog leaked the fd, read()
+    would block until SIGKILL (ittime+5s); we assert EOF arrives well before.
+    """
+    read_fd, write_fd = os.pipe()
+    # Stub interactor: sleep briefly then exit 0 (holds notify fd while alive).
+    interactor = [sys.executable, '-c', 'import time; time.sleep(0.2)']
+    pid = None
+    try:
+        pid = _fork_launch(interactor, ittime=2, notify_fd=write_fd)
+        os.close(write_fd)  # drop the parent's copy; only the interactor holds it
+        write_fd = -1
+
+        # EOF must arrive once the interactor (the sole remaining holder) exits,
+        # i.e. ~0.2s -- well before the watchdog kill grace (ittime+5 = 7s).
+        ready, _, _ = select.select([read_fd], [], [], 4.0)
+        assert ready, 'notify fd did not close (leaked into watchdog?)'
+        assert os.read(read_fd, 64) == b''  # EOF
+    finally:
+        if write_fd != -1:
+            os.close(write_fd)
+        os.close(read_fd)
+        if pid is not None:
+            os.waitpid(pid, 0)
+
+
+@pytest.mark.slow
+def test_interactor_launcher_watchdog_kills_hanging_interactor(tmp_path):
+    """The watchdog must kill a hung interactor at ~ittime (+kill grace), not
+    let it run for its full sleep."""
+    import time
+
+    read_fd, write_fd = os.pipe()
+    # Stub interactor that would hang for 60s if not killed.
+    interactor = [sys.executable, '-c', 'import time; time.sleep(60)']
+    pid = None
+    try:
+        start = time.monotonic()
+        pid = _fork_launch(interactor, ittime=1, notify_fd=write_fd)
+        os.close(write_fd)
+        write_fd = -1
+
+        # Reap the interactor; it must die within ittime + kill_grace + slack.
+        deadline = start + 9.0
+        reaped = False
+        status = 0
+        while time.monotonic() < deadline:
+            wpid, status = os.waitpid(pid, os.WNOHANG)
+            if wpid == pid:
+                reaped = True
+                break
+            time.sleep(0.05)
+        elapsed = time.monotonic() - start
+        if not reaped:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+            pytest.fail('watchdog did not kill the interactor within 9s')
+        assert elapsed < 9.0
+        # Killed by signal (SIGTERM at ittime, or SIGKILL at ittime+grace).
+        assert os.WIFSIGNALED(status) or (
+            os.WIFEXITED(status) and os.WEXITSTATUS(status) != 0
+        )
+        pid = None
+    finally:
+        if write_fd != -1:
+            os.close(write_fd)
+        os.close(read_fd)
+        if pid is not None:
+            try:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+            except OSError:
+                pass

--- a/tests/rbx/box/packaging/boca_next/test_integration.py
+++ b/tests/rbx/box/packaging/boca_next/test_integration.py
@@ -14,6 +14,7 @@ import select
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -233,6 +234,16 @@ def _fork_launch(interactor_argv, ittime, notify_fd):
     the child pid in the parent."""
     pid = os.fork()
     if pid == 0:  # child
+        # Become a new session/group leader BEFORE launch(). The watchdog uses
+        # killpg(0, ...), which in production targets the BOCA job's group; in
+        # the test it would otherwise target pytest's own group and could
+        # SIGTERM/SIGKILL the test runner. setsid() contains killpg(0) to this
+        # child's group. (launch() itself is unchanged to match bash production
+        # behavior.)
+        try:
+            os.setsid()
+        except OSError:
+            pass
         try:
             interactor_launcher.launch(
                 interactor_argv, ittime=ittime, notify_fd=notify_fd
@@ -250,10 +261,21 @@ def test_interactor_launcher_fd_closes_when_interactor_exits(tmp_path):
     Proves: launch() cleared CLOEXEC so the interactor inherited the fd AND the
     watchdog child closed its own copy. If the watchdog leaked the fd, read()
     would block until SIGKILL (ittime+5s); we assert EOF arrives well before.
+
+    Non-vacuity: the stub interactor writes a sentinel file before exiting, so we
+    can assert exec() actually happened (rather than the launcher crashing before
+    exec, which would make the EOF assertion pass trivially).
     """
     read_fd, write_fd = os.pipe()
-    # Stub interactor: sleep briefly then exit 0 (holds notify fd while alive).
-    interactor = [sys.executable, '-c', 'import time; time.sleep(0.2)']
+    sentinel = tmp_path / 'exec_happened'
+    # Stub interactor: write a sentinel proving exec, sleep briefly, exit 0
+    # (holds notify fd while alive).
+    interactor = [
+        sys.executable,
+        '-c',
+        'import time, pathlib; pathlib.Path({!r}).write_text("1"); '
+        'time.sleep(0.2)'.format(str(sentinel)),
+    ]
     pid = None
     try:
         pid = _fork_launch(interactor, ittime=2, notify_fd=write_fd)
@@ -265,6 +287,10 @@ def test_interactor_launcher_fd_closes_when_interactor_exits(tmp_path):
         ready, _, _ = select.select([read_fd], [], [], 4.0)
         assert ready, 'notify fd did not close (leaked into watchdog?)'
         assert os.read(read_fd, 64) == b''  # EOF
+        # The interactor really reached exec (not an early launcher crash).
+        assert sentinel.exists(), (
+            'stub interactor never ran -> launch() crashed pre-exec'
+        )
     finally:
         if write_fd != -1:
             os.close(write_fd)
@@ -276,12 +302,22 @@ def test_interactor_launcher_fd_closes_when_interactor_exits(tmp_path):
 @pytest.mark.slow
 def test_interactor_launcher_watchdog_kills_hanging_interactor(tmp_path):
     """The watchdog must kill a hung interactor at ~ittime (+kill grace), not
-    let it run for its full sleep."""
-    import time
+    let it run for its full sleep.
 
+    Non-vacuity: the stub interactor writes a sentinel before hanging, so we
+    assert exec() actually happened and the watchdog killed a *running*
+    interactor (not a launcher that crashed before exec).
+    """
     read_fd, write_fd = os.pipe()
-    # Stub interactor that would hang for 60s if not killed.
-    interactor = [sys.executable, '-c', 'import time; time.sleep(60)']
+    sentinel = tmp_path / 'exec_happened'
+    # Stub interactor that writes a sentinel proving exec, then hangs for 60s if
+    # not killed.
+    interactor = [
+        sys.executable,
+        '-c',
+        'import time, pathlib; pathlib.Path({!r}).write_text("1"); '
+        'time.sleep(60)'.format(str(sentinel)),
+    ]
     pid = None
     try:
         start = time.monotonic()
@@ -305,6 +341,11 @@ def test_interactor_launcher_watchdog_kills_hanging_interactor(tmp_path):
             os.waitpid(pid, 0)
             pytest.fail('watchdog did not kill the interactor within 9s')
         assert elapsed < 9.0
+        # The interactor really reached exec (so the watchdog killed a running
+        # interactor, not a launcher that crashed before exec).
+        assert sentinel.exists(), (
+            'stub interactor never ran -> launch() crashed pre-exec'
+        )
         # Killed by signal (SIGTERM at ittime, or SIGKILL at ittime+grace).
         assert os.WIFSIGNALED(status) or (
             os.WIFEXITED(status) and os.WEXITSTATUS(status) != 0
@@ -430,6 +471,7 @@ def test_interactive_run_still_parses_pipelog(tmp_path):
         interactor_launch_argv=[sys.executable, '-m', 'rbx_boca'],
         make_fifos=lambda: None,
     )
+    (tmp_path / 'in.txt').write_text('21\n')
     rc = tasks.InteractiveTask().run(
         ctx, ['run', str(tmp_path / 'in.txt'), '3', '1', '256', '65536']
     )

--- a/tests/rbx/box/packaging/boca_next/test_integration.py
+++ b/tests/rbx/box/packaging/boca_next/test_integration.py
@@ -95,7 +95,12 @@ def _interpreted_language_json():
             'run_argv': ['{interp}', '{exe}'],
             'syntax_check': False,
         },
-        'limits': {'time_sec': 3, 'runs': 1, 'memory_mb': 256},
+        'limits': {
+            'time_sec': 3,
+            'runs': 1,
+            'memory_mb': 256,
+            'wall_time_sec': 12,
+        },
     }
 
 
@@ -115,7 +120,12 @@ def test_pyz_limits_end_to_end(tmp_path):
                 'compiler_argv': ['g++', '-o', '{exe}', '{src}'],
                 'run_argv': ['{exe}'],
             },
-            'limits': {'time_sec': 3, 'runs': 2, 'memory_mb': 256},
+            'limits': {
+                'time_sec': 3,
+                'runs': 2,
+                'memory_mb': 256,
+                'wall_time_sec': 12,
+            },
         },
     )
     result = subprocess.run(
@@ -192,7 +202,9 @@ def test_compare_end_to_end_via_entrypoint(tmp_path):
             language=manifest.LanguageSpec.from_dict(
                 _interpreted_language_json()['language']
             ),
-            limits=manifest.LimitsConfig(time_sec=3, runs=1, memory_mb=256),
+            limits=manifest.LimitsConfig(
+                time_sec=3, runs=1, memory_mb=256, wall_time_sec=12
+            ),
         )
         return tasks.RunContext(
             task=manifest.TaskConfig(task_type='batch', output_kb=65536),
@@ -377,7 +389,9 @@ def _interactive_ctx(tmp_path):
     )
     lang = manifest.LanguageManifest(
         language=spec,
-        limits=manifest.LimitsConfig(time_sec=3, runs=1, memory_mb=256),
+        limits=manifest.LimitsConfig(
+            time_sec=3, runs=1, memory_mb=256, wall_time_sec=12
+        ),
     )
     return tasks.RunContext(
         task=manifest.TaskConfig(task_type='interactive', output_kb=65536),
@@ -432,7 +446,7 @@ def test_build_pipe_argv_shape(tmp_path):
         '-m',
         'rbx_boca',
         '__interactor_launcher__',
-        '4',  # ittime = timelimit(3) + 1
+        '13',  # ittime = wall_time_sec(12) + 1
         '__FD__',
         '--',
         '/box/interactor.exe',
@@ -461,7 +475,9 @@ def test_interactive_run_still_parses_pipelog(tmp_path):
                     'run_argv': ['{exe}'],
                 }
             ),
-            limits=manifest.LimitsConfig(time_sec=3, runs=1, memory_mb=256),
+            limits=manifest.LimitsConfig(
+                time_sec=3, runs=1, memory_mb=256, wall_time_sec=12
+            ),
         ),
         cwd=tmp_path,
         runner=runner,

--- a/tests/rbx/box/packaging/boca_next/test_interactor_launcher.py
+++ b/tests/rbx/box/packaging/boca_next/test_interactor_launcher.py
@@ -1,0 +1,10 @@
+from rbx_boca import interactor_launcher as il
+
+
+def test_address_space_limit_bytes():
+    # bash `ulimit -v 1024000` is in KiB -> bytes
+    assert il.address_space_limit() == 1024000 * 1024
+
+
+def test_watchdog_timeout():
+    assert il.watchdog_timeout(7) == (7, 5)  # (term_after_seconds, kill_after_seconds)

--- a/tests/rbx/box/packaging/boca_next/test_languages.py
+++ b/tests/rbx/box/packaging/boca_next/test_languages.py
@@ -1,0 +1,25 @@
+from rbx_boca import languages
+
+
+def test_render_argv_string_substitution():
+    out = languages.render_argv(
+        ['g++', '{flags}', '-o', '{exe}', '{src}'],
+        flags='-O2 -static',
+        exe='run.exe',
+        src='sol.cpp',
+    )
+    assert out == ['g++', '-O2', '-static', '-o', 'run.exe', 'sol.cpp']
+
+
+def test_render_argv_list_splice():
+    out = languages.render_argv(
+        ['java', '{jvm_flags}', '-jar', '{jar}'],
+        jvm_flags=['-Xmx256000K', '-Xss25600K'],
+        jar='run.jar',
+    )
+    assert out == ['java', '-Xmx256000K', '-Xss25600K', '-jar', 'run.jar']
+
+
+def test_render_argv_empty_token_dropped():
+    out = languages.render_argv(['cc', '{flags}', '{src}'], flags='', src='a.c')
+    assert out == ['cc', 'a.c']

--- a/tests/rbx/box/packaging/boca_next/test_languages.py
+++ b/tests/rbx/box/packaging/boca_next/test_languages.py
@@ -23,3 +23,37 @@ def test_render_argv_list_splice():
 def test_render_argv_empty_token_dropped():
     out = languages.render_argv(['cc', '{flags}', '{src}'], flags='', src='a.c')
     assert out == ['cc', 'a.c']
+
+
+def test_resolve_compiler_prefers_path(monkeypatch):
+    spec = languages.LanguageSpec.from_dict(
+        {
+            'id': 'cpp',
+            'kind': 'compiled_static',
+            'compiler_argv': ['g++', '{src}'],
+            'compiler_fallbacks': ['/opt/g++'],
+            'flags': '',
+            'run_argv': ['{exe}'],
+        }
+    )
+    monkeypatch.setattr(languages.shutil, 'which', lambda name: '/usr/bin/g++')
+    assert languages.resolve_compiler(spec) == '/usr/bin/g++'
+
+
+def test_resolve_compiler_uses_fallback(monkeypatch, tmp_path):
+    fallback = tmp_path / 'kotlinc'
+    fallback.write_text('#!/bin/sh\n')
+    fallback.chmod(0o755)
+    spec = languages.LanguageSpec.from_dict(
+        {
+            'id': 'kt',
+            'kind': 'jvm_jar',
+            'compiler_argv': ['kotlinc', '{src}'],
+            'compiler_fallbacks': [str(fallback)],
+            'flags': '',
+            'run_argv': ['java', '-jar', '{jar}'],
+            'build': 'kotlinc_include_runtime',
+        }
+    )
+    monkeypatch.setattr(languages.shutil, 'which', lambda name: None)
+    assert languages.resolve_compiler(spec) == str(fallback)

--- a/tests/rbx/box/packaging/boca_next/test_languages.py
+++ b/tests/rbx/box/packaging/boca_next/test_languages.py
@@ -115,3 +115,74 @@ def test_interpreted_run_argv():
         spec, exe='run.exe', memory_mb=256, interp='python3', src='sol.py'
     )
     assert out == ['python3', 'sol.py']
+
+
+def test_compile_plan_compiled_static():
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    object.__setattr__(spec, 'flags', '-O2 -static')
+    plan = languages.build_compile_plan(
+        spec, src='sol.cpp', exe='run.exe', basename='run'
+    )
+    assert plan.steps[0] == ['cc', 'sol.cpp']
+    assert plan.static_link_check is True
+    assert plan.artifact == 'exe'
+    assert plan.shebang is None
+    assert plan.write_script is None
+
+
+def test_compile_plan_interpreted_writes_shebang_script():
+    spec = _spec('py3', 'interpreted', run_argv=['{interp}', '{src}'])
+    object.__setattr__(spec, 'syntax_check', True)
+    plan = languages.build_compile_plan(
+        spec, src='sol.py', exe='run.exe', basename='run', interp='python3'
+    )
+    assert plan.shebang == '#!python3'
+    assert plan.write_script == ('sol.py', 'run.exe')
+    assert plan.static_link_check is False
+    assert plan.artifact == 'script'
+    assert plan.syntax_check_argv == ['python3', '-m', 'py_compile', 'sol.py']
+    assert plan.steps == []
+
+
+def test_compile_plan_interpreted_no_syntax_check():
+    spec = _spec('py2', 'interpreted', run_argv=['{interp}', '{src}'])
+    plan = languages.build_compile_plan(
+        spec, src='sol.py', exe='run.exe', basename='run', interp='python2'
+    )
+    assert plan.shebang == '#!python2'
+    assert plan.syntax_check_argv is None
+
+
+def test_compile_plan_jvm_javac_then_jar():
+    spec = _spec(
+        'java',
+        'jvm_jar',
+        run_argv=['java', '-jar', '{jar}'],
+        build='javac_then_jar',
+    )
+    object.__setattr__(spec, 'compiler_argv', ['javac', '{src}'])
+    plan = languages.build_compile_plan(
+        spec, src='Main.java', exe='run.jar', basename='Main'
+    )
+    assert ['javac', 'Main.java'] in plan.steps
+    assert ['jar', 'cfm', 'run.jar', 'Manifest.txt', '.'] in plan.steps
+    assert plan.manifest_class == 'Main'
+    assert plan.artifact == 'jar'
+    assert plan.static_link_check is False
+
+
+def test_compile_plan_kotlin_include_runtime():
+    spec = _spec(
+        'kt',
+        'jvm_jar',
+        run_argv=['java', '-cp', '{jar}', 'MainKt'],
+        build='kotlinc_include_runtime',
+    )
+    object.__setattr__(spec, 'compiler_argv', ['kotlinc', '{src}'])
+    plan = languages.build_compile_plan(
+        spec, src='sol.kt', exe='run.jar', basename='run'
+    )
+    assert plan.rename == ('sol.kt', 'Main.kt')
+    assert ['kotlinc', '-d', 'run.jar', '-include-runtime', 'Main.kt'] in plan.steps
+    assert plan.artifact == 'jar'
+    assert plan.manifest_class is None

--- a/tests/rbx/box/packaging/boca_next/test_languages.py
+++ b/tests/rbx/box/packaging/boca_next/test_languages.py
@@ -57,3 +57,61 @@ def test_resolve_compiler_uses_fallback(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(languages.shutil, 'which', lambda name: None)
     assert languages.resolve_compiler(spec) == str(fallback)
+
+
+def _spec(id, kind, run_argv, build=None):
+    return languages.LanguageSpec.from_dict(
+        {
+            'id': id,
+            'kind': kind,
+            'compiler_argv': ['cc', '{src}'],
+            'compiler_fallbacks': [],
+            'flags': '',
+            'run_argv': run_argv,
+            'build': build,
+        }
+    )
+
+
+def test_compiled_static_run_argv():
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    assert languages.build_run_argv(spec, exe='run.exe', memory_mb=256) == ['run.exe']
+
+
+def test_jvm_run_argv_injects_jvm_flags():
+    spec = _spec(
+        'java',
+        'jvm_jar',
+        run_argv=['java', '-jar', '{jar}', '{jvm_flags}'],
+        build='javac_then_jar',
+    )
+    out = languages.build_run_argv(spec, exe='run.jar', memory_mb=256)
+    assert out == [
+        'java',
+        '-jar',
+        'run.jar',
+        '-XX:+UseSerialGC',
+        '-Xmx256000K',
+        '-Xss25600K',
+        '-Xms256000K',
+    ]
+
+
+def test_kotlin_run_argv_uses_classpath_mainkt():
+    spec = _spec(
+        'kt',
+        'jvm_jar',
+        run_argv=['java', '-cp', '{jar}', '{jvm_flags}', 'MainKt'],
+        build='kotlinc_include_runtime',
+    )
+    out = languages.build_run_argv(spec, exe='run.jar', memory_mb=256)
+    assert out[:4] == ['java', '-cp', 'run.jar', '-XX:+UseSerialGC']
+    assert out[-1] == 'MainKt'
+
+
+def test_interpreted_run_argv():
+    spec = _spec('py3', 'interpreted', run_argv=['{interp}', '{src}'])
+    out = languages.build_run_argv(
+        spec, exe='run.exe', memory_mb=256, interp='python3', src='sol.py'
+    )
+    assert out == ['python3', 'sol.py']

--- a/tests/rbx/box/packaging/boca_next/test_manifest.py
+++ b/tests/rbx/box/packaging/boca_next/test_manifest.py
@@ -9,9 +9,10 @@ LANG_JSON = """
     "compiler_argv": ["g++", "{flags}", "-o", "{exe}", "{src}"],
     "compiler_fallbacks": ["/usr/bin/g++"],
     "flags": "-std=c++20 -O2 -lm -static",
-    "run_argv": ["{exe}"]
+    "run_argv": ["{exe}"],
+    "compile_time_sec": 45
   },
-  "limits": {"time_sec": 3, "runs": 2, "memory_mb": 256}
+  "limits": {"time_sec": 3, "runs": 2, "memory_mb": 256, "wall_time_sec": 12}
 }
 """
 
@@ -30,7 +31,23 @@ def test_language_manifest_parses():
     assert m.language.build is None
     assert m.language.syntax_check is False
     assert m.language.sandbox_overrides == {}
+    assert m.language.compile_time_sec == 45
     assert m.limits.runs == 2
+    assert m.limits.wall_time_sec == 12
+
+
+def test_language_spec_compile_time_sec_defaults_to_30():
+    spec = manifest.LanguageSpec.from_dict(
+        {
+            'id': 'cpp',
+            'kind': 'compiled_static',
+            'compiler_argv': ['g++', '{src}'],
+            'compiler_fallbacks': [],
+            'flags': '',
+            'run_argv': ['{exe}'],
+        }
+    )
+    assert spec.compile_time_sec == 30
 
 
 def test_language_spec_optional_fields():

--- a/tests/rbx/box/packaging/boca_next/test_manifest.py
+++ b/tests/rbx/box/packaging/boca_next/test_manifest.py
@@ -1,0 +1,48 @@
+from rbx_boca import manifest
+
+TASK_JSON = '{"task_type": "interactive", "output_kb": 65536}'
+LANG_JSON = """
+{
+  "language": {
+    "id": "cpp",
+    "kind": "compiled_static",
+    "compiler_argv": ["g++", "{flags}", "-o", "{exe}", "{src}"],
+    "compiler_fallbacks": ["/usr/bin/g++"],
+    "flags": "-std=c++20 -O2 -lm -static",
+    "run_argv": ["{exe}"]
+  },
+  "limits": {"time_sec": 3, "runs": 2, "memory_mb": 256}
+}
+"""
+
+
+def test_task_config_parses():
+    t = manifest.TaskConfig.from_json(TASK_JSON)
+    assert t.task_type == 'interactive'
+    assert t.output_kb == 65536
+
+
+def test_language_manifest_parses():
+    m = manifest.LanguageManifest.from_json(LANG_JSON)
+    assert m.language.id == 'cpp'
+    assert m.language.kind == 'compiled_static'
+    assert m.language.run_argv == ['{exe}']
+    assert m.language.build is None
+    assert m.language.syntax_check is False
+    assert m.language.sandbox_overrides == {}
+    assert m.limits.runs == 2
+
+
+def test_language_spec_optional_fields():
+    spec = manifest.LanguageSpec.from_dict(
+        {
+            'id': 'java',
+            'kind': 'jvm_jar',
+            'compiler_argv': ['javac', '{src}'],
+            'compiler_fallbacks': [],
+            'flags': '',
+            'run_argv': ['java', '-jar', '{jar}', '{jvm_flags}'],
+            'build': 'javac_then_jar',
+        }
+    )
+    assert spec.build == 'javac_then_jar'

--- a/tests/rbx/box/packaging/boca_next/test_sandbox.py
+++ b/tests/rbx/box/packaging/boca_next/test_sandbox.py
@@ -80,7 +80,7 @@ def test_profile_for_compiled_static_run():
     assert spec.stdin == 'stdin0'
 
 
-def test_profile_for_jvm_jar_run_forces_nruns_and_hardcodes():
+def test_profile_for_jvm_jar_run_honors_nruns_and_hardcodes():
     spec = sandbox.profile_for(
         'jvm_jar',
         'run',
@@ -96,7 +96,7 @@ def test_profile_for_jvm_jar_run_forces_nruns_and_hardcodes():
     assert spec.n == 0
     assert spec.mem_kb == 20000000
     assert spec.out_kb == 20000
-    assert spec.runs == 1
+    assert spec.runs == 5
     assert spec.wall_sec == 8
     assert spec.stdin == 'stdin0'
 
@@ -117,7 +117,7 @@ def test_profile_for_interpreted_run():
     assert spec.n == 0
     assert spec.mem_kb == 256000
     assert spec.out_kb == 4096
-    assert spec.runs == 1
+    assert spec.runs == 5
     assert spec.wall_sec == 8
 
 

--- a/tests/rbx/box/packaging/boca_next/test_sandbox.py
+++ b/tests/rbx/box/packaging/boca_next/test_sandbox.py
@@ -1,3 +1,4 @@
+import pytest
 from rbx_boca import sandbox
 
 
@@ -53,3 +54,146 @@ def test_build_safeexec_argv_includes_procs_and_chroot():
     argv = sandbox.build_safeexec_argv(spec, program=['java', '-jar', 'run.jar'])
     assert '-u256' in argv and '-R/jail' in argv and '-n0' in argv
     assert argv[-3:] == ['java', '-jar', 'run.jar']
+
+
+def test_profile_for_compiled_static_run():
+    spec = sandbox.profile_for(
+        'compiled_static',
+        'run',
+        cpu_sec=3,
+        memory_mb=256,
+        nruns=2,
+        out_kb=65536,
+        uid=1,
+        gid=1,
+    )
+    assert spec.fds == 10
+    assert spec.n == 1
+    assert spec.procs is None
+    assert spec.mem_kb == 256000
+    assert spec.out_kb == 65536
+    assert spec.runs == 2
+    assert spec.wall_sec == 12
+    assert spec.cpu_sec == 3
+    assert spec.stdin == 'stdin0'
+
+
+def test_profile_for_jvm_jar_run_forces_nruns_and_hardcodes():
+    spec = sandbox.profile_for(
+        'jvm_jar',
+        'run',
+        cpu_sec=2,
+        memory_mb=256,
+        nruns=5,
+        out_kb=100,
+        uid=1,
+        gid=1,
+    )
+    assert spec.fds == 256
+    assert spec.procs == 256
+    assert spec.n == 0
+    assert spec.mem_kb == 20000000
+    assert spec.out_kb == 20000
+    assert spec.runs == 1
+    assert spec.wall_sec == 8
+    assert spec.stdin == 'stdin0'
+
+
+def test_profile_for_interpreted_run():
+    spec = sandbox.profile_for(
+        'interpreted',
+        'run',
+        cpu_sec=2,
+        memory_mb=256,
+        nruns=5,
+        out_kb=4096,
+        uid=1,
+        gid=1,
+    )
+    assert spec.fds == 256
+    assert spec.procs == 256
+    assert spec.n == 0
+    assert spec.mem_kb == 256000
+    assert spec.out_kb == 4096
+    assert spec.runs == 1
+    assert spec.wall_sec == 8
+
+
+def test_profile_for_compiled_static_compile():
+    spec = sandbox.profile_for(
+        'compiled_static',
+        'compile',
+        cpu_sec=10,
+        memory_mb=512,
+        uid=1,
+        gid=1,
+    )
+    assert spec.fds == 1000
+    assert spec.n == 0
+    assert spec.procs is None
+    assert spec.out_kb == 50000
+    assert spec.runs == 1
+    assert spec.wall_sec == 20
+    assert spec.mem_kb == 512000
+    assert spec.stdin is None
+
+
+def test_profile_for_interpreted_compile():
+    spec = sandbox.profile_for(
+        'interpreted',
+        'compile',
+        cpu_sec=10,
+        memory_mb=512,
+        uid=1,
+        gid=1,
+    )
+    assert spec.fds == 1000
+    assert spec.n == 0
+    assert spec.procs is None
+    assert spec.out_kb == 50000
+    assert spec.runs == 1
+    assert spec.stdin is None
+
+
+def test_profile_for_jvm_jar_compile_unified():
+    spec = sandbox.profile_for(
+        'jvm_jar',
+        'compile',
+        cpu_sec=10,
+        memory_mb=512,
+        uid=1,
+        gid=1,
+    )
+    assert spec.fds == 256
+    assert spec.n == 0
+    assert spec.procs == 256
+    assert spec.mem_kb == 20000000
+    assert spec.out_kb == 50000
+    assert spec.runs == 1
+    assert spec.wall_sec == 20
+    assert spec.stdin is None
+
+
+def test_profile_for_overrides_win():
+    spec = sandbox.profile_for(
+        'compiled_static',
+        'run',
+        cpu_sec=1,
+        memory_mb=64,
+        uid=1,
+        gid=1,
+        overrides={'fds': 99},
+    )
+    assert spec.fds == 99
+
+
+def test_profile_for_unknown_kind_raises():
+    with pytest.raises(ValueError):
+        sandbox.profile_for('nope', 'run', cpu_sec=1, memory_mb=64, uid=1, gid=1)
+
+
+def test_profile_for_unknown_phase_raises():
+    with pytest.raises(ValueError):
+        sandbox.profile_for(
+            'compiled_static', 'nope', cpu_sec=1, memory_mb=64, uid=1, gid=1
+        )

--- a/tests/rbx/box/packaging/boca_next/test_sandbox.py
+++ b/tests/rbx/box/packaging/boca_next/test_sandbox.py
@@ -54,6 +54,8 @@ def test_build_safeexec_argv_includes_procs_and_chroot():
     argv = sandbox.build_safeexec_argv(spec, program=['java', '-jar', 'run.jar'])
     assert '-u256' in argv and '-R/jail' in argv and '-n0' in argv
     assert argv[-3:] == ['java', '-jar', 'run.jar']
+    assert '--' in argv
+    assert argv[argv.index('--') + 1 :] == ['java', '-jar', 'run.jar']
 
 
 def test_profile_for_compiled_static_run():
@@ -133,6 +135,7 @@ def test_profile_for_compiled_static_compile():
     assert spec.procs is None
     assert spec.out_kb == 50000
     assert spec.runs == 1
+    assert spec.cpu_sec == 20
     assert spec.wall_sec == 20
     assert spec.mem_kb == 512000
     assert spec.stdin is None

--- a/tests/rbx/box/packaging/boca_next/test_sandbox.py
+++ b/tests/rbx/box/packaging/boca_next/test_sandbox.py
@@ -1,0 +1,55 @@
+from rbx_boca import sandbox
+
+
+def test_build_safeexec_argv_compiled_run_profile():
+    spec = sandbox.SafeExecSpec(
+        runs=2,
+        cpu_sec=3,
+        wall_sec=12,
+        mem_kb=256000,
+        out_kb=65536,
+        fds=10,
+        n=1,
+        procs=None,
+        uid=65534,
+        gid=65534,
+        chdir='.',
+        chroot=None,
+        stdin='stdin0',
+        stdout='stdout0',
+        stderr='stderr0',
+    )
+    argv = sandbox.build_safeexec_argv(spec, program=['./run.exe'])
+    assert argv[0].endswith('safeexec') or argv[0] == 'safeexec'
+    body = argv[1:]
+    assert '-r2' in body and '-t3' in body and '-T12' in body
+    assert '-d256000' in body and '-m256000' in body
+    assert '-f65536' in body and '-F10' in body and '-n1' in body
+    assert '-U65534' in body and '-G65534' in body
+    assert '-C.' in body and '-istdin0' in body
+    assert '-ostdout0' in body and '-estderr0' in body
+    assert '-u' not in ''.join(body)  # procs None -> no -u flag
+    assert body[-1] == './run.exe'
+
+
+def test_build_safeexec_argv_includes_procs_and_chroot():
+    spec = sandbox.SafeExecSpec(
+        runs=1,
+        cpu_sec=2,
+        wall_sec=8,
+        mem_kb=512000,
+        out_kb=1024,
+        fds=256,
+        n=0,
+        procs=256,
+        uid=1,
+        gid=1,
+        chdir='.',
+        chroot='/jail',
+        stdin='stdin0',
+        stdout='stdout0',
+        stderr='stderr0',
+    )
+    argv = sandbox.build_safeexec_argv(spec, program=['java', '-jar', 'run.jar'])
+    assert '-u256' in argv and '-R/jail' in argv and '-n0' in argv
+    assert argv[-3:] == ['java', '-jar', 'run.jar']

--- a/tests/rbx/box/packaging/boca_next/test_sandbox.py
+++ b/tests/rbx/box/packaging/boca_next/test_sandbox.py
@@ -63,6 +63,7 @@ def test_profile_for_compiled_static_run():
         'compiled_static',
         'run',
         cpu_sec=3,
+        wall_sec=12,
         memory_mb=256,
         nruns=2,
         out_kb=65536,
@@ -85,6 +86,7 @@ def test_profile_for_jvm_jar_run_honors_nruns_and_hardcodes():
         'jvm_jar',
         'run',
         cpu_sec=2,
+        wall_sec=8,
         memory_mb=256,
         nruns=5,
         out_kb=100,
@@ -106,6 +108,7 @@ def test_profile_for_interpreted_run():
         'interpreted',
         'run',
         cpu_sec=2,
+        wall_sec=8,
         memory_mb=256,
         nruns=5,
         out_kb=4096,
@@ -122,10 +125,12 @@ def test_profile_for_interpreted_run():
 
 
 def test_profile_for_compiled_static_compile():
+    # Compile uses caller-supplied cpu == wall == compile_time_sec (TL == wall TL).
     spec = sandbox.profile_for(
         'compiled_static',
         'compile',
-        cpu_sec=10,
+        cpu_sec=20,
+        wall_sec=20,
         memory_mb=512,
         uid=1,
         gid=1,
@@ -145,7 +150,8 @@ def test_profile_for_interpreted_compile():
     spec = sandbox.profile_for(
         'interpreted',
         'compile',
-        cpu_sec=10,
+        cpu_sec=20,
+        wall_sec=20,
         memory_mb=512,
         uid=1,
         gid=1,
@@ -162,7 +168,8 @@ def test_profile_for_jvm_jar_compile_unified():
     spec = sandbox.profile_for(
         'jvm_jar',
         'compile',
-        cpu_sec=10,
+        cpu_sec=20,
+        wall_sec=20,
         memory_mb=512,
         uid=1,
         gid=1,
@@ -182,6 +189,7 @@ def test_profile_for_overrides_win():
         'compiled_static',
         'run',
         cpu_sec=1,
+        wall_sec=4,
         memory_mb=64,
         uid=1,
         gid=1,
@@ -192,13 +200,15 @@ def test_profile_for_overrides_win():
 
 def test_profile_for_unknown_kind_raises():
     with pytest.raises(ValueError):
-        sandbox.profile_for('nope', 'run', cpu_sec=1, memory_mb=64, uid=1, gid=1)
+        sandbox.profile_for(
+            'nope', 'run', cpu_sec=1, wall_sec=4, memory_mb=64, uid=1, gid=1
+        )
 
 
 def test_profile_for_unknown_phase_raises():
     with pytest.raises(ValueError):
         sandbox.profile_for(
-            'compiled_static', 'nope', cpu_sec=1, memory_mb=64, uid=1, gid=1
+            'compiled_static', 'nope', cpu_sec=1, wall_sec=4, memory_mb=64, uid=1, gid=1
         )
 
 

--- a/tests/rbx/box/packaging/boca_next/test_sandbox.py
+++ b/tests/rbx/box/packaging/boca_next/test_sandbox.py
@@ -197,3 +197,34 @@ def test_profile_for_unknown_phase_raises():
         sandbox.profile_for(
             'compiled_static', 'nope', cpu_sec=1, memory_mb=64, uid=1, gid=1
         )
+
+
+def test_safeexec_run_invokes_runner_and_returns_exit():
+    calls = []
+
+    def fake_runner(argv, **kw):
+        calls.append(argv)
+        return 7  # MLE
+
+    ex = sandbox.SafeExec(path='/usr/bin/safeexec', runner=fake_runner)
+    spec = sandbox.SafeExecSpec(
+        runs=1,
+        cpu_sec=1,
+        wall_sec=4,
+        mem_kb=64000,
+        out_kb=1024,
+        fds=10,
+        n=1,
+        procs=None,
+        uid=1,
+        gid=1,
+        chdir='.',
+        chroot=None,
+        stdin='stdin0',
+        stdout='stdout0',
+        stderr='stderr0',
+    )
+    code = ex.run(spec, program=['./run.exe'])
+    assert code == 7
+    assert calls[0][0] == '/usr/bin/safeexec'
+    assert calls[0][-1] == './run.exe'

--- a/tests/rbx/box/packaging/boca_next/test_tasks.py
+++ b/tests/rbx/box/packaging/boca_next/test_tasks.py
@@ -67,9 +67,9 @@ def _ctx(
         gid=65534,
         chroot=None,
         cache_dir=Path(tmp_path) / 'cache',
-        checker_path=Path(checker_path),
-        interactor_path=Path(interactor_path),
-        pipe_path=Path(pipe_path),
+        checker_path=Path(checker_path) if checker_path is not None else None,
+        interactor_path=Path(interactor_path) if interactor_path is not None else None,
+        pipe_path=Path(pipe_path) if pipe_path is not None else None,
         static_link_ok=static_link_ok
         if static_link_ok is not None
         else (lambda exe: True),
@@ -183,6 +183,30 @@ def test_batch_compare_runs_checker(tmp_path):
     assert rc == 6  # compare_verdict(None, 1)
 
 
+def test_compare_without_checker_path_returns_judge_error(tmp_path):
+    """No testlib marker + checker_path unconfigured -> fail loudly with 47,
+    and the checker/runner is never invoked."""
+    (tmp_path / 'team.out').write_text('42\n')
+    (tmp_path / 'exp.out').write_text('42\n')
+    (tmp_path / 'in.txt').write_text('x\n')
+    called = []
+    ctx = _ctx(
+        tmp_path,
+        runner=lambda argv, **kw: called.append(argv) or 0,
+        checker_path=None,
+    )
+    rc = tasks.BatchTask().compare(
+        ctx,
+        [
+            str(tmp_path / 'team.out'),
+            str(tmp_path / 'exp.out'),
+            str(tmp_path / 'in.txt'),
+        ],
+    )
+    assert rc == 47  # OTHER_ERROR
+    assert called == []  # checker NOT invoked
+
+
 def test_interactive_compare_uses_testlib_line_without_checker(tmp_path):
     (tmp_path / 'team.out').write_text('testlib exitcode 3\n')
     (tmp_path / 'exp.out').write_text('\n')
@@ -276,6 +300,57 @@ def test_interactive_run_malformed_log_returns_judge_error(tmp_path):
         ctx, ['run.exe', str(tmp_path / 'in.txt'), '3', '1', '256', '65536']
     )
     assert rc == 4  # judge error
+
+
+def test_interactive_run_without_pipe_path_returns_judge_error(tmp_path):
+    """pipe_path unconfigured -> fail loudly with judge error 4, runner never
+    invoked (no pipe.exe built/run)."""
+    called = []
+
+    def runner(argv, **kw):
+        called.append(argv)
+        return 0
+
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    (tmp_path / 'in.txt').write_text('x\n')
+    ctx = _ctx(
+        tmp_path,
+        runner=runner,
+        lang_spec=spec,
+        task_type='interactive',
+        pipe_path=None,
+        make_fifos=lambda: None,
+    )
+    rc = tasks.InteractiveTask().run(
+        ctx, ['run.exe', str(tmp_path / 'in.txt'), '3', '1', '256', '65536']
+    )
+    assert rc == 4  # judge error
+    assert called == []  # runner NOT invoked
+
+
+def test_interactive_run_without_interactor_path_returns_judge_error(tmp_path):
+    """interactor_path unconfigured -> fail loudly with judge error 4."""
+    called = []
+
+    def runner(argv, **kw):
+        called.append(argv)
+        return 0
+
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    (tmp_path / 'in.txt').write_text('x\n')
+    ctx = _ctx(
+        tmp_path,
+        runner=runner,
+        lang_spec=spec,
+        task_type='interactive',
+        interactor_path=None,
+        make_fifos=lambda: None,
+    )
+    rc = tasks.InteractiveTask().run(
+        ctx, ['run.exe', str(tmp_path / 'in.txt'), '3', '1', '256', '65536']
+    )
+    assert rc == 4  # judge error
+    assert called == []  # runner NOT invoked
 
 
 # --- Task 6.5: compile paths (jvm manifest, interpreted, kotlin) ---

--- a/tests/rbx/box/packaging/boca_next/test_tasks.py
+++ b/tests/rbx/box/packaging/boca_next/test_tasks.py
@@ -52,7 +52,9 @@ def _ctx(
     spec = lang_spec if lang_spec is not None else _spec('cpp', 'compiled_static')
     lang = manifest.LanguageManifest(
         language=spec,
-        limits=manifest.LimitsConfig(time_sec=1, runs=1, memory_mb=256),
+        limits=manifest.LimitsConfig(
+            time_sec=1, runs=1, memory_mb=256, wall_time_sec=12
+        ),
     )
     task = manifest.TaskConfig(task_type=task_type, output_kb=output_kb)
     if safeexec is None:

--- a/tests/rbx/box/packaging/boca_next/test_tasks.py
+++ b/tests/rbx/box/packaging/boca_next/test_tasks.py
@@ -216,6 +216,8 @@ def test_interactive_run_parses_pipelog_and_emits_testlib(tmp_path):
         return 0
 
     spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    input_path = tmp_path / 'in.txt'
+    input_path.write_text('7 11\n')
     ctx = _ctx(
         tmp_path,
         runner=runner,
@@ -225,10 +227,12 @@ def test_interactive_run_parses_pipelog_and_emits_testlib(tmp_path):
         make_fifos=lambda: None,
     )
     rc = tasks.InteractiveTask().run(
-        ctx, ['run.exe', str(tmp_path / 'in.txt'), '3', '1', '256', '65536']
+        ctx, ['run.exe', str(input_path), '3', '1', '256', '65536']
     )
     assert rc == 0  # interactive_run_decision(2,0,1) -> run_exit 0, testlib 1
     assert (tmp_path / 'stdout0').read_text().strip() == 'testlib exitcode 1'
+    # The test input was copied into stdin0 so the interactor reads real data.
+    assert (tmp_path / 'stdin0').read_text() == '7 11\n'
 
 
 def test_interactive_run_pipe_failure_returns_judge_error(tmp_path):
@@ -237,6 +241,7 @@ def test_interactive_run_pipe_failure_returns_judge_error(tmp_path):
         return 1
 
     spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    (tmp_path / 'in.txt').write_text('x\n')
     ctx = _ctx(
         tmp_path,
         runner=runner,
@@ -258,6 +263,7 @@ def test_interactive_run_malformed_log_returns_judge_error(tmp_path):
         return 0
 
     spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    (tmp_path / 'in.txt').write_text('x\n')
     ctx = _ctx(
         tmp_path,
         runner=runner,

--- a/tests/rbx/box/packaging/boca_next/test_tasks.py
+++ b/tests/rbx/box/packaging/boca_next/test_tasks.py
@@ -119,3 +119,17 @@ def test_batch_compile_fails_when_not_static(tmp_path):
     )
     rc = tasks.BatchTask().compile(ctx, src='sol.cpp', exe='run.exe', basename='run')
     assert rc == 47
+
+
+# --- Task 6.2: BatchTask.run ---
+
+
+def test_batch_run_maps_safeexec_exit(tmp_path):
+    fake = sandbox.SafeExec(path='/usr/bin/safeexec', runner=lambda argv, **kw: 11)
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    (tmp_path / 'in.txt').write_text('5\n')
+    ctx = _ctx(tmp_path, safeexec=fake, lang_spec=spec)
+    rc = tasks.BatchTask().run(
+        ctx, ['run.exe', str(tmp_path / 'in.txt'), '3', '2', '256', '65536']
+    )
+    assert rc == 9  # batch_run_exit(11)

--- a/tests/rbx/box/packaging/boca_next/test_tasks.py
+++ b/tests/rbx/box/packaging/boca_next/test_tasks.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from rbx_boca import manifest, sandbox, tasks
@@ -200,3 +201,125 @@ def test_interactive_run_parses_pipelog_and_emits_testlib(tmp_path):
     )
     assert rc == 0  # interactive_run_decision(2,0,1) -> run_exit 0, testlib 1
     assert (tmp_path / 'stdout0').read_text().strip() == 'testlib exitcode 1'
+
+
+def test_interactive_run_pipe_failure_returns_judge_error(tmp_path):
+    def runner(argv, **kw):
+        # pipe.exe failed: nonzero, no pipe.log written.
+        return 1
+
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    ctx = _ctx(
+        tmp_path,
+        runner=runner,
+        lang_spec=spec,
+        task_type='interactive',
+        pipe_path='/bin/pipe.exe',
+        make_fifos=lambda: None,
+    )
+    rc = tasks.InteractiveTask().run(
+        ctx, ['run.exe', str(tmp_path / 'in.txt'), '3', '1', '256', '65536']
+    )
+    assert rc == 4  # judge error
+
+
+def test_interactive_run_malformed_log_returns_judge_error(tmp_path):
+    def runner(argv, **kw):
+        # pipe.exe succeeds but writes a garbage/short log.
+        (tmp_path / 'pipe.log').write_text('garbage\n')
+        return 0
+
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    ctx = _ctx(
+        tmp_path,
+        runner=runner,
+        lang_spec=spec,
+        task_type='interactive',
+        pipe_path='/bin/pipe.exe',
+        make_fifos=lambda: None,
+    )
+    rc = tasks.InteractiveTask().run(
+        ctx, ['run.exe', str(tmp_path / 'in.txt'), '3', '1', '256', '65536']
+    )
+    assert rc == 4  # judge error
+
+
+# --- Task 6.5: compile paths (jvm manifest, interpreted, kotlin) ---
+
+
+def test_jvm_compile_writes_manifest(tmp_path):
+    seen = []
+
+    def runner(argv, **kw):
+        seen.append(argv)
+        return 0
+
+    spec = _spec(
+        'java',
+        'jvm_jar',
+        compiler_argv=['javac', '{flags}', '-d', '.', '{src}'],
+        build='javac_then_jar',
+        run_argv=['java', '-jar', '{exe}'],
+    )
+    ctx = _ctx(tmp_path, runner=runner, lang_spec=spec)
+    rc = tasks.BatchTask().compile(ctx, src='Main.java', exe='run.jar', basename='run')
+    assert rc == 0
+    manifest_path = ctx.cwd / 'Manifest.txt'
+    assert manifest_path.exists()
+    assert manifest_path.read_text() == 'Main-Class: run\n'
+    cmds = [argv[0] for argv in seen]
+    assert 'javac' in cmds
+    assert 'jar' in cmds
+
+
+def test_interpreted_compile_writes_shebang_script(tmp_path):
+    seen = []
+
+    def runner(argv, **kw):
+        seen.append(argv)
+        return 0
+
+    spec = _spec(
+        'py3',
+        'interpreted',
+        compiler_argv=['python3'],
+        run_argv=['python3', '{exe}'],
+        syntax_check=True,
+    )
+    from rbx_boca import languages
+
+    (tmp_path / 'sol.py').write_text('print(42)\n')
+    ctx = _ctx(tmp_path, runner=runner, lang_spec=spec)
+    interp = languages.resolve_compiler(spec)
+    rc = tasks.BatchTask().compile(ctx, src='sol.py', exe='run', basename='run')
+    assert rc == 0
+    exe_path = ctx.cwd / 'run'
+    contents = exe_path.read_text()
+    assert contents.startswith('#!' + interp)
+    assert 'print(42)' in contents
+    assert os.stat(str(exe_path)).st_mode & 0o777 == 0o755
+    # syntax_check argv was run.
+    assert any('py_compile' in argv for argv in seen)
+
+
+def test_kotlin_compile_renames_source(tmp_path):
+    seen = []
+
+    def runner(argv, **kw):
+        seen.append(argv)
+        return 0
+
+    spec = _spec(
+        'kt',
+        'jvm_jar',
+        compiler_argv=['kotlinc'],
+        build='kotlinc_include_runtime',
+        run_argv=['java', '-jar', '{exe}'],
+    )
+    (tmp_path / 'sol.kt').write_text('fun main() {}\n')
+    ctx = _ctx(tmp_path, runner=runner, lang_spec=spec)
+    rc = tasks.BatchTask().compile(ctx, src='sol.kt', exe='run.jar', basename='run')
+    assert rc == 0
+    assert (ctx.cwd / 'Main.kt').exists()
+    assert not (ctx.cwd / 'sol.kt').exists()
+    assert any(argv[0] == 'kotlinc' for argv in seen)

--- a/tests/rbx/box/packaging/boca_next/test_tasks.py
+++ b/tests/rbx/box/packaging/boca_next/test_tasks.py
@@ -133,3 +133,45 @@ def test_batch_run_maps_safeexec_exit(tmp_path):
         ctx, ['run.exe', str(tmp_path / 'in.txt'), '3', '2', '256', '65536']
     )
     assert rc == 9  # batch_run_exit(11)
+
+
+# --- Task 6.3: compare (batch + interactive) ---
+
+
+def test_batch_compare_runs_checker(tmp_path):
+    (tmp_path / 'team.out').write_text('42\n')
+    (tmp_path / 'exp.out').write_text('42\n')
+    (tmp_path / 'in.txt').write_text('x\n')
+    ctx = _ctx(tmp_path, runner=lambda argv, **kw: 1, checker_path='/bin/checker')
+    rc = tasks.BatchTask().compare(
+        ctx,
+        [
+            str(tmp_path / 'team.out'),
+            str(tmp_path / 'exp.out'),
+            str(tmp_path / 'in.txt'),
+        ],
+    )
+    assert rc == 6  # compare_verdict(None, 1)
+
+
+def test_interactive_compare_uses_testlib_line_without_checker(tmp_path):
+    (tmp_path / 'team.out').write_text('testlib exitcode 3\n')
+    (tmp_path / 'exp.out').write_text('\n')
+    (tmp_path / 'in.txt').write_text('x\n')
+    called = []
+    ctx = _ctx(
+        tmp_path,
+        runner=lambda argv, **kw: called.append(argv) or 0,
+        checker_path='/bin/checker',
+        task_type='interactive',
+    )
+    rc = tasks.InteractiveTask().compare(
+        ctx,
+        [
+            str(tmp_path / 'team.out'),
+            str(tmp_path / 'exp.out'),
+            str(tmp_path / 'in.txt'),
+        ],
+    )
+    assert rc == 43  # compare_verdict(3, None)
+    assert called == []  # checker NOT invoked

--- a/tests/rbx/box/packaging/boca_next/test_tasks.py
+++ b/tests/rbx/box/packaging/boca_next/test_tasks.py
@@ -175,3 +175,28 @@ def test_interactive_compare_uses_testlib_line_without_checker(tmp_path):
     )
     assert rc == 43  # compare_verdict(3, None)
     assert called == []  # checker NOT invoked
+
+
+# --- Task 6.4: InteractiveTask.run ---
+
+
+def test_interactive_run_parses_pipelog_and_emits_testlib(tmp_path):
+    def runner(argv, **kw):
+        # emulate pipe.exe writing its 3-line log: interactor-first, sol ok, WA(1)
+        (tmp_path / 'pipe.log').write_text('2\n0\n1\n')
+        return 0
+
+    spec = _spec('cpp', 'compiled_static', run_argv=['{exe}'])
+    ctx = _ctx(
+        tmp_path,
+        runner=runner,
+        lang_spec=spec,
+        task_type='interactive',
+        pipe_path='/bin/pipe.exe',
+        make_fifos=lambda: None,
+    )
+    rc = tasks.InteractiveTask().run(
+        ctx, ['run.exe', str(tmp_path / 'in.txt'), '3', '1', '256', '65536']
+    )
+    assert rc == 0  # interactive_run_decision(2,0,1) -> run_exit 0, testlib 1
+    assert (tmp_path / 'stdout0').read_text().strip() == 'testlib exitcode 1'

--- a/tests/rbx/box/packaging/boca_next/test_tasks.py
+++ b/tests/rbx/box/packaging/boca_next/test_tasks.py
@@ -122,6 +122,34 @@ def test_batch_compile_fails_when_not_static(tmp_path):
     assert rc == 47
 
 
+def test_interactive_task_compile_works(tmp_path):
+    """InteractiveTask inherits compile from BaseTask: same behavior as batch."""
+    seen = []
+
+    def runner(argv, **kw):
+        seen.append(argv)
+        return 0
+
+    spec = _spec(
+        'cpp',
+        'compiled_static',
+        compiler_argv=['g++', '{flags}', '-o', '{exe}', '{src}'],
+        flags='-O2 -static',
+        run_argv=['{exe}'],
+    )
+    ctx = _ctx(
+        tmp_path,
+        runner=runner,
+        lang_spec=spec,
+        static_link_ok=lambda exe: True,
+        task_type='interactive',
+    )
+    rc = tasks.InteractiveTask().compile(ctx, src='sol.cpp', exe='run', basename='run')
+    assert rc == 0
+    flat = [tok for argv in seen for tok in argv]
+    assert 'g++' in flat and '-o' in flat and 'run' in flat and 'sol.cpp' in flat
+
+
 # --- Task 6.2: BatchTask.run ---
 
 

--- a/tests/rbx/box/packaging/boca_next/test_tasks.py
+++ b/tests/rbx/box/packaging/boca_next/test_tasks.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+from rbx_boca import manifest, sandbox, tasks
+
+
+def _spec(
+    id,
+    kind,
+    compiler_argv=None,
+    compiler_fallbacks=None,
+    flags='',
+    run_argv=None,
+    build=None,
+    syntax_check=False,
+    sandbox_overrides=None,
+):
+    return manifest.LanguageSpec.from_dict(
+        {
+            'id': id,
+            'kind': kind,
+            'compiler_argv': compiler_argv if compiler_argv is not None else [],
+            'compiler_fallbacks': compiler_fallbacks or [],
+            'flags': flags,
+            'run_argv': run_argv if run_argv is not None else ['{exe}'],
+            'build': build,
+            'syntax_check': syntax_check,
+            'sandbox_overrides': sandbox_overrides or {},
+        }
+    )
+
+
+def _ctx(
+    tmp_path,
+    runner=None,
+    lang_spec=None,
+    static_link_ok=None,
+    task_type='batch',
+    output_kb=65536,
+    safeexec=None,
+    checker_path='/bin/checker',
+    interactor_path='/bin/interactor.exe',
+    pipe_path='/bin/pipe.exe',
+    interactor_launch_argv=None,
+    make_fifos=None,
+):
+    if runner is None:
+
+        def runner(argv, **kw):
+            return 0
+
+    spec = lang_spec if lang_spec is not None else _spec('cpp', 'compiled_static')
+    lang = manifest.LanguageManifest(
+        language=spec,
+        limits=manifest.LimitsConfig(time_sec=1, runs=1, memory_mb=256),
+    )
+    task = manifest.TaskConfig(task_type=task_type, output_kb=output_kb)
+    if safeexec is None:
+        safeexec = sandbox.SafeExec(path='/usr/bin/safeexec', runner=runner)
+    return tasks.RunContext(
+        task=task,
+        lang=lang,
+        cwd=Path(tmp_path),
+        runner=runner,
+        safeexec=safeexec,
+        uid=65534,
+        gid=65534,
+        chroot=None,
+        cache_dir=Path(tmp_path) / 'cache',
+        checker_path=Path(checker_path),
+        interactor_path=Path(interactor_path),
+        pipe_path=Path(pipe_path),
+        static_link_ok=static_link_ok
+        if static_link_ok is not None
+        else (lambda exe: True),
+        interactor_launch_argv=interactor_launch_argv
+        if interactor_launch_argv is not None
+        else ['interactor-launch'],
+        make_fifos=make_fifos,
+    )
+
+
+# --- Task 6.1: BatchTask.compile ---
+
+
+def test_batch_compile_runs_compiler_and_checks_static_link(tmp_path):
+    seen = []
+
+    def runner(argv, **kw):
+        seen.append(argv)
+        return 0
+
+    spec = _spec(
+        'cpp',
+        'compiled_static',
+        compiler_argv=['g++', '{flags}', '-o', '{exe}', '{src}'],
+        flags='-O2 -static',
+        run_argv=['{exe}'],
+    )
+    ctx = _ctx(tmp_path, runner=runner, lang_spec=spec, static_link_ok=lambda exe: True)
+    rc = tasks.BatchTask().compile(ctx, src='sol.cpp', exe='run.exe', basename='run')
+    assert rc == 0
+    flat = [tok for argv in seen for tok in argv]
+    assert 'g++' in flat and '-o' in flat and 'run.exe' in flat and 'sol.cpp' in flat
+
+
+def test_batch_compile_fails_when_not_static(tmp_path):
+    spec = _spec(
+        'cpp',
+        'compiled_static',
+        compiler_argv=['g++', '{flags}', '-o', '{exe}', '{src}'],
+        flags='-static',
+        run_argv=['{exe}'],
+    )
+    ctx = _ctx(
+        tmp_path,
+        runner=lambda argv, **kw: 0,
+        lang_spec=spec,
+        static_link_ok=lambda exe: False,
+    )
+    rc = tasks.BatchTask().compile(ctx, src='sol.cpp', exe='run.exe', basename='run')
+    assert rc == 47

--- a/tests/rbx/box/packaging/boca_next/test_verdicts.py
+++ b/tests/rbx/box/packaging/boca_next/test_verdicts.py
@@ -34,3 +34,17 @@ def test_pipelog_rejects_short_log():
 )
 def test_batch_run_exit(safeexec_exit, expected):
     assert verdicts.batch_run_exit(safeexec_exit) == expected
+
+
+@pytest.mark.parametrize(
+    'testlib,expected', [(1, 6), (2, 6), (3, 43), (4, 47), (5, 47)]
+)
+def test_compare_verdict_testlib(testlib, expected):
+    assert verdicts.compare_verdict(testlib_code=testlib, checker_exit=None) == expected
+
+
+@pytest.mark.parametrize(
+    'checker,expected', [(0, 4), (1, 6), (2, 6), (3, 43), (4, 47), (9, 47)]
+)
+def test_compare_verdict_checker(checker, expected):
+    assert verdicts.compare_verdict(testlib_code=None, checker_exit=checker) == expected

--- a/tests/rbx/box/packaging/boca_next/test_verdicts.py
+++ b/tests/rbx/box/packaging/boca_next/test_verdicts.py
@@ -17,3 +17,20 @@ def test_pipelog_tolerates_whitespace():
 def test_pipelog_rejects_short_log():
     with pytest.raises(ValueError):
         verdicts.PipeLog.parse('1\n0\n')
+
+
+@pytest.mark.parametrize(
+    'safeexec_exit,expected',
+    [
+        (0, 0),
+        (3, 3),
+        (7, 7),
+        (2, 2),
+        (9, 9),
+        (10, 10),  # boundary: not remapped
+        (11, 9),  # child nonzero (1+10) -> RTE
+        (52, 9),  # child nonzero (42+10) -> RTE
+    ],
+)
+def test_batch_run_exit(safeexec_exit, expected):
+    assert verdicts.batch_run_exit(safeexec_exit) == expected

--- a/tests/rbx/box/packaging/boca_next/test_verdicts.py
+++ b/tests/rbx/box/packaging/boca_next/test_verdicts.py
@@ -48,3 +48,29 @@ def test_compare_verdict_testlib(testlib, expected):
 )
 def test_compare_verdict_checker(checker, expected):
     assert verdicts.compare_verdict(testlib_code=None, checker_exit=checker) == expected
+
+
+D = verdicts.RunDecision
+
+
+@pytest.mark.parametrize(
+    'first_tag,ecsf,ecint,expected',
+    [
+        (2, 0, 139, D(run_exit=4, testlib_code=None)),
+        (2, 0, 5, D(run_exit=4, testlib_code=None)),
+        (1, 3, 0, D(run_exit=3, testlib_code=None)),
+        (1, 7, 0, D(run_exit=7, testlib_code=None)),
+        (2, 3, 1, D(run_exit=3, testlib_code=None)),
+        (2, 0, 1, D(run_exit=0, testlib_code=1)),
+        (2, 0, 2, D(run_exit=0, testlib_code=2)),
+        (2, 0, 3, D(run_exit=0, testlib_code=3)),
+        (2, 0, 4, D(run_exit=0, testlib_code=4)),
+        (2, 0, 0, D(run_exit=0, testlib_code=None)),
+        (1, 11, 0, D(run_exit=11, testlib_code=None)),
+        (1, 0, 1, D(run_exit=0, testlib_code=1)),
+        (1, 0, 5, D(run_exit=4, testlib_code=None)),
+        (1, 0, 0, D(run_exit=0, testlib_code=None)),
+    ],
+)
+def test_interactive_run_decision(first_tag, ecsf, ecint, expected):
+    assert verdicts.interactive_run_decision(first_tag, ecsf, ecint) == expected

--- a/tests/rbx/box/packaging/boca_next/test_verdicts.py
+++ b/tests/rbx/box/packaging/boca_next/test_verdicts.py
@@ -19,6 +19,15 @@ def test_pipelog_rejects_short_log():
         verdicts.PipeLog.parse('1\n0\n')
 
 
+def test_pipelog_rejects_non_numeric_line():
+    with pytest.raises(ValueError):
+        verdicts.PipeLog.parse('a\nb\nc\n')
+
+
+def test_pipelog_ignores_extra_lines():
+    assert verdicts.PipeLog.parse('1\n2\n3\n4\n5\n') == verdicts.PipeLog(1, 2, 3)
+
+
 @pytest.mark.parametrize(
     'safeexec_exit,expected',
     [
@@ -58,6 +67,7 @@ D = verdicts.RunDecision
     [
         (2, 0, 139, D(run_exit=4, testlib_code=None)),
         (2, 0, 5, D(run_exit=4, testlib_code=None)),
+        (2, 0, -1, D(run_exit=4, testlib_code=None)),
         (1, 3, 0, D(run_exit=3, testlib_code=None)),
         (1, 7, 0, D(run_exit=7, testlib_code=None)),
         (2, 3, 1, D(run_exit=3, testlib_code=None)),

--- a/tests/rbx/box/packaging/boca_next/test_verdicts.py
+++ b/tests/rbx/box/packaging/boca_next/test_verdicts.py
@@ -1,0 +1,19 @@
+import pytest
+from rbx_boca import verdicts
+
+
+def test_pipelog_parses_three_lines():
+    log = verdicts.PipeLog.parse('2\n0\n1\n')
+    assert log == verdicts.PipeLog(first_tag=2, solution_status=0, interactor_status=1)
+
+
+def test_pipelog_tolerates_whitespace():
+    log = verdicts.PipeLog.parse(' 1 \n 139 \n 0 \n')
+    assert log == verdicts.PipeLog(
+        first_tag=1, solution_status=139, interactor_status=0
+    )
+
+
+def test_pipelog_rejects_short_log():
+    with pytest.raises(ValueError):
+        verdicts.PipeLog.parse('1\n0\n')


### PR DESCRIPTION
## Summary

Implements **Layer 2** of BocaNext (#488): a stdlib-only, fully unit-tested **judge-side runtime** (`rbx_boca`) that replaces the duplicated BOCA bash scripts with one composable, testable Python package. This is a *new, separate* packager — the existing bash `BocaPackager` is untouched.

`rbx_boca` lives at `rbx/resources/packagers/boca_next/runtime/rbx_boca/` and is authored as a normal package so it is directly unit-testable; Layer 1 will (later) zipapp-bundle it into each `compile/run/compare/limits/tests` `.pyz`. See the design doc `docs/plans/2026-05-29-boca-next-python-packager-design.md` and the implementation plan `docs/plans/2026-05-29-boca-next-layer2-runtime.md`.

### What's included
- **`verdicts`** — pure exit-code logic: `PipeLog` parser, `batch_run_exit`, `compare_verdict`, and the 6-level `interactive_run_decision` (verified byte-for-byte against `interactor_run.sh` over the full input domain).
- **`manifest`** — two-manifest config (`task.json` language-agnostic + per-language `language.json`) as frozen dataclasses.
- **`languages`** — one generic `kind`-driven engine (`compiled_static` / `jvm_jar` / `interpreted`) collapsing the 7×130–1200-line compile scripts; `LanguageSpec` data fills small holes.
- **`sandbox`** — pure `build_safeexec_argv` (incl. `-n` and `--` separator) + per-kind/per-phase `profile_for` + injectable `SafeExec` executor.
- **`assets`** — `NativeAsset` MD5 compile cache with atomic (`os.replace`) publish, race-safe.
- **`tasks`** — `BaseTask` (shared compile/compare) + `BatchTask`/`InteractiveTask` orchestration.
- **`interactor_launcher`** — re-entrant interactor wrapper (best-effort `RLIMIT_AS`, process-group watchdog, CLOEXEC-cleared notify fd).
- **`entrypoints` + `__main__`** — dispatcher; manifests read via zip-safe `pkgutil.get_data` (with `RBX_BOCA_BUNDLE_DIR` override).
- **Integration harness** — real `.pyz` via `zipapp`; batch e2e via stub `safeexec`; fd-inheritance + watchdog integration tests for the launcher.

### Process
Built TDD, one module per phase, each gated by spec-compliance + code-quality review. Review caught real bugs the fakes masked — jvm `Manifest.txt`, pipe-failure handling, a research error that wrongly forced `nruns=1` for JVM/Python, and vacuously-passing fd-tests — all fixed and re-verified. As-built deviations are recorded in the design doc's "Implementation corrections" section.

### Out of scope (Layer 1 — #489)
env-config → `LanguageSpec` resolution, real `.pyz` assembly + `rbx package boca-next` CLI, `NativeAsset.ensure` wiring for checker/safeexec/interactor/pipe, and a real-binary (gcc + SUID safeexec) interactive e2e.

## Test Plan
- [x] `uv run pytest tests/rbx/box/packaging/boca_next/` — **108 passed** (2 slow launcher tests included)
- [x] `uv run pytest tests/rbx/box/packaging/boca_next/ -m "not slow"` — 106 passed, 2 deselected
- [x] `uv run ruff check` + `ruff format --check` on the new code — clean
- [x] Full package imports cleanly (stdlib-only, Python 3.8+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)