### PR TITLE
fix(boca): emit exact fractional time limits, deprecate rounding (#494)

### DIFF
--- a/docs/plans/2026-06-01-boca-exact-fractional-tl-design.md
+++ b/docs/plans/2026-06-01-boca-exact-fractional-tl-design.md
@@ -66,8 +66,7 @@ else:
 ```
 
 `minRunningTime` is an optional, setter-controlled floor on the **total** BOCA budget
-(`reps · tl ≥ minRunningTime`). It exists to amortize fixed startup/JIT overhead and
-measurement noise on very small TLs. When unset, rbx always does a single run.
+(`reps · tl ≥ minRunningTime`). When unset, rbx always does a single run.
 
 The cap keeps the effective per-run TL exact; only the total budget falls short of the
 requested minimum, which is the safe failure mode (a warning is printed).

--- a/docs/plans/2026-06-01-boca-exact-fractional-tl-design.md
+++ b/docs/plans/2026-06-01-boca-exact-fractional-tl-design.md
@@ -1,0 +1,123 @@
+# Deprecate BOCA rounding + approximation — exact fractional time limits
+
+Issue: https://github.com/rsalesc/rbx/issues/494
+
+## Problem
+
+BOCA `limits/{lang}` scripts emit a total time budget (line 1, seconds), a number of
+repetitions (line 2), memory (line 3), and output limit (line 4). The judge runs the
+solution `repetitions` times and compares the **total** CPU time against the budget, so
+the effective per-run time limit is `budget / repetitions`.
+
+Historically BOCA only accepted integer budgets, so rbx (inheriting a heuristic from
+`box`) picks a repetition count `i` such that
+
+```
+|round(tl·i) − tl·i| / (tl·i) ≤ maximumTimeError    (default 20%)
+```
+
+and emits `budget = round(tl·i)` as an **integer**. Because the budget is rounded, the
+effective per-run TL `budget / i` drifts away from the real TL whenever `tl·i` is not
+close to an integer.
+
+Measured drift with the current code (`maximumTimeError = 0.2`):
+
+| TL    | reps | budget | effective per-run TL | drift   |
+|-------|------|--------|----------------------|---------|
+| 1.2s  | 1    | 1s     | 1.000s               | −16.7%  |
+| 0.3s  | 3    | 1s     | 0.333s               | +11.1%  |
+| 0.1s  | 9    | 1s     | 0.111s               | +11.1%  |
+| 1.9s  | 1    | 2s     | 2.000s               | +5.3%   |
+| 3.9s  | 1    | 4s     | 4.000s               | +2.6%   |
+
+This silently changes verdicts: a −16.7% drift makes intended-AC solutions wrongly TLE,
+and a +11.1% drift lets intended-TLE solutions wrongly pass. The issue only stayed hidden
+on past contests (PdA) because the TL formula resolution happened to be 0.5s, which always
+lands on near-integer products. rbx's default formula uses 0.1s resolution, which routinely
+produces "ugly" TLs like 1.2s, 3.9s.
+
+`box` allowed this error for BOCA's integer-only constraint. BOCA/safeexec now supports
+fractional time budgets (rbx already emits fractional budgets for COMMUNICATION tasks), so
+the rounding is no longer necessary and must not be ported.
+
+## Goal
+
+Never approximate the time limit. Always emit a budget whose effective per-run TL equals
+the real TL **exactly**.
+
+## Design
+
+Scope: **BOCA packager only**. MOJ already emits `pkg.timeLimit / 1000` directly with no
+repetition mechanism, so it is unaffected.
+
+### Repetition count
+
+```
+tl_ms  = _get_pkg_timelimit(language)        # int ms
+min_ms = extension.minRunningTime            # Optional[int] ms, default None
+
+if min_ms is None:
+    reps = 1                                 # single run, exact fractional TL
+else:
+    reps = max(1, ceil(min_ms / tl_ms))
+    if reps > _MAX_REPS:                     # safety cap (= 10)
+        warn("minRunningTime could not be fully honored; capping at N reps")
+        reps = _MAX_REPS
+```
+
+`minRunningTime` is an optional, setter-controlled floor on the **total** BOCA budget
+(`reps · tl ≥ minRunningTime`). It exists to amortize fixed startup/JIT overhead and
+measurement noise on very small TLs. When unset, rbx always does a single run.
+
+The cap keeps the effective per-run TL exact; only the total budget falls short of the
+requested minimum, which is the safe failure mode (a warning is printed).
+
+### Budget formatting (exact, no rounding)
+
+`budget_ms = reps · tl_ms` is exact integer milliseconds. Emit it as fractional seconds
+without floating-point rounding:
+
+```python
+def _fmt_seconds(ms: int) -> str:
+    return f'{ms // 1000}.{ms % 1000:03d}'   # 1234 -> "1.234", 2000 -> "2.000", 500 -> "0.500"
+```
+
+- BATCH path: budget = `_fmt_seconds(reps · tl_ms)`, reps as above.
+- COMMUNICATION path: reps = 1, budget = `_fmt_seconds(tl_ms)` — replaces the current
+  lossy `:.2f` formatting so interactive TLs like 1234ms no longer round to 1.23s.
+
+### Removed / deprecated
+
+- Remove `test_time`, the inner `rounding_error` / `error_percentage` helpers,
+  `_MAX_REP_TIME`, and the "TL too large → 1 run" branch (redundant: no minimum ⇒ 1 run).
+- Keep `_MAX_REPS = 10` as the repetition safety cap.
+- `BocaExtension.maximumTimeError`: keep the field for backward compatibility (no schema
+  break), mark it `deprecated=`, and stop reading it. Emit a one-time warning if a user
+  has set it, pointing them to `minRunningTime`.
+- Add `BocaExtension.minRunningTime: Optional[int] = None` (milliseconds), validated `> 0`.
+
+### Worked examples (post-fix)
+
+| TL     | minRunningTime | reps        | budget | effective TL | note                  |
+|--------|----------------|-------------|--------|--------------|-----------------------|
+| 1.2s   | (unset)        | 1           | 1.200  | 1.2s         | exact                 |
+| 0.3s   | 1000ms         | 4           | 1.200  | 0.3s         | exact                 |
+| 0.05s  | 2000ms         | 10 (capped) | 0.500  | 0.05s        | exact, warns budget<2s|
+| 1.234s | (unset)        | 1           | 1.234  | 1.234s       | exact                 |
+
+## Behavior change note
+
+Packages that previously got "nice" TLs now get a single run with the identical effective
+TL — no verdict change, but the emitted `limits/{lang}` files change (reps may drop to 1
+and the budget becomes fractional). Packages with "ugly" TLs stop drifting, which is the
+fix. The old multi-run rounding behavior is gone entirely.
+
+## Testing (TDD)
+
+- Unit: `_get_number_of_runs` returns 1 when `minRunningTime` unset; `ceil` behavior when
+  set; cap + warning path when `min/tl > _MAX_REPS`.
+- Unit: `_fmt_seconds` exactness (1234 → "1.234", 2000 → "2.000", 500 → "0.500", 50 → "0.050").
+- Integration: package a fixture with an "ugly" TL (e.g. 1200ms) and assert the emitted
+  `limits/cpp` script contains the exact budget and reps (regression guard for the drift).
+  Reuse existing BOCA packaging test fixtures.
+- Assert a set `maximumTimeError` no longer affects the emitted limits.

--- a/docs/plans/2026-06-01-boca-exact-fractional-tl-design.md
+++ b/docs/plans/2026-06-01-boca-exact-fractional-tl-design.md
@@ -105,6 +105,45 @@ def _fmt_seconds(ms: int) -> str:
 | 0.05s  | 2000ms         | 10 (capped) | 0.500  | 0.05s        | exact, warns budget<2s|
 | 1.234s | (unset)        | 1           | 1.234  | 1.234s       | exact                 |
 
+### Judge-side `run/{lang}` scripts (resources)
+
+Emitting a fractional budget in `limits/{lang}` is only half the fix: the BOCA judge runs
+the submission through `rbx/resources/packagers/boca/run/{lang}`, which receives the budget
+as `$3` and passes it to `safeexec -t$time`. `safeexec.c` parses `-t` with `atof`, so it
+accepts fractional CPU limits — but the batch `run/*` scripts wrapped `$3` in **bash
+integer** operations:
+
+```bash
+time=$3
+if [ "$time" -gt "0" ]; then        # errors on "1.200": integer expression expected
+  let "ttime = $time + 30"          # bash integer arithmetic, also errors
+else
+  time=1                            # <-- silently resets the CPU limit to 1 second
+  ttime=30
+fi
+```
+
+With a fractional `$3`, the comparison errors (returns false) and the `else` branch resets
+`time=1`, so **every** batch problem would be judged with a 1-second CPU limit regardless of
+its real TL. The interactive `run/*` scripts already avoid this by computing an integer
+ceiling via `awk` for the bash-only operations while still passing the fractional `$time` to
+safeexec. The fix mirrors that in all eight batch scripts (`c`, `cc`, `cpp`, `java`, `kt`,
+`py2`, `py3`, and the unused `bkp` template):
+
+```bash
+time=$3
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")   # ceil, for bash integer ops only
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"                           # wall limit = ceil(time) + 30
+else
+  time=1
+  ttime=30
+fi
+# safeexec still receives the exact fractional CPU budget: ... -t$time -T$ttime ...
+```
+
+MOJ run scripts use a different runtime and never had this block, so they are unaffected.
+
 ## Behavior change note
 
 Packages that previously got "nice" TLs now get a single run with the identical effective

--- a/docs/plans/2026-06-01-boca-exact-fractional-tl.md
+++ b/docs/plans/2026-06-01-boca-exact-fractional-tl.md
@@ -1,0 +1,426 @@
+# BOCA Exact Fractional Time Limits Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop the BOCA packager from rounding/approximating time limits; always emit a budget whose effective per-run TL equals the real TL exactly, with an optional `minRunningTime` floor.
+
+**Architecture:** Extract two pure helper functions (`_fmt_seconds`, `_compute_reps`) into `rbx/box/packaging/boca/packager.py` so the timing logic is unit-testable without a loaded package. Rewrite `_get_number_of_runs` and `_get_limits` as thin wrappers over those helpers. Add `minRunningTime` to `BocaExtension` and deprecate `maximumTimeError`.
+
+**Tech Stack:** Python 3, Pydantic v2, pytest, ruff. Single-quote strings, absolute imports only.
+
+Design doc: `docs/plans/2026-06-01-boca-exact-fractional-tl-design.md`
+
+---
+
+## Background for the implementer
+
+BOCA's `limits/{lang}` script echoes four lines: total time budget (seconds), number of
+repetitions, memory (MB), output limit (KB). The judge runs the solution `repetitions`
+times and compares the **total** CPU time against the budget, so the effective per-run
+limit is `budget / repetitions`. The current code rounds the budget to an integer, which
+shifts the effective TL by up to 20%. We make the budget exact.
+
+Relevant current code:
+- `rbx/box/packaging/boca/packager.py:25-32` — `_MAX_REP_TIME`, `_MAX_REPS`, `test_time`.
+- `rbx/box/packaging/boca/packager.py:125-162` — `_get_number_of_runs`.
+- `rbx/box/packaging/boca/packager.py:164-182` — `_get_limits`.
+- `rbx/box/packaging/boca/extension.py:7,13` — `_MAX_REP_ERROR`, `maximumTimeError`.
+
+`_get_pkg_timelimit(language)` returns the per-language time limit in **integer milliseconds**.
+
+---
+
+## Task 1: Add `minRunningTime` and deprecate `maximumTimeError` on `BocaExtension`
+
+**Files:**
+- Modify: `rbx/box/packaging/boca/extension.py:10-15`
+- Test: `tests/rbx/box/packaging/boca/test_extension.py`
+
+**Step 1: Write the failing tests**
+
+Add to `tests/rbx/box/packaging/boca/test_extension.py`:
+
+```python
+def test_min_running_time_defaults_to_none():
+    assert BocaExtension().minRunningTime is None
+
+
+def test_min_running_time_rejects_non_positive():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        BocaExtension(minRunningTime=0)
+    with pytest.raises(ValidationError):
+        BocaExtension(minRunningTime=-5)
+
+
+def test_min_running_time_accepts_positive_ms():
+    assert BocaExtension(minRunningTime=1000).minRunningTime == 1000
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_extension.py -v`
+Expected: the three new tests FAIL (`minRunningTime` not a field).
+
+**Step 3: Implement the schema change**
+
+In `rbx/box/packaging/boca/extension.py`, update the import and the model:
+
+```python
+from pydantic import BaseModel, Field
+
+
+class BocaExtension(BaseModel):
+    languages: typing.List[BocaLanguage] = []
+    flags: typing.Dict[BocaLanguage, str] = {}
+    # Optional floor (in milliseconds) on the TOTAL BOCA time budget. When set, the
+    # solution is run ceil(minRunningTime / timeLimit) times so the accumulated budget
+    # reaches the floor, amortizing fixed startup/JIT overhead and measurement noise on
+    # small TLs. The effective per-run TL always stays exactly equal to the real TL.
+    minRunningTime: typing.Optional[int] = Field(default=None, gt=0)
+    # Deprecated (issue #494): BOCA/safeexec supports fractional time budgets, so rbx no
+    # longer rounds TLs. This field is ignored; use `minRunningTime` instead.
+    maximumTimeError: typing.Optional[float] = Field(
+        default=None,
+        deprecated='Ignored since #494; rbx emits exact fractional TLs. Use minRunningTime.',
+    )
+    preferContestLetter: bool = False
+    usePypy: bool = False
+```
+
+Remove the `_MAX_REP_ERROR = 0.2` constant (line 7) — it is no longer referenced.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_extension.py -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/packaging/boca/extension.py tests/rbx/box/packaging/boca/test_extension.py
+git commit  # use the /commit skill -> feat(boca): add minRunningTime, deprecate maximumTimeError (#494)
+```
+
+---
+
+## Task 2: Add the pure `_fmt_seconds` helper
+
+**Files:**
+- Modify: `rbx/box/packaging/boca/packager.py` (add module-level helper near line 31)
+- Test: `tests/rbx/box/packaging/boca/test_timing.py` (create)
+
+**Step 1: Write the failing test**
+
+Create `tests/rbx/box/packaging/boca/test_timing.py`:
+
+```python
+from rbx.box.packaging.boca.packager import _fmt_seconds
+
+
+def test_fmt_seconds_is_exact():
+    assert _fmt_seconds(1234) == '1.234'
+    assert _fmt_seconds(2000) == '2.000'
+    assert _fmt_seconds(500) == '0.500'
+    assert _fmt_seconds(50) == '0.050'
+    assert _fmt_seconds(1200) == '1.200'
+    assert _fmt_seconds(0) == '0.000'
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_timing.py -v`
+Expected: FAIL with ImportError (`_fmt_seconds` not defined).
+
+**Step 3: Implement `_fmt_seconds`**
+
+In `rbx/box/packaging/boca/packager.py`, replace the `test_time` function (lines 31-32)
+with:
+
+```python
+def _fmt_seconds(ms: int) -> str:
+    """Format integer milliseconds as exact fractional seconds (no float rounding)."""
+    return f'{ms // 1000}.{ms % 1000:03d}'
+```
+
+Leave `_MAX_REPS = 10` (line 28). Remove `_MAX_REP_TIME` (lines 25-27) — it becomes unused
+in Task 3; if ruff complains about an unused import of `fabs` (line 3) now, remove it in
+Task 3 where the last user disappears (keep this commit green by leaving `fabs` for now if
+still referenced).
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_timing.py -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/packaging/boca/packager.py tests/rbx/box/packaging/boca/test_timing.py
+git commit  # /commit skill -> refactor(boca): add exact _fmt_seconds helper (#494)
+```
+
+---
+
+## Task 3: Add the pure `_compute_reps` helper and rewrite `_get_number_of_runs`
+
+**Files:**
+- Modify: `rbx/box/packaging/boca/packager.py:125-162` (`_get_number_of_runs`) and add helper
+- Test: `tests/rbx/box/packaging/boca/test_timing.py`
+
+**Step 1: Write the failing tests**
+
+Append to `tests/rbx/box/packaging/boca/test_timing.py`:
+
+```python
+from rbx.box.packaging.boca.packager import _compute_reps
+
+
+def test_compute_reps_single_run_when_no_minimum():
+    assert _compute_reps(1200, None) == (1, False)
+    assert _compute_reps(50, None) == (1, False)
+
+
+def test_compute_reps_ceil_to_reach_minimum_budget():
+    # 0.3s TL, 1s minimum -> ceil(1000/300) = 4 reps, budget 1.2s, not capped.
+    assert _compute_reps(300, 1000) == (4, False)
+    # exact multiple: 0.5s TL, 1s minimum -> 2 reps.
+    assert _compute_reps(500, 1000) == (2, False)
+    # TL already >= minimum -> 1 rep.
+    assert _compute_reps(1500, 1000) == (1, False)
+
+
+def test_compute_reps_caps_at_max_reps_and_flags():
+    # 0.05s TL, 2s minimum would need 40 reps; cap at 10 and flag capped=True.
+    assert _compute_reps(50, 2000) == (10, True)
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_timing.py -v`
+Expected: new tests FAIL (`_compute_reps` not defined).
+
+**Step 3: Implement `_compute_reps` and rewrite `_get_number_of_runs`**
+
+Add the module-level helper (near `_fmt_seconds`):
+
+```python
+import math
+
+
+def _compute_reps(tl_ms: int, min_ms: Optional[int]) -> Tuple[int, bool]:
+    """Return (repetitions, was_capped) for a BOCA limits script.
+
+    When `min_ms` is None, always a single run. Otherwise run enough times for the
+    accumulated budget (reps * tl) to reach `min_ms`, capped at `_MAX_REPS`. The effective
+    per-run TL stays exactly `tl_ms` regardless of the cap.
+    """
+    if min_ms is None:
+        return 1, False
+    reps = max(1, math.ceil(min_ms / tl_ms))
+    if reps > _MAX_REPS:
+        return _MAX_REPS, True
+    return reps, False
+```
+
+Add `Tuple` to the `typing` import at the top (`from typing import List, Optional, Tuple`).
+
+Replace the entire body of `_get_number_of_runs` (lines 125-162) with:
+
+```python
+    def _get_number_of_runs(self, language: BocaLanguage) -> int:
+        extension = get_extension_or_default('boca', BocaExtension)
+        tl_ms = self._get_pkg_timelimit(language)
+        reps, capped = _compute_reps(tl_ms, extension.minRunningTime)
+        if capped:
+            console.console.print(
+                f'[warning]minRunningTime of {extension.minRunningTime}ms could not be '
+                f'fully honored for language [item]{language}[/item] (TL is {tl_ms}ms); '
+                f'capping at {reps} run(s). The effective TL stays exact.[/warning]'
+            )
+        return reps
+```
+
+Now remove the dead code:
+- Delete `_MAX_REP_TIME` (lines 25-27 in the original).
+- Remove `from math import fabs` (line 3) — `fabs` is no longer used (we use `math.ceil`).
+  Keep `import math`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_timing.py -v`
+Expected: all PASS.
+
+**Step 5: Run ruff to confirm no unused imports/vars**
+
+Run: `uv run ruff check rbx/box/packaging/boca/packager.py`
+Expected: no errors. Fix any unused-import findings.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/packaging/boca/packager.py tests/rbx/box/packaging/boca/test_timing.py
+git commit  # /commit skill -> fix(boca): compute reps from minRunningTime without rounding (#494)
+```
+
+---
+
+## Task 4: Rewrite `_get_limits` to emit exact fractional budgets
+
+**Files:**
+- Modify: `rbx/box/packaging/boca/packager.py:164-182` (`_get_limits`)
+- Test: `tests/rbx/box/packaging/boca/test_timing.py`
+
+**Step 1: Write the failing test**
+
+This needs a real package, so use an existing packaging fixture. First inspect how
+`tests/rbx/box/packaging/boca_next/` builds a package (see its `conftest.py` and
+`test_manifest.py`) and reuse that fixture style. The test should:
+
+1. Build/load a BOCA package whose problem TL is an "ugly" value (e.g. 1200ms).
+2. Call `BocaPackager(...)._get_limits('cpp')`.
+3. Assert the emitted script's first echo is `1.200` and second echo is `1` (no drift,
+   not rounded to `1`/`1` budget=1 like the old behavior would give for 1.2s).
+
+Sketch (adapt fixture/setup to the existing conftest helpers):
+
+```python
+def test_get_limits_emits_exact_fractional_budget(...fixture that yields a BocaPackager in a
+        problem with timeLimit 1200ms and no minRunningTime...):
+    script = packager._get_limits('cpp')
+    lines = [ln for ln in script.splitlines() if ln.startswith('echo ')]
+    assert lines[0] == 'echo 1.200'   # budget
+    assert lines[1] == 'echo 1'       # reps
+
+
+def test_get_limits_with_min_running_time(...fixture: timeLimit 300ms, minRunningTime 1000...):
+    script = packager._get_limits('cpp')
+    lines = [ln for ln in script.splitlines() if ln.startswith('echo ')]
+    assert lines[0] == 'echo 1.200'   # 4 * 0.300
+    assert lines[1] == 'echo 4'
+```
+
+If a full package fixture is too heavyweight, an acceptable alternative is to test
+`_get_limits` with `_get_pkg_timelimit`, `_get_pkg_memorylimit`, and
+`package.find_problem_package_or_die` patched via `unittest.mock.patch`, asserting the two
+echo lines. Prefer reusing a real fixture if one already exists in `boca_next/conftest.py`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_timing.py -v`
+Expected: FAIL — current code emits `echo 1` (budget rounded to integer 1) for the 1200ms
+case, so the assertion `echo 1.200` fails. This is the regression guard for the bug.
+
+**Step 3: Implement the rewrite**
+
+Replace `_get_limits` (lines 164-182) with:
+
+```python
+    def _get_limits(self, language: BocaLanguage) -> str:
+        pkg = package.find_problem_package_or_die()
+        tl_ms = self._get_pkg_timelimit(language)
+        if pkg.type == TaskType.COMMUNICATION:
+            # Interactive tasks only support a single run.
+            no_of_runs = 1
+        else:
+            no_of_runs = self._get_number_of_runs(language)
+        time_limit = _fmt_seconds(tl_ms * no_of_runs)
+        return (
+            '#!/bin/bash\n'
+            f'echo {time_limit}\n'
+            f'echo {no_of_runs}\n'
+            f'echo {self._get_pkg_memorylimit(language)}\n'
+            f'echo {pkg.outputLimit}\n'
+            f'exit 0\n'
+        )
+```
+
+Note: COMMUNICATION now also routes through `_fmt_seconds`, replacing the lossy `:.2f`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_timing.py -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/packaging/boca/packager.py tests/rbx/box/packaging/boca/test_timing.py
+git commit  # /commit skill -> fix(boca): emit exact fractional time budgets in limits (#494)
+```
+
+---
+
+## Task 5: Sweep for other references and regression-check the full BOCA suite
+
+**Files:**
+- Inspect: anything referencing `test_time`, `_MAX_REP_TIME`, `maximumTimeError`,
+  `_MAX_REP_ERROR`.
+
+**Step 1: Grep for stale references**
+
+Run: `grep -rn "test_time\|_MAX_REP_TIME\|_MAX_REP_ERROR\|maximumTimeError" rbx/ tests/ docs/ --include='*.py' --include='*.md'`
+Expected: no remaining *functional* uses in `rbx/` (only the deprecated field definition in
+`extension.py` and doc mentions). Fix any leftover importers of `test_time`.
+
+Also check docs: `grep -rn "maximumTimeError\|rounding" docs/` and update the BOCA docs page
+if it documents `maximumTimeError` (mark deprecated, document `minRunningTime`).
+
+**Step 2: Run the full BOCA packaging test suites**
+
+Run:
+```bash
+uv run pytest tests/rbx/box/packaging/boca tests/rbx/box/packaging/boca_next -v
+```
+Expected: all PASS. Investigate any failure — `boca_next/test_manifest.py` or
+`test_tasks.py` may assert on the limits script content and need updating to the new exact
+format (this is expected and correct; update the assertions to match exact fractional
+budgets / single runs).
+
+**Step 3: Run ruff over the touched files**
+
+Run: `uv run ruff check rbx/box/packaging/boca/ tests/rbx/box/packaging/boca/`
+And: `uv run ruff format rbx/box/packaging/boca/ tests/rbx/box/packaging/boca/`
+Expected: clean.
+
+**Step 4: Commit any fixups**
+
+```bash
+git add -p
+git commit  # /commit skill -> test(boca): update limits assertions for exact TLs (#494)
+```
+
+---
+
+## Task 6: Final verification
+
+**Step 1: Run the broader packaging test slice**
+
+Run: `uv run pytest tests/rbx/box/packaging -n auto`
+Expected: all PASS (excluding pre-existing C++/sandbox/docker failures known to fail on
+this machine — see project memory; verify any failure is one of those, not a regression).
+
+**Step 2: Manually confirm the fix removes drift**
+
+Run a quick sanity check matching the original repro:
+```bash
+uv run python -c "
+from rbx.box.packaging.boca.packager import _compute_reps, _fmt_seconds
+for tl_ms, min_ms in [(1200, None), (300, 1000), (50, 2000), (1234, None)]:
+    reps, capped = _compute_reps(tl_ms, min_ms)
+    budget = _fmt_seconds(tl_ms * reps)
+    print(f'tl={tl_ms}ms min={min_ms} -> reps={reps} budget={budget}s eff={tl_ms}ms capped={capped}')
+"
+```
+Expected: `tl=1200 -> reps=1 budget=1.200`, `tl=300 min=1000 -> reps=4 budget=1.200`,
+`tl=50 min=2000 -> reps=10 budget=0.500 capped=True`, `tl=1234 -> reps=1 budget=1.234`.
+Effective per-run TL = `budget/reps` equals the original TL exactly in every row.
+
+**Step 3: Confirm nothing else regressed**
+
+Run: `uv run pytest --ignore=tests/rbx/box/cli -n auto -q`
+Expected: PASS apart from the documented pre-existing failures.
+```
+```

--- a/docs/plans/2026-06-01-boca-exact-fractional-tl.md
+++ b/docs/plans/2026-06-01-boca-exact-fractional-tl.md
@@ -77,8 +77,7 @@ class BocaExtension(BaseModel):
     flags: typing.Dict[BocaLanguage, str] = {}
     # Optional floor (in milliseconds) on the TOTAL BOCA time budget. When set, the
     # solution is run ceil(minRunningTime / timeLimit) times so the accumulated budget
-    # reaches the floor, amortizing fixed startup/JIT overhead and measurement noise on
-    # small TLs. The effective per-run TL always stays exactly equal to the real TL.
+    # reaches this floor, while the effective per-run TL stays exactly equal to the real TL.
     minRunningTime: typing.Optional[int] = Field(default=None, gt=0)
     # Deprecated (issue #494): BOCA/safeexec supports fractional time budgets, so rbx no
     # longer rounds TLs. This field is ignored; use `minRunningTime` instead.

--- a/rbx/box/packaging/CLAUDE.md
+++ b/rbx/box/packaging/CLAUDE.md
@@ -49,7 +49,7 @@ The main entry point in `packager.py`. Pipeline:
 ### BOCA (`boca/`)
 
 **`BocaPackager`** -- Most structurally complex. Produces zip with per-language shell scripts:
-- `limits/{lang}` -- time limit script (uses clever rounding with multiple runs to minimize error)
+- `limits/{lang}` -- time limit script. Emits an EXACT fractional time budget (no rounding). When the optional `minRunningTime` is set, it runs the solution `ceil(minRunningTime / timeLimit)` times (capped at 10) so the accumulated budget reaches the floor while the effective per-run TL stays exact.
 - `compile/{lang}` -- embeds checker source, testlib.h, rbx.h inline in shell scripts
 - `compare/{lang}`, `run/{lang}`, `tests/{lang}` -- per-language scripts from templates
 - `description/problem.info` + PDF statement
@@ -57,7 +57,7 @@ The main entry point in `packager.py`. Pipeline:
 
 Supports interactive problems with special `run` scripts.
 
-**`extension.py`** -- `BocaExtension` model with language mapping, flags, `maximumTimeError`, `preferContestLetter`, `usePypy`.
+**`extension.py`** -- `BocaExtension` model with language mapping, flags, `minRunningTime`, `preferContestLetter`, `usePypy`. (`maximumTimeError` is deprecated/ignored -- see issue #494.)
 
 ### MOJ (`moj/`)
 

--- a/rbx/box/packaging/boca/extension.py
+++ b/rbx/box/packaging/boca/extension.py
@@ -4,13 +4,21 @@ from pydantic import BaseModel, Field
 
 BocaLanguage = typing.Literal['c', 'cpp', 'cc', 'kt', 'java', 'py2', 'py3']
 
-_MAX_REP_ERROR = 0.2  # 20% error allowed in time limit when adding reps
-
 
 class BocaExtension(BaseModel):
     languages: typing.List[BocaLanguage] = []
     flags: typing.Dict[BocaLanguage, str] = {}
-    maximumTimeError: float = _MAX_REP_ERROR
+    # Optional floor (in milliseconds) on the TOTAL BOCA time budget. When set, the
+    # solution is run ceil(minRunningTime / timeLimit) times so the accumulated budget
+    # reaches the floor, amortizing fixed startup/JIT overhead and measurement noise on
+    # small TLs. The effective per-run TL always stays exactly equal to the real TL.
+    minRunningTime: typing.Optional[int] = Field(default=None, gt=0)
+    # Deprecated (issue #494): BOCA/safeexec supports fractional time budgets, so rbx no
+    # longer rounds TLs. This field is ignored; use `minRunningTime` instead.
+    maximumTimeError: typing.Optional[float] = Field(
+        default=None,
+        deprecated='Ignored since #494; rbx emits exact fractional TLs. Use minRunningTime.',
+    )
     preferContestLetter: bool = False
     usePypy: bool = False
 

--- a/rbx/box/packaging/boca/extension.py
+++ b/rbx/box/packaging/boca/extension.py
@@ -10,8 +10,7 @@ class BocaExtension(BaseModel):
     flags: typing.Dict[BocaLanguage, str] = {}
     # Optional floor (in milliseconds) on the TOTAL BOCA time budget. When set, the
     # solution is run ceil(minRunningTime / timeLimit) times so the accumulated budget
-    # reaches the floor, amortizing fixed startup/JIT overhead and measurement noise on
-    # small TLs. The effective per-run TL always stays exactly equal to the real TL.
+    # reaches this floor, while the effective per-run TL stays exactly equal to the real TL.
     minRunningTime: typing.Optional[int] = Field(default=None, gt=0)
     # Deprecated (issue #494): BOCA/safeexec supports fractional time budgets, so rbx no
     # longer rounds TLs. This field is ignored; use `minRunningTime` instead.

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -156,13 +156,13 @@ class BocaPackager(BasePackager):
 
     def _get_limits(self, language: BocaLanguage) -> str:
         pkg = package.find_problem_package_or_die()
+        tl_ms = self._get_pkg_timelimit(language)
         if pkg.type == TaskType.COMMUNICATION:
             # Interactive tasks only support a single run.
             no_of_runs = 1
-            time_limit = f'{self._get_pkg_timelimit(language) / 1000:.2f}'
         else:
             no_of_runs = self._get_number_of_runs(language)
-            time_limit = _fmt_seconds(self._get_pkg_timelimit(language) * no_of_runs)
+        time_limit = _fmt_seconds(tl_ms * no_of_runs)
         return (
             '#!/bin/bash\n'
             f'echo {time_limit}\n'

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -1,7 +1,7 @@
+import math
 import pathlib
 import shutil
-from math import fabs
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import typer
 
@@ -23,15 +23,27 @@ from rbx.box.schema import TaskType
 from rbx.box.statements.schema import Statement
 from rbx.config import get_default_app_path, get_testlib
 
-_MAX_REP_TIME = (
-    7  # TL to allow for additional rounding reps should be < _MAX_REP_TIME in seconds
-)
 _MAX_REPS = 10  # Maximum number of reps to add
 
 
 def _fmt_seconds(ms: int) -> str:
     """Format integer milliseconds as exact fractional seconds (no float rounding)."""
     return f'{ms // 1000}.{ms % 1000:03d}'
+
+
+def _compute_reps(tl_ms: int, min_ms: Optional[int]) -> Tuple[int, bool]:
+    """Return (repetitions, was_capped) for a BOCA limits script.
+
+    When `min_ms` is None, always a single run. Otherwise run enough times for the
+    accumulated budget (reps * tl) to reach `min_ms`, capped at `_MAX_REPS`. The effective
+    per-run TL stays exactly `tl_ms` regardless of the cap.
+    """
+    if min_ms is None:
+        return 1, False
+    reps = max(1, math.ceil(min_ms / tl_ms))
+    if reps > _MAX_REPS:
+        return _MAX_REPS, True
+    return reps, False
 
 
 class BocaPackager(BasePackager):
@@ -131,43 +143,16 @@ class BocaPackager(BasePackager):
         return limits.memory
 
     def _get_number_of_runs(self, language: BocaLanguage) -> int:
-        pkg = package.find_problem_package_or_die()
         extension = get_extension_or_default('boca', BocaExtension)
-        pkg_timelimit = self._get_pkg_timelimit(language)
-        time = pkg_timelimit / 1000  # convert to seconds
-
-        if time >= _MAX_REP_TIME:
+        tl_ms = self._get_pkg_timelimit(language)
+        reps, capped = _compute_reps(tl_ms, extension.minRunningTime)
+        if capped:
             console.console.print(
-                f'[warning]Use time limit of {time} seconds instead of {pkg_timelimit}ms because TL is too large.[/warning]'
+                f'[warning]minRunningTime of {extension.minRunningTime}ms could not be '
+                f'fully honored for language [item]{language}[/item] (TL is {tl_ms}ms); '
+                f'capping at {reps} run(s). The effective TL stays exact.[/warning]'
             )
-            return 1
-
-        def rounding_error(time):
-            return fabs(time - max(1, round(time)))
-
-        def error_percentage(time, runs):
-            return rounding_error(time * runs) / (time * runs)
-
-        for i in range(1, _MAX_REPS + 1):
-            if error_percentage(time, i) <= (extension.maximumTimeError or 0.0):
-                console.console.print(
-                    f'[warning]Using {i} run(s) to define integer TL for BOCA when using language [item]{language}[/item] '
-                    f'(original TL is {pkg_timelimit}ms, new TL is {max(1, round(time * i)) * 1000}ms).[/warning]'
-                )
-                return i
-
-        percent_str = f'{round((extension.maximumTimeError or 0.0) * 100)}%'
-        console.console.print(
-            f'[error]Error while defining limits for problem [item]{pkg.name}[/item], language [item]{language}[/item].[/error]'
-        )
-        console.console.print(
-            f'[error]Introducing an error of less than {percent_str} in the TL in less than '
-            f'{_MAX_REPS} runs is not possible.[/error]'
-        )
-        console.console.print(
-            f'[error]Original TL for [item]{language}[/item] is {pkg_timelimit}ms, please review it.[/error]'
-        )
-        raise typer.Exit(1)
+        return reps
 
     def _get_limits(self, language: BocaLanguage) -> str:
         pkg = package.find_problem_package_or_die()

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -38,6 +38,8 @@ def _compute_reps(tl_ms: int, min_ms: Optional[int]) -> Tuple[int, bool]:
     accumulated budget (reps * tl) to reach `min_ms`, capped at `_MAX_REPS`. The effective
     per-run TL stays exactly `tl_ms` regardless of the cap.
     """
+    if tl_ms <= 0:
+        return 1, False
     if min_ms is None:
         return 1, False
     reps = max(1, math.ceil(min_ms / tl_ms))

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -29,8 +29,9 @@ _MAX_REP_TIME = (
 _MAX_REPS = 10  # Maximum number of reps to add
 
 
-def test_time(time):
-    return max(1, round(time))
+def _fmt_seconds(ms: int) -> str:
+    """Format integer milliseconds as exact fractional seconds (no float rounding)."""
+    return f'{ms // 1000}.{ms % 1000:03d}'
 
 
 class BocaPackager(BasePackager):
@@ -142,20 +143,20 @@ class BocaPackager(BasePackager):
             return 1
 
         def rounding_error(time):
-            return fabs(time - test_time(time))
+            return fabs(time - max(1, round(time)))
 
         def error_percentage(time, runs):
             return rounding_error(time * runs) / (time * runs)
 
         for i in range(1, _MAX_REPS + 1):
-            if error_percentage(time, i) <= extension.maximumTimeError:
+            if error_percentage(time, i) <= (extension.maximumTimeError or 0.0):
                 console.console.print(
                     f'[warning]Using {i} run(s) to define integer TL for BOCA when using language [item]{language}[/item] '
-                    f'(original TL is {pkg_timelimit}ms, new TL is {test_time(time * i) * 1000}ms).[/warning]'
+                    f'(original TL is {pkg_timelimit}ms, new TL is {max(1, round(time * i)) * 1000}ms).[/warning]'
                 )
                 return i
 
-        percent_str = f'{round(extension.maximumTimeError * 100)}%'
+        percent_str = f'{round((extension.maximumTimeError or 0.0) * 100)}%'
         console.console.print(
             f'[error]Error while defining limits for problem [item]{pkg.name}[/item], language [item]{language}[/item].[/error]'
         )
@@ -176,9 +177,7 @@ class BocaPackager(BasePackager):
             time_limit = f'{self._get_pkg_timelimit(language) / 1000:.2f}'
         else:
             no_of_runs = self._get_number_of_runs(language)
-            time_limit = test_time(
-                self._get_pkg_timelimit(language) / 1000 * no_of_runs
-            )
+            time_limit = _fmt_seconds(self._get_pkg_timelimit(language) * no_of_runs)
         return (
             '#!/bin/bash\n'
             f'echo {time_limit}\n'

--- a/rbx/resources/packagers/boca/run/bkp
+++ b/rbx/resources/packagers/boca/run/bkp
@@ -80,8 +80,12 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-if [ "$time" -gt "0" ]; then
-  let "ttime = $time + 30"
+# $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
+# verbatim. Use an integer ceiling only for the bash integer comparison and the
+# real (wall) time limit, mirroring the interactive scripts (see #494).
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"
 else
   time=1
   ttime=30

--- a/rbx/resources/packagers/boca/run/c
+++ b/rbx/resources/packagers/boca/run/c
@@ -80,8 +80,12 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-if [ "$time" -gt "0" ]; then
-  let "ttime = $time + 30"
+# $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
+# verbatim. Use an integer ceiling only for the bash integer comparison and the
+# real (wall) time limit, mirroring the interactive scripts (see #494).
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"
 else
   time=1
   ttime=30

--- a/rbx/resources/packagers/boca/run/cc
+++ b/rbx/resources/packagers/boca/run/cc
@@ -80,8 +80,12 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-if [ "$time" -gt "0" ]; then
-  let "ttime = $time + 30"
+# $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
+# verbatim. Use an integer ceiling only for the bash integer comparison and the
+# real (wall) time limit, mirroring the interactive scripts (see #494).
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"
 else
   time=1
   ttime=30

--- a/rbx/resources/packagers/boca/run/cpp
+++ b/rbx/resources/packagers/boca/run/cpp
@@ -80,8 +80,12 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-if [ "$time" -gt "0" ]; then
-  let "ttime = $time + 30"
+# $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
+# verbatim. Use an integer ceiling only for the bash integer comparison and the
+# real (wall) time limit, mirroring the interactive scripts (see #494).
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"
 else
   time=1
   ttime=30

--- a/rbx/resources/packagers/boca/run/java
+++ b/rbx/resources/packagers/boca/run/java
@@ -98,8 +98,12 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-if [ "$time" -gt "0" ]; then
-  let "ttime = $time + 30"
+# $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
+# verbatim. Use an integer ceiling only for the bash integer comparison and the
+# real (wall) time limit, mirroring the interactive scripts (see #494).
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"
 else
   time=1
   ttime=30

--- a/rbx/resources/packagers/boca/run/kt
+++ b/rbx/resources/packagers/boca/run/kt
@@ -98,8 +98,12 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-if [ "$time" -gt "0" ]; then
-  let "ttime = $time + 30"
+# $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
+# verbatim. Use an integer ceiling only for the bash integer comparison and the
+# real (wall) time limit, mirroring the interactive scripts (see #494).
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"
 else
   time=1
   ttime=30

--- a/rbx/resources/packagers/boca/run/py2
+++ b/rbx/resources/packagers/boca/run/py2
@@ -78,8 +78,12 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-if [ "$time" -gt "0" ]; then
-  let "ttime = $time + 30"
+# $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
+# verbatim. Use an integer ceiling only for the bash integer comparison and the
+# real (wall) time limit, mirroring the interactive scripts (see #494).
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"
 else
   time=1
   ttime=30

--- a/rbx/resources/packagers/boca/run/py3
+++ b/rbx/resources/packagers/boca/run/py3
@@ -78,8 +78,12 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-if [ "$time" -gt "0" ]; then
-  let "ttime = $time + 30"
+# $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
+# verbatim. Use an integer ceiling only for the bash integer comparison and the
+# real (wall) time limit, mirroring the interactive scripts (see #494).
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"
 else
   time=1
   ttime=30

--- a/tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/env.rbx.yml
+++ b/tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/env.rbx.yml
@@ -1,0 +1,34 @@
+---
+# Local env for the BOCA minRunningTime e2e scenario (#494). It maps the rbx
+# `cpp` language onto the single BOCA variant `cc` and sets a BOCA minimum
+# running time of 1000ms, so a small fractional TL is run multiple times with
+# an EXACT accumulated budget (no rounding).
+sandbox: "stupid"
+defaultCompilation:
+  sandbox:
+    maxProcesses: 1000
+    timeLimit: 50000 # 50 seconds
+    wallTimeLimit: 50000 # 50 seconds
+    memoryLimit: 1024 # 1gb
+defaultExecution:
+  sandbox:
+    timeLimit: 50000 # 50 seconds
+    wallTimeLimit: 50000 # 50 seconds
+    memoryLimit: 1024 # 1gb
+languages:
+  - name: "cpp"
+    readableName: "C++20"
+    extension: "cpp"
+    compilation:
+      commands: ["g++ -std=c++20 -O2 -o {executable} {compilable}"]
+    execution:
+      command: "./{executable}"
+    extensions:
+      boca:
+        bocaLanguage: "cc"
+extensions:
+  boca:
+    languages: ["cc"]
+    flags:
+      cc: "-std=c++20 -O2 -lm -static"
+    minRunningTime: 1000

--- a/tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/preset.rbx.yml
+++ b/tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/preset.rbx.yml
@@ -1,0 +1,5 @@
+---
+name: "e2e-boca-min-running-time"
+uri: "test/e2e-boca-min-running-time"
+min_version: "0.14.0"
+env: "env.rbx.yml"

--- a/tests/e2e/testdata/pkg-boca-min-running-time/e2e.rbx.yml
+++ b/tests/e2e/testdata/pkg-boca-min-running-time/e2e.rbx.yml
@@ -1,0 +1,27 @@
+scenarios:
+  - name: package-boca-min-running-time
+    description: >
+      Regression guard for #494 (deprecate BOCA rounding + approximation).
+
+      The problem TL is an "ugly" 300ms and the local env sets the BOCA
+      `minRunningTime` extension to 1000ms. The limits script echoes, in
+      order: time budget (seconds), number of runs, memory (MB), output
+      limit. Since #494 the budget is EXACT and never rounded: the solution
+      runs ceil(1000 / 300) = 4 times with an accumulated budget of
+      4 * 0.300 = 1.200s, so the effective per-run TL is exactly 300ms.
+
+      The line-anchored regex asserts the budget line (`echo 1.200`) and the
+      run count (`echo 4`). The OLD rounding heuristic instead emitted an
+      integer budget of `echo 1` over `echo 3` runs (effective 0.333s, a
+      +11% drift), so this regex fails to match the pre-#494 output.
+    steps:
+      - cmd: build
+      - cmd: time -s inherit -p boca
+      - cmd: pkg boca
+        expect:
+          files_exist:
+            - "build/*.zip"
+          zip_file_contains:
+            path: build/*.zip
+            entries:
+              limits/cc: "/(?ms)^echo 1.200$.*^echo 4$/"

--- a/tests/e2e/testdata/pkg-boca-min-running-time/gens/gen.cpp
+++ b/tests/e2e/testdata/pkg-boca-min-running-time/gens/gen.cpp
@@ -1,0 +1,14 @@
+#include <cstdio>
+#include <cstdlib>
+
+// Minimal generator: takes two integers as args and prints them as the input.
+// Usage: gen <a> <b>
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        return 1;
+    }
+    int a = atoi(argv[1]);
+    int b = atoi(argv[2]);
+    printf("%d %d\n", a, b);
+    return 0;
+}

--- a/tests/e2e/testdata/pkg-boca-min-running-time/problem.rbx.yml
+++ b/tests/e2e/testdata/pkg-boca-min-running-time/problem.rbx.yml
@@ -1,0 +1,27 @@
+name: pkg-boca-min-running-time
+
+# A small, "ugly" time limit (300ms) that the old BOCA rounding heuristic
+# would have approximated. Combined with the BOCA `minRunningTime: 1000`
+# extension (see .local.rbx/env.rbx.yml), the limits script must run the
+# solution ceil(1000 / 300) = 4 times with an EXACT accumulated budget of
+# 4 * 0.300 = 1.200s, so the effective per-run TL stays exactly 300ms. See #494.
+timeLimit: 300
+memoryLimit: 256
+
+generators:
+  - name: gen
+    path: gens/gen.cpp
+
+solutions:
+  - path: sols/main.cpp
+    outcome: ac
+
+testcases:
+  - name: main
+    subgroups:
+      - name: gen
+        generators:
+          - name: gen
+            args: 1 2
+          - name: gen
+            args: 3 4

--- a/tests/e2e/testdata/pkg-boca-min-running-time/sols/main.cpp
+++ b/tests/e2e/testdata/pkg-boca-min-running-time/sols/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+using namespace std;
+
+int main() {
+    int a, b;
+    cin >> a >> b;
+    cout << a + b << endl;
+    return 0;
+}

--- a/tests/e2e/testdata/pkg-boca/e2e.rbx.yml
+++ b/tests/e2e/testdata/pkg-boca/e2e.rbx.yml
@@ -29,12 +29,13 @@ scenarios:
       and fell back to the base limits (1000ms / 256MB).
 
       The limits script echoes, in order: time (seconds), number of runs,
-      memory (MB), output limit. One line-anchored regex per entry asserts
-      both the time line (`echo 2`, from 2000ms) and the memory line
-      (`echo 512`). Anchoring matters: the literal `echo 2` would otherwise
-      match as a substring of the base-limit memory line `echo 256`, masking
-      a regression. Before #493 the `cc` script echoed `echo 1` / `echo 256`
-      (base limits) and this regex fails to match.
+      memory (MB), output limit. Since #494 the time line is an EXACT
+      fractional budget with no rounding, so a 2000ms TL emits `echo 2.000`
+      over a single run (`echo 1`). One line-anchored regex per entry
+      asserts the time line (`echo 2.000`), the run count (`echo 1`), and
+      the memory line (`echo 512`, from the 512MB modifier). Before #493 the
+      `cc` script echoed the base limits instead, so this regex fails to
+      match a regression.
     steps:
       - cmd: build
       - cmd: time -s inherit -p boca
@@ -43,5 +44,5 @@ scenarios:
           zip_file_contains:
             path: build/*.zip
             entries:
-              limits/cpp: "/(?ms)^echo 2$.*^echo 512$/"
-              limits/cc: "/(?ms)^echo 2$.*^echo 512$/"
+              limits/cpp: "/(?ms)^echo 2.000$.*^echo 1$.*^echo 512$/"
+              limits/cc: "/(?ms)^echo 2.000$.*^echo 1$.*^echo 512$/"

--- a/tests/rbx/box/packaging/boca/test_extension.py
+++ b/tests/rbx/box/packaging/boca/test_extension.py
@@ -41,3 +41,21 @@ def test_resolved_template_none_when_unset():
 
 def test_boca_extension_languages_defaults_to_empty():
     assert BocaExtension().languages == []
+
+
+def test_min_running_time_defaults_to_none():
+    assert BocaExtension().minRunningTime is None
+
+
+def test_min_running_time_rejects_non_positive():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        BocaExtension(minRunningTime=0)
+    with pytest.raises(ValidationError):
+        BocaExtension(minRunningTime=-5)
+
+
+def test_min_running_time_accepts_positive_ms():
+    assert BocaExtension(minRunningTime=1000).minRunningTime == 1000

--- a/tests/rbx/box/packaging/boca/test_timing.py
+++ b/tests/rbx/box/packaging/boca/test_timing.py
@@ -38,6 +38,11 @@ def test_compute_reps_caps_at_max_reps_and_flags():
     assert _compute_reps(50, 2000) == (10, True)
 
 
+def test_compute_reps_handles_nonpositive_tl():
+    assert _compute_reps(0, 1000) == (1, False)
+    assert _compute_reps(-5, 1000) == (1, False)
+
+
 class _StubPackage:
     def __init__(self, task_type=TaskType.BATCH, output_limit=65536):
         self.type = task_type
@@ -72,6 +77,8 @@ def test_get_limits_batch_emits_exact_budget_single_run():
         echos = _echo_lines(packager._get_limits('cpp'))  # noqa: SLF001
     assert echos[0] == 'echo 1.200'
     assert echos[1] == 'echo 1'
+    assert echos[2] == 'echo 256'
+    assert echos[3] == 'echo 65536'
 
 
 def test_get_limits_batch_honors_min_running_time():
@@ -80,6 +87,8 @@ def test_get_limits_batch_honors_min_running_time():
         echos = _echo_lines(packager._get_limits('cpp'))  # noqa: SLF001
     assert echos[0] == 'echo 1.200'
     assert echos[1] == 'echo 4'
+    assert echos[2] == 'echo 256'
+    assert echos[3] == 'echo 65536'
 
 
 def test_get_limits_communication_is_single_run_and_exact():
@@ -87,3 +96,5 @@ def test_get_limits_communication_is_single_run_and_exact():
         echos = _echo_lines(packager._get_limits('cpp'))  # noqa: SLF001
     assert echos[0] == 'echo 1.234'
     assert echos[1] == 'echo 1'
+    assert echos[2] == 'echo 256'
+    assert echos[3] == 'echo 65536'

--- a/tests/rbx/box/packaging/boca/test_timing.py
+++ b/tests/rbx/box/packaging/boca/test_timing.py
@@ -1,4 +1,4 @@
-from rbx.box.packaging.boca.packager import _fmt_seconds
+from rbx.box.packaging.boca.packager import _compute_reps, _fmt_seconds
 
 
 def test_fmt_seconds_is_exact():
@@ -8,3 +8,22 @@ def test_fmt_seconds_is_exact():
     assert _fmt_seconds(50) == '0.050'
     assert _fmt_seconds(1200) == '1.200'
     assert _fmt_seconds(0) == '0.000'
+
+
+def test_compute_reps_single_run_when_no_minimum():
+    assert _compute_reps(1200, None) == (1, False)
+    assert _compute_reps(50, None) == (1, False)
+
+
+def test_compute_reps_ceil_to_reach_minimum_budget():
+    # 0.3s TL, 1s minimum -> ceil(1000/300) = 4 reps, budget 1.2s, not capped.
+    assert _compute_reps(300, 1000) == (4, False)
+    # exact multiple: 0.5s TL, 1s minimum -> 2 reps.
+    assert _compute_reps(500, 1000) == (2, False)
+    # TL already >= minimum -> 1 rep.
+    assert _compute_reps(1500, 1000) == (1, False)
+
+
+def test_compute_reps_caps_at_max_reps_and_flags():
+    # 0.05s TL, 2s minimum would need 40 reps; cap at 10 and flag capped=True.
+    assert _compute_reps(50, 2000) == (10, True)

--- a/tests/rbx/box/packaging/boca/test_timing.py
+++ b/tests/rbx/box/packaging/boca/test_timing.py
@@ -1,4 +1,13 @@
-from rbx.box.packaging.boca.packager import _compute_reps, _fmt_seconds
+import contextlib
+from unittest import mock
+
+from rbx.box.packaging.boca.extension import BocaExtension
+from rbx.box.packaging.boca.packager import (
+    BocaPackager,
+    _compute_reps,
+    _fmt_seconds,
+)
+from rbx.box.schema import TaskType
 
 
 def test_fmt_seconds_is_exact():
@@ -27,3 +36,54 @@ def test_compute_reps_ceil_to_reach_minimum_budget():
 def test_compute_reps_caps_at_max_reps_and_flags():
     # 0.05s TL, 2s minimum would need 40 reps; cap at 10 and flag capped=True.
     assert _compute_reps(50, 2000) == (10, True)
+
+
+class _StubPackage:
+    def __init__(self, task_type=TaskType.BATCH, output_limit=65536):
+        self.type = task_type
+        self.outputLimit = output_limit
+
+
+@contextlib.contextmanager
+def _patched_packager(tl_ms, task_type=TaskType.BATCH, extension=None):
+    pkg = _StubPackage(task_type=task_type)
+    packager = BocaPackager(testcase_entries=[])
+    with (
+        mock.patch.object(packager, '_get_pkg_timelimit', return_value=tl_ms),
+        mock.patch.object(packager, '_get_pkg_memorylimit', return_value=256),
+        mock.patch(
+            'rbx.box.packaging.boca.packager.package.find_problem_package_or_die',
+            return_value=pkg,
+        ),
+        mock.patch(
+            'rbx.box.packaging.boca.packager.get_extension_or_default',
+            return_value=extension if extension is not None else BocaExtension(),
+        ),
+    ):
+        yield packager
+
+
+def _echo_lines(script):
+    return [line for line in script.splitlines() if line.startswith('echo ')]
+
+
+def test_get_limits_batch_emits_exact_budget_single_run():
+    with _patched_packager(1200) as packager:
+        echos = _echo_lines(packager._get_limits('cpp'))  # noqa: SLF001
+    assert echos[0] == 'echo 1.200'
+    assert echos[1] == 'echo 1'
+
+
+def test_get_limits_batch_honors_min_running_time():
+    ext = BocaExtension(minRunningTime=1000)
+    with _patched_packager(300, extension=ext) as packager:
+        echos = _echo_lines(packager._get_limits('cpp'))  # noqa: SLF001
+    assert echos[0] == 'echo 1.200'
+    assert echos[1] == 'echo 4'
+
+
+def test_get_limits_communication_is_single_run_and_exact():
+    with _patched_packager(1234, task_type=TaskType.COMMUNICATION) as packager:
+        echos = _echo_lines(packager._get_limits('cpp'))  # noqa: SLF001
+    assert echos[0] == 'echo 1.234'
+    assert echos[1] == 'echo 1'

--- a/tests/rbx/box/packaging/boca/test_timing.py
+++ b/tests/rbx/box/packaging/boca/test_timing.py
@@ -1,0 +1,10 @@
+from rbx.box.packaging.boca.packager import _fmt_seconds
+
+
+def test_fmt_seconds_is_exact():
+    assert _fmt_seconds(1234) == '1.234'
+    assert _fmt_seconds(2000) == '2.000'
+    assert _fmt_seconds(500) == '0.500'
+    assert _fmt_seconds(50) == '0.050'
+    assert _fmt_seconds(1200) == '1.200'
+    assert _fmt_seconds(0) == '0.000'


### PR DESCRIPTION
## Summary

Fixes #494. The BOCA packager previously rounded time limits to an **integer** budget within a 20% `maximumTimeError` tolerance, then ran the solution multiple times to approximate the real TL. Because BOCA's effective per-run TL is `budget / repetitions`, rounding the budget silently shifted the effective TL whenever the product wasn't near-integer:

| TL | old effective TL | drift |
|----|------------------|-------|
| 1.2s | 1.0s | **−16.7%** (intended-AC solutions wrongly TLE) |
| 0.3s | 0.333s | **+11.1%** (intended-TLE solutions wrongly pass) |
| 1.9s | 2.0s | +5.3% |

This only stayed hidden on past contests (e.g. PdA) because they used a 0.5s TL-formula resolution, which always lands on near-integer products. rbx's default 0.1s resolution routinely produces "ugly" TLs like 1.2s/3.9s.

BOCA/safeexec supports fractional time budgets (rbx already emits them for interactive tasks), so the rounding is unnecessary and is removed.

## What changed

- **Exact fractional budgets, no rounding.** New `_fmt_seconds(ms)` formats integer milliseconds as exact fractional seconds via integer arithmetic (`f'{ms//1000}.{ms%1000:03d}'`) — no float error. Used by both BATCH and COMMUNICATION paths (the latter previously used a lossy `:.2f`).
- **Optional `minRunningTime` (ms) floor** on `BocaExtension`. When set, the solution runs `ceil(minRunningTime / timeLimit)` times so the accumulated budget reaches the floor (e.g. min=1000ms, TL=300ms → 4 runs, 1.200s budget), while the effective per-run TL stays **exactly** the real TL. Capped at 10 runs with a warning; unset → a single run.
- **`maximumTimeError` deprecated and ignored** (kept as a field for back-compat — no schema break).
- Extracted pure helpers `_fmt_seconds` and `_compute_reps` for direct unit testing; removed dead code (`test_time`, `_MAX_REP_TIME`, `_MAX_REP_ERROR`, `from math import fabs`).

MOJ is unaffected — it already emits fractional TLs directly.

## Testing

- New unit tests for `_fmt_seconds` (exactness across edge cases), `_compute_reps` (ceil, cap+flag, no-minimum, non-positive-TL guard), and `_get_limits` (asserts all four echo lines; the 1200ms case fails against the old rounding code — regression guard).
- `tests/rbx/box/packaging/boca` + `boca_next`: **145 passed**.
- Full `tests/rbx/box/packaging` slice: 148 passed, 1 xfailed (the 3 docker-compose e2e errors are environmental/pre-existing, unrelated to this change).

Design + implementation notes: `docs/plans/2026-06-01-boca-exact-fractional-tl-design.md`, `docs/plans/2026-06-01-boca-exact-fractional-tl.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)