### PR TITLE
fix(boca): map cc/cpp alias to rbx language for limit lookup (#493)

### DIFF
--- a/docs/plans/2026-06-01-boca-cc-cpp-timelimit-design.md
+++ b/docs/plans/2026-06-01-boca-cc-cpp-timelimit-design.md
@@ -1,0 +1,101 @@
+# BOCA cc/cpp limit lookup fix (#493)
+
+## Problem
+
+In older BOCA installs, C++20 is named `cc`; newer ones use `cpp`. rbx supports
+both, and the default preset aliases the rbx `cpp` language onto **both** BOCA
+variants (`languages: ["cc", "cpp"]`, introduced for #453). The BOCA packager
+therefore emits a `limits/<lang>` script for each variant.
+
+The time/memory limit for a variant is looked up by passing the **BOCA** language
+name straight into `limits_info.get_limits(language, profile='boca')`
+(`packager.py:115`, `:120`). That bottoms out in
+`LimitsProfile.timelimit_for_language` / `memorylimit_for_language`
+(`schema.py:799`, `:812`), whose modifier lookup (`if language in self.modifiers`)
+is keyed by **rbx** language names.
+
+So when a package has a `cpp` modifier:
+
+- `cpp` lookup finds the modifier → modified limit.
+- `cc` lookup finds nothing → falls back to the base limit.
+
+`limits/cc` and `limits/cpp` end up with different limits even though both are the
+same underlying C++ compiler. Reproduced:
+
+```
+TL queried as 'cpp': 2000   # modifier applied
+TL queried as 'cc' : 1000   # modifier missed, base fallback
+```
+
+## Fix
+
+Reverse-map the emitted BOCA name to its underlying rbx language *before* the
+limits lookup, using the existing `get_rbx_language_from_boca_language()` helper
+(`boca_language_utils.py`, from #453). It maps `cc`→`cpp` and returns any
+non-aliased name unchanged, so:
+
+- both `cc` and `cpp` read the same rbx `cpp` entry → identical limits;
+- `c`, `java`, `py3`, etc. are unaffected (no-op translation);
+- it generalises to any future BOCA aliasing.
+
+Applied in `BocaPackager._get_pkg_timelimit` and `_get_pkg_memorylimit`. Covers
+both time and memory. `MojPackager` extends `BocaPackager` and inherits both
+methods, so it is fixed for free. Polygon passes `None` and is untouched. The
+limits layer (`limits_info` / `LimitsProfile`) stays packager-agnostic — BOCA
+aliasing knowledge lives only where the BOCA names originate.
+
+## Testing
+
+### Fast unit regression
+
+A packager-level test asserting
+`_get_pkg_timelimit('cc') == _get_pkg_timelimit('cpp')` and the memory
+equivalent, under the default-preset env (cpp→`["cc","cpp"]`) with a package
+that declares a `cpp` modifier. Fails today, passes after the fix.
+
+### e2e regression (per request)
+
+The unzipped limit scripts live in a `tempfile.TemporaryDirectory` and are
+deleted after zipping (`packaging/packager.py:283`); only the zip persists. The
+bug therefore lives in zip **entry content**, which the e2e DSL cannot currently
+assert (`zip_contains` checks presence only).
+
+**New `zip_file_contains` matcher.** Mirrors `file_contains`'s substring/regex
+semantics but reads a named entry out of a zip:
+
+```yaml
+expect:
+  zip_file_contains:
+    path: build/*.zip
+    entries:
+      limits/cc:  "echo 512"
+      limits/cpp: "echo 512"
+```
+
+Touch points (each mirrors an existing pattern):
+
+- `tests/e2e/spec.py`: `ZipFileMatcher` (`path: str`, `entries: Dict[str,str]`)
+  + `Expect.zip_file_contains`.
+- `tests/e2e/assertions.py`: `check_zip_file_contains`, reusing a `_match_text`
+  helper factored out of `check_file_contains` (no behavior change to the latter).
+- `tests/e2e/runner.py`: register in `_GENERIC_CHECKS`.
+- `tests/e2e/test_assertions.py`: unit tests (hit, miss, regex, missing entry,
+  missing zip).
+- `tests/e2e/README.md`: schema-reference entry.
+
+**Fixture.** Extend `tests/e2e/testdata/pkg-boca/`: add a `cpp` modifier to
+`problem.rbx.yml` — primarily a **memory** override (e.g. `cpp: {memory: 512}`
+over base 256), since memory is echoed verbatim with no rounding, giving a clean
+exact assertion. A new scenario runs `build` → `time -s inherit -p boca` →
+`pkg boca` and asserts both `limits/cc` and `limits/cpp` echo the modified
+memory. A `cpp` time modifier is also added, with its emitted TL line pinned
+empirically (time goes through BOCA's run-count rounding). The existing scenario
+only checks entry presence, so the added modifier does not perturb it.
+
+## Build order (TDD)
+
+1. Failing unit test → core fix → green.
+2. `zip_file_contains` matcher (+ its unit tests) → green.
+3. Extend `pkg-boca` fixture + new scenario; confirm it fails before the core
+   fix and passes after.
+4. Run BOCA packaging suite + e2e.

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -12,6 +12,7 @@ from rbx.box.generation_schema import GenerationTestcaseEntry
 from rbx.box.packaging.boca.boca_language_utils import (
     get_boca_template_name,
     get_emitted_boca_languages,
+    get_rbx_language_from_boca_language,
 )
 from rbx.box.packaging.boca.extension import (
     BocaExtension,
@@ -113,12 +114,18 @@ class BocaPackager(BasePackager):
         )
 
     def _get_pkg_timelimit(self, language: BocaLanguage) -> int:
-        limits = limits_info.get_limits(language, profile='boca')
+        # Limit modifiers are keyed by the underlying rbx language, so a BOCA
+        # variant (e.g. the legacy `cc` alias of `cpp`) must be mapped back to
+        # its rbx language before lookup -- otherwise it misses the modifier and
+        # falls back to the base limit (#493).
+        rbx_language = get_rbx_language_from_boca_language(language)
+        limits = limits_info.get_limits(rbx_language, profile='boca')
         assert limits.time is not None
         return limits.time
 
     def _get_pkg_memorylimit(self, language: BocaLanguage) -> int:
-        limits = limits_info.get_limits(language, profile='boca')
+        rbx_language = get_rbx_language_from_boca_language(language)
+        limits = limits_info.get_limits(rbx_language, profile='boca')
         assert limits.memory is not None
         return limits.memory
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -160,6 +160,29 @@ slashes, so `input/*` matches `input/foo/bar` too. `zip_not_contains`
 uses the same shape and asserts none of the patterns match. A missing
 zip in either matcher is an error, not a silent pass.
 
+#### `zip_file_contains`
+
+Asserts the **content** of named entries inside a zip (whereas
+`zip_contains` only checks entry presence). `path` is a glob locating the
+zip; `entries` maps a literal zip entry name to a matcher with the same
+substring/regex semantics as [`file_contains`](#file_contains) (a value
+longer than two chars wrapped in slashes is a regex, otherwise a literal
+substring).
+
+```yaml
+expect:
+  zip_file_contains:
+    path: build/*.zip
+    entries:
+      limits/cc:  "echo 512"                      # literal substring
+      limits/cpp: "/(?ms)^echo 2$.*^echo 512$/"   # multiline regex
+```
+
+Entry names are matched literally (no globbing). A missing zip, or a named
+entry absent from the zip, is an error. Because `entries` is a map, each
+entry takes a single matcher — assert multiple lines of one entry with a
+single (multiline) regex rather than repeating the key.
+
 #### `solutions`
 
 Per-solution verdict map. Reads `.box/runs/skeleton.yml` and the

--- a/tests/e2e/assertions.py
+++ b/tests/e2e/assertions.py
@@ -24,7 +24,12 @@ from rbx.box.solutions import (
 )
 from rbx.box.testcase_schema import TestcaseEntry
 from rbx.grading.steps import Evaluation
-from tests.e2e.spec import SolutionMatcher, TestsMatcher, ZipMatcher
+from tests.e2e.spec import (
+    SolutionMatcher,
+    TestsMatcher,
+    ZipFileMatcher,
+    ZipMatcher,
+)
 
 
 @dataclass
@@ -108,13 +113,22 @@ def check_file_contains(ctx: AssertionContext, mapping: Dict[str, str]) -> None:
         target = ctx.package_root / path
         if not target.exists():
             raise AssertionError(f'{path}: file does not exist')
-        text = target.read_text()
-        if len(needle) > 2 and needle.startswith('/') and needle.endswith('/'):
-            regex = needle[1:-1]
-            if not re.search(regex, text):
-                raise AssertionError(f'{path}: regex {needle} no match')
-        elif needle not in text:
-            raise AssertionError(f'{path}: missing {needle!r}')
+        _match_text(path, target.read_text(), needle)
+
+
+def _match_text(label: str, text: str, needle: str) -> None:
+    """Assert ``text`` matches ``needle`` using ``file_contains`` semantics.
+
+    A value longer than two chars wrapped in forward slashes is a regex (the
+    slashes are stripped); everything else is a literal substring. Raises
+    ``AssertionError`` prefixed with ``label`` on mismatch.
+    """
+    if len(needle) > 2 and needle.startswith('/') and needle.endswith('/'):
+        regex = needle[1:-1]
+        if not re.search(regex, text):
+            raise AssertionError(f'{label}: regex {needle} no match')
+    elif needle not in text:
+        raise AssertionError(f'{label}: missing {needle!r}')
 
 
 def _glob_in_zip(zip_path: pathlib.Path, pattern: str) -> bool:
@@ -131,6 +145,20 @@ def check_zip_contains(ctx: AssertionContext, matcher: ZipMatcher) -> None:
     for entry in matcher.entries:
         if not _glob_in_zip(zip_path, entry):
             raise AssertionError(f'{zip_path.name}: missing entry {entry!r}')
+
+
+def check_zip_file_contains(ctx: AssertionContext, matcher: ZipFileMatcher) -> None:
+    zip_paths = _glob(ctx.package_root, matcher.path)
+    if not zip_paths:
+        raise AssertionError(f'no zip matched {matcher.path!r}')
+    zip_path = zip_paths[0]
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+        for entry, needle in matcher.entries.items():
+            if entry not in names:
+                raise AssertionError(f'{zip_path.name}: no entry {entry!r}')
+            text = zf.read(entry).decode()
+            _match_text(f'{zip_path.name}:{entry}', text, needle)
 
 
 def _load_skeleton(package_root: pathlib.Path) -> SolutionReportSkeleton:

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -42,6 +42,7 @@ from tests.e2e.assertions import (
     check_stdout_matches,
     check_tests,
     check_zip_contains,
+    check_zip_file_contains,
     check_zip_not_contains,
 )
 from tests.e2e.spec import Expect, Scenario, Step
@@ -84,6 +85,7 @@ _GENERIC_CHECKS = (
     ('file_contains', check_file_contains),
     ('zip_contains', check_zip_contains),
     ('zip_not_contains', check_zip_not_contains),
+    ('zip_file_contains', check_zip_file_contains),
     ('solutions', check_solutions),
     ('tests', check_tests),
 )

--- a/tests/e2e/spec.py
+++ b/tests/e2e/spec.py
@@ -96,6 +96,19 @@ class ZipMatcher(_Forbid):
     entries: List[str]
 
 
+class ZipFileMatcher(_Forbid):
+    """Assert the *content* of named entries inside a zip.
+
+    ``path`` is a glob locating the zip under the package root; ``entries`` maps
+    a literal zip entry name to a matcher with the same substring/regex
+    semantics as ``file_contains`` (a value wrapped in slashes and longer than
+    two chars is a regex, otherwise a literal substring).
+    """
+
+    path: str
+    entries: Dict[str, str]
+
+
 class Expect(_Forbid):
     stdout_contains: Union[str, List[str], None] = None
     stderr_contains: Union[str, List[str], None] = None
@@ -105,6 +118,7 @@ class Expect(_Forbid):
     file_contains: Dict[str, str] = Field(default_factory=dict)
     zip_contains: Optional[ZipMatcher] = None
     zip_not_contains: Optional[ZipMatcher] = None
+    zip_file_contains: Optional[ZipFileMatcher] = None
     solutions: Optional[
         Dict[str, Annotated[SolutionMatcher, BeforeValidator(_coerce_solution_matcher)]]
     ] = None

--- a/tests/e2e/test_assertions.py
+++ b/tests/e2e/test_assertions.py
@@ -14,9 +14,10 @@ from tests.e2e.assertions import (
     check_stdout_contains,
     check_stdout_matches,
     check_zip_contains,
+    check_zip_file_contains,
     check_zip_not_contains,
 )
-from tests.e2e.spec import ZipMatcher
+from tests.e2e.spec import ZipFileMatcher, ZipMatcher
 
 
 def _ctx(
@@ -296,3 +297,76 @@ def test_zip_not_contains_missing_zip_raises(tmp_path):
             _ctx(tmp_path),
             ZipMatcher(path='build/boca/*.zip', entries=['secrets/*']),
         )
+
+
+# ---------------------------------------------------------------------------
+# zip_file_contains
+# ---------------------------------------------------------------------------
+
+
+def _build_zip_with_contents(
+    path: pathlib.Path, entries: dict[str, str]
+) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, 'w') as zf:
+        for entry, contents in entries.items():
+            zf.writestr(entry, contents)
+    return path
+
+
+def test_zip_file_contains_substring_pass(tmp_path):
+    _build_zip_with_contents(
+        tmp_path / 'pkg.zip',
+        {'limits/cc': 'echo 2.00\necho 512\n', 'limits/cpp': 'echo 2.00\necho 512\n'},
+    )
+    check_zip_file_contains(
+        _ctx(tmp_path),
+        ZipFileMatcher(
+            path='pkg.zip',
+            entries={'limits/cc': 'echo 512', 'limits/cpp': 'echo 512'},
+        ),
+    )
+
+
+def test_zip_file_contains_substring_fail(tmp_path):
+    _build_zip_with_contents(tmp_path / 'pkg.zip', {'limits/cc': 'echo 256\n'})
+    with pytest.raises(AssertionError, match='missing'):
+        check_zip_file_contains(
+            _ctx(tmp_path),
+            ZipFileMatcher(path='pkg.zip', entries={'limits/cc': 'echo 512'}),
+        )
+
+
+def test_zip_file_contains_regex_pass(tmp_path):
+    _build_zip_with_contents(tmp_path / 'pkg.zip', {'limits/cc': 'echo 2.00\n'})
+    check_zip_file_contains(
+        _ctx(tmp_path),
+        ZipFileMatcher(path='pkg.zip', entries={'limits/cc': r'/echo \d+\.\d+/'}),
+    )
+
+
+def test_zip_file_contains_missing_entry_raises(tmp_path):
+    _build_zip_with_contents(tmp_path / 'pkg.zip', {'limits/cc': 'echo 512\n'})
+    with pytest.raises(AssertionError, match='no entry'):
+        check_zip_file_contains(
+            _ctx(tmp_path),
+            ZipFileMatcher(path='pkg.zip', entries={'limits/cpp': 'echo 512'}),
+        )
+
+
+def test_zip_file_contains_missing_zip_raises(tmp_path):
+    with pytest.raises(AssertionError, match='no zip matched'):
+        check_zip_file_contains(
+            _ctx(tmp_path),
+            ZipFileMatcher(path='build/*.zip', entries={'limits/cc': 'echo 512'}),
+        )
+
+
+def test_zip_file_contains_path_glob_pass(tmp_path):
+    _build_zip_with_contents(
+        tmp_path / 'build' / 'pkg-name.zip', {'limits/cc': 'echo 512\n'}
+    )
+    check_zip_file_contains(
+        _ctx(tmp_path),
+        ZipFileMatcher(path='build/*.zip', entries={'limits/cc': 'echo 512'}),
+    )

--- a/tests/e2e/testdata/pkg-boca/e2e.rbx.yml
+++ b/tests/e2e/testdata/pkg-boca/e2e.rbx.yml
@@ -19,3 +19,29 @@ scenarios:
               - "input/*"
               - "output/*"
               - "limits/*"
+
+  - name: package-boca-cc-cpp-limits
+    description: >
+      The default preset aliases the rbx `cpp` language onto both BOCA
+      variants `cc` and `cpp`. The package's `cpp` limit modifier
+      (time 2000ms, memory 512MB) must therefore apply to BOTH emitted
+      `limits/` scripts. Before #493 the `cc` script missed the modifier
+      and fell back to the base limits (1000ms / 256MB).
+
+      The limits script echoes, in order: time (seconds), number of runs,
+      memory (MB), output limit. One line-anchored regex per entry asserts
+      both the time line (`echo 2`, from 2000ms) and the memory line
+      (`echo 512`). Anchoring matters: the literal `echo 2` would otherwise
+      match as a substring of the base-limit memory line `echo 256`, masking
+      a regression. Before #493 the `cc` script echoed `echo 1` / `echo 256`
+      (base limits) and this regex fails to match.
+    steps:
+      - cmd: build
+      - cmd: time -s inherit -p boca
+      - cmd: pkg boca
+        expect:
+          zip_file_contains:
+            path: build/*.zip
+            entries:
+              limits/cpp: "/(?ms)^echo 2$.*^echo 512$/"
+              limits/cc: "/(?ms)^echo 2$.*^echo 512$/"

--- a/tests/e2e/testdata/pkg-boca/problem.rbx.yml
+++ b/tests/e2e/testdata/pkg-boca/problem.rbx.yml
@@ -2,6 +2,14 @@ name: pkg-boca
 timeLimit: 1000
 memoryLimit: 256
 
+# A cpp-specific limit override. The default preset aliases the rbx `cpp`
+# language onto both BOCA variants `cc` and `cpp`, so both emitted limits
+# scripts must reflect this modifier rather than the base limits (#493).
+modifiers:
+  cpp:
+    time: 2000
+    memory: 512
+
 generators:
   - name: gen
     path: gens/gen.cpp

--- a/tests/rbx/box/packaging/boca/test_packager_limits.py
+++ b/tests/rbx/box/packaging/boca/test_packager_limits.py
@@ -1,0 +1,47 @@
+"""Regression tests for BOCA per-language limit resolution.
+
+When the default preset aliases the rbx ``cpp`` language onto both BOCA variants
+``cc`` and ``cpp`` (see #453), the package's ``cpp`` limit modifier must apply to
+*both* emitted variants. Looking the limit up by the raw BOCA name made ``cc``
+miss the modifier and fall back to the base limit (#493).
+"""
+
+from unittest import mock
+
+from rbx.box.packaging.boca import boca_language_utils
+from rbx.box.packaging.boca.extension import BocaLanguageExtension
+from rbx.box.packaging.boca.packager import BocaPackager
+from rbx.box.schema import LimitModifiers
+
+
+def _env_aliasing_cpp_to_cc_and_cpp():
+    cpp_lang = mock.MagicMock()
+    cpp_lang.name = 'cpp'
+    cpp_lang.get_extension_or_default.return_value = BocaLanguageExtension(
+        languages=['cc', 'cpp']
+    )
+    env = mock.MagicMock()
+    env.languages = [cpp_lang]
+    return env
+
+
+def test_cc_inherits_cpp_limit_modifier(testing_pkg, monkeypatch):
+    env = _env_aliasing_cpp_to_cc_and_cpp()
+    monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
+    monkeypatch.setattr(
+        boca_language_utils, 'get_language_by_extension_or_nil', lambda _: None
+    )
+
+    testing_pkg.yml.timeLimit = 1000
+    testing_pkg.yml.memoryLimit = 256
+    testing_pkg.yml.modifiers = {'cpp': LimitModifiers(time=2000, memory=512)}
+    testing_pkg.save()
+
+    packager = BocaPackager(testcase_entries=[])
+
+    # cpp resolves its own modifier; cc must resolve the same underlying rbx
+    # entry rather than falling back to the base limit.
+    assert packager._get_pkg_timelimit('cpp') == 2000  # noqa: SLF001
+    assert packager._get_pkg_timelimit('cc') == 2000  # noqa: SLF001
+    assert packager._get_pkg_memorylimit('cpp') == 512  # noqa: SLF001
+    assert packager._get_pkg_memorylimit('cc') == 512  # noqa: SLF001


### PR DESCRIPTION
## Problem

Closes #493.

In older BOCA installs C++20 is named `cc`; newer ones use `cpp`. The default preset aliases the rbx `cpp` language onto **both** BOCA variants (`languages: ["cc", "cpp"]`, from #453), so the BOCA packager emits a `limits/<lang>` script for each.

The per-variant limit was looked up by passing the **BOCA** name straight into `limits_info.get_limits(...)`, which bottoms out in `LimitsProfile.timelimit_for_language` / `memorylimit_for_language` — whose modifier lookup is keyed by **rbx** language names. So with a `cpp` modifier:

- `cpp` lookup finds the modifier → modified limit
- `cc` lookup finds nothing → falls back to the base limit

`limits/cc` and `limits/cpp` ended up with different time/memory limits even though both are the same C++ compiler.

```
TL queried as 'cpp': 2000   # modifier applied
TL queried as 'cc' : 1000   # modifier missed, base fallback
```

## Fix

Reverse-map the emitted BOCA name to its underlying rbx language via the existing `get_rbx_language_from_boca_language()` helper (from #453) **before** the limits lookup, in both `_get_pkg_timelimit` and `_get_pkg_memorylimit`. Both `cc` and `cpp` then resolve the same rbx `cpp` entry.

- `MojPackager` extends `BocaPackager` and inherits both methods → fixed for free.
- Non-aliased languages (`c`, `java`, `py3`, …) map to themselves → no behavior change.
- The limits layer stays packager-agnostic; BOCA aliasing knowledge lives only where the BOCA names originate.

## Tests

- **Fast packager unit regression** (`tests/rbx/box/packaging/boca/test_packager_limits.py`): asserts `cc` and `cpp` resolve the same modifier (RED→GREEN).
- **e2e regression** on the `pkg-boca` fixture: adds a `cpp` time/memory modifier and asserts both `limits/cc` and `limits/cpp` carry the modified limits in the produced zip. Verified to **fail without the fix** (`limits/cc: regex ... no match`) and pass with it.
- **New `zip_file_contains` e2e matcher** (spec/assertions/runner + unit tests + README): the unzipped limit scripts are deleted after zipping, so the bug only manifests in zip *entry content*, which the existing DSL (presence-only `zip_contains`) couldn't assert.

Design doc: `docs/plans/2026-06-01-boca-cc-cpp-timelimit-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)