### PR TITLE
feat: configurable per-language wall time limits (#490)

### DIFF
--- a/docs/plans/2026-06-01-configurable-walltime-design.md
+++ b/docs/plans/2026-06-01-configurable-walltime-design.md
@@ -96,25 +96,56 @@ two computed values.
 
 ### 4. BOCA (`rbx/box/packaging/boca/packager.py` + templates)
 
-Remove the hardcoded `let "ttime = $time + 30"` from the `run/*` and
-`interactive/*` templates. Substitute the per-language coefficients in
-`_expand_run_script` / `_replace_common`, using `awk` for the float multiply
-(bash `let` is integer-only):
+> **Updated for upstream main (PRs #493, #494).** Since this design was first
+> written, #494 reworked the wall block and #493 added a BOCA→rbx language
+> mapping helper. The current wall block in every `run/*` and `interactive/*`
+> template is:
+> ```bash
+> time=$3
+> rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+> if [ "$rtime" -gt "0" ]; then
+>   let "ttime = $rtime + 30"
+> else
+>   time=1
+>   ttime=30
+> fi
+> ```
+> `$time` is now an **exact fractional CPU budget in seconds** (aggregated over
+> `nruns`, emitted via `_fmt_seconds`), and `rtime` is its integer ceiling used
+> only for the `> 0` guard and for `-T`.
+
+Replace the hardcoded `let "ttime = $rtime + 30"` with the configurable formula,
+computed directly from the fractional `$time` via `awk` (bash arithmetic is
+integer-only) and ceiled to whole seconds for safeexec's `-T`:
 
 ```bash
 time=$3
-if [ "$time" -gt "0" ]; then
-  ttime=$(awk "BEGIN{print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrementSec}} + 0.999)}")
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime={{rbxWallIncrementSec}}
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 ```
 
-`{{rbxWallIncrementSec}} = ceil(b_ms / 1000)`. BOCA's `$time` is the per-language
-CPU TL in integer seconds (aggregated over `nruns`), which matches `x`. This
-deletes the Maratona-Mineira hack and makes rbx and BOCA agree by construction,
-since both derive from the same coefficients.
+`{{rbxWallMultiplier}}` = `a` (e.g. `2`); `{{rbxWallIncrement}}` = `b` in
+**exact fractional seconds** via the existing `_fmt_seconds(b_ms)` (e.g.
+`1.000`). BOCA's `$time` is the per-language CPU budget in fractional seconds
+(aggregated over `nruns`), which matches `x`. This deletes the Maratona-Mineira
+hack and makes rbx and BOCA agree by construction.
+
+Substitution lives in `_replace_common(text, lang)` (already called for every
+run/interactive script via `_expand_run_script`). `lang` is the **emitted BOCA
+language** (e.g. `cc`, `py3`); map it to the rbx language with the existing
+`get_rbx_language_from_boca_language(lang)` (added by #493) before resolving
+coefficients, so a `cpp` per-language override applies to both `cc` and `cpp`.
+The two placeholders are absent from non-run templates, so the extra `.replace`
+calls are harmless no-ops there.
+
+Templates to edit: `run/{c,cc,cpp,java,kt,py2,py3}` and
+`interactive/{c,cc,cpp,java,kt,py2,py3}`. Leave `run/bkp` (a backup, not
+emitted) untouched.
 
 ### 5. Sensible defaults in the shipped preset (`rbx/resources/presets/default/env.rbx.yml`)
 
@@ -138,8 +169,10 @@ Conservative defaults (small increments), not the old flat `+30s` cushion.
 - Unit: `resolve_walltime_coeffs` (env default, per-language override, fallback)
   and `compute_walltime`.
 - `tasks.py`: wall time uses the resolved per-language coefficients.
-- BOCA: emitted run/interactive scripts substitute the correct coefficients
-  (update existing packaging snapshot/tests).
+- BOCA: emitted run/interactive scripts substitute the correct coefficients.
+  Test homes added upstream: `tests/rbx/box/packaging/boca/test_timing.py`,
+  `test_default_preset_integration.py`, and the e2e `zip_file_contains` matcher
+  (`tests/e2e/`) for asserting limit/run script contents inside the zip.
 
 ## Decisions (confirmed)
 

--- a/docs/plans/2026-06-01-configurable-walltime-design.md
+++ b/docs/plans/2026-06-01-configurable-walltime-design.md
@@ -1,0 +1,152 @@
+# Configurable per-language wall time limits (issue #490)
+
+## Problem
+
+Wall time limit is too tight for slow languages (Java/Kotlin/Python), where
+interpreter/JVM startup eats into the wall-clock budget even when CPU time is
+fine. Today the wall time is hardcoded and not configurable per language:
+
+- **rbx local judging** (`rbx/box/tasks.py:_get_execution_config`, lines 188–202):
+  `wallTimeLimit = expanded_cpu_TL × 2` for every language (the stupid sandbox
+  always uses a soft timeout).
+- **BOCA packaging**: wall time is hardcoded in each per-language run/interactive
+  shell script as `ttime = cpu_time_seconds + 30`
+  (`rbx/resources/packagers/boca/run/*`, `.../interactive/*`). This was `× 4`
+  until commit `dc88cd8` flipped it to `+30` as an ad-hoc hack for Maratona
+  Mineira — direct evidence that the formula needs to be configurable rather
+  than periodically re-tweaked.
+
+## Goal
+
+Support a configurable `wall = a·x + b` formula per language, where:
+
+- `a` = `wallTimeMultiplier`
+- `b` = `wallTimeIncrement` (milliseconds)
+- `x` = the **expanded per-language CPU time limit** (after `timeMultiplier` /
+  `doubleTL` is applied)
+
+Defaults live in the environment (`env.rbx.yml`), with optional per-language
+overrides, and a single shared implementation is used by both rbx and BOCA.
+
+## Design
+
+### 1. Schema (`rbx/box/environment.py`)
+
+Env-level defaults go on the existing `TimingConfig` (already wired into
+`Environment.timing`, line 316):
+
+```python
+class TimingConfig(BaseModel):
+    formula: str = ...                    # existing
+    wallTimeMultiplier: float = 2.0       # a
+    wallTimeIncrement: int = 0            # b, in milliseconds
+```
+
+Per-language override is a new optional sub-model on `EnvironmentLanguage`:
+
+```python
+class LanguageTimingConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    wallTimeMultiplier: Optional[float] = None
+    wallTimeIncrement: Optional[int] = None
+
+class EnvironmentLanguage(BaseModel):
+    ...
+    timing: Optional[LanguageTimingConfig] = None
+```
+
+**Resolution:** per-language value when set, otherwise the env `timing` default.
+Increment is in **milliseconds** everywhere (rbx's native unit); BOCA converts to
+seconds at emit time.
+
+### 2. Shared computation (single source of truth)
+
+```python
+def resolve_walltime_coeffs(language: Optional[str]) -> tuple[float, int]:
+    """Returns (multiplier, increment_ms), language override over env default."""
+
+def compute_walltime(cpu_tl_ms: int, language: Optional[str]) -> int:
+    a, b = resolve_walltime_coeffs(language)
+    return int(cpu_tl_ms * a + b)
+```
+
+Both rbx and BOCA call `compute_walltime` / `resolve_walltime_coeffs`. Lives in
+`rbx/box/environment.py` (or `limits_info.py`) so it can read the active
+environment.
+
+### 3. rbx local judging (`rbx/box/tasks.py`)
+
+Thread `language` into `_get_execution_config` and replace the hardcoded `× 2`:
+
+```python
+sandbox.wallTimeLimit = sandbox.timeLimit
+if sandbox.timeLimit is not None and sandbox_type.use_soft_timeout():
+    sandbox.wallTimeLimit = compute_walltime(sandbox.timeLimit, language)
+```
+
+`x = sandbox.timeLimit` is already the expanded CPU TL (after `doubleTL`).
+With defaults `a=2.0, b=0` this reproduces today's behavior exactly — zero
+regression. The non-soft-timeout branch (real sandboxes that enforce CPU
+directly) keeps `wall = cpu` and the formula does **not** apply there.
+
+Callers (`_run_communication_solution_on_testcase` and the batch equivalent)
+already compute `language = find_language_name(solution)` and pass it in. The
+interactive path that sums solution + interactor wall times keeps summing the
+two computed values.
+
+### 4. BOCA (`rbx/box/packaging/boca/packager.py` + templates)
+
+Remove the hardcoded `let "ttime = $time + 30"` from the `run/*` and
+`interactive/*` templates. Substitute the per-language coefficients in
+`_expand_run_script` / `_replace_common`, using `awk` for the float multiply
+(bash `let` is integer-only):
+
+```bash
+time=$3
+if [ "$time" -gt "0" ]; then
+  ttime=$(awk "BEGIN{print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrementSec}} + 0.999)}")
+else
+  time=1
+  ttime={{rbxWallIncrementSec}}
+fi
+```
+
+`{{rbxWallIncrementSec}} = ceil(b_ms / 1000)`. BOCA's `$time` is the per-language
+CPU TL in integer seconds (aggregated over `nruns`), which matches `x`. This
+deletes the Maratona-Mineira hack and makes rbx and BOCA agree by construction,
+since both derive from the same coefficients.
+
+### 5. Sensible defaults in the shipped preset (`rbx/resources/presets/default/env.rbx.yml`)
+
+```yaml
+timing:
+  wallTimeMultiplier: 2.0
+  wallTimeIncrement: 1000        # 1s headroom
+languages:
+  - name: java
+    timing: { wallTimeIncrement: 3000 }   # JVM startup
+  - name: kt
+    timing: { wallTimeIncrement: 3000 }
+  - name: py
+    timing: { wallTimeIncrement: 2000 }   # interpreter startup
+```
+
+Conservative defaults (small increments), not the old flat `+30s` cushion.
+
+### 6. Testing
+
+- Unit: `resolve_walltime_coeffs` (env default, per-language override, fallback)
+  and `compute_walltime`.
+- `tasks.py`: wall time uses the resolved per-language coefficients.
+- BOCA: emitted run/interactive scripts substitute the correct coefficients
+  (update existing packaging snapshot/tests).
+
+## Decisions (confirmed)
+
+1. **Config home:** `env.rbx.yml` — env-level default in `timing`, optional
+   per-language override.
+2. **`x`:** expanded per-language CPU TL.
+3. **BOCA integration:** compute in Python, substitute `a`/`b` into scripts.
+4. **Default increment:** conservative (1s global, 2–3s for slow languages).
+5. **Increment unit:** milliseconds at the config level.
+6. **Scope:** formula applies only in the soft-timeout (stupid sandbox) branch.

--- a/docs/plans/2026-06-01-configurable-walltime.md
+++ b/docs/plans/2026-06-01-configurable-walltime.md
@@ -1,0 +1,499 @@
+# Configurable per-language wall time limits — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the wall-time limit configurable per language via an `a·x + b` formula (`wallTimeMultiplier`, `wallTimeIncrement`), with defaults in `env.rbx.yml`'s `timing` block and optional per-language overrides, shared by rbx local judging and BOCA packaging.
+
+**Architecture:** Add coefficients to the env-level `TimingConfig` and an optional per-language `LanguageTimingConfig` override on `EnvironmentLanguage`. A pure resolver picks the effective `(multiplier, increment_ms)`; `compute_walltime(cpu_tl_ms, language)` applies the formula where `x` = expanded per-language CPU TL. `tasks.py` uses it for local judging (soft-timeout branch only); the BOCA packager substitutes the resolved coefficients into the run/interactive shell templates, replacing the hardcoded `ttime = $time + 30`.
+
+**Tech Stack:** Python 3, Pydantic v2, Typer, pytest. Single quotes, absolute imports only (ruff). Conventional Commits via the `commit` workflow (`.claude/skills/commit.md`).
+
+**Reference:** Design doc `docs/plans/2026-06-01-configurable-walltime-design.md`.
+
+**Notes for the implementer:**
+- The active BOCA packager is the legacy `rbx/box/packaging/boca/packager.py`. `boca_next/` is a stub (CLAUDE.md only) — out of scope.
+- `environment.TimingConfig` (env.rbx.yml `timing:`) is the target. Do NOT touch `rbx/box/timing.py` (`TimingProfile`) — that is the unrelated per-problem TL-estimation profile.
+- Defaults `multiplier=2.0, increment=0` reproduce today's rbx behavior exactly.
+- New `@functools.cache` on module-level `rbx/box/` functions must be registered in `rbx.testing_utils.clear_all_functools_cache` (test isolation rule). The resolver below is a plain function (no cache) to avoid this.
+- Run tests with `uv run pytest ...`. Lint with `uv run ruff check --fix . && uv run ruff format .`.
+
+---
+
+### Task 1: Schema — add wall-time coefficients to the environment
+
+**Files:**
+- Modify: `rbx/box/environment.py` (`TimingConfig` ~line 276; new `LanguageTimingConfig`; `EnvironmentLanguage` ~line 209)
+- Test: `tests/rbx/box/walltime_test.py` (create)
+
+**Step 1: Write the failing test**
+
+Create `tests/rbx/box/walltime_test.py`:
+
+```python
+from rbx.box.environment import (
+    EnvironmentLanguage,
+    ExecutionConfig,
+    LanguageTimingConfig,
+    TimingConfig,
+)
+
+
+def test_timing_config_walltime_defaults():
+    cfg = TimingConfig()
+    assert cfg.wallTimeMultiplier == 2.0
+    assert cfg.wallTimeIncrement == 0
+
+
+def test_language_timing_config_optional_fields():
+    cfg = LanguageTimingConfig()
+    assert cfg.wallTimeMultiplier is None
+    assert cfg.wallTimeIncrement is None
+
+
+def test_environment_language_accepts_timing():
+    lang = EnvironmentLanguage(
+        name='java',
+        extension='java',
+        execution=ExecutionConfig(),
+        timing=LanguageTimingConfig(wallTimeIncrement=3000),
+    )
+    assert lang.timing is not None
+    assert lang.timing.wallTimeIncrement == 3000
+    assert lang.timing.wallTimeMultiplier is None
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/walltime_test.py -v`
+Expected: FAIL (`ImportError: cannot import name 'LanguageTimingConfig'`).
+
+**Step 3: Implement**
+
+In `rbx/box/environment.py`, extend `TimingConfig`:
+
+```python
+class TimingConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    formula: str = Field(
+        default='step_up(max(fastest * 3, slowest * 1.5), 100)',
+        description="""Formula to use to calculate the time limit for the environment.""",
+    )
+
+    wallTimeMultiplier: float = Field(
+        default=2.0,
+        description="""Default multiplier `a` in the wall-time formula `a*x + b`, where `x` is the expanded CPU time limit.""",
+    )
+
+    wallTimeIncrement: int = Field(
+        default=0,
+        description="""Default increment `b` (in milliseconds) in the wall-time formula `a*x + b`.""",
+    )
+```
+
+Add a new model just before `EnvironmentLanguage`:
+
+```python
+class LanguageTimingConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    wallTimeMultiplier: Optional[float] = Field(
+        default=None,
+        description="""Overrides the environment wall-time multiplier `a` for this language.""",
+    )
+
+    wallTimeIncrement: Optional[int] = Field(
+        default=None,
+        description="""Overrides the environment wall-time increment `b` (in milliseconds) for this language.""",
+    )
+```
+
+Add the field to `EnvironmentLanguage` (next to `extensions`/`linters`):
+
+```python
+    timing: Optional[LanguageTimingConfig] = Field(
+        default=None,
+        description="""Per-language overrides for timing configuration (e.g. wall time).""",
+    )
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/walltime_test.py -v`
+Expected: PASS.
+
+**Step 5: Commit** (use the `.claude/skills/commit.md` workflow)
+
+```
+feat(environment): add per-language wall-time coefficients to schema
+```
+
+---
+
+### Task 2: Shared resolver + `compute_walltime`
+
+**Files:**
+- Modify: `rbx/box/environment.py` (add functions near `get_language_or_nil`, ~line 367)
+- Test: `tests/rbx/box/walltime_test.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/rbx/box/walltime_test.py`:
+
+```python
+from rbx.box.environment import (
+    apply_walltime_formula,
+    resolve_walltime_coeffs,
+)
+
+
+def test_resolve_coeffs_uses_env_default_when_no_language_override():
+    env_timing = TimingConfig(wallTimeMultiplier=2.0, wallTimeIncrement=1000)
+    lang = EnvironmentLanguage(name='cpp', extension='cpp', execution=ExecutionConfig())
+    assert resolve_walltime_coeffs(env_timing, lang) == (2.0, 1000)
+
+
+def test_resolve_coeffs_language_override_wins_field_by_field():
+    env_timing = TimingConfig(wallTimeMultiplier=2.0, wallTimeIncrement=1000)
+    lang = EnvironmentLanguage(
+        name='java',
+        extension='java',
+        execution=ExecutionConfig(),
+        timing=LanguageTimingConfig(wallTimeIncrement=3000),
+    )
+    # multiplier falls back to env, increment overridden
+    assert resolve_walltime_coeffs(env_timing, lang) == (2.0, 3000)
+
+
+def test_resolve_coeffs_with_none_language():
+    env_timing = TimingConfig(wallTimeMultiplier=3.0, wallTimeIncrement=500)
+    assert resolve_walltime_coeffs(env_timing, None) == (3.0, 500)
+
+
+def test_apply_walltime_formula():
+    # wall = 2*x + b
+    assert apply_walltime_formula(1000, (2.0, 0)) == 2000
+    assert apply_walltime_formula(1000, (2.0, 1000)) == 3000
+    assert apply_walltime_formula(1500, (1.5, 250)) == 2500  # int(1500*1.5+250)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/walltime_test.py -v`
+Expected: FAIL (`ImportError`).
+
+**Step 3: Implement**
+
+In `rbx/box/environment.py` (after `get_language_or_nil`):
+
+```python
+def resolve_walltime_coeffs(
+    timing: TimingConfig,
+    language: Optional[EnvironmentLanguage],
+) -> Tuple[float, int]:
+    """Resolves the effective (wall_time_multiplier, wall_time_increment_ms),
+    where a per-language override takes precedence field-by-field over the
+    environment-level timing defaults."""
+    multiplier = timing.wallTimeMultiplier
+    increment = timing.wallTimeIncrement
+    if language is not None and language.timing is not None:
+        if language.timing.wallTimeMultiplier is not None:
+            multiplier = language.timing.wallTimeMultiplier
+        if language.timing.wallTimeIncrement is not None:
+            increment = language.timing.wallTimeIncrement
+    return multiplier, increment
+
+
+def apply_walltime_formula(cpu_tl_ms: int, coeffs: Tuple[float, int]) -> int:
+    """Applies wall = a*x + b, where x is the expanded CPU time limit (ms)."""
+    multiplier, increment = coeffs
+    return int(cpu_tl_ms * multiplier + increment)
+
+
+def get_walltime_coeffs_for_language(
+    language: Optional[str],
+) -> Tuple[float, int]:
+    """Reads the active environment and resolves wall-time coefficients for the
+    given language name (None -> environment defaults)."""
+    env = get_environment()
+    lang = get_language_or_nil(language) if language is not None else None
+    return resolve_walltime_coeffs(env.timing, lang)
+
+
+def compute_walltime(cpu_tl_ms: int, language: Optional[str]) -> int:
+    return apply_walltime_formula(
+        cpu_tl_ms, get_walltime_coeffs_for_language(language)
+    )
+```
+
+Ensure `Tuple` is imported from `typing` (add to the existing typing import if missing).
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/walltime_test.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+feat(environment): add shared wall-time resolver and formula
+```
+
+---
+
+### Task 3: Wire wall-time formula into rbx local judging
+
+**Files:**
+- Modify: `rbx/box/tasks.py` (`_get_execution_config` ~lines 188–202; its callers ~line 124 and ~lines 239–240)
+- Test: `tests/rbx/box/tasks_test.py` (add) — if environment-dependent wiring is hard to unit test there, add a focused test in `tests/rbx/box/walltime_test.py` patching `environment.compute_walltime`.
+
+**Step 1: Write the failing test**
+
+Add to `tests/rbx/box/walltime_test.py`:
+
+```python
+from unittest import mock
+
+from rbx.box import tasks
+from rbx.grading.judge.sandboxes.stupid_sandbox import StupidSandbox
+from rbx.grading.limits import Limits
+
+
+def test_get_execution_config_uses_walltime_formula_for_language():
+    limits = Limits(time=1000, memory=256, output=4096)
+    with mock.patch.object(
+        tasks.environment, 'compute_walltime', return_value=4242
+    ) as m:
+        cfg = tasks._get_execution_config(limits, StupidSandbox, language='java')
+    assert cfg.sandbox is not None
+    assert cfg.sandbox.timeLimit == 1000
+    assert cfg.sandbox.wallTimeLimit == 4242
+    m.assert_called_once_with(1000, 'java')
+
+
+def test_get_execution_config_doubletl_passes_expanded_tl_as_x():
+    limits = Limits(time=1000, memory=256, output=4096, isDoubleTL=True)
+    with mock.patch.object(
+        tasks.environment, 'compute_walltime', return_value=9999
+    ) as m:
+        cfg = tasks._get_execution_config(limits, StupidSandbox, language='cpp')
+    # x must be the expanded (doubled) CPU TL
+    m.assert_called_once_with(2000, 'cpp')
+    assert cfg.sandbox.wallTimeLimit == 9999
+```
+
+> Note: confirm `tasks.py` imports the `environment` module (it currently imports specific names from `rbx.box.environment`). If not, add `from rbx.box import environment` so the patch target `tasks.environment.compute_walltime` exists. Adjust the test's patch target to match the actual import style.
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/walltime_test.py -k execution_config -v`
+Expected: FAIL (`_get_execution_config()` got an unexpected keyword `language`).
+
+**Step 3: Implement**
+
+In `rbx/box/tasks.py`, add `from rbx.box import environment` (if not present). Change `_get_execution_config`:
+
+```python
+def _get_execution_config(
+    limits: Limits,
+    sandbox_type: Type[SandboxBase],
+    language: Optional[str] = None,
+) -> ExecutionConfig:
+    sandbox = EnvironmentSandbox()
+    sandbox.timeLimit = limits.time
+    if limits.isDoubleTL and sandbox.timeLimit is not None:
+        # Double TL.
+        sandbox.timeLimit = sandbox.timeLimit * 2
+    sandbox.wallTimeLimit = sandbox.timeLimit
+    if sandbox.timeLimit is not None and sandbox_type.use_soft_timeout():
+        sandbox.wallTimeLimit = environment.compute_walltime(
+            sandbox.timeLimit, language
+        )
+    sandbox.memoryLimit = limits.memory
+    sandbox.fileSizeLimit = limits.output
+    return ExecutionConfig(sandbox=sandbox, problemLimits=limits)
+```
+
+Update both call sites to pass the already-computed `language`:
+- ~line 124 (batch path): `extra_config = _get_execution_config(limits, sandbox_type, language)`
+- ~lines 239–240 (communication path): pass `language` to both `_get_execution_config(...)` calls. The existing interactor-wall-time summation stays as-is (it sums the two computed wall times).
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/rbx/box/walltime_test.py -v` then `uv run pytest tests/rbx/box/tasks_test.py -v`
+Expected: PASS (and no regression in tasks_test).
+
+**Step 5: Commit**
+
+```
+feat(tasks): apply per-language wall-time formula in local judging
+```
+
+---
+
+### Task 4: Wire wall-time formula into BOCA packaging
+
+**Files:**
+- Modify templates (replace hardcoded `ttime = $time + 30`):
+  - `rbx/resources/packagers/boca/run/{c,cpp,java,kt,py2,py3}`
+  - `rbx/resources/packagers/boca/interactive/{c,cpp,java,kt,py2,py3}`
+- Modify: `rbx/box/packaging/boca/packager.py` (`_replace_common` ~line 193 and/or `_expand_run_script` ~line 319; uses `_get_pkg_timelimit`/`limits_info`)
+- Test: `tests/rbx/box/packaging/` (find the existing BOCA packaging test; otherwise add a focused unit test on the substitution helper)
+
+**Step 1: Write the failing test**
+
+First locate an existing BOCA packaging test (`grep -rl "BocaPackager\|_expand_run_script\|run/cpp" tests/`). Add a test asserting the emitted run script no longer contains `+ 30` and substitutes the resolved coefficients. Prefer testing the pure substitution: factor the coefficient→script substitution into a helper, e.g. `_replace_walltime(text, language)`, and unit-test it:
+
+```python
+def test_boca_walltime_substitution(...):
+    # Given a template containing the {{rbxWallMultiplier}}/{{rbxWallIncrementSec}}
+    # placeholders and a language whose coeffs resolve to (2.0, 3000 ms),
+    # the substituted script contains 2.0 and ceil(3000/1000)=3, and no '+ 30'.
+```
+
+Match the project's existing BOCA test fixtures/patterns (see `tests/e2e/testdata/pkg-boca*`). If the cleanest seam is an e2e snapshot, update the snapshot instead and assert the script content.
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest <the boca test> -v`
+Expected: FAIL (placeholders unsubstituted / `+ 30` still present).
+
+**Step 3: Implement**
+
+Edit each `run/*` and `interactive/*` template, replacing the block:
+
+```bash
+time=$3
+if [ "$time" -gt "0" ]; then
+  let "ttime = $time + 30"
+else
+  time=1
+  ttime=30
+fi
+```
+
+with (Java/Kotlin/Python templates have the same block at a different line — replace all):
+
+```bash
+time=$3
+if [ "$time" -gt "0" ]; then
+  ttime=$(awk "BEGIN{print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrementSec}} + 0.999)}")
+else
+  time=1
+  ttime={{rbxWallIncrementSec}}
+fi
+```
+
+In `packager.py`, resolve coefficients per language using the shared resolver and the BOCA CPU TL, and substitute. Add a helper and call it from `_replace_common` (which already runs for run, interactive, compile, checker — only the run/interactive templates contain the placeholders, so substitution is a no-op elsewhere):
+
+```python
+import math
+from rbx.box import environment
+
+def _replace_walltime(self, text: str, language: BocaLanguage) -> str:
+    env = environment.get_environment()
+    lang = environment.get_language_or_nil(language)
+    multiplier, increment_ms = environment.resolve_walltime_coeffs(
+        env.timing, lang
+    )
+    increment_sec = math.ceil(increment_ms / 1000)
+    text = text.replace('{{rbxWallMultiplier}}', f'{multiplier:g}')
+    text = text.replace('{{rbxWallIncrementSec}}', str(increment_sec))
+    return text
+```
+
+> NOTE on the BOCA language identifier: `_replace_common` receives the BOCA template language (e.g. `cc`, `py3`), not the rbx language name (`cpp`, `py`). `get_language_or_nil` expects the rbx name. Map BOCA→rbx before resolving (reuse the existing BOCA language mapping in `boca/utils.py` / `get_boca_template_name`, inverted) so per-language overrides resolve correctly. If a clean inverse mapping is unavailable, resolve from the rbx language at the `_expand_run_script` call site (which is per emitted rbx language) instead of inside `_replace_common`. Choose the seam that lets coefficients resolve from the correct rbx language; verify against the env preset (java increment 3000 → `ttime` uses 3).
+
+Call `self._replace_walltime(text, language)` inside `_replace_common` (or `_expand_run_script`).
+
+**Step 4: Run tests**
+
+Run: `uv run pytest <the boca test> -v`
+Expected: PASS. Also `grep -rn "+ 30\|let \"ttime" rbx/resources/packagers/boca/` returns nothing.
+
+**Step 5: Commit**
+
+```
+feat(boca): derive wall time from shared per-language formula
+```
+
+---
+
+### Task 5: Sensible defaults in the shipped preset
+
+**Files:**
+- Modify: `rbx/resources/presets/default/env.rbx.yml`
+- Test: an e2e/packaging assertion if one covers preset values; otherwise manual verification.
+
+**Step 1: Edit the preset**
+
+Add the `timing` block and per-language overrides:
+
+```yaml
+timing:
+  wallTimeMultiplier: 2.0
+  wallTimeIncrement: 1000
+languages:
+  - name: "cpp"
+    ...
+  - name: "py"
+    ...
+    timing:
+      wallTimeIncrement: 2000
+  - name: "java"
+    ...
+    timing:
+      wallTimeIncrement: 3000
+  - name: "kt"
+    ...
+    timing:
+      wallTimeIncrement: 3000
+```
+
+(Insert `timing:` at the top level alongside `sandbox`, `defaultCompilation`, etc.; add the per-language `timing:` under the existing `py`/`java`/`kt` entries. Keep `cpp`/`c` on the env default.)
+
+**Step 2: Verify the preset loads**
+
+Run: `uv run python -c "from rbx.box.environment import Environment; from rbx.box.yaml_validation import load_yaml_model; import pathlib; e=load_yaml_model(pathlib.Path('rbx/resources/presets/default/env.rbx.yml'), Environment); print(e.timing.wallTimeMultiplier, e.timing.wallTimeIncrement); print({l.name: (l.timing and l.timing.wallTimeIncrement) for l in e.languages})"`
+Expected: prints `2.0 1000` and a dict showing `java`/`kt` = 3000, `py` = 2000, others `None`.
+
+**Step 3: Commit**
+
+```
+feat(preset): set default per-language wall-time coefficients
+```
+
+---
+
+### Task 6: Full verification
+
+**Step 1: Lint/format**
+
+Run: `uv run ruff check --fix . && uv run ruff format .`
+
+**Step 2: Targeted tests**
+
+Run: `uv run pytest tests/rbx/box/walltime_test.py tests/rbx/box/tasks_test.py tests/rbx/box/test_timing.py -v`
+Expected: PASS.
+
+**Step 3: Broader suite (excluding slow CLI)**
+
+Run: `uv run pytest --ignore=tests/rbx/box/cli -n auto`
+Expected: PASS (note: per the project memory, some C++/checker/validator/sandbox/docker tests fail pre-existingly on this machine and are unrelated to this change — confirm any failures are in that known set).
+
+**Step 4: BOCA e2e (if environment allows)**
+
+Run: `mise run test-e2e` (or the targeted BOCA e2e fixture). Verify emitted `run/*` scripts contain the substituted formula and no `+ 30`.
+
+**Step 5: Use superpowers:requesting-code-review, then finishing-a-development-branch**
+
+After review, open a PR referencing issue #490.
+
+---
+
+## Risks / things to watch
+
+- **BOCA language mapping**: the substitution must resolve coefficients from the correct rbx language (Task 4 NOTE). Getting this wrong means per-language overrides silently fall back to env defaults — verify java/kt/py emit `ttime` increment 3/3/2.
+- **`awk` availability** on BOCA judge hosts: `awk` is part of base BOCA images (the run scripts already use standard coreutils); acceptable. If undesirable, compute integer `ttime` in Python and substitute a literal — but that loses the `$time`-relative formula. Keep `awk`.
+- **Regression safety**: default `(2.0, 0)` keeps rbx identical to today; BOCA changes from `+30` to `2*x + 1` (preset). Confirm this is intended (it is — the `+30` was the Maratona-Mineira hack being removed).
+- **doubleTL**: `x` is the already-expanded CPU TL — confirmed via Task 3 test.

--- a/docs/plans/2026-06-01-configurable-walltime.md
+++ b/docs/plans/2026-06-01-configurable-walltime.md
@@ -11,9 +11,14 @@
 **Reference:** Design doc `docs/plans/2026-06-01-configurable-walltime-design.md`.
 
 **Notes for the implementer:**
-- The active BOCA packager is the legacy `rbx/box/packaging/boca/packager.py`. `boca_next/` is a stub (CLAUDE.md only) — out of scope.
+- This branch is rebased on top of upstream main including PRs #491 (BocaNext L2),
+  #493 (cc/cpp→rbx language mapping), and #494 (exact fractional BOCA time limits).
+  Tasks 4–6 below already account for those changes.
+- The active BOCA packager is the legacy `rbx/box/packaging/boca/packager.py`. `boca_next/` is now partially implemented but the `rbx package boca` CLI still wires `BocaPackager` (legacy) — out of scope. (Applying the same formula to BocaNext is a follow-up.)
 - `environment.TimingConfig` (env.rbx.yml `timing:`) is the target. Do NOT touch `rbx/box/timing.py` (`TimingProfile`) — that is the unrelated per-problem TL-estimation profile.
 - Defaults `multiplier=2.0, increment=0` reproduce today's rbx behavior exactly.
+- BOCA→rbx language mapping already exists: `get_rbx_language_from_boca_language` in `rbx/box/packaging/boca/boca_language_utils.py` (already imported in `packager.py`). Use it — the earlier "mapping risk" is resolved upstream.
+- BOCA emits exact fractional seconds via `_fmt_seconds(ms)` (`packager.py:29`). Reuse it for the wall-time increment placeholder.
 - New `@functools.cache` on module-level `rbx/box/` functions must be registered in `rbx.testing_utils.clear_all_functools_cache` (test isolation rule). The resolver below is a plain function (no cache) to avoid this.
 - Run tests with `uv run pytest ...`. Lint with `uv run ruff check --fix . && uv run ruff format .`.
 
@@ -333,83 +338,83 @@ feat(tasks): apply per-language wall-time formula in local judging
 
 ### Task 4: Wire wall-time formula into BOCA packaging
 
+> **Reworked for upstream #493/#494.** The wall block is now `ttime = $rtime + 30`
+> with `$time` an exact fractional-seconds budget; the cc/cpp→rbx mapping helper
+> already exists. See the design doc's updated section 4.
+
 **Files:**
-- Modify templates (replace hardcoded `ttime = $time + 30`):
-  - `rbx/resources/packagers/boca/run/{c,cpp,java,kt,py2,py3}`
-  - `rbx/resources/packagers/boca/interactive/{c,cpp,java,kt,py2,py3}`
-- Modify: `rbx/box/packaging/boca/packager.py` (`_replace_common` ~line 193 and/or `_expand_run_script` ~line 319; uses `_get_pkg_timelimit`/`limits_info`)
-- Test: `tests/rbx/box/packaging/` (find the existing BOCA packaging test; otherwise add a focused unit test on the substitution helper)
+- Modify templates (replace the `let "ttime = $rtime + 30"` line + the `else ttime=30` line):
+  - `rbx/resources/packagers/boca/run/{c,cc,cpp,java,kt,py2,py3}`
+  - `rbx/resources/packagers/boca/interactive/{c,cc,cpp,java,kt,py2,py3}`
+  - Leave `rbx/resources/packagers/boca/run/bkp` untouched (backup, not emitted).
+- Modify: `rbx/box/packaging/boca/packager.py` (`_replace_common` ~line 186; reuse `_fmt_seconds` ~line 29 and the already-imported `get_rbx_language_from_boca_language`)
+- Test: `tests/rbx/box/packaging/boca/test_timing.py` (unit) + optionally an e2e assertion in `tests/rbx/box/packaging/e2e/test_boca_e2e.py` / `tests/e2e/` via `zip_file_contains`.
 
 **Step 1: Write the failing test**
 
-First locate an existing BOCA packaging test (`grep -rl "BocaPackager\|_expand_run_script\|run/cpp" tests/`). Add a test asserting the emitted run script no longer contains `+ 30` and substitutes the resolved coefficients. Prefer testing the pure substitution: factor the coefficient→script substitution into a helper, e.g. `_replace_walltime(text, language)`, and unit-test it:
+Add a unit test in `tests/rbx/box/packaging/boca/test_timing.py` that exercises the substitution helper directly (follow the fixture style already in that file for setting up a package + boca limits profile). Assert:
+- The emitted `run`/`interactive` script for a language whose coeffs resolve to `(2.0, 1000 ms)` contains `* 2` and `+ 1.000` in the `ttime` awk expression, and **no** `+ 30`.
+- For `java` (preset increment 3000 ms) the script contains `+ 3.000`.
+- `cc` and `cpp` resolve to the **same** coefficients (verifies the BOCA→rbx mapping; a `cpp` per-language override applies to both).
 
-```python
-def test_boca_walltime_substitution(...):
-    # Given a template containing the {{rbxWallMultiplier}}/{{rbxWallIncrementSec}}
-    # placeholders and a language whose coeffs resolve to (2.0, 3000 ms),
-    # the substituted script contains 2.0 and ceil(3000/1000)=3, and no '+ 30'.
-```
-
-Match the project's existing BOCA test fixtures/patterns (see `tests/e2e/testdata/pkg-boca*`). If the cleanest seam is an e2e snapshot, update the snapshot instead and assert the script content.
+If a pure-string seam is cleaner, test the new `_replace_walltime` helper on a minimal template string containing the two placeholders.
 
 **Step 2: Run test to verify it fails**
 
-Run: `uv run pytest <the boca test> -v`
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_timing.py -v`
 Expected: FAIL (placeholders unsubstituted / `+ 30` still present).
 
 **Step 3: Implement**
 
-Edit each `run/*` and `interactive/*` template, replacing the block:
+Edit each `run/*` and `interactive/*` template (cc/cpp/c at one line offset, java/kt/py2/py3 at another — `grep -n 'ttime = \$rtime' rbx/resources/packagers/boca/{run,interactive}/*` lists them all). Replace:
 
 ```bash
-time=$3
-if [ "$time" -gt "0" ]; then
-  let "ttime = $time + 30"
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  let "ttime = $rtime + 30"
 else
   time=1
   ttime=30
 fi
 ```
 
-with (Java/Kotlin/Python templates have the same block at a different line — replace all):
+with:
 
 ```bash
-time=$3
-if [ "$time" -gt "0" ]; then
-  ttime=$(awk "BEGIN{print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrementSec}} + 0.999)}")
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime={{rbxWallIncrementSec}}
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 ```
 
-In `packager.py`, resolve coefficients per language using the shared resolver and the BOCA CPU TL, and substitute. Add a helper and call it from `_replace_common` (which already runs for run, interactive, compile, checker — only the run/interactive templates contain the placeholders, so substitution is a no-op elsewhere):
+In `packager.py`, add a helper and call it from `_replace_common` (it already runs for every run/interactive/compile/checker template; the placeholders only exist in run/interactive, so it is a harmless no-op elsewhere):
 
 ```python
-import math
-from rbx.box import environment
-
-def _replace_walltime(self, text: str, language: BocaLanguage) -> str:
+def _replace_walltime(self, text: str, lang: str) -> str:
+    # `lang` is the emitted BOCA language (e.g. 'cc', 'py3'); map to rbx.
+    rbx_language = get_rbx_language_from_boca_language(lang)
     env = environment.get_environment()
-    lang = environment.get_language_or_nil(language)
+    language = environment.get_language_or_nil(rbx_language)
     multiplier, increment_ms = environment.resolve_walltime_coeffs(
-        env.timing, lang
+        env.timing, language
     )
-    increment_sec = math.ceil(increment_ms / 1000)
     text = text.replace('{{rbxWallMultiplier}}', f'{multiplier:g}')
-    text = text.replace('{{rbxWallIncrementSec}}', str(increment_sec))
+    text = text.replace('{{rbxWallIncrement}}', _fmt_seconds(max(0, increment_ms)))
     return text
 ```
 
-> NOTE on the BOCA language identifier: `_replace_common` receives the BOCA template language (e.g. `cc`, `py3`), not the rbx language name (`cpp`, `py`). `get_language_or_nil` expects the rbx name. Map BOCA→rbx before resolving (reuse the existing BOCA language mapping in `boca/utils.py` / `get_boca_template_name`, inverted) so per-language overrides resolve correctly. If a clean inverse mapping is unavailable, resolve from the rbx language at the `_expand_run_script` call site (which is per emitted rbx language) instead of inside `_replace_common`. Choose the seam that lets coefficients resolve from the correct rbx language; verify against the env preset (java increment 3000 → `ttime` uses 3).
+Add `from rbx.box import environment` to `packager.py` if not already importable as a module (it currently imports specific names via `from rbx.box.environment import get_extension_or_default`). Then call `text = self._replace_walltime(text, lang)` at the end of `_replace_common` (before/after the existing `{{rbxPython3}}` replace).
 
-Call `self._replace_walltime(text, language)` inside `_replace_common` (or `_expand_run_script`).
+> `_fmt_seconds` formats ms as exact fractional seconds (`1000 -> '1.000'`), so the increment stays exact and the awk ceil yields whole seconds for safeexec `-T`. `{multiplier:g}` renders `2.0 -> '2'`, `1.5 -> '1.5'`.
 
 **Step 4: Run tests**
 
-Run: `uv run pytest <the boca test> -v`
-Expected: PASS. Also `grep -rn "+ 30\|let \"ttime" rbx/resources/packagers/boca/` returns nothing.
+Run: `uv run pytest tests/rbx/box/packaging/boca/test_timing.py -v`
+Expected: PASS. Also verify no leftover hardcoded wall increment in emitted templates:
+`grep -rn 'ttime = \$rtime + 30\|ttime=30' rbx/resources/packagers/boca/run rbx/resources/packagers/boca/interactive` returns nothing (bkp excluded).
 
 **Step 5: Commit**
 
@@ -452,6 +457,8 @@ languages:
 
 (Insert `timing:` at the top level alongside `sandbox`, `defaultCompilation`, etc.; add the per-language `timing:` under the existing `py`/`java`/`kt` entries. Keep `cpp`/`c` on the env default.)
 
+> The `extensions.boca` block in this preset is unaffected. Note #494 deprecated `maximumTimeError` (now ignored) and added `minRunningTime`; the default preset does not set either, so no change is needed there.
+
 **Step 2: Verify the preset loads**
 
 Run: `uv run python -c "from rbx.box.environment import Environment; from rbx.box.yaml_validation import load_yaml_model; import pathlib; e=load_yaml_model(pathlib.Path('rbx/resources/presets/default/env.rbx.yml'), Environment); print(e.timing.wallTimeMultiplier, e.timing.wallTimeIncrement); print({l.name: (l.timing and l.timing.wallTimeIncrement) for l in e.languages})"`
@@ -473,7 +480,7 @@ Run: `uv run ruff check --fix . && uv run ruff format .`
 
 **Step 2: Targeted tests**
 
-Run: `uv run pytest tests/rbx/box/walltime_test.py tests/rbx/box/tasks_test.py tests/rbx/box/test_timing.py -v`
+Run: `uv run pytest tests/rbx/box/walltime_test.py tests/rbx/box/tasks_test.py tests/rbx/box/test_timing.py tests/rbx/box/packaging/boca/test_timing.py tests/rbx/box/packaging/boca/test_default_preset_integration.py -v`
 Expected: PASS.
 
 **Step 3: Broader suite (excluding slow CLI)**
@@ -493,7 +500,9 @@ After review, open a PR referencing issue #490.
 
 ## Risks / things to watch
 
-- **BOCA language mapping**: the substitution must resolve coefficients from the correct rbx language (Task 4 NOTE). Getting this wrong means per-language overrides silently fall back to env defaults — verify java/kt/py emit `ttime` increment 3/3/2.
-- **`awk` availability** on BOCA judge hosts: `awk` is part of base BOCA images (the run scripts already use standard coreutils); acceptable. If undesirable, compute integer `ttime` in Python and substitute a literal — but that loses the `$time`-relative formula. Keep `awk`.
-- **Regression safety**: default `(2.0, 0)` keeps rbx identical to today; BOCA changes from `+30` to `2*x + 1` (preset). Confirm this is intended (it is — the `+30` was the Maratona-Mineira hack being removed).
+- **BOCA language mapping** *(resolved upstream)*: use `get_rbx_language_from_boca_language` (#493). Still worth a test assertion that `cc`/`cpp` resolve identically (Task 4 Step 1).
+- **`awk` availability**: the run/interactive scripts already use `awk` for the fractional `$time`/`rtime` math (post-#494), so depending on it for `ttime` is consistent and safe.
+- **Regression safety**: default `(2.0, 0)` keeps rbx identical to today. BOCA changes from `$rtime + 30` to `2*$time + 1` (preset) — a behavior change. The old `+30` was the Maratona-Mineira hack; confirm the smaller cushion is acceptable, and consider whether the global preset increment should be larger than 1 s for safety margin on real judges. **Open the PR description noting this BOCA wall-time change explicitly.**
 - **doubleTL**: `x` is the already-expanded CPU TL — confirmed via Task 3 test.
+- **`$time` is fractional seconds** (post-#494): the formula multiplies the exact fractional budget, not the integer `rtime` ceiling, so `2 * 0.5s = 1s` wall rather than `2 * 1s`. Intended (matches the rbx side which works in ms).
+- **BocaNext** (`boca_next/`, #491): not wired into the `boca` CLI yet; applying the same formula there is a follow-up, out of scope.

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -203,6 +203,51 @@ timing:
   formula: "step_up(max(fastest * 2, slowest * 1.5), 100)"
 ```
 
+## Wall time limits
+
+Solutions are also bounded by a **wall (real) time** limit, in addition to the
+CPU time limit. Slow languages (Java, Kotlin, Python) can spend significant
+wall-clock time on JVM/interpreter startup before doing any work, so a wall
+limit that is too tight produces spurious time-limit verdicts.
+
+{{rbx}} computes the wall time limit from the CPU time limit with a configurable
+`a * x + b` formula, where `x` is the **effective per-language CPU time limit**
+(after any per-language modifiers and double-TL expansion):
+
+- `wallTimeMultiplier` (`a`) -- multiplier applied to the CPU time limit. Must be
+  `>= 1.0` (the wall limit can never be tighter than the CPU limit). Defaults to `2.0`.
+- `wallTimeIncrement` (`b`) -- extra wall time, in **milliseconds**, added on top.
+  Must be `>= 0`. Defaults to `0`.
+
+Configure the environment-wide defaults under the `timing` field:
+
+```yaml
+timing:
+  formula: "step_up(max(fastest * 3, slowest * 1.5), 100)"
+  wallTimeMultiplier: 2.0
+  wallTimeIncrement: 1000   # +1s of wall headroom for every solution
+```
+
+You can override either coefficient for a specific language using that
+language's `timing` field. Unspecified coefficients fall back to the
+environment-wide defaults:
+
+```yaml
+languages:
+  - name: "java"
+    # ...
+    timing:
+      wallTimeIncrement: 3000   # JVM startup headroom; multiplier inherited
+```
+
+The same formula and coefficients are used both when judging locally and when
+packaging for BOCA, so the wall time a solution gets is consistent across both.
+
+!!! note
+    The shipped default preset sets `wallTimeMultiplier: 2.0` and
+    `wallTimeIncrement: 1000`, with larger increments for slow languages
+    (`py: 2000`, `java`/`kt: 3000`).
+
 
 
 

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -206,6 +206,20 @@ class LinterConfig(BaseModel):
         return out
 
 
+class LanguageTimingConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    wallTimeMultiplier: Optional[float] = Field(
+        default=None,
+        description="""Overrides the environment wall-time multiplier `a` for this language.""",
+    )
+
+    wallTimeIncrement: Optional[int] = Field(
+        default=None,
+        description="""Overrides the environment wall-time increment `b` (in milliseconds) for this language.""",
+    )
+
+
 class EnvironmentLanguage(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
@@ -255,6 +269,11 @@ for the environment will be used.""",
         description="""Linters to run for this language during compilation.""",
     )
 
+    timing: Optional[LanguageTimingConfig] = Field(
+        default=None,
+        description="""Per-language overrides for timing configuration (e.g. wall time).""",
+    )
+
     @field_validator('linters', mode='before')
     @classmethod
     def _coerce_linter_shorthand(cls, v):
@@ -279,6 +298,16 @@ class TimingConfig(BaseModel):
     formula: str = Field(
         default='step_up(max(fastest * 3, slowest * 1.5), 100)',
         description="""Formula to use to calculate the time limit for the environment.""",
+    )
+
+    wallTimeMultiplier: float = Field(
+        default=2.0,
+        description="""Default multiplier `a` in the wall-time formula `a*x + b`, where `x` is the expanded CPU time limit.""",
+    )
+
+    wallTimeIncrement: int = Field(
+        default=0,
+        description="""Default increment `b` (in milliseconds) in the wall-time formula `a*x + b`.""",
     )
 
 

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -211,11 +211,13 @@ class LanguageTimingConfig(BaseModel):
 
     wallTimeMultiplier: Optional[float] = Field(
         default=None,
+        ge=1.0,
         description="""Overrides the environment wall-time multiplier `a` for this language.""",
     )
 
     wallTimeIncrement: Optional[int] = Field(
         default=None,
+        ge=0,
         description="""Overrides the environment wall-time increment `b` (in milliseconds) for this language.""",
     )
 
@@ -302,11 +304,13 @@ class TimingConfig(BaseModel):
 
     wallTimeMultiplier: float = Field(
         default=2.0,
+        ge=1.0,
         description="""Default multiplier `a` in the wall-time formula `a*x + b`, where `x` is the expanded CPU time limit.""",
     )
 
     wallTimeIncrement: int = Field(
         default=0,
+        ge=0,
         description="""Default increment `b` (in milliseconds) in the wall-time formula `a*x + b`.""",
     )
 

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -435,6 +435,7 @@ def get_walltime_coeffs_for_language(
 
 
 def compute_walltime(cpu_tl_ms: int, language: Optional[str]) -> int:
+    """Computes the wall-time limit (ms) for a CPU time limit (ms) under the active environment's coefficients for the given language."""
     return apply_walltime_formula(cpu_tl_ms, get_walltime_coeffs_for_language(language))
 
 

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -1,7 +1,7 @@
 import functools
 import pathlib
 from enum import Enum
-from typing import Annotated, Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Annotated, Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import typer
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -399,6 +399,43 @@ def get_language_or_nil(name: str) -> Optional[EnvironmentLanguage]:
         if lang.name == name:
             return lang
     return None
+
+
+def resolve_walltime_coeffs(
+    timing: TimingConfig,
+    language: Optional[EnvironmentLanguage],
+) -> Tuple[float, int]:
+    """Resolves the effective (wall_time_multiplier, wall_time_increment_ms),
+    where a per-language override takes precedence field-by-field over the
+    environment-level timing defaults."""
+    multiplier = timing.wallTimeMultiplier
+    increment = timing.wallTimeIncrement
+    if language is not None and language.timing is not None:
+        if language.timing.wallTimeMultiplier is not None:
+            multiplier = language.timing.wallTimeMultiplier
+        if language.timing.wallTimeIncrement is not None:
+            increment = language.timing.wallTimeIncrement
+    return multiplier, increment
+
+
+def apply_walltime_formula(cpu_tl_ms: int, coeffs: Tuple[float, int]) -> int:
+    """Applies wall = a*x + b, where x is the expanded CPU time limit (ms)."""
+    multiplier, increment = coeffs
+    return int(cpu_tl_ms * multiplier + increment)
+
+
+def get_walltime_coeffs_for_language(
+    language: Optional[str],
+) -> Tuple[float, int]:
+    """Reads the active environment and resolves wall-time coefficients for the
+    given language name (None -> environment defaults)."""
+    env = get_environment()
+    lang = get_language_or_nil(language) if language is not None else None
+    return resolve_walltime_coeffs(env.timing, lang)
+
+
+def compute_walltime(cpu_tl_ms: int, language: Optional[str]) -> int:
+    return apply_walltime_formula(cpu_tl_ms, get_walltime_coeffs_for_language(language))
 
 
 def get_language(name: str) -> EnvironmentLanguage:

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 import typer
 
 from rbx import console, utils
-from rbx.box import header, limits_info, naming, package
+from rbx.box import environment, header, limits_info, naming, package
 from rbx.box.environment import get_extension_or_default
 from rbx.box.generation_schema import GenerationTestcaseEntry
 from rbx.box.packaging.boca.boca_language_utils import (
@@ -183,14 +183,27 @@ class BocaPackager(BasePackager):
             raise typer.Exit(1)
         return compare_path.read_text()
 
+    def _replace_walltime(self, text: str, lang: str) -> str:
+        # `lang` is the emitted BOCA language (e.g. 'cc', 'py3'); map to rbx.
+        rbx_language = get_rbx_language_from_boca_language(lang)
+        env = environment.get_environment()
+        language = environment.get_language_or_nil(rbx_language)
+        multiplier, increment_ms = environment.resolve_walltime_coeffs(
+            env.timing, language
+        )
+        text = text.replace('{{rbxWallMultiplier}}', f'{multiplier:g}')
+        text = text.replace('{{rbxWallIncrement}}', _fmt_seconds(max(0, increment_ms)))
+        return text
+
     def _replace_common(self, text: str, lang: str) -> str:
         extension = get_extension_or_default('boca', BocaExtension)
         flags = extension.flags_with_defaults()
         if lang in flags:
             text = text.replace('{{rbxFlags}}', flags[lang])
-        return text.replace(
+        text = text.replace(
             '{{rbxPython3}}', 'pypy3' if extension.usePypy else 'python3'
         )
+        return self._replace_walltime(text, lang)
 
     def _get_checker(self) -> str:
         checker_path = get_default_app_path() / 'packagers' / 'boca' / 'checker.sh'

--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -269,6 +269,9 @@ async def _run_communication_solution_on_testcase(
             interactor_extra_config.sandbox.wallTimeLimit = _interactor_wall_time(
                 extra_config.sandbox.wallTimeLimit
             )
+        # When the solution has no wall limit (sandbox without soft timeout),
+        # neither process gets one, so the interactor still outlives the
+        # solution; the override above is correctly skipped.
 
         if output_dir is None:
             assert testcase.outputPath is not None

--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -28,6 +28,11 @@ from rbx.utils import model_to_yaml
 
 STDERR_THRESHOLD_IN_BYTES = 1024 * 1024  # 1MB
 
+# Extra wall time (ms) granted to the interactor on top of the solution's wall
+# time in communication tasks, so the interactor never times out before the
+# solution does. Mirrors BOCA's `ittime = ttime + 1`.
+_INTERACTOR_WALL_MARGIN_MS = 1000
+
 
 class TooMuchStderrIssue(Issue):
     def __init__(self, solution: CodeItem):
@@ -205,6 +210,18 @@ def _get_execution_config(
     return ExecutionConfig(sandbox=sandbox, problemLimits=limits)
 
 
+def _interactor_wall_time(solution_wall_ms: int) -> int:
+    """Wall time (ms) for the interactor in a communication task.
+
+    The interactor only needs to outlive the solution so that it is never the
+    process that times out first (which would prematurely kill a still-legal
+    solution). It is a separate program (usually C++), so we do NOT re-apply the
+    solution's per-language wall formula to it; we just add a small fixed margin
+    to the solution's wall time, mirroring BOCA's `ittime = ttime + 1`.
+    """
+    return solution_wall_ms + _INTERACTOR_WALL_MARGIN_MS
+
+
 async def _run_communication_solution_on_testcase(
     solution: CodeItem,
     compiled_digest: str,
@@ -240,21 +257,18 @@ async def _run_communication_solution_on_testcase(
         )
 
         extra_config = _get_execution_config(limits, sandbox_type, language)
-        # The interactor reuses the solution's language for its wall-time
-        # coefficients. This is an intentional approximation: it can only widen
-        # the interactor's wall budget (which is then summed with the solution's
-        # below), never tighten it. See the TODO below.
-        interactor_extra_config = _get_execution_config(limits, sandbox_type, language)
+        # The interactor is not language-specific, so it is built without the
+        # solution's language. Its wall time is set below from the solution's
+        # wall plus a fixed margin so it always outlives the solution.
+        interactor_extra_config = _get_execution_config(limits, sandbox_type)
         if (
             interactor_extra_config.sandbox is not None
-            and interactor_extra_config.sandbox.wallTimeLimit is not None
             and extra_config.sandbox is not None
             and extra_config.sandbox.wallTimeLimit is not None
         ):
-            interactor_extra_config.sandbox.wallTimeLimit += (
+            interactor_extra_config.sandbox.wallTimeLimit = _interactor_wall_time(
                 extra_config.sandbox.wallTimeLimit
             )
-        # TODO: maybe combine wall time limits?
 
         if output_dir is None:
             assert testcase.outputPath is not None

--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -1,7 +1,7 @@
 import pathlib
 from typing import Optional, Tuple, Type
 
-from rbx.box import checkers, limits_info, package, state
+from rbx.box import checkers, environment, limits_info, package, state
 from rbx.box.code import (
     CommunicationItem,
     find_language_name,
@@ -121,7 +121,7 @@ async def run_solution_on_testcase(
             timelimit_override,
             use_timelimit=use_timelimit,
         )
-        extra_config = _get_execution_config(limits, sandbox_type)
+        extra_config = _get_execution_config(limits, sandbox_type, language)
 
         if output_dir is None:
             assert testcase.outputPath is not None
@@ -188,6 +188,7 @@ async def run_solution_on_testcase(
 def _get_execution_config(
     limits: Limits,
     sandbox_type: Type[SandboxBase],
+    language: Optional[str] = None,
 ) -> ExecutionConfig:
     sandbox = EnvironmentSandbox()
     sandbox.timeLimit = limits.time
@@ -196,7 +197,9 @@ def _get_execution_config(
         sandbox.timeLimit = sandbox.timeLimit * 2
     sandbox.wallTimeLimit = sandbox.timeLimit
     if sandbox.timeLimit is not None and sandbox_type.use_soft_timeout():
-        sandbox.wallTimeLimit = sandbox.timeLimit * 2
+        sandbox.wallTimeLimit = environment.compute_walltime(
+            sandbox.timeLimit, language
+        )
     sandbox.memoryLimit = limits.memory
     sandbox.fileSizeLimit = limits.output
     return ExecutionConfig(sandbox=sandbox, problemLimits=limits)
@@ -236,8 +239,8 @@ async def _run_communication_solution_on_testcase(
             use_timelimit=use_timelimit,
         )
 
-        extra_config = _get_execution_config(limits, sandbox_type)
-        interactor_extra_config = _get_execution_config(limits, sandbox_type)
+        extra_config = _get_execution_config(limits, sandbox_type, language)
+        interactor_extra_config = _get_execution_config(limits, sandbox_type, language)
         if (
             interactor_extra_config.sandbox is not None
             and interactor_extra_config.sandbox.wallTimeLimit is not None

--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -240,6 +240,10 @@ async def _run_communication_solution_on_testcase(
         )
 
         extra_config = _get_execution_config(limits, sandbox_type, language)
+        # The interactor reuses the solution's language for its wall-time
+        # coefficients. This is an intentional approximation: it can only widen
+        # the interactor's wall budget (which is then summed with the solution's
+        # below), never tighten it. See the TODO below.
         interactor_extra_config = _get_execution_config(limits, sandbox_type, language)
         if (
             interactor_extra_config.sandbox is not None

--- a/rbx/resources/packagers/boca/interactive/c
+++ b/rbx/resources/packagers/boca/interactive/c
@@ -91,12 +91,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/interactive/c
+++ b/rbx/resources/packagers/boca/interactive/c
@@ -89,7 +89,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/c
+++ b/rbx/resources/packagers/boca/interactive/c
@@ -86,10 +86,10 @@ fi
 time=$3
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/c
+++ b/rbx/resources/packagers/boca/interactive/c
@@ -84,20 +84,20 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "1" ]; then
     echo "WARNING: nruns is set to $4, but it will be ignored because it's not supported by interactive problems"
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/interactive/cc
+++ b/rbx/resources/packagers/boca/interactive/cc
@@ -91,12 +91,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/interactive/cc
+++ b/rbx/resources/packagers/boca/interactive/cc
@@ -89,7 +89,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/cc
+++ b/rbx/resources/packagers/boca/interactive/cc
@@ -86,10 +86,10 @@ fi
 time=$3
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/cc
+++ b/rbx/resources/packagers/boca/interactive/cc
@@ -84,20 +84,20 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "1" ]; then
     echo "WARNING: nruns is set to $4, but it will be ignored because it's not supported by interactive problems"
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/interactive/cpp
+++ b/rbx/resources/packagers/boca/interactive/cpp
@@ -91,12 +91,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/interactive/cpp
+++ b/rbx/resources/packagers/boca/interactive/cpp
@@ -89,7 +89,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/cpp
+++ b/rbx/resources/packagers/boca/interactive/cpp
@@ -86,10 +86,10 @@ fi
 time=$3
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/cpp
+++ b/rbx/resources/packagers/boca/interactive/cpp
@@ -84,20 +84,20 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "1" ]; then
     echo "WARNING: nruns is set to $4, but it will be ignored because it's not supported by interactive problems"
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/interactive/java
+++ b/rbx/resources/packagers/boca/interactive/java
@@ -107,7 +107,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/java
+++ b/rbx/resources/packagers/boca/interactive/java
@@ -109,12 +109,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/interactive/java
+++ b/rbx/resources/packagers/boca/interactive/java
@@ -104,10 +104,10 @@ fi
 time=$3
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/java
+++ b/rbx/resources/packagers/boca/interactive/java
@@ -102,20 +102,20 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "1" ]; then
     echo "WARNING: nruns is set to $4, but it will be ignored because it's not supported by interactive problems"
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/interactive/kt
+++ b/rbx/resources/packagers/boca/interactive/kt
@@ -107,7 +107,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/kt
+++ b/rbx/resources/packagers/boca/interactive/kt
@@ -109,12 +109,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/interactive/kt
+++ b/rbx/resources/packagers/boca/interactive/kt
@@ -104,10 +104,10 @@ fi
 time=$3
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/kt
+++ b/rbx/resources/packagers/boca/interactive/kt
@@ -102,20 +102,20 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "1" ]; then
     echo "WARNING: nruns is set to $4, but it will be ignored because it's not supported by interactive problems"
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/interactive/py2
+++ b/rbx/resources/packagers/boca/interactive/py2
@@ -83,10 +83,10 @@ fi
 time=$3
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/py2
+++ b/rbx/resources/packagers/boca/interactive/py2
@@ -86,7 +86,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/py2
+++ b/rbx/resources/packagers/boca/interactive/py2
@@ -88,12 +88,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/interactive/py2
+++ b/rbx/resources/packagers/boca/interactive/py2
@@ -81,20 +81,20 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "1" ]; then
     echo "WARNING: nruns is set to $4, but it will be ignored because it's not supported by interactive problems"
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/interactive/py3
+++ b/rbx/resources/packagers/boca/interactive/py3
@@ -83,10 +83,10 @@ fi
 time=$3
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/py3
+++ b/rbx/resources/packagers/boca/interactive/py3
@@ -86,7 +86,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/interactive/py3
+++ b/rbx/resources/packagers/boca/interactive/py3
@@ -88,12 +88,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/interactive/py3
+++ b/rbx/resources/packagers/boca/interactive/py3
@@ -81,20 +81,20 @@ if [ ! -x "$sf" ]; then
 fi
 
 time=$3
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "1" ]; then
     echo "WARNING: nruns is set to $4, but it will be ignored because it's not supported by interactive problems"
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/run/c
+++ b/rbx/resources/packagers/boca/run/c
@@ -83,20 +83,20 @@ time=$3
 # $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
 # verbatim. Use an integer ceiling only for the bash integer comparison and the
 # real (wall) time limit, mirroring the interactive scripts (see #494).
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "0" ]; then
     nruns=$4
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/run/c
+++ b/rbx/resources/packagers/boca/run/c
@@ -90,12 +90,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/run/c
+++ b/rbx/resources/packagers/boca/run/c
@@ -85,10 +85,10 @@ time=$3
 # real (wall) time limit, mirroring the interactive scripts (see #494).
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/c
+++ b/rbx/resources/packagers/boca/run/c
@@ -88,7 +88,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/cc
+++ b/rbx/resources/packagers/boca/run/cc
@@ -83,20 +83,20 @@ time=$3
 # $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
 # verbatim. Use an integer ceiling only for the bash integer comparison and the
 # real (wall) time limit, mirroring the interactive scripts (see #494).
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "0" ]; then
     nruns=$4
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/run/cc
+++ b/rbx/resources/packagers/boca/run/cc
@@ -90,12 +90,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/run/cc
+++ b/rbx/resources/packagers/boca/run/cc
@@ -85,10 +85,10 @@ time=$3
 # real (wall) time limit, mirroring the interactive scripts (see #494).
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/cc
+++ b/rbx/resources/packagers/boca/run/cc
@@ -88,7 +88,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/cpp
+++ b/rbx/resources/packagers/boca/run/cpp
@@ -83,20 +83,20 @@ time=$3
 # $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
 # verbatim. Use an integer ceiling only for the bash integer comparison and the
 # real (wall) time limit, mirroring the interactive scripts (see #494).
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "0" ]; then
     nruns=$4
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/run/cpp
+++ b/rbx/resources/packagers/boca/run/cpp
@@ -90,12 +90,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/run/cpp
+++ b/rbx/resources/packagers/boca/run/cpp
@@ -85,10 +85,10 @@ time=$3
 # real (wall) time limit, mirroring the interactive scripts (see #494).
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/cpp
+++ b/rbx/resources/packagers/boca/run/cpp
@@ -88,7 +88,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/java
+++ b/rbx/resources/packagers/boca/run/java
@@ -106,7 +106,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/java
+++ b/rbx/resources/packagers/boca/run/java
@@ -103,10 +103,10 @@ time=$3
 # real (wall) time limit, mirroring the interactive scripts (see #494).
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/java
+++ b/rbx/resources/packagers/boca/run/java
@@ -101,20 +101,20 @@ time=$3
 # $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
 # verbatim. Use an integer ceiling only for the bash integer comparison and the
 # real (wall) time limit, mirroring the interactive scripts (see #494).
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "0" ]; then
     nruns=$4
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/run/java
+++ b/rbx/resources/packagers/boca/run/java
@@ -108,12 +108,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/run/kt
+++ b/rbx/resources/packagers/boca/run/kt
@@ -106,7 +106,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/kt
+++ b/rbx/resources/packagers/boca/run/kt
@@ -103,10 +103,10 @@ time=$3
 # real (wall) time limit, mirroring the interactive scripts (see #494).
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/kt
+++ b/rbx/resources/packagers/boca/run/kt
@@ -101,20 +101,20 @@ time=$3
 # $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
 # verbatim. Use an integer ceiling only for the bash integer comparison and the
 # real (wall) time limit, mirroring the interactive scripts (see #494).
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "0" ]; then
     nruns=$4
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/run/kt
+++ b/rbx/resources/packagers/boca/run/kt
@@ -108,12 +108,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/run/py2
+++ b/rbx/resources/packagers/boca/run/py2
@@ -86,7 +86,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/py2
+++ b/rbx/resources/packagers/boca/run/py2
@@ -83,10 +83,10 @@ time=$3
 # real (wall) time limit, mirroring the interactive scripts (see #494).
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/py2
+++ b/rbx/resources/packagers/boca/run/py2
@@ -88,12 +88,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/run/py2
+++ b/rbx/resources/packagers/boca/run/py2
@@ -81,20 +81,20 @@ time=$3
 # $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
 # verbatim. Use an integer ceiling only for the bash integer comparison and the
 # real (wall) time limit, mirroring the interactive scripts (see #494).
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "0" ]; then
     nruns=$4
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/packagers/boca/run/py3
+++ b/rbx/resources/packagers/boca/run/py3
@@ -86,7 +86,7 @@ if [ "$rtime" -gt "0" ]; then
   ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/py3
+++ b/rbx/resources/packagers/boca/run/py3
@@ -83,10 +83,10 @@ time=$3
 # real (wall) time limit, mirroring the interactive scripts (see #494).
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
 if [ "$rtime" -gt "0" ]; then
-  let "ttime = $rtime + 30"
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
 else
   time=1
-  ttime=30
+  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")
 fi
 
 nruns=1

--- a/rbx/resources/packagers/boca/run/py3
+++ b/rbx/resources/packagers/boca/run/py3
@@ -88,12 +88,12 @@ if [ "$4" != "" ]; then
   fi
 fi
 rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
-else
+# A non-positive (rounded) time limit means "no real limit"; force a 1s CPU
+# budget so the wall formula below still yields a sane positive wall time.
+if [ "$rtime" -le "0" ]; then
   time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 fi
+ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
 
 maxm=512000
 if [ "$5" != "" ]; then

--- a/rbx/resources/packagers/boca/run/py3
+++ b/rbx/resources/packagers/boca/run/py3
@@ -81,20 +81,20 @@ time=$3
 # $time is an EXACT fractional CPU budget (seconds); safeexec's -t accepts it
 # verbatim. Use an integer ceiling only for the bash integer comparison and the
 # real (wall) time limit, mirroring the interactive scripts (see #494).
-rtime=$(awk "BEGIN {print int($time+0.9999999)}")
-if [ "$rtime" -gt "0" ]; then
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-else
-  time=1
-  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} + 0.9999999)}")
-fi
-
 nruns=1
 if [ "$4" != "" ]; then
   if [ "$4" -gt "0" ]; then
     nruns=$4
   fi
 fi
+rtime=$(awk "BEGIN {print int($time+0.9999999)}")
+if [ "$rtime" -gt "0" ]; then
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+else
+  time=1
+  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} + {{rbxWallIncrement}} * $nruns + 0.9999999)}")
+fi
+
 maxm=512000
 if [ "$5" != "" ]; then
   if [ "$5" -gt "0" ]; then

--- a/rbx/resources/presets/default/env.rbx.yml
+++ b/rbx/resources/presets/default/env.rbx.yml
@@ -1,5 +1,8 @@
 ---
 sandbox: "stupid"
+timing:
+  wallTimeMultiplier: 2.0
+  wallTimeIncrement: 1000
 defaultCompilation:
   sandbox:
     maxProcesses: 1000
@@ -43,6 +46,8 @@ languages:
     extension: "py"
     execution:
       command: "python3 {executable}"
+    timing:
+      wallTimeIncrement: 2000
     fileMapping:
       executable: "{compilable}"
     extensions:
@@ -58,6 +63,8 @@ languages:
         - "jar cvf {executable} @glob:*.class"
     execution:
       command: "java -Xss100m -Xmx{memory}m -Xms{initialMemory}m -cp {executable} {javaClass}"
+    timing:
+      wallTimeIncrement: 3000
     fileMapping:
       compilable: "{javaClass}.java"
       executable: "Main.jar"
@@ -75,6 +82,8 @@ languages:
         - "kotlinc -d {executable} -include-runtime {compilable}"
     execution:
       command: "java -Xss100m -Xmx{memory}m -Xms{initialMemory}m -cp {executable} MainKt"
+    timing:
+      wallTimeIncrement: 3000
     fileMapping:
       compilable: "Main.kt"
       executable: "Main.jar"

--- a/tests/rbx/box/packaging/boca/test_timing.py
+++ b/tests/rbx/box/packaging/boca/test_timing.py
@@ -107,11 +107,11 @@ _WALL_SAMPLE = (
     'rtime=$(awk "BEGIN {print int($time+0.9999999)}")\n'
     'if [ "$rtime" -gt "0" ]; then\n'
     '  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} '
-    '+ {{rbxWallIncrement}} + 0.9999999)}")\n'
+    '+ {{rbxWallIncrement}} * $nruns + 0.9999999)}")\n'
     'else\n'
     '  time=1\n'
     '  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} '
-    '+ {{rbxWallIncrement}} + 0.9999999)}")\n'
+    '+ {{rbxWallIncrement}} * $nruns + 0.9999999)}")\n'
     'fi\n'
 )
 
@@ -139,6 +139,7 @@ def test_replace_walltime_uses_default_formula_no_plus_30():
         out = packager._replace_walltime(_WALL_SAMPLE, 'cc')  # noqa: SLF001
     assert '* 2' in out
     assert '+ 0.000' in out
+    assert '* $nruns' in out
     assert '{{rbxWallMultiplier}}' not in out
     assert '{{rbxWallIncrement}}' not in out
     assert '+ 30' not in out
@@ -171,7 +172,7 @@ def test_replace_walltime_else_branch_keeps_wall_floor_on_real_template():
     ).read_text()
     with _patched_coeffs(2.0, 0) as packager:
         out = packager._replace_walltime(template, 'cc')  # noqa: SLF001
-    awk_expr = 'int($time * 2 + 0.000 + 0.9999999)'
+    awk_expr = 'int($time * 2 + 0.000 * $nruns + 0.9999999)'
     assert out.count(awk_expr) == 2
     assert 'int(0.000+0.9999999)' not in out
     assert 'int(0.000 + 0.9999999)' not in out

--- a/tests/rbx/box/packaging/boca/test_timing.py
+++ b/tests/rbx/box/packaging/boca/test_timing.py
@@ -110,7 +110,8 @@ _WALL_SAMPLE = (
     '+ {{rbxWallIncrement}} + 0.9999999)}")\n'
     'else\n'
     '  time=1\n'
-    '  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")\n'
+    '  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} '
+    '+ {{rbxWallIncrement}} + 0.9999999)}")\n'
     'fi\n'
 )
 
@@ -156,6 +157,24 @@ def test_replace_walltime_on_real_run_template():
     assert '+ 0.000' in out
     assert '+ 30' not in out
     assert 'ttime=30' not in out
+
+
+def test_replace_walltime_else_branch_keeps_wall_floor_on_real_template():
+    # The degenerate else-branch (forced time=1) must apply the FULL formula
+    # so wall stays >= the forced 1s CPU. With default coeffs both branches
+    # share the identical awk expression and no increment-only expression
+    # (which would yield ttime=0 under increment=0) survives.
+    from rbx.config import get_default_app_path
+
+    template = (
+        get_default_app_path() / 'packagers' / 'boca' / 'run' / 'cc'
+    ).read_text()
+    with _patched_coeffs(2.0, 0) as packager:
+        out = packager._replace_walltime(template, 'cc')  # noqa: SLF001
+    awk_expr = 'int($time * 2 + 0.000 + 0.9999999)'
+    assert out.count(awk_expr) == 2
+    assert 'int(0.000+0.9999999)' not in out
+    assert 'int(0.000 + 0.9999999)' not in out
 
 
 def test_cc_and_cpp_map_to_same_rbx_language_and_substitution():

--- a/tests/rbx/box/packaging/boca/test_timing.py
+++ b/tests/rbx/box/packaging/boca/test_timing.py
@@ -1,6 +1,9 @@
 import contextlib
 from unittest import mock
 
+from rbx.box.packaging.boca.boca_language_utils import (
+    get_rbx_language_from_boca_language,
+)
 from rbx.box.packaging.boca.extension import BocaExtension
 from rbx.box.packaging.boca.packager import (
     BocaPackager,
@@ -98,3 +101,76 @@ def test_get_limits_communication_is_single_run_and_exact():
     assert echos[1] == 'echo 1'
     assert echos[2] == 'echo 256'
     assert echos[3] == 'echo 65536'
+
+
+_WALL_SAMPLE = (
+    'rtime=$(awk "BEGIN {print int($time+0.9999999)}")\n'
+    'if [ "$rtime" -gt "0" ]; then\n'
+    '  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} '
+    '+ {{rbxWallIncrement}} + 0.9999999)}")\n'
+    'else\n'
+    '  time=1\n'
+    '  ttime=$(awk "BEGIN {print int({{rbxWallIncrement}}+0.9999999)}")\n'
+    'fi\n'
+)
+
+
+@contextlib.contextmanager
+def _patched_coeffs(multiplier, increment_ms):
+    with (
+        mock.patch(
+            'rbx.box.packaging.boca.packager.environment.resolve_walltime_coeffs',
+            return_value=(multiplier, increment_ms),
+        ),
+        mock.patch(
+            'rbx.box.packaging.boca.packager.environment.get_environment',
+        ),
+        mock.patch(
+            'rbx.box.packaging.boca.packager.environment.get_language_or_nil',
+        ),
+    ):
+        yield BocaPackager(testcase_entries=[])
+
+
+def test_replace_walltime_uses_default_formula_no_plus_30():
+    # Default coefficients: multiplier=2.0, increment=0ms.
+    with _patched_coeffs(2.0, 0) as packager:
+        out = packager._replace_walltime(_WALL_SAMPLE, 'cc')  # noqa: SLF001
+    assert '* 2' in out
+    assert '+ 0.000' in out
+    assert '{{rbxWallMultiplier}}' not in out
+    assert '{{rbxWallIncrement}}' not in out
+    assert '+ 30' not in out
+    assert 'ttime=30' not in out
+
+
+def test_replace_walltime_on_real_run_template():
+    from rbx.config import get_default_app_path
+
+    template = (
+        get_default_app_path() / 'packagers' / 'boca' / 'run' / 'cc'
+    ).read_text()
+    with _patched_coeffs(2.0, 0) as packager:
+        out = packager._replace_walltime(template, 'cc')  # noqa: SLF001
+    assert '* 2' in out
+    assert '+ 0.000' in out
+    assert '+ 30' not in out
+    assert 'ttime=30' not in out
+
+
+def test_cc_and_cpp_map_to_same_rbx_language_and_substitution():
+    assert get_rbx_language_from_boca_language(
+        'cc'
+    ) == get_rbx_language_from_boca_language('cpp')
+    with _patched_coeffs(2.0, 0) as packager:
+        cc_out = packager._replace_walltime(_WALL_SAMPLE, 'cc')  # noqa: SLF001
+        cpp_out = packager._replace_walltime(_WALL_SAMPLE, 'cpp')  # noqa: SLF001
+    assert cc_out == cpp_out
+
+
+def test_replace_walltime_honors_per_language_increment_override():
+    # Simulate an override of the increment to 3000ms.
+    with _patched_coeffs(2.0, 3000) as packager:
+        out = packager._replace_walltime(_WALL_SAMPLE, 'java')  # noqa: SLF001
+    assert '+ 3.000' in out
+    assert '+ 30' not in out

--- a/tests/rbx/box/packaging/boca/test_timing.py
+++ b/tests/rbx/box/packaging/boca/test_timing.py
@@ -105,14 +105,11 @@ def test_get_limits_communication_is_single_run_and_exact():
 
 _WALL_SAMPLE = (
     'rtime=$(awk "BEGIN {print int($time+0.9999999)}")\n'
-    'if [ "$rtime" -gt "0" ]; then\n'
-    '  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} '
-    '+ {{rbxWallIncrement}} * $nruns + 0.9999999)}")\n'
-    'else\n'
+    'if [ "$rtime" -le "0" ]; then\n'
     '  time=1\n'
-    '  ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} '
-    '+ {{rbxWallIncrement}} * $nruns + 0.9999999)}")\n'
     'fi\n'
+    'ttime=$(awk "BEGIN {print int($time * {{rbxWallMultiplier}} '
+    '+ {{rbxWallIncrement}} * $nruns + 0.9999999)}")\n'
 )
 
 
@@ -160,11 +157,11 @@ def test_replace_walltime_on_real_run_template():
     assert 'ttime=30' not in out
 
 
-def test_replace_walltime_else_branch_keeps_wall_floor_on_real_template():
-    # The degenerate else-branch (forced time=1) must apply the FULL formula
-    # so wall stays >= the forced 1s CPU. With default coeffs both branches
-    # share the identical awk expression and no increment-only expression
-    # (which would yield ttime=0 under increment=0) survives.
+def test_replace_walltime_uses_single_formula_with_wall_floor():
+    # The wall formula now appears exactly once; the degenerate branch only
+    # forces time=1 (so wall stays >= the forced 1s CPU) before the shared
+    # awk expression runs. No increment-only expression (which would yield
+    # ttime=0 under increment=0) survives.
     from rbx.config import get_default_app_path
 
     template = (
@@ -173,7 +170,7 @@ def test_replace_walltime_else_branch_keeps_wall_floor_on_real_template():
     with _patched_coeffs(2.0, 0) as packager:
         out = packager._replace_walltime(template, 'cc')  # noqa: SLF001
     awk_expr = 'int($time * 2 + 0.000 * $nruns + 0.9999999)'
-    assert out.count(awk_expr) == 2
+    assert out.count(awk_expr) == 1
     assert 'int(0.000+0.9999999)' not in out
     assert 'int(0.000 + 0.9999999)' not in out
 

--- a/tests/rbx/box/walltime_test.py
+++ b/tests/rbx/box/walltime_test.py
@@ -1,5 +1,8 @@
 from unittest import mock
 
+import pytest
+from pydantic import ValidationError
+
 from rbx.box import tasks
 from rbx.box.environment import (
     EnvironmentLanguage,
@@ -47,6 +50,26 @@ def test_language_timing_config_optional_fields():
     cfg = LanguageTimingConfig()
     assert cfg.wallTimeMultiplier is None
     assert cfg.wallTimeIncrement is None
+
+
+def test_walltime_multiplier_must_be_at_least_one():
+    with pytest.raises(ValidationError):
+        TimingConfig(wallTimeMultiplier=0.5)
+
+
+def test_walltime_increment_must_be_nonnegative():
+    with pytest.raises(ValidationError):
+        TimingConfig(wallTimeIncrement=-1)
+
+
+def test_language_walltime_multiplier_must_be_at_least_one():
+    with pytest.raises(ValidationError):
+        LanguageTimingConfig(wallTimeMultiplier=0.5)
+
+
+def test_language_walltime_increment_must_be_nonnegative():
+    with pytest.raises(ValidationError):
+        LanguageTimingConfig(wallTimeIncrement=-1)
 
 
 def test_environment_language_accepts_timing():

--- a/tests/rbx/box/walltime_test.py
+++ b/tests/rbx/box/walltime_test.py
@@ -120,7 +120,13 @@ def test_apply_walltime_formula_truncates():
 def test_compute_walltime_uses_active_environment(
     testing_pkg: testing_package.TestingPackage,
 ):
-    # The default preset environment has wallTimeMultiplier=2.0,
-    # wallTimeIncrement=0, so the wall time is twice the CPU time limit.
-    assert compute_walltime(1000, 'cpp') == 2000
-    assert compute_walltime(1000, None) == 2000
+    # The default preset environment has wallTimeMultiplier=2.0 and
+    # wallTimeIncrement=1000ms, so wall = 2 * cpu_tl + 1000 for languages
+    # without a per-language override (cpp, and the env default).
+    assert compute_walltime(1000, 'cpp') == 3000
+    assert compute_walltime(1000, None) == 3000
+    # Slow languages add a larger per-language increment in the preset:
+    # py +2000ms, java/kt +3000ms.
+    assert compute_walltime(1000, 'py') == 4000
+    assert compute_walltime(1000, 'java') == 5000
+    assert compute_walltime(1000, 'kt') == 5000

--- a/tests/rbx/box/walltime_test.py
+++ b/tests/rbx/box/walltime_test.py
@@ -130,3 +130,11 @@ def test_compute_walltime_uses_active_environment(
     assert compute_walltime(1000, 'py') == 4000
     assert compute_walltime(1000, 'java') == 5000
     assert compute_walltime(1000, 'kt') == 5000
+
+
+def test_interactor_wall_time_is_solution_wall_plus_fixed_margin():
+    # The interactor gets the solution's wall time plus a small fixed margin so
+    # it always outlives the solution; it does NOT double the solution's wall.
+    margin = tasks._INTERACTOR_WALL_MARGIN_MS  # noqa: SLF001
+    assert tasks._interactor_wall_time(2000) == 2000 + margin  # noqa: SLF001
+    assert tasks._interactor_wall_time(5000) == 5000 + margin  # noqa: SLF001

--- a/tests/rbx/box/walltime_test.py
+++ b/tests/rbx/box/walltime_test.py
@@ -4,8 +4,10 @@ from rbx.box.environment import (
     LanguageTimingConfig,
     TimingConfig,
     apply_walltime_formula,
+    compute_walltime,
     resolve_walltime_coeffs,
 )
+from rbx.box.testing import testing_package
 
 
 def test_timing_config_walltime_defaults():
@@ -58,3 +60,17 @@ def test_apply_walltime_formula():
     assert apply_walltime_formula(1000, (2.0, 0)) == 2000
     assert apply_walltime_formula(1000, (2.0, 1000)) == 3000
     assert apply_walltime_formula(1500, (1.5, 250)) == 2500
+
+
+def test_apply_walltime_formula_truncates():
+    # 1001 * 1.5 = 1501.5 -> int() truncates toward zero to 1501.
+    assert apply_walltime_formula(1001, (1.5, 0)) == 1501
+
+
+def test_compute_walltime_uses_active_environment(
+    testing_pkg: testing_package.TestingPackage,
+):
+    # The default preset environment has wallTimeMultiplier=2.0,
+    # wallTimeIncrement=0, so the wall time is twice the CPU time limit.
+    assert compute_walltime(1000, 'cpp') == 2000
+    assert compute_walltime(1000, None) == 2000

--- a/tests/rbx/box/walltime_test.py
+++ b/tests/rbx/box/walltime_test.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+from rbx.box import tasks
 from rbx.box.environment import (
     EnvironmentLanguage,
     ExecutionConfig,
@@ -8,6 +11,30 @@ from rbx.box.environment import (
     resolve_walltime_coeffs,
 )
 from rbx.box.testing import testing_package
+from rbx.grading.judge.sandboxes.stupid_sandbox import StupidSandbox
+from rbx.grading.limits import Limits
+
+
+def test_get_execution_config_uses_walltime_formula_for_language():
+    limits = Limits(time=1000, memory=256, output=4096)
+    with mock.patch.object(
+        tasks.environment, 'compute_walltime', return_value=4242
+    ) as m:
+        cfg = tasks._get_execution_config(limits, StupidSandbox, language='java')  # noqa: SLF001
+    assert cfg.sandbox is not None
+    assert cfg.sandbox.timeLimit == 1000
+    assert cfg.sandbox.wallTimeLimit == 4242
+    m.assert_called_once_with(1000, 'java')
+
+
+def test_get_execution_config_doubletl_passes_expanded_tl_as_x():
+    limits = Limits(time=1000, memory=256, output=4096, isDoubleTL=True)
+    with mock.patch.object(
+        tasks.environment, 'compute_walltime', return_value=9999
+    ) as m:
+        cfg = tasks._get_execution_config(limits, StupidSandbox, language='cpp')  # noqa: SLF001
+    m.assert_called_once_with(2000, 'cpp')
+    assert cfg.sandbox.wallTimeLimit == 9999
 
 
 def test_timing_config_walltime_defaults():

--- a/tests/rbx/box/walltime_test.py
+++ b/tests/rbx/box/walltime_test.py
@@ -3,6 +3,8 @@ from rbx.box.environment import (
     ExecutionConfig,
     LanguageTimingConfig,
     TimingConfig,
+    apply_walltime_formula,
+    resolve_walltime_coeffs,
 )
 
 
@@ -28,3 +30,31 @@ def test_environment_language_accepts_timing():
     assert lang.timing is not None
     assert lang.timing.wallTimeIncrement == 3000
     assert lang.timing.wallTimeMultiplier is None
+
+
+def test_resolve_coeffs_uses_env_default_when_no_language_override():
+    env_timing = TimingConfig(wallTimeMultiplier=2.0, wallTimeIncrement=1000)
+    lang = EnvironmentLanguage(name='cpp', extension='cpp', execution=ExecutionConfig())
+    assert resolve_walltime_coeffs(env_timing, lang) == (2.0, 1000)
+
+
+def test_resolve_coeffs_language_override_wins_field_by_field():
+    env_timing = TimingConfig(wallTimeMultiplier=2.0, wallTimeIncrement=1000)
+    lang = EnvironmentLanguage(
+        name='java',
+        extension='java',
+        execution=ExecutionConfig(),
+        timing=LanguageTimingConfig(wallTimeIncrement=3000),
+    )
+    assert resolve_walltime_coeffs(env_timing, lang) == (2.0, 3000)
+
+
+def test_resolve_coeffs_with_none_language():
+    env_timing = TimingConfig(wallTimeMultiplier=3.0, wallTimeIncrement=500)
+    assert resolve_walltime_coeffs(env_timing, None) == (3.0, 500)
+
+
+def test_apply_walltime_formula():
+    assert apply_walltime_formula(1000, (2.0, 0)) == 2000
+    assert apply_walltime_formula(1000, (2.0, 1000)) == 3000
+    assert apply_walltime_formula(1500, (1.5, 250)) == 2500

--- a/tests/rbx/box/walltime_test.py
+++ b/tests/rbx/box/walltime_test.py
@@ -1,0 +1,30 @@
+from rbx.box.environment import (
+    EnvironmentLanguage,
+    ExecutionConfig,
+    LanguageTimingConfig,
+    TimingConfig,
+)
+
+
+def test_timing_config_walltime_defaults():
+    cfg = TimingConfig()
+    assert cfg.wallTimeMultiplier == 2.0
+    assert cfg.wallTimeIncrement == 0
+
+
+def test_language_timing_config_optional_fields():
+    cfg = LanguageTimingConfig()
+    assert cfg.wallTimeMultiplier is None
+    assert cfg.wallTimeIncrement is None
+
+
+def test_environment_language_accepts_timing():
+    lang = EnvironmentLanguage(
+        name='java',
+        extension='java',
+        execution=ExecutionConfig(),
+        timing=LanguageTimingConfig(wallTimeIncrement=3000),
+    )
+    assert lang.timing is not None
+    assert lang.timing.wallTimeIncrement == 3000
+    assert lang.timing.wallTimeMultiplier is None


### PR DESCRIPTION
## Summary

Closes #490. Wall time limits were too tight for slow languages (Java/Kotlin/Python), where JVM/interpreter startup eats into the wall-clock budget even when CPU time is fine — and there was no per-language knob. The wall time was hardcoded as `cpu_TL × 2` in local judging and `ttime = $rtime + 30` in the BOCA run scripts (the `+30` being an ad-hoc Maratona Mineira hack, since superseded by exact fractional limits in #494).

This adds a configurable `wall = a·x + b` formula, shared by **rbx local judging** and **BOCA packaging**, where:
- `a` = `wallTimeMultiplier` (≥ 1.0, default `2.0`)
- `b` = `wallTimeIncrement` in ms (≥ 0, default `0`)
- `x` = the effective per-language CPU time limit (after per-language modifiers and double-TL expansion)

Env-wide defaults live in the `timing` block of `env.rbx.yml`; each language can override either coefficient via its own `timing` field (unspecified coefficients fall back to the env default).

### Changes
- **`environment.py`**: `wallTimeMultiplier`/`wallTimeIncrement` on `TimingConfig` and a new `LanguageTimingConfig`; `EnvironmentLanguage.timing`; shared `resolve_walltime_coeffs` / `apply_walltime_formula` / `compute_walltime`.
- **`tasks.py`**: `_get_execution_config` applies `compute_walltime` in the soft-timeout branch (replaces hardcoded `× 2`); all call sites thread the language through.
- **BOCA** (`packager.py` + 14 `run/`/`interactive/` templates): `_replace_walltime` maps the emitted BOCA language to its rbx language (reusing #493's helper) and substitutes the coefficients; the shell multiplies the exact fractional `$time` directly for accuracy. The degenerate `rtime ≤ 0` branch keeps a wall floor.
- **Default preset**: `wallTimeMultiplier: 2.0`, `wallTimeIncrement: 1000`, with `py: +2000`, `java`/`kt: +3000`.
- **Docs**: "Wall time limits" section in the Environment reference.

Defaults are chosen so rbx local judging is **unchanged** (`2.0×, +0` at the schema level reproduces today's `× 2`); the preset adds modest slack. The BOCA cushion changes from a flat `+30 s` to `2·x + 1 s` (plus per-language slack) — an intended replacement of the old hack.

Design + implementation plan: `docs/plans/2026-06-01-configurable-walltime-design.md`, `docs/plans/2026-06-01-configurable-walltime.md`.

## Test Plan
- [x] `tests/rbx/box/walltime_test.py` — schema constraints, field-by-field override precedence, formula truncation, end-to-end resolution against the shipped preset (py=4000, java/kt=5000), `_get_execution_config` wiring incl. double-TL.
- [x] `tests/rbx/box/packaging/boca/test_timing.py` — substitution against real templates, cc/cpp mapping equivalence, per-language override, degenerate else-branch floor.
- [x] Broader sweep: 223 passed across `tests/rbx/box/packaging`, `tasks_test`, `limits_info_test`, `test_timing` (3 BOCA e2e errors are Docker-infra only, pre-existing).
- [ ] Manual: package a problem with Java/Python solutions for BOCA and confirm emitted `run/*` wall times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)