### PR TITLE
feat(timing): language groups for time-limit estimation (#497)

### DIFF
--- a/docs/plans/2026-06-01-language-groups-timing-design.md
+++ b/docs/plans/2026-06-01-language-groups-timing-design.md
@@ -1,0 +1,215 @@
+# Language groups for time-limit estimation (issue #497)
+
+Date: 2026-06-01
+Issue: https://github.com/rsalesc/rbx/issues/497
+
+## Problem
+
+When `rbx time` estimates per-language time limits, it stores overrides in
+`.limits/{profile}.yml` `modifiers` for languages that *have* solutions, while the
+base `timeLimit` reflects only the represented languages. Any language **without a
+solution** (Java, Kotlin, Go, …) silently falls back to that base TL, which can be
+unreasonably tight. The change is invisible — setting specific limits masks the
+fallback — so it surfaces as a contest surprise.
+
+## Goals
+
+The issue's three proposals, all in scope:
+
+1. **Language grouping** — related languages (C/C++, Java/Kotlin) share an estimated
+   TL bucket so an unrepresented language inherits a sibling's limit instead of the
+   global base.
+2. **Visibility after `rbx time`** — a detailed per-group table showing resolved TL
+   and its origin (estimated / multiplier / defaulted).
+3. **Visibility at BOCA package build** — the *same* table, printed last, so what
+   ships is unambiguous.
+
+We are **not** changing the global fallback default; instead groups + clear
+visibility address the risk.
+
+## Approach (A): groups are an estimation-time abstraction
+
+Groups live only in `env.rbx.yml` and in `timing.py`. At the end of estimation they
+**compile down** to the existing per-language `modifiers[lang].time` entries that the
+rest of the system (`timelimit_for_language()`, the BOCA packager) already consumes.
+No consumer changes, no resolution-path changes, fully backward-compatible. The
+`.limits` file additionally carries *metadata* describing the grouping for later
+presentation, but that metadata is never used for resolution.
+
+Rejected alternatives:
+- **B (groups first-class in `LimitsProfile`)** — invasive; touches the schema and
+  every consumer, adds a second indirection over the BOCA `cc`→`cpp` mapping (#493).
+- **C (hybrid: store groups *and* expanded values redundantly)** — over-engineered.
+
+## Section 1 — Schema (`env.rbx.yml`)
+
+Groups are **anonymous**. They are referenced (only by `whenEmpty.relativeTo`) via any
+language they contain.
+
+```yaml
+timing:
+  formula: "step_up(max(fastest * 3, slowest * 1.5), 100)"
+  groups:
+    - languages: [c, cpp]
+    - languages: [java, kotlin]
+      whenEmpty:                 # used ONLY if this group has no solutions
+        relativeTo: cpp          # any language; resolves to the group containing it.
+        multiplier: 2.0          #   omit relativeTo -> multiply the base estimate
+    - languages: [python]
+```
+
+New models in `rbx/box/environment.py`:
+
+```python
+class LanguageGroupFallback(BaseModel):
+    relativeTo: Optional[str] = None   # a language name; None = base estimate
+    multiplier: float
+
+class LanguageGroup(BaseModel):
+    languages: List[str]               # rbx language names
+    whenEmpty: Optional[LanguageGroupFallback] = None
+
+class TimingConfig(BaseModel):
+    formula: str = ...
+    groups: List[LanguageGroup] = Field(default_factory=list)
+```
+
+Load-time validation:
+- A language may appear in **at most one** group (disjoint partition); duplicates error.
+- Env languages not listed → their own **implicit singleton** group.
+- `relativeTo` must be a known language resolving to a *different* group; `whenEmpty`
+  reference chains must be acyclic.
+
+## Section 2 — Estimation flow (`rbx/box/timing.py`)
+
+`estimate_time_limit()` becomes group-aware:
+
+1. **Build the partition** — every env language → its group (explicit + implicit
+   singletons).
+2. **Pool timings per group** — run all ACCEPTED solutions unlimited (as today),
+   attribute each solution's timings to its language's group, pooling members together.
+3. **Estimate per non-empty group** — `fastest`/`slowest` over pooled timings → formula
+   → group TL.
+4. **Base `timeLimit`** = overall estimate across *all* accepted solutions pooled
+   (unchanged from today). This is the fallback for empty-no-`whenEmpty` groups.
+5. **Resolve empty groups** in dependency order (acyclic):
+   - `whenEmpty` present → `referenced_group_TL * multiplier` (or `base * multiplier`
+     when `relativeTo` omitted).
+   - `whenEmpty` absent → base TL, **emit a loud warning** naming affected languages.
+6. **Expand** every group's TL into per-language `modifiers[lang].time`.
+
+### Interactive repartitioning (only when not `--auto`)
+
+A checkbox-style prompt where **each language carries a group number**:
+
+- Numbers prepopulated from `env.rbx.yml`: env group #1 → `1`, #2 → `2`, …; languages
+  in no env group start at `0`.
+- User edits per language: `0` = unassigned (own implicit singleton); `N ≥ 1` =
+  member of group `N`. Same number = same bucket.
+- Groups are reconstructed from the final numbers. This replaces today's "checkbox of
+  which languages get a specific TL" prompt.
+
+**`whenEmpty` preservation rule:** for each resulting group, if its membership is
+*identical* to an env-defined group (same languages, no more/less), that env group's
+`whenEmpty` carries over. If membership changed at all, `whenEmpty` is dropped and the
+group uses defaults (base TL + loud warning if empty).
+
+`--auto` uses env groups verbatim, no prompt; DEFAULTED warnings still print.
+
+## Section 3 — Storage & metadata (`.limits/{profile}.yml`)
+
+Per Approach A, per-language TLs expand into `modifiers` so all consumers are
+untouched. Additionally, store **thorough** grouping metadata so the table is fully
+reconstructable from a saved profile.
+
+```python
+class TimingGroupOrigin(str, Enum):
+    ESTIMATED  = 'estimated'    # group had solutions; TL from the formula
+    MULTIPLIER = 'multiplier'   # empty group resolved via whenEmpty
+    DEFAULTED  = 'defaulted'    # empty group, no whenEmpty -> base TL (warned)
+
+class TimingGroupReport(BaseModel):
+    languages: List[str]
+    timeLimit: int                              # resolved TL, ms
+    origin: TimingGroupOrigin
+    solutionCount: int = 0                      # contributing ACCEPTED solutions
+    fastest: Optional[int] = None               # ms; ESTIMATED only
+    slowest: Optional[int] = None               # ms; ESTIMATED only
+    relativeToLanguage: Optional[str] = None    # MULTIPLIER only; None = base estimate
+    multiplier: Optional[float] = None          # MULTIPLIER only
+
+class LimitsProfile(BaseModel):
+    ...
+    groups: Optional[List[TimingGroupReport]] = None   # metadata only; never resolution
+```
+
+`groups` is **optional**: pre-existing files and the `inherit`/`custom` strategies
+leave it `None`, and presentation degrades gracefully (per-language rows from
+`modifiers` + base, without origin/solution-count annotations). Group TLs are not
+duplicated into the table renderer beyond `timeLimit`; per-member TLs remain in
+`modifiers`.
+
+Example:
+
+```yaml
+timeLimit: 2000
+modifiers:
+  c: {time: 1000}
+  cpp: {time: 1000}
+  java: {time: 4000}
+  kotlin: {time: 4000}
+  python: {time: 5000}
+groups:
+  - languages: [c, cpp]
+    timeLimit: 1000
+    origin: estimated
+    solutionCount: 2
+    fastest: 280
+    slowest: 600
+  - languages: [java, kotlin]
+    timeLimit: 4000
+    origin: multiplier
+    relativeToLanguage: cpp
+    multiplier: 4.0
+  - languages: [python]
+    timeLimit: 5000
+    origin: estimated
+    solutionCount: 1
+    fastest: 1600
+    slowest: 1600
+```
+
+## Section 4 — Presentation tables
+
+A **shared renderer** (e.g. `timing.render_limits_table(limits_profile)`) used by both
+`rbx time` and the BOCA packager so the table is identical. One row per group when
+`groups` metadata is present; otherwise one row per `modifiers` language plus a base row.
+
+| Languages    | Solutions | Time Limit  | Source                          |
+|--------------|-----------|-------------|---------------------------------|
+| c, cpp       | 2         | 1000 ms     | estimated (fastest 280 / 600)   |
+| python       | 1         | 5000 ms     | estimated (1600 / 1600)         |
+| java, kotlin | 0         | 4000 ms     | ×4.0 of cpp                     |
+| go           | 0         | **2000 ms** | ⚠ DEFAULTED to base             |
+
+- `rbx time`: rendered **always** at the end of estimation (not gated by `--detailed`;
+  `--detailed` continues to gate the per-solution breakdown).
+- BOCA package build: rendered from `.limits/boca.yml` and printed **last** in the
+  packaging command, so DEFAULTED warnings are the final visible output. **No error.**
+- DEFAULTED rows are highlighted (warning color) and also emit the loud log warning.
+
+## Section 5 — Edge cases
+
+- **No groups configured anywhere** → all languages implicit singletons; behaves ≈
+  today, now with the table.
+- **`relativeTo` target also empty** → resolves transitively (acyclic guarantee); if the
+  chain bottoms out at a DEFAULTED group, the multiplier applies to base.
+- **`--auto`** → env groups verbatim, no prompt; DEFAULTED warnings still print.
+- **`inherit`/`custom` strategies** → `groups` left `None`; degraded table view.
+- **Language in `modifiers` but no group metadata** (older files) → degraded view.
+
+## Out of scope
+
+- Memory/output limit grouping (issue is time-only).
+- Changing the global fallback default.
+- Persisting groups as a first-class resolution concept (Approach B).

--- a/docs/plans/2026-06-01-language-groups-timing.md
+++ b/docs/plans/2026-06-01-language-groups-timing.md
@@ -1,0 +1,1300 @@
+# Language Groups for Time-Limit Estimation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let related languages share an estimated time-limit bucket so languages without a solution inherit a sibling's limit (or a configured multiplier) instead of silently defaulting to a tight base TL, and surface a per-group TL table after `rbx time` and at BOCA package build.
+
+**Architecture:** Approach A — groups are an *estimation-time* abstraction defined in `env.rbx.yml` (`timing.groups`). `rbx time` pools accepted-solution timings per group, estimates per-group TLs, resolves empty groups via a `whenEmpty` multiplier rule (or base TL + loud warning), then **compiles down** to the existing per-language `modifiers[lang].time` entries the rest of the system already consumes. A new optional `groups` metadata list on `LimitsProfile` records the resolved grouping so a shared table renderer can present it (live after `rbx time`, and from the saved profile at BOCA build). No consumer (`timelimit_for_language`, BOCA packager) changes resolution behavior.
+
+**Tech Stack:** Python 3, Pydantic v2, Typer, `questionary` (interactive prompts), `rich` (tables), pytest. Single quotes, absolute imports only (ruff `TID`).
+
+**Design doc:** `docs/plans/2026-06-01-language-groups-timing-design.md`
+
+**Reference commands:**
+- Run a test: `uv run pytest tests/path/test.py::test_name -v`
+- Lint+format before each commit: `uv run ruff check --fix . && uv run ruff format .`
+- Commits MUST follow Conventional Commits (commitizen). Use the `.claude/skills/commit.md` workflow: stage by name, HEREDOC message, append `Co-Authored-By: Claude <noreply@anthropic.com>`. Never amend; on hook rejection make a NEW commit.
+
+**Pre-existing test caveat (from memory):** some C++/checker/validator/sandbox/docker tests fail on this machine regardless of our changes — do not treat those as regressions. Our new tests must be pure-Python and not depend on the sandbox.
+
+---
+
+## Task 1: Env schema — `LanguageGroup` / `LanguageGroupFallback` + `TimingConfig.groups`
+
+**Files:**
+- Modify: `rbx/box/environment.py` (add models near `TimingConfig` at line 276; extend `TimingConfig`)
+- Test: `tests/rbx/box/test_environment_groups.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+import pytest
+from pydantic import ValidationError
+
+from rbx.box.environment import (
+    LanguageGroup,
+    LanguageGroupFallback,
+    TimingConfig,
+)
+
+
+def test_timing_config_defaults_to_no_groups():
+    cfg = TimingConfig()
+    assert cfg.groups == []
+
+
+def test_language_group_with_when_empty_parses():
+    cfg = TimingConfig.model_validate(
+        {
+            'groups': [
+                {'languages': ['c', 'cpp']},
+                {
+                    'languages': ['java', 'kotlin'],
+                    'whenEmpty': {'relativeTo': 'cpp', 'multiplier': 2.0},
+                },
+            ]
+        }
+    )
+    assert cfg.groups[0].languages == ['c', 'cpp']
+    assert cfg.groups[1].whenEmpty == LanguageGroupFallback(
+        relativeTo='cpp', multiplier=2.0
+    )
+
+
+def test_language_cannot_appear_in_two_groups():
+    with pytest.raises(ValidationError, match='cpp'):
+        TimingConfig.model_validate(
+            {'groups': [{'languages': ['c', 'cpp']}, {'languages': ['cpp']}]}
+        )
+
+
+def test_when_empty_requires_multiplier():
+    with pytest.raises(ValidationError):
+        LanguageGroupFallback.model_validate({'relativeTo': 'cpp'})
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_environment_groups.py -v`
+Expected: FAIL with ImportError (`LanguageGroup` not defined).
+
+**Step 3: Implement the models**
+
+In `rbx/box/environment.py`, immediately before `class TimingConfig` (line 276):
+
+```python
+class LanguageGroupFallback(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    relativeTo: Optional[str] = Field(
+        default=None,
+        description="""A language name whose group's estimated TL this empty group is
+relative to. If omitted, the multiplier is applied to the base estimate.""",
+    )
+    multiplier: float = Field(
+        description="""Multiplier applied when this group has no solutions.""",
+    )
+
+
+class LanguageGroup(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    languages: List[str] = Field(
+        description="""rbx language names that share a single estimated time limit.""",
+    )
+    whenEmpty: Optional[LanguageGroupFallback] = Field(
+        default=None,
+        description="""How to derive a TL for this group when it has no solutions.""",
+    )
+```
+
+Extend `TimingConfig` (add field after `formula`):
+
+```python
+    groups: List[LanguageGroup] = Field(
+        default_factory=list,
+        description="""Groups of related languages that share an estimated time limit.""",
+    )
+
+    @model_validator(mode='after')
+    def _validate_disjoint_groups(self):
+        seen: set[str] = set()
+        for group in self.groups:
+            for lang in group.languages:
+                if lang in seen:
+                    raise ValueError(
+                        f'Language {lang!r} appears in more than one timing group; '
+                        'groups must be disjoint.'
+                    )
+                seen.add(lang)
+        return self
+```
+
+Ensure `model_validator` is imported from `pydantic` at the top of the file (check existing imports; add to the existing `from pydantic import ...` line if missing). `Optional`, `List`, `Field`, `ConfigDict` are already imported (used by surrounding models).
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_environment_groups.py -v`
+Expected: PASS (4 tests).
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/environment.py tests/rbx/box/test_environment_groups.py
+# commit: feat(timing): add language group config to env schema
+```
+
+---
+
+## Task 2: `LimitsProfile` group metadata models
+
+**Files:**
+- Modify: `rbx/box/schema.py` (add `TimingGroupOrigin`, `TimingGroupReport` near `LimitModifiers` line 630; add `groups` field to `LimitsProfile` ~line 797)
+- Test: `tests/rbx/box/test_limits_profile_groups.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+from rbx.box.schema import LimitsProfile, TimingGroupOrigin, TimingGroupReport
+
+
+def test_limits_profile_groups_defaults_to_none():
+    profile = LimitsProfile(timeLimit=1000)
+    assert profile.groups is None
+
+
+def test_limits_profile_round_trips_group_metadata():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+            TimingGroupReport(
+                languages=['java', 'kotlin'],
+                timeLimit=4000,
+                origin=TimingGroupOrigin.MULTIPLIER,
+                relativeToLanguage='cpp',
+                multiplier=4.0,
+            ),
+        ],
+    )
+    reloaded = LimitsProfile.model_validate(profile.model_dump())
+    assert reloaded.groups is not None
+    assert reloaded.groups[1].origin == TimingGroupOrigin.MULTIPLIER
+    assert reloaded.groups[1].relativeToLanguage == 'cpp'
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_limits_profile_groups.py -v`
+Expected: FAIL with ImportError.
+
+**Step 3: Implement the models**
+
+In `rbx/box/schema.py`, after `class LimitModifiers` (line 639). Confirm `enum` is importable; the file already imports many stdlib types — add `import enum` at top if absent, or reuse the existing AutoEnum/str-Enum pattern used by `ExpectedOutcome`. Use a plain `str, enum.Enum`:
+
+```python
+class TimingGroupOrigin(str, enum.Enum):
+    ESTIMATED = 'estimated'
+    MULTIPLIER = 'multiplier'
+    DEFAULTED = 'defaulted'
+
+
+class TimingGroupReport(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    languages: List[str]
+    timeLimit: int
+    origin: TimingGroupOrigin
+    solutionCount: int = 0
+    fastest: Optional[int] = None
+    slowest: Optional[int] = None
+    relativeToLanguage: Optional[str] = None
+    multiplier: Optional[float] = None
+```
+
+In `class LimitsProfile`, after the `formula` field (line ~797), add:
+
+```python
+    groups: Optional[List[TimingGroupReport]] = Field(
+        default=None,
+        description="""
+Metadata describing the language grouping used when this profile was estimated.
+Presentation-only; never used for limit resolution.
+""",
+    )
+```
+
+`extra='forbid'` on `LimitsProfile` (line 764) means older files without `groups` still load (absent optional field is fine), and unknown keys still error as before.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_limits_profile_groups.py -v`
+Expected: PASS (2 tests).
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/schema.py tests/rbx/box/test_limits_profile_groups.py
+# commit: feat(timing): add optional group metadata to LimitsProfile
+```
+
+---
+
+## Task 3: Pure partition builder
+
+A new module holds all pure grouping logic so it is unit-testable without the sandbox.
+
+**Files:**
+- Create: `rbx/box/timing_groups.py`
+- Test: `tests/rbx/box/test_timing_groups.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+from rbx.box.timing_groups import ResolvedGroup, build_partition
+
+
+def test_implicit_singletons_for_unlisted_languages():
+    groups = build_partition(
+        env_groups=[LanguageGroup(languages=['c', 'cpp'])],
+        all_languages=['c', 'cpp', 'python'],
+    )
+    # one explicit group + one implicit singleton, order preserved
+    assert [g.languages for g in groups] == [['c', 'cpp'], ['python']]
+    assert groups[0].whenEmpty is None
+
+
+def test_partition_preserves_when_empty():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            )
+        ],
+        all_languages=['java', 'kotlin'],
+    )
+    assert groups[0].whenEmpty.multiplier == 2.0
+```
+
+`ResolvedGroup` is a small dataclass/BaseModel: `languages: List[str]`, `whenEmpty: Optional[LanguageGroupFallback]`.
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: FAIL with ImportError.
+
+**Step 3: Implement**
+
+```python
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+
+
+class ResolvedGroup(BaseModel):
+    languages: List[str]
+    whenEmpty: Optional[LanguageGroupFallback] = None
+
+
+def build_partition(
+    env_groups: List[LanguageGroup],
+    all_languages: List[str],
+) -> List[ResolvedGroup]:
+    """Build a disjoint partition: explicit env groups first (in order), then an
+    implicit singleton for every language not covered by an explicit group."""
+    grouped: set[str] = set()
+    result: List[ResolvedGroup] = []
+    for group in env_groups:
+        result.append(
+            ResolvedGroup(languages=list(group.languages), whenEmpty=group.whenEmpty)
+        )
+        grouped.update(group.languages)
+    for lang in all_languages:
+        if lang not in grouped:
+            result.append(ResolvedGroup(languages=[lang]))
+            grouped.add(lang)
+    return result
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing_groups.py tests/rbx/box/test_timing_groups.py
+# commit: feat(timing): add pure language-group partition builder
+```
+
+---
+
+## Task 4: Pure group resolution → reports + per-language TLs
+
+This is the heart: given per-group pooled timings and a formula evaluator, produce the base TL, the per-group `TimingGroupReport`s, and the expanded `lang -> tl` modifier map. Empty groups resolve via `whenEmpty` (transitively, acyclic).
+
+**Files:**
+- Modify: `rbx/box/timing_groups.py`
+- Test: `tests/rbx/box/test_timing_groups.py` (extend)
+
+**Step 1: Write the failing tests**
+
+```python
+from rbx.box.schema import TimingGroupOrigin
+from rbx.box.timing_groups import GroupTimings, resolve_groups
+
+
+def _eval(fastest, slowest):
+    # simple deterministic formula for tests: max(fastest*3, slowest*2)
+    return max(fastest * 3, slowest * 2)
+
+
+def test_resolves_estimated_and_multiplier_and_default_groups():
+    groups = [
+        ResolvedGroup(languages=['c', 'cpp']),
+        ResolvedGroup(
+            languages=['java', 'kotlin'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=4.0),
+        ),
+        ResolvedGroup(languages=['go']),  # empty, no whenEmpty -> DEFAULTED
+        ResolvedGroup(languages=['python']),
+    ]
+    timings = {
+        'cpp': GroupTimings(fastest=100, slowest=200, solution_count=2),
+        'python': GroupTimings(fastest=500, slowest=500, solution_count=1),
+    }
+    # keyed by GROUP INDEX -> pooled timings of that group (only non-empty groups present)
+    pooled = {0: timings['cpp'], 3: timings['python']}
+    base = GroupTimings(fastest=100, slowest=500, solution_count=3)
+
+    result = resolve_groups(groups, pooled, base, _eval)
+
+    assert result.base_time_limit == _eval(100, 500)  # 1000
+    by_lang = result.time_limit_per_language
+    # cpp group estimated
+    assert by_lang['cpp'] == _eval(100, 200)  # 400
+    assert by_lang['c'] == 400
+    # jvm group: multiplier of cpp's TL
+    assert by_lang['java'] == int(400 * 4.0)
+    assert by_lang['kotlin'] == int(400 * 4.0)
+    # go defaulted to base -> NO modifier emitted (uses base TL)
+    assert 'go' not in by_lang
+    # python estimated
+    assert by_lang['python'] == _eval(500, 500)  # 1500
+
+    origins = {tuple(r.languages): r.origin for r in result.reports}
+    assert origins[('c', 'cpp')] == TimingGroupOrigin.ESTIMATED
+    assert origins[('java', 'kotlin')] == TimingGroupOrigin.MULTIPLIER
+    assert origins[('go',)] == TimingGroupOrigin.DEFAULTED
+    assert result.defaulted_languages == ['go']
+
+
+def test_multiplier_relative_to_base_when_relative_to_omitted():
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['java'],
+            whenEmpty=LanguageGroupFallback(multiplier=3.0),
+        ),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=100, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=100, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval)
+    assert result.time_limit_per_language['java'] == int(result.base_time_limit * 3.0)
+
+
+def test_multiplier_chain_through_another_empty_group():
+    # jvm relativeTo cpp; mobile relativeTo java -> resolves transitively
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['java'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        ),
+        ResolvedGroup(
+            languages=['dart'],
+            whenEmpty=LanguageGroupFallback(relativeTo='java', multiplier=2.0),
+        ),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=100, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=100, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval)
+    cpp_tl = result.time_limit_per_language['cpp']
+    assert result.time_limit_per_language['java'] == cpp_tl * 2
+    assert result.time_limit_per_language['dart'] == cpp_tl * 2 * 2
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: FAIL with ImportError (`GroupTimings`, `resolve_groups`).
+
+**Step 3: Implement**
+
+Add to `rbx/box/timing_groups.py`:
+
+```python
+from typing import Callable
+
+from rbx.box.schema import TimingGroupOrigin, TimingGroupReport
+
+
+class GroupTimings(BaseModel):
+    fastest: int
+    slowest: int
+    solution_count: int
+
+
+class ResolutionResult(BaseModel):
+    base_time_limit: int
+    reports: List[TimingGroupReport]
+    time_limit_per_language: Dict[str, int]
+    defaulted_languages: List[str]
+
+
+EvalFn = Callable[[int, int], int]
+
+
+def _lang_to_group_index(groups: List[ResolvedGroup]) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    for idx, group in enumerate(groups):
+        for lang in group.languages:
+            out[lang] = idx
+    return out
+
+
+def resolve_groups(
+    groups: List[ResolvedGroup],
+    pooled: Dict[int, GroupTimings],  # group index -> pooled timings (non-empty only)
+    base: GroupTimings,
+    eval_fn: EvalFn,
+) -> ResolutionResult:
+    base_tl = eval_fn(base.fastest, base.slowest)
+    lang_index = _lang_to_group_index(groups)
+
+    resolved_tl: Dict[int, int] = {}
+    resolved_report: Dict[int, TimingGroupReport] = {}
+    resolving: set[int] = set()  # cycle guard (validation should prevent cycles)
+
+    def resolve(idx: int) -> int:
+        if idx in resolved_tl:
+            return resolved_tl[idx]
+        if idx in resolving:
+            # Acyclic is guaranteed by env validation; fall back defensively.
+            return base_tl
+        resolving.add(idx)
+        group = groups[idx]
+        timings = pooled.get(idx)
+        if timings is not None:
+            tl = eval_fn(timings.fastest, timings.slowest)
+            report = TimingGroupReport(
+                languages=list(group.languages),
+                timeLimit=tl,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=timings.solution_count,
+                fastest=timings.fastest,
+                slowest=timings.slowest,
+            )
+        elif group.whenEmpty is not None:
+            ref = group.whenEmpty.relativeTo
+            ref_tl = base_tl if ref is None else resolve(lang_index[ref])
+            tl = int(ref_tl * group.whenEmpty.multiplier)
+            report = TimingGroupReport(
+                languages=list(group.languages),
+                timeLimit=tl,
+                origin=TimingGroupOrigin.MULTIPLIER,
+                solutionCount=0,
+                relativeToLanguage=ref,
+                multiplier=group.whenEmpty.multiplier,
+            )
+        else:
+            tl = base_tl
+            report = TimingGroupReport(
+                languages=list(group.languages),
+                timeLimit=tl,
+                origin=TimingGroupOrigin.DEFAULTED,
+                solutionCount=0,
+            )
+        resolving.discard(idx)
+        resolved_tl[idx] = tl
+        resolved_report[idx] = report
+        return tl
+
+    for idx in range(len(groups)):
+        resolve(idx)
+
+    reports = [resolved_report[i] for i in range(len(groups))]
+    tl_per_language: Dict[str, int] = {}
+    defaulted: List[str] = []
+    for idx, group in enumerate(groups):
+        report = resolved_report[idx]
+        if report.origin == TimingGroupOrigin.DEFAULTED:
+            defaulted.extend(group.languages)
+            continue  # uses base TL -> no modifier
+        for lang in group.languages:
+            tl_per_language[lang] = report.timeLimit
+    return ResolutionResult(
+        base_time_limit=base_tl,
+        reports=reports,
+        time_limit_per_language=tl_per_language,
+        defaulted_languages=defaulted,
+    )
+```
+
+Note: DEFAULTED groups emit no modifier (they intentionally use the base TL); this is the "loud warning" case surfaced via `defaulted_languages`.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: PASS (all tests).
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing_groups.py tests/rbx/box/test_timing_groups.py
+# commit: feat(timing): resolve per-group time limits with empty-group fallback
+```
+
+---
+
+## Task 5: env-side `whenEmpty.relativeTo` validation
+
+`relativeTo` must name a known group language and resolve to a *different* group, and `whenEmpty` chains must be acyclic. This needs the full env (all languages), so validate it in a helper called during `rbx time` rather than inside `TimingConfig` (which doesn't know all env languages). Add a pure validator to `timing_groups.py`.
+
+**Files:**
+- Modify: `rbx/box/timing_groups.py`
+- Test: `tests/rbx/box/test_timing_groups.py` (extend)
+
+**Step 1: Write the failing tests**
+
+```python
+import pytest
+
+from rbx.box.timing_groups import GroupValidationError, validate_partition
+
+
+def test_relative_to_unknown_language_errors():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(
+                languages=['java'],
+                whenEmpty=LanguageGroupFallback(relativeTo='rust', multiplier=2.0),
+            )
+        ],
+        all_languages=['java'],
+    )
+    with pytest.raises(GroupValidationError, match='rust'):
+        validate_partition(groups)
+
+
+def test_relative_to_same_group_errors():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='kotlin', multiplier=2.0),
+            )
+        ],
+        all_languages=['java', 'kotlin'],
+    )
+    with pytest.raises(GroupValidationError, match='same group'):
+        validate_partition(groups)
+
+
+def test_cyclic_when_empty_errors():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(
+                languages=['a'],
+                whenEmpty=LanguageGroupFallback(relativeTo='b', multiplier=2.0),
+            ),
+            LanguageGroup(
+                languages=['b'],
+                whenEmpty=LanguageGroupFallback(relativeTo='a', multiplier=2.0),
+            ),
+        ],
+        all_languages=['a', 'b'],
+    )
+    with pytest.raises(GroupValidationError, match='cycle'):
+        validate_partition(groups)
+
+
+def test_valid_partition_passes():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(languages=['cpp']),
+            LanguageGroup(
+                languages=['java'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            ),
+        ],
+        all_languages=['cpp', 'java'],
+    )
+    validate_partition(groups)  # no raise
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: FAIL with ImportError.
+
+**Step 3: Implement**
+
+```python
+class GroupValidationError(ValueError):
+    pass
+
+
+def validate_partition(groups: List[ResolvedGroup]) -> None:
+    lang_index = _lang_to_group_index(groups)
+    # reference target existence + not-self
+    for idx, group in enumerate(groups):
+        if group.whenEmpty is None or group.whenEmpty.relativeTo is None:
+            continue
+        ref = group.whenEmpty.relativeTo
+        if ref not in lang_index:
+            raise GroupValidationError(
+                f'whenEmpty.relativeTo references unknown language {ref!r}.'
+            )
+        if lang_index[ref] == idx:
+            raise GroupValidationError(
+                f'whenEmpty.relativeTo {ref!r} points to the same group; it must '
+                'reference a different group.'
+            )
+    # cycle detection over group-to-group reference edges
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = [WHITE] * len(groups)
+
+    def visit(idx: int) -> None:
+        color[idx] = GRAY
+        group = groups[idx]
+        if group.whenEmpty is not None and group.whenEmpty.relativeTo is not None:
+            nxt = lang_index[group.whenEmpty.relativeTo]
+            if color[nxt] == GRAY:
+                raise GroupValidationError(
+                    'whenEmpty.relativeTo forms a cycle between timing groups.'
+                )
+            if color[nxt] == WHITE:
+                visit(nxt)
+        color[idx] = BLACK
+
+    for idx in range(len(groups)):
+        if color[idx] == WHITE:
+            visit(idx)
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing_groups.py tests/rbx/box/test_timing_groups.py
+# commit: feat(timing): validate whenEmpty references and reject cycles
+```
+
+---
+
+## Task 6: Shared limits table renderer
+
+A single renderer used by both `rbx time` and the BOCA packager so the table is identical. Reads a `LimitsProfile`; uses `groups` metadata when present, else degrades to per-language/base rows.
+
+**Files:**
+- Modify: `rbx/box/limits_info.py` (add `render_limits_table`)
+- Test: `tests/rbx/box/test_limits_table.py` (create)
+
+**Step 1: Write the failing test** (assert on the structured rows, not exact rich formatting)
+
+```python
+from rbx.box.limits_info import build_limits_table_rows
+from rbx.box.schema import (
+    LimitsProfile,
+    LimitModifiers,
+    TimingGroupOrigin,
+    TimingGroupReport,
+)
+
+
+def test_rows_from_group_metadata():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        modifiers={'cpp': LimitModifiers(time=1000)},
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+            TimingGroupReport(
+                languages=['go'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+            ),
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    assert rows[0].languages == 'c, cpp'
+    assert rows[0].time_limit_ms == 1000
+    assert rows[0].solutions == 2
+    assert 'estimated' in rows[0].source.lower()
+    assert rows[1].defaulted is True
+    assert 'default' in rows[1].source.lower()
+
+
+def test_rows_degrade_without_group_metadata():
+    profile = LimitsProfile(
+        timeLimit=2000, modifiers={'python': LimitModifiers(time=5000)}
+    )
+    rows = build_limits_table_rows(profile)
+    # one base row + one per-language modifier row, in some defined order
+    langs = {r.languages for r in rows}
+    assert 'python' in langs
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_limits_table.py -v`
+Expected: FAIL with ImportError.
+
+**Step 3: Implement**
+
+In `rbx/box/limits_info.py` add a small row model + builder + renderer. Keep `build_limits_table_rows` pure (testable); `render_limits_table` wraps it in a `rich.table.Table`.
+
+```python
+from pydantic import BaseModel  # add if not present
+from rbx.box.schema import TimingGroupOrigin  # add to existing schema import
+
+
+class LimitsTableRow(BaseModel):
+    languages: str
+    solutions: Optional[int]
+    time_limit_ms: int
+    source: str
+    defaulted: bool = False
+
+
+def build_limits_table_rows(profile: LimitsProfile) -> list[LimitsTableRow]:
+    rows: list[LimitsTableRow] = []
+    if profile.groups:
+        for report in profile.groups:
+            if report.origin == TimingGroupOrigin.ESTIMATED:
+                source = f'estimated (fastest {report.fastest} / slowest {report.slowest})'
+            elif report.origin == TimingGroupOrigin.MULTIPLIER:
+                ref = report.relativeToLanguage or 'base'
+                source = f'×{report.multiplier} of {ref}'
+            else:
+                source = 'DEFAULTED to base'
+            rows.append(
+                LimitsTableRow(
+                    languages=', '.join(report.languages),
+                    solutions=report.solutionCount,
+                    time_limit_ms=report.timeLimit,
+                    source=source,
+                    defaulted=report.origin == TimingGroupOrigin.DEFAULTED,
+                )
+            )
+        return rows
+    # Degraded view: base row + each per-language modifier override.
+    base = profile.timeLimit or 0
+    rows.append(
+        LimitsTableRow(
+            languages='(base)', solutions=None, time_limit_ms=base, source='base'
+        )
+    )
+    for lang, mod in sorted(profile.modifiers.items()):
+        if mod.time is not None:
+            rows.append(
+                LimitsTableRow(
+                    languages=lang,
+                    solutions=None,
+                    time_limit_ms=mod.time,
+                    source='override',
+                )
+            )
+    return rows
+
+
+def render_limits_table(profile: LimitsProfile, title: str = 'Time limits') -> None:
+    import rich.table
+
+    table = rich.table.Table(title=title, show_lines=False)
+    table.add_column('Languages')
+    table.add_column('Solutions', justify='right')
+    table.add_column('Time Limit', justify='right')
+    table.add_column('Source')
+    for row in build_limits_table_rows(profile):
+        sols = '' if row.solutions is None else str(row.solutions)
+        tl = f'{row.time_limit_ms} ms'
+        if row.defaulted:
+            table.add_row(
+                f'[warning]{row.languages}[/warning]',
+                sols,
+                f'[warning]{tl}[/warning]',
+                f'[warning]⚠ {row.source}[/warning]',
+            )
+        else:
+            table.add_row(row.languages, sols, tl, row.source)
+    console.console.print(table)
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_limits_table.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/limits_info.py tests/rbx/box/test_limits_table.py
+# commit: feat(timing): add shared per-group limits table renderer
+```
+
+---
+
+## Task 7: Interactive repartition helper
+
+A pure helper that turns a `{language: group_number}` map into a partition, applying the `whenEmpty` preservation rule (carry over env `whenEmpty` only for groups whose membership is byte-identical to an env group). The `questionary` prompt is a thin wrapper added in Task 8.
+
+**Files:**
+- Modify: `rbx/box/timing_groups.py`
+- Test: `tests/rbx/box/test_timing_groups.py` (extend)
+
+**Step 1: Write the failing tests**
+
+```python
+from rbx.box.timing_groups import partition_from_assignment
+
+
+def test_assignment_zero_makes_singletons():
+    env_groups = [LanguageGroup(languages=['c', 'cpp'])]
+    groups = partition_from_assignment(
+        assignment={'c': 0, 'cpp': 0, 'python': 0},
+        env_groups=env_groups,
+    )
+    assert sorted(g.languages for g in groups) == [['c'], ['cpp'], ['python']]
+
+
+def test_identical_membership_preserves_when_empty():
+    env_groups = [
+        LanguageGroup(
+            languages=['java', 'kotlin'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        )
+    ]
+    # user kept java+kotlin together as group 1
+    groups = partition_from_assignment(
+        assignment={'java': 1, 'kotlin': 1, 'cpp': 2},
+        env_groups=env_groups,
+    )
+    jvm = next(g for g in groups if set(g.languages) == {'java', 'kotlin'})
+    assert jvm.whenEmpty is not None and jvm.whenEmpty.multiplier == 2.0
+
+
+def test_changed_membership_drops_when_empty():
+    env_groups = [
+        LanguageGroup(
+            languages=['java', 'kotlin'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        )
+    ]
+    # user added scala to the jvm bucket -> membership changed -> drop whenEmpty
+    groups = partition_from_assignment(
+        assignment={'java': 1, 'kotlin': 1, 'scala': 1},
+        env_groups=env_groups,
+    )
+    jvm = next(g for g in groups if 'java' in g.languages)
+    assert jvm.whenEmpty is None
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: FAIL with ImportError.
+
+**Step 3: Implement**
+
+```python
+def partition_from_assignment(
+    assignment: Dict[str, int],
+    env_groups: List[LanguageGroup],
+) -> List[ResolvedGroup]:
+    """Build groups from a {language: number} map. 0 = own singleton; N>=1 share a
+    bucket. Carries over an env group's whenEmpty only when the resulting membership
+    is identical to that env group."""
+    # number -> languages (preserve insertion order of assignment for stability)
+    buckets: Dict[int, List[str]] = {}
+    singletons: List[List[str]] = []
+    for lang, number in assignment.items():
+        if number == 0:
+            singletons.append([lang])
+        else:
+            buckets.setdefault(number, []).append(lang)
+
+    env_when_empty = {
+        frozenset(g.languages): g.whenEmpty for g in env_groups
+    }
+    result: List[ResolvedGroup] = []
+    for _, langs in sorted(buckets.items()):
+        when_empty = env_when_empty.get(frozenset(langs))
+        result.append(ResolvedGroup(languages=langs, whenEmpty=when_empty))
+    result.extend(ResolvedGroup(languages=s) for s in singletons)
+    return result
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing_groups.py tests/rbx/box/test_timing_groups.py
+# commit: feat(timing): build partition from interactive group assignment
+```
+
+---
+
+## Task 8: Rewrite `estimate_time_limit` to be group-aware
+
+Replace the per-language selection block (`timing.py` lines 150–181) with grouping. Build the partition from env groups + all env languages, validate it, optionally run the interactive repartition prompt (skipped under `--auto`), pool timings per group, resolve, populate `TimingProfile` with `timeLimitPerLanguage` (= resolved modifiers) and the new `groups` reports, and print the DEFAULTED warning.
+
+**Files:**
+- Modify: `rbx/box/timing.py` (`TimingProfile` lines 25–38; `estimate_time_limit` lines 60–181)
+- Test: `tests/rbx/box/test_timing_estimation.py` (create) — drive `estimate_time_limit` with a fabricated `RunSolutionResult`, OR refactor the timing-collection and resolution into a thin seam and test the seam. **Prefer** extracting a pure `_build_timing_profile(timing_per_solution_per_language, formula_eval, env_groups, all_languages, repartition=None)` so it is unit-testable without sandbox/questionary.
+
+**Step 1: Write the failing test (against the extracted pure seam)**
+
+```python
+from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+from rbx.box.schema import TimingGroupOrigin
+from rbx.box.timing import build_timing_profile
+
+
+def test_build_timing_profile_groups_languages():
+    # per-language -> {solution_path: max_timing_ms}
+    timings = {
+        'cpp': {'a.cpp': 100, 'b.cpp': 150},
+        'python': {'p.py': 500},
+    }
+    profile = build_timing_profile(
+        timing_per_solution_per_language=timings,
+        formula='max(fastest * 3, slowest * 2)',
+        env_groups=[
+            LanguageGroup(languages=['c', 'cpp']),
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=4.0),
+            ),
+        ],
+        all_languages=['c', 'cpp', 'java', 'kotlin', 'python'],
+    )
+    limits = profile.to_limits()
+    assert limits.modifiers['java'].time == limits.modifiers['cpp'].time * 4
+    assert limits.modifiers['c'].time == limits.modifiers['cpp'].time
+    assert limits.groups is not None
+    origins = {tuple(r.languages): r.origin for r in limits.groups}
+    assert origins[('java', 'kotlin')] == TimingGroupOrigin.MULTIPLIER
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_estimation.py -v`
+Expected: FAIL with ImportError (`build_timing_profile`).
+
+**Step 3: Implement**
+
+1. Extend `TimingProfile` (timing.py lines 25–38) to carry reports and wire them into `to_limits()`:
+
+```python
+class TimingProfile(BaseModel):
+    timeLimit: int
+    formula: Optional[str] = None
+    timeLimitPerLanguage: Dict[str, int] = Field(default_factory=dict)
+    groups: Optional[List[schema.TimingGroupReport]] = None
+
+    def to_limits(self):
+        return schema.LimitsProfile(
+            timeLimit=self.timeLimit,
+            formula=self.formula,
+            modifiers={
+                lang: schema.LimitModifiers(time=tl)
+                for lang, tl in self.timeLimitPerLanguage.items()
+            },
+            groups=self.groups,
+        )
+```
+
+2. Add the pure seam `build_timing_profile(...)`:
+
+```python
+from rbx.box import timing_groups
+
+
+def build_timing_profile(
+    timing_per_solution_per_language: Dict[str, Dict[str, int]],
+    formula: str,
+    env_groups,  # List[environment.LanguageGroup]
+    all_languages,  # List[str]
+    repartition: Optional[Dict[str, int]] = None,
+) -> TimingProfile:
+    def _eval(fastest: int, slowest: int) -> int:
+        return int(
+            safeeval.eval_int(formula, {'fastest': fastest, 'slowest': slowest})
+        )
+
+    if repartition is not None:
+        groups = timing_groups.partition_from_assignment(repartition, env_groups)
+    else:
+        groups = timing_groups.build_partition(env_groups, all_languages)
+    timing_groups.validate_partition(groups)
+
+    # Pool timings per group index.
+    pooled: Dict[int, timing_groups.GroupTimings] = {}
+    all_values = []
+    for idx, group in enumerate(groups):
+        values = []
+        count = 0
+        for lang in group.languages:
+            per_sol = timing_per_solution_per_language.get(lang, {})
+            values.extend(per_sol.values())
+            count += len(per_sol)
+        if values:
+            pooled[idx] = timing_groups.GroupTimings(
+                fastest=min(values), slowest=max(values), solution_count=count
+            )
+            all_values.extend(values)
+
+    base = timing_groups.GroupTimings(
+        fastest=min(all_values), slowest=max(all_values), solution_count=len(all_values)
+    )
+    result = timing_groups.resolve_groups(groups, pooled, base, _eval)
+    return TimingProfile(
+        timeLimit=result.base_time_limit,
+        formula=formula,
+        timeLimitPerLanguage=result.time_limit_per_language,
+        groups=result.reports,
+    )
+```
+
+3. Rewrite `estimate_time_limit` (lines 150–181 region) to: build `all_languages = [l.name for l in environment.get_environment().languages]` and `env_groups = environment.get_environment().timing.groups`; when not `auto` AND more than one group would be non-trivial, run the interactive repartition prompt (Step 3b) to get an `assignment`; call `build_timing_profile(...)`; if `result`/profile has DEFAULTED languages, print a loud warning. Then `return profile`. Remove the old `questionary.checkbox` block (lines 162–175) and the `final_estimated_tls_per_language` logic.
+
+   Keep the existing fastest/slowest **run report** prints (lines 99–148) — they are still useful — but the per-language TL decision now comes from grouping.
+
+**Step 3b: Interactive repartition prompt** (only when `not auto`). Add a helper in `timing.py`:
+
+```python
+async def _prompt_repartition(
+    all_languages: List[str], env_groups
+) -> Optional[Dict[str, int]]:
+    # Prepopulate numbers from env groups: group #1 -> 1, ...; unlisted -> 0.
+    default_number: Dict[str, int] = {lang: 0 for lang in all_languages}
+    for i, group in enumerate(env_groups, start=1):
+        for lang in group.languages:
+            default_number[lang] = i
+    assignment: Dict[str, int] = {}
+    for lang in all_languages:
+        answer = await questionary.text(
+            f'Group number for {lang} (0 = its own group)',
+            default=str(default_number[lang]),
+            validate=lambda x: x.isdigit(),
+        ).ask_async()
+        if answer is None:
+            return None
+        assignment[lang] = int(answer)
+    return assignment
+```
+
+(Only prompt for languages that actually have solutions plus those listed in env groups — to avoid prompting for every exotic language. Filter `all_languages` to `set(langs_with_timings) | set(env-grouped langs)` before prompting. Document this filter in a comment.)
+
+DEFAULTED warning (after building the profile):
+
+```python
+defaulted = [
+    lang
+    for report in (profile.groups or [])
+    if report.origin == schema.TimingGroupOrigin.DEFAULTED
+    for lang in report.languages
+]
+if defaulted:
+    console.print(
+        '[warning]⚠ The following languages have no solution and no whenEmpty rule, '
+        f'so they fall back to the base time limit of {profile.timeLimit} ms: '
+        f'{", ".join(defaulted)}.[/warning]'
+    )
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_estimation.py -v`
+Expected: PASS.
+Then full timing module: `uv run pytest tests/rbx/box -k 'timing or limits or group' -v`.
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing.py tests/rbx/box/test_timing_estimation.py
+# commit: feat(timing): estimate time limits per language group
+```
+
+---
+
+## Task 9: `rbx time` always renders the table
+
+After `compute_time_limits` writes the profile (`timing.py` lines 238–244), render the shared table (always, regardless of `--detailed`).
+
+**Files:**
+- Modify: `rbx/box/timing.py` (`compute_time_limits`, after line 244)
+- Test: covered by Task 8 unit tests + a light CLI smoke is optional (CLI tests are slow/excluded). Add an assertion-light test only if a fast fixture exists; otherwise verify manually (Step 4).
+
+**Step 1–3: Implement**
+
+After writing `limits_path` in `compute_time_limits`, add:
+
+```python
+from rbx.box import limits_info
+
+limits_info.render_limits_table(
+    estimated_tl.to_limits(), title=f'Time limits ({profile})'
+)
+```
+
+Replace the raw `console.console.print(estimated_tl, highlight=True)` (line 242) with the table for the estimate strategy (keep the "Writing the following timing profile to ..." line). Keep `pretty_print_profile` for `inherit`/`custom` paths.
+
+**Step 4: Manual verification**
+
+In a fixture problem with multi-language accepted solutions and an `env.rbx.yml` defining `timing.groups`, run:
+`uv run rbx time -p boca --auto` and confirm the table prints with one row per group, DEFAULTED rows highlighted.
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing.py
+# commit: feat(timing): always show per-group table after rbx time
+```
+
+---
+
+## Task 10: BOCA packager prints the table last
+
+Render the same table from the saved `.limits/boca.yml` at the END of `BocaPackager.package()`, after all scripts are written (so DEFAULTED warnings are the final output). No error on DEFAULTED.
+
+**Files:**
+- Modify: `rbx/box/packaging/boca/packager.py` (`package()`, return statement region after line 403; add the render just before `return`)
+- Test: `tests/rbx/box/packaging/test_boca_limits_table.py` (create) — call `build_limits_table_rows` against a constructed `boca` profile to assert the rows the packager would show. (Full packaging e2e is heavy; keep the unit test on the renderer + a check that `package()` calls it.)
+
+**Step 1: Write the failing test**
+
+```python
+from rbx.box.limits_info import build_limits_table_rows
+from rbx.box.schema import LimitsProfile, TimingGroupOrigin, TimingGroupReport
+
+
+def test_boca_table_flags_defaulted_language():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['java'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+            )
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    assert rows[0].defaulted is True
+```
+
+**Step 2: Run to verify it fails / passes**
+
+Run: `uv run pytest tests/rbx/box/packaging/test_boca_limits_table.py -v`
+(This passes already if Task 6 is done; it documents the BOCA expectation. The behavioral wiring is verified manually in Step 4.)
+
+**Step 3: Implement**
+
+At the end of `package()` (just before `return ...`), add:
+
+```python
+from rbx.box import limits_info
+
+boca_profile = limits_info.get_saved_limits_profile('boca')
+if boca_profile is not None:
+    limits_info.render_limits_table(
+        boca_profile, title='BOCA time limits (per language group)'
+    )
+```
+
+Place this as the last statement before the method returns its path, so it is the final console output of the packaging step.
+
+**Step 4: Manual verification**
+
+`uv run rbx package boca` on a fixture with a `boca` profile; confirm the table is the last thing printed and DEFAULTED rows are highlighted, with no error raised.
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/packaging/boca/packager.py tests/rbx/box/packaging/test_boca_limits_table.py
+# commit: feat(boca): print per-group time-limit table at end of packaging
+```
+
+---
+
+## Task 11: Documentation + module guides
+
+**Files:**
+- Modify: `rbx/box/CLAUDE.md` (Schema System: note `TimingGroupReport`/`TimingGroupOrigin`; Environment: note `timing.groups`)
+- Modify: any user-facing docs for `env.rbx.yml` / `rbx time` under `docs/` (search for existing timing docs: `grep -rl "rbx time\|timeLimit\|env.rbx.yml" docs`)
+- Test: docs build — `uv run mkdocs build` (non-strict; per memory, ~9 pre-existing strict warnings are unrelated — do not chase them).
+
+**Steps:**
+1. Document `timing.groups`, `whenEmpty.relativeTo`/`multiplier`, implicit singletons, and the DEFAULTED warning behavior.
+2. Add a short example matching the design doc's `env.rbx.yml` snippet.
+3. Build docs non-strict to confirm no new errors.
+4. Commit: `docs: document language groups for time-limit estimation`.
+
+---
+
+## Final verification (before finishing the branch)
+
+Run the full non-CLI suite plus our new tests:
+
+```bash
+uv run pytest --ignore=tests/rbx/box/cli -k 'timing or limits or group or environment or boca' -v
+uv run pytest --ignore=tests/rbx/box/cli -n auto
+uv run ruff check . && uv run ruff format --check .
+```
+
+Expected: our new tests pass; any failures are limited to the known pre-existing C++/checker/validator/sandbox/docker cases on this machine (see memory). Then use superpowers:finishing-a-development-branch to integrate.
+
+## Notes / decisions baked in
+- **DRY:** all grouping math lives in `timing_groups.py`; the table renderer is shared by `rbx time` and BOCA.
+- **YAGNI:** no memory/output grouping; no first-class group resolution in `LimitsProfile`; `groups` metadata is presentation-only.
+- **Backward compat:** `LimitsProfile.groups` is optional; old `.limits/*.yml` load unchanged; `timelimit_for_language` and BOCA resolution paths are untouched.
+- **DEFAULTED languages** intentionally emit no per-language modifier (they use base TL) and are surfaced via a loud warning + highlighted table rows.

--- a/docs/plans/2026-06-01-three-state-language-bucketing-design.md
+++ b/docs/plans/2026-06-01-three-state-language-bucketing-design.md
@@ -1,0 +1,121 @@
+# Three-state language bucketing in `rbx time` (refines #497 / PR #499)
+
+Date: 2026-06-01
+Refines: `docs/plans/2026-06-01-language-groups-timing-design.md`
+PR: https://github.com/rsalesc/rbx/pull/499
+
+## Motivation
+
+The original language-groups design gave every language exactly two fates: a member
+of an explicit env group, or an **implicit singleton** (its own pool). Languages not
+listed in any env group therefore each became a singleton.
+
+That collapses two genuinely different intents into one:
+
+- "Estimate this language on its own" (a deliberate, isolated bucket), and
+- "I didn't configure this language; lump it with the other leftovers."
+
+We split them into **three** states, and change the default for unconfigured
+languages from *singleton* to *unbucketed (leftover pool)*.
+
+## The three states
+
+Every language in scope is in exactly one state:
+
+| State | Box | Meaning at resolution |
+|-------|-----|-----------------------|
+| (a) Explicit group | `[N]` | Pools with all other `[N]` languages. `whenEmpty` carries over iff membership exactly matches an env group. |
+| (b) Singleton | `[X]` | Its own pool. Has solutions → own estimate; empty → DEFAULTED to base + warning. "Isolate this language; don't let it ride the leftover pool." |
+| (c) Unbucketed | `[ ]` | Joins the single shared **leftover pool**. Pool has any solutions → all members inherit that pooled estimate; pool empty → all DEFAULTED to base + one warning. **New default for unconfigured languages.** |
+
+### Why a leftover pool (and not base TL directly)
+
+When the unbucketed set has **no** accepted solutions (the common #497 case:
+java/go/etc. with no solution), an empty leftover pool DEFAULTs to *exactly* the base
+TL anyway — so there is no numerical change, only better visibility (one grouped
+DEFAULTED row + warning instead of an invisible base fallback).
+
+The leftover pool only changes the *number* when the unbucketed set itself contains
+solutions: then its TL is `formula(fastest, slowest)` over **only** those languages'
+timings, and unrepresented members inherit that sibling estimate instead of the global
+base. This is the intended win.
+
+## Scope change: all env languages participate
+
+`relevant_languages_for_estimation()` previously returned only languages that had
+solutions, were in an env group, or were a `whenEmpty.relativeTo` target. An env
+language with no solution and no group never entered the picker and silently rode the
+base TL — the #497 symptom, just narrowed.
+
+It now returns **all env languages** (still unioning in `whenEmpty` refs and any stray
+timing languages), ordered by the environment's language order. This is what places
+unrepresented languages into the picker and into the leftover pool / DEFAULTED warning.
+
+Consequence: `--auto` output changes slightly for problems that declare languages with
+no solutions — they now appear as one DEFAULTED leftover row instead of being absent.
+
+## Picker UX
+
+Single-screen picker, one row per language, each row showing its box.
+
+Keybindings:
+
+- `1`–`9` — assign group `[N]`
+- `Space` / `Tab` — toggle the current language between singleton `[X]` and unbucketed
+  `[ ]` (from a numbered `[N]`, the first press goes to `[X]`)
+- `Enter` — submit
+- `q` / `Ctrl-C` — cancel
+
+Prepopulation:
+
+- Env-grouped languages → their group number `[N]` (single-member env groups stay
+  `[N]`, preserving `whenEmpty`).
+- All other env languages → unbucketed `[ ]`.
+- `[X]` is never a default; reachable only via toggle.
+
+## Data model
+
+Each language's state is an int in the assignment map:
+
+- `N ≥ 1` → group N
+- `0` → unbucketed (leftover pool)
+- `-1` → singleton
+
+This redefines today's `0` (was "singleton") to mean "unbucketed", so the existing
+`{lang: 0}` prepopulation default flips to the new default for free.
+
+## Partition building
+
+- `partition_from_assignment(assignment, env_groups)`:
+  - `N ≥ 1` → shared buckets; carry an env group's `whenEmpty` only on exact-membership
+    match (unchanged rule).
+  - each `-1` → its own singleton group.
+  - all `0` → **one** leftover-pool group (no `whenEmpty`). Omitted if empty.
+- `build_partition(env_groups, all_languages)` (the `--auto` / non-interactive path):
+  env groups verbatim, then **one** leftover group of all remaining languages, instead
+  of N implicit singletons.
+
+## Unchanged
+
+`resolve_groups` and the limits-table renderer need no changes: both already handle
+multi-language groups, the ESTIMATED / MULTIPLIER / DEFAULTED origins, and DEFAULTED
+highlighting. The leftover pool flows through as one ordinary group / row.
+
+## Tests
+
+- `test_timing_group_picker.py` — toggle to `[X]`, toggle back to `[ ]`, number → group,
+  prepopulation defaults (env-grouped → `[N]`, others → `[ ]`), Enter submits.
+- `test_timing_groups.py` — `partition_from_assignment` with all three states (one
+  leftover pool group, singletons separate); `build_partition` yields a single leftover
+  group.
+- `test_timing_estimation.py` — unrepresented languages inherit a non-empty leftover
+  pool; an empty leftover pool DEFAULTs and the warning lists all of them.
+- Update existing assertions that depend on the old "0 = singleton" / implicit-singleton
+  behavior.
+
+## Out of scope
+
+Unchanged from the original design: memory/output limit grouping, the global fallback
+default mechanism itself (we change *which* languages are visibly bucketed, not the
+DEFAULTED-to-base resolution), and Approach B (groups as a first-class resolution
+concept).

--- a/docs/plans/2026-06-01-three-state-language-bucketing.md
+++ b/docs/plans/2026-06-01-three-state-language-bucketing.md
@@ -1,0 +1,563 @@
+# Three-State Language Bucketing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the implicit-singleton default for unconfigured languages in `rbx time` with three explicit states — explicit group `[N]`, singleton `[X]`, and unbucketed `[ ]` (a single shared leftover pool, the new default) — and make all env languages participate.
+
+**Architecture:** Pure grouping logic stays in `timing_groups.py` (partition builders) and the interactive picker in `timing_group_picker.py`. The assignment map encodes state per language as an int: `N≥1` = group N, `0` = unbucketed, `-1` = singleton. `partition_from_assignment` / `build_partition` collapse all unbucketed languages into one `ResolvedGroup`. `resolve_groups` and the table renderer are unchanged. `timing.relevant_languages_for_estimation` widens scope to all env languages.
+
+**Tech Stack:** Python 3, Pydantic v2, prompt_toolkit (picker), pytest (`uv run pytest`).
+
+**Design:** `docs/plans/2026-06-01-three-state-language-bucketing-design.md`
+
+**Conventions:** Single quotes; absolute imports; commit via the `commit` skill workflow (`.claude/skills/commit.md`) — conventional commits, append `Co-Authored-By: Claude <noreply@anthropic.com>`. Run tests with `uv run pytest`.
+
+---
+
+## Task 1: Leftover pool in `build_partition`
+
+**Files:**
+- Modify: `rbx/box/timing_groups.py` (`build_partition`)
+- Test: `tests/rbx/box/test_timing_groups.py`
+
+**Step 1: Update the failing tests**
+
+In `tests/rbx/box/test_timing_groups.py`, replace `test_implicit_singletons_for_unlisted_languages` and `test_build_partition_with_no_env_groups_makes_all_singletons` with:
+
+```python
+def test_leftover_pool_for_unlisted_languages():
+    groups = build_partition(
+        env_groups=[LanguageGroup(languages=['c', 'cpp'])],
+        all_languages=['c', 'cpp', 'python', 'go'],
+    )
+    # one explicit group + ONE leftover pool of all unlisted languages, in order
+    assert [g.languages for g in groups] == [['c', 'cpp'], ['python', 'go']]
+    assert groups[0].whenEmpty is None
+    assert groups[1].whenEmpty is None
+
+
+def test_build_partition_with_no_env_groups_makes_one_leftover_pool():
+    groups = build_partition(env_groups=[], all_languages=['c', 'cpp', 'python'])
+    assert [g.languages for g in groups] == [['c', 'cpp', 'python']]
+
+
+def test_build_partition_no_leftover_when_all_grouped():
+    groups = build_partition(
+        env_groups=[LanguageGroup(languages=['c', 'cpp'])],
+        all_languages=['c', 'cpp'],
+    )
+    assert [g.languages for g in groups] == [['c', 'cpp']]
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -k "leftover or no_leftover or no_env_groups" -v`
+Expected: FAIL (current code emits one singleton group per unlisted language).
+
+**Step 3: Implement**
+
+Replace the trailing per-language loop in `build_partition` (`rbx/box/timing_groups.py`) so unlisted languages collapse into one group:
+
+```python
+def build_partition(
+    env_groups: List[LanguageGroup],
+    all_languages: List[str],
+) -> List[ResolvedGroup]:
+    """Build a disjoint partition: explicit env groups first (in order), then a
+    single leftover pool holding every language not covered by an explicit group."""
+    grouped: set[str] = set()
+    result: List[ResolvedGroup] = []
+    for group in env_groups:
+        result.append(
+            ResolvedGroup(languages=list(group.languages), whenEmpty=group.whenEmpty)
+        )
+        grouped.update(group.languages)
+    leftover = [lang for lang in all_languages if lang not in grouped]
+    if leftover:
+        result.append(ResolvedGroup(languages=leftover))
+    return result
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: PASS (all tests in the file).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/timing_groups.py tests/rbx/box/test_timing_groups.py
+git commit -m "$(cat <<'EOF'
+feat(timing): collapse unlisted languages into one leftover pool
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Three states in `partition_from_assignment`
+
+**Files:**
+- Modify: `rbx/box/timing_groups.py` (`partition_from_assignment`)
+- Test: `tests/rbx/box/test_timing_groups.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/rbx/box/test_timing_groups.py`:
+
+```python
+def test_partition_from_assignment_three_states():
+    # 1/2 = shared groups, -1 = singleton, 0 = unbucketed leftover pool
+    groups = partition_from_assignment(
+        assignment={
+            'c': 1,
+            'cpp': 1,
+            'java': 2,
+            'kotlin': 2,
+            'python': -1,
+            'go': 0,
+            'rust': 0,
+        },
+        env_groups=[],
+    )
+    langs = [g.languages for g in groups]
+    assert ['c', 'cpp'] in langs
+    assert ['java', 'kotlin'] in langs
+    assert ['python'] in langs          # singleton -> own group
+    assert ['go', 'rust'] in langs      # unbucketed -> ONE leftover pool
+    # numbered groups first (sorted), then singletons, then the leftover pool
+    assert langs[-1] == ['go', 'rust']
+
+
+def test_partition_from_assignment_no_leftover_group_when_none_unbucketed():
+    groups = partition_from_assignment(
+        assignment={'cpp': 1, 'python': -1},
+        env_groups=[],
+    )
+    assert [g.languages for g in groups] == [['cpp'], ['python']]
+
+
+def test_partition_from_assignment_preserves_when_empty_on_exact_match():
+    groups = partition_from_assignment(
+        assignment={'java': 1, 'kotlin': 1},
+        env_groups=[
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            ),
+        ],
+    )
+    assert groups[0].whenEmpty is not None
+    assert groups[0].whenEmpty.multiplier == 2.0
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -k "three_states or no_leftover_group or preserves_when_empty_on_exact" -v`
+Expected: FAIL (current code treats `0` as singleton and has no `-1`/leftover handling).
+
+**Step 3: Implement**
+
+Replace `partition_from_assignment` in `rbx/box/timing_groups.py`:
+
+```python
+def partition_from_assignment(
+    assignment: Dict[str, int],
+    env_groups: List[LanguageGroup],
+) -> List[ResolvedGroup]:
+    """Build groups from a {language: state} map. State per language:
+    N>=1 share bucket N; -1 = own singleton group; 0 = the shared leftover pool.
+    Carries over an env group's whenEmpty only when the resulting membership is
+    identical to that env group."""
+    buckets: Dict[int, List[str]] = {}
+    singletons: List[List[str]] = []
+    leftover: List[str] = []
+    for lang, state in assignment.items():
+        if state == 0:
+            leftover.append(lang)
+        elif state < 0:
+            singletons.append([lang])
+        else:
+            buckets.setdefault(state, []).append(lang)
+
+    env_when_empty = {frozenset(g.languages): g.whenEmpty for g in env_groups}
+    result: List[ResolvedGroup] = []
+    for _, langs in sorted(buckets.items()):
+        when_empty = env_when_empty.get(frozenset(langs))
+        result.append(ResolvedGroup(languages=langs, whenEmpty=when_empty))
+    result.extend(ResolvedGroup(languages=s) for s in singletons)
+    if leftover:
+        result.append(ResolvedGroup(languages=leftover))
+    return result
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/timing_groups.py tests/rbx/box/test_timing_groups.py
+git commit -m "$(cat <<'EOF'
+feat(timing): three-state partition (group/singleton/leftover)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Three-state picker UI
+
+**Files:**
+- Modify: `rbx/box/timing_group_picker.py`
+- Test: `tests/rbx/box/test_timing_group_picker.py`
+
+**Step 1: Update / add failing tests**
+
+In `tests/rbx/box/test_timing_group_picker.py`:
+
+Replace `test_render_fragments_marks_cursor_and_numbers` and add new tests:
+
+```python
+def test_render_fragments_shows_three_states():
+    # cpp -> group 3, java -> unbucketed (0), python -> singleton (-1)
+    s = GroupPickerState(['cpp', 'java', 'python'], {'cpp': 3, 'python': -1})
+    text = ''.join(t for _, t in s.render_fragments())
+    assert '[3] cpp' in text
+    assert '[ ] java' in text
+    assert '[X] python' in text
+    assert text.count('❯') == 1
+
+
+def test_toggle_singleton_cycles():
+    s = GroupPickerState(['cpp'], {'cpp': 0})
+    s.toggle_singleton()
+    assert s.assignment() == {'cpp': -1}  # unbucketed -> singleton
+    s.toggle_singleton()
+    assert s.assignment() == {'cpp': 0}  # singleton -> unbucketed
+
+
+def test_toggle_singleton_from_group_goes_to_singleton():
+    s = GroupPickerState(['cpp'], {'cpp': 2})
+    s.toggle_singleton()
+    assert s.assignment() == {'cpp': -1}
+
+
+async def test_picker_toggle_and_group_then_confirm():
+    with create_pipe_input() as inp:
+        inp.send_text('1')         # cpp -> group 1
+        inp.send_text('\x1b[B')    # down -> java
+        inp.send_text(' ')         # space -> java singleton [X]
+        inp.send_text('\x1b[B')    # down -> python (stays unbucketed [ ])
+        inp.send_text('\r')        # enter -> confirm
+        result = await prompt_group_assignment(
+            ['cpp', 'java', 'python'],
+            {'cpp': 0, 'java': 0, 'python': 0},
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert result == {'cpp': 1, 'java': -1, 'python': 0}
+```
+
+Keep `test_state_move_clamps`, `test_state_set_group_and_assignment`, `test_picker_assigns_and_confirms`, `test_picker_cancel_returns_none` as-is (they remain valid: default `0` still means unbucketed/blank box).
+
+**Step 2: Run to verify the new tests fail**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -k "three_states or toggle or toggle_and_group" -v`
+Expected: FAIL (`toggle_singleton` undefined; `[X]` not rendered).
+
+**Step 3: Implement**
+
+In `rbx/box/timing_group_picker.py`:
+
+Add the toggle method to `GroupPickerState` (next to `set_group`):
+
+```python
+    def toggle_singleton(self) -> None:
+        if not self.languages:
+            return
+        lang = self.languages[self.cursor]
+        # toggle between singleton (-1) and unbucketed (0); a numbered language
+        # goes to singleton on the first press.
+        self.numbers[lang] = 0 if self.numbers[lang] == -1 else -1
+```
+
+Update `render_fragments` box computation:
+
+```python
+            number = self.numbers[lang]
+            if number > 0:
+                box = str(number)
+            elif number < 0:
+                box = 'X'
+            else:
+                box = ' '
+```
+
+Update the header hint text in `prompt_group_assignment`:
+
+```python
+            (
+                'class:hint',
+                '↑/↓ or j/k move · 1-9 set group · space/tab toggle '
+                'singleton [X] / unbucketed [ ] · Enter confirm · q cancel\n',
+            ),
+```
+
+Bind the digits to groups `1-9` only (group 0 is meaningless) and add the toggle keys. Replace the digit-binding loop and add bindings:
+
+```python
+    for _digit in '123456789':
+
+        @kb.add(_digit)
+        def _(event, _digit=_digit):
+            state.set_group(int(_digit))
+
+    @kb.add('0')
+    def _(event):
+        # explicit clear to unbucketed
+        state.set_group(0)
+
+    @kb.add('space')
+    @kb.add('tab')
+    def _(event):
+        state.toggle_singleton()
+```
+
+(Leave the existing `enter` = submit and `c-c`/`q` = cancel bindings unchanged. `set_group(0)` works because `set_group` already writes the raw number; `0` lands as unbucketed.)
+
+**Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -v`
+Expected: PASS (all tests).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/timing_group_picker.py tests/rbx/box/test_timing_group_picker.py
+git commit -m "$(cat <<'EOF'
+feat(timing): three-state language group picker
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Widen estimation scope to all env languages
+
+**Files:**
+- Modify: `rbx/box/timing.py` (`relevant_languages_for_estimation`)
+- Test: `tests/rbx/box/test_timing_estimation.py`
+
+**Step 1: Update the failing tests**
+
+In `tests/rbx/box/test_timing_estimation.py`, replace the two `relevant_languages_*` tests:
+
+```python
+def test_relevant_languages_includes_all_env_languages():
+    result = relevant_languages_for_estimation(
+        env_languages=['c', 'cpp', 'java', 'kotlin', 'python', 'go'],
+        timing_languages=['python'],
+        env_groups=[
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            ),
+        ],
+    )
+    # every env language is now in scope, ordered by env order
+    assert result == ['c', 'cpp', 'java', 'kotlin', 'python', 'go']
+
+
+def test_relevant_languages_appends_unknown_timing_langs():
+    result = relevant_languages_for_estimation(
+        env_languages=['cpp', 'python'],
+        timing_languages=['python', 'rust'],  # rust not in env list
+        env_groups=[],
+    )
+    assert result == ['cpp', 'python', 'rust']
+```
+
+**Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_timing_estimation.py -k relevant -v`
+Expected: FAIL (current code excludes env languages with no solution / no group, e.g. `go`, `c`, and `cpp` in the second test).
+
+**Step 3: Implement**
+
+Replace the body of `relevant_languages_for_estimation` in `rbx/box/timing.py` (keep the signature, including `env_groups`, for call-site/back-compat stability even though it is no longer read):
+
+```python
+def relevant_languages_for_estimation(
+    env_languages: List[str],
+    timing_languages: List[str],
+    env_groups: List[environment.LanguageGroup],
+) -> List[str]:
+    """Languages that participate in the partition during estimation: every
+    environment language (so unrepresented ones land in the picker and the
+    leftover pool / DEFAULTED warning), followed by any timing language not
+    declared in the environment. Ordered by the environment's language order."""
+    del env_groups  # no longer needed; all env languages are in scope
+    ordered = list(env_languages)
+    for lang in timing_languages:
+        if lang not in ordered:
+            ordered.append(lang)
+    return ordered
+```
+
+**Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_estimation.py -v`
+Expected: PASS (including the unchanged `test_build_timing_profile_groups_languages`).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/timing.py tests/rbx/box/test_timing_estimation.py
+git commit -m "$(cat <<'EOF'
+feat(timing): include all env languages in estimation scope
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: End-to-end leftover-pool behavior test
+
+**Files:**
+- Test: `tests/rbx/box/test_timing_estimation.py`
+
+**Step 1: Write the failing tests**
+
+Append to `tests/rbx/box/test_timing_estimation.py`:
+
+```python
+def test_unrepresented_languages_inherit_leftover_pool():
+    # cpp has solutions and is unbucketed; go/java are unbucketed with no
+    # solutions -> they share cpp's pooled estimate via the leftover pool.
+    profile = build_timing_profile(
+        timing_per_solution_per_language={'cpp': {'a.cpp': 100, 'b.cpp': 150}},
+        formula='max(fastest * 3, slowest * 2)',
+        env_groups=[],
+        all_languages=['cpp', 'go', 'java'],
+    )
+    limits = profile.to_limits()
+    # one leftover pool: cpp's estimate applies to all members
+    assert limits.modifiers['cpp'].time == limits.modifiers['go'].time
+    assert limits.modifiers['go'].time == limits.modifiers['java'].time
+    assert profile.groups is not None
+    origins = {tuple(sorted(r.languages)): r.origin for r in profile.groups}
+    assert origins[('cpp', 'go', 'java')] == TimingGroupOrigin.ESTIMATED
+
+
+def test_empty_leftover_pool_defaults_to_base():
+    # No solutions for any leftover language other than the represented one in
+    # its own group; the leftover pool is empty -> DEFAULTED to base, no modifier.
+    profile = build_timing_profile(
+        timing_per_solution_per_language={'cpp': {'a.cpp': 100, 'b.cpp': 150}},
+        formula='max(fastest * 3, slowest * 2)',
+        env_groups=[LanguageGroup(languages=['cpp'])],
+        all_languages=['cpp', 'go', 'java'],
+    )
+    limits = profile.to_limits()
+    # leftover pool (go, java) has no solutions -> DEFAULTED, no modifiers
+    assert 'go' not in limits.modifiers
+    assert 'java' not in limits.modifiers
+    assert profile.groups is not None
+    defaulted = {
+        tuple(sorted(r.languages)): r
+        for r in profile.groups
+        if r.origin == TimingGroupOrigin.DEFAULTED
+    }
+    assert ('go', 'java') in defaulted
+```
+
+**Step 2: Run to verify pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_estimation.py -k "leftover" -v`
+Expected: PASS (logic already implemented in Tasks 1-2; these lock in the behavior).
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/box/test_timing_estimation.py
+git commit -m "$(cat <<'EOF'
+test(timing): cover leftover-pool inherit and DEFAULTED behavior
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Docs
+
+**Files:**
+- Modify: `docs/setters/reference/environment/index.md`
+- Read first: the existing `timing.groups` section to match tone.
+
+**Step 1: Update the docs**
+
+In the `timing.groups` section of `docs/setters/reference/environment/index.md`, update the description of how unlisted languages behave: change any wording that says unlisted languages become "implicit singletons" to describe the new behavior — unlisted languages join a single shared **leftover pool** (so an unrepresented language inherits a represented sibling's estimate when the pool has solutions, or DEFAULTs to base with a warning when it does not). Mention that `rbx time`'s interactive picker lets you place each language into a numbered group, a singleton `[X]`, or leave it unbucketed `[ ]` (the default).
+
+**Step 2: Verify the docs build**
+
+Run: `uv run mkdocs build` (non-strict; the ~9 pre-existing strict warnings are unrelated — see memory).
+Expected: build succeeds.
+
+**Step 3: Commit**
+
+```bash
+git add docs/setters/reference/environment/index.md
+git commit -m "$(cat <<'EOF'
+docs: describe leftover pool and three-state picker
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Full verification
+
+**Step 1: Run the full relevant suite**
+
+Run:
+```bash
+uv run pytest tests/rbx/box/test_timing_groups.py \
+  tests/rbx/box/test_timing_group_picker.py \
+  tests/rbx/box/test_timing_estimation.py \
+  tests/rbx/box/test_timing.py \
+  tests/rbx/box/test_limits_table.py \
+  tests/rbx/box/test_environment_groups.py \
+  tests/rbx/box/test_limits_profile_groups.py \
+  tests/rbx/box/packaging/test_boca_limits_table.py -v
+```
+Expected: all PASS. (Per memory, checker/validator/sandbox/docker suites fail pre-existingly on this machine and are unrelated.)
+
+**Step 2: Lint & format**
+
+Run: `uv run ruff check rbx/box/timing_groups.py rbx/box/timing_group_picker.py rbx/box/timing.py && uv run ruff format --check rbx/box/timing_groups.py rbx/box/timing_group_picker.py rbx/box/timing.py`
+Expected: clean.
+
+**Step 3: Sanity-check `test_timing.py`** for any remaining assumption that unlisted languages are singletons; if a test asserts old behavior, update it to the leftover-pool expectation and re-run.
+
+---
+
+## Notes for the implementer
+
+- The assignment-map encoding (`N≥1`/`0`/`-1`) is internal to the picker + `partition_from_assignment`; no persisted file format changes (`.limits/*.yml` is untouched).
+- `_prompt_repartition` in `timing.py` already prepopulates `{lang: 0}` then overwrites env-grouped languages with their group index. Since `0` now means *unbucketed*, the default is already correct — **do not change it**. Verify by reading `_prompt_repartition` before touching it.
+- `resolve_groups` and `limits_info.render_limits_table` need NO changes — a leftover pool is just an ordinary multi-language group.

--- a/docs/plans/2026-06-02-leftover-group-visibility-design.md
+++ b/docs/plans/2026-06-02-leftover-group-visibility-design.md
@@ -1,0 +1,105 @@
+# Leftover-group visibility: table marker + picker legend (PR #499 follow-up)
+
+Date: 2026-06-02
+Builds on: `docs/plans/2026-06-01-three-state-language-bucketing-design.md`
+PR: https://github.com/rsalesc/rbx/pull/499
+
+## Motivation
+
+The three-state bucketing landed, but the **leftover pool** is invisible in two places:
+
+1. In the rendered time-limits table it looks like any other multi-language group —
+   you can't tell which row is the catch-all default, and it renders **last**.
+2. The interactive picker has only a terse one-line key hint; new users don't learn
+   what "grouped / singleton / leftover" actually mean.
+
+This change makes the leftover group obvious in the table (asterisk + footer, moved to
+first position) and teaches the three states in the picker (a static legend).
+
+Locked terminology (used in legend, key hint, table footer, docs):
+**`[N]` grouped · `[X]` singleton · `[ ]` leftover.**
+
+## Section 1 — Persist a leftover marker
+
+The table is rebuilt from saved `.limits/*.yml` metadata, so "which group is the
+leftover" must be persisted, not inferred.
+
+- `ResolvedGroup` (`timing_groups.py`) gains `is_leftover: bool = False`. Both
+  `build_partition` and `partition_from_assignment` set it `True` on the single
+  leftover group they create.
+- `TimingGroupReport` (`schema.py`) gains `isLeftover: bool = False`. `resolve_groups`
+  copies it from the group into the report. It serializes into `.limits/*.yml`.
+- Old saved files have no `isLeftover` → defaults `False` → no row is treated as
+  leftover → table renders exactly as before (graceful degradation).
+
+## Section 2 — Table (`limits_info.py`)
+
+- `LimitsTableRow` gains `is_leftover: bool = False`.
+- `build_limits_table_rows`: when `profile.groups` is present, emit the leftover
+  report **first**, then the remaining reports in their existing order. (Render-time
+  reorder only; resolution and saved order are untouched.)
+- The leftover row's Languages cell gets a **leading asterisk**: `* go, java`
+  (still warning-highlighted when DEFAULTED).
+- `build_limits_table` sets a rich `caption` (footer) **only when a leftover row is
+  present**:
+  `* leftover: languages not assigned to a group, estimated together (default).`
+- Degraded view (no `groups` metadata) is unchanged — no leftover concept applies.
+
+Example:
+
+| Languages    | Solutions | Time Limit  | Source                          |
+|--------------|-----------|-------------|---------------------------------|
+| * go, java   | 0         | **2000 ms** | ⚠ DEFAULTED to base             |
+| c, cpp       | 2         | 1000 ms     | estimated (fastest 280 / 600)   |
+| python       | 1         | 5000 ms     | estimated (1600 / 1600)         |
+
+`* leftover: languages not assigned to a group, estimated together (default).`
+
+## Section 3 — Picker static legend (`timing_group_picker.py`)
+
+Replace the current 2-line header (title + key hint) with a static legend block
+(~7 lines), explaining each state once:
+
+```
+Assign each language to a time-limit bucket:
+
+  [N] grouped    shares one estimated limit with same-numbered langs
+  [X] singleton  its own estimated limit
+  [ ] leftover   pooled with all other unmarked langs (default)
+
+1-9 group · space/tab [X]/[ ] · 0 clear · enter confirm · q cancel
+```
+
+- Legend lines extracted to a module-level constant (e.g. `LEGEND_LINES` or a
+  `legend_text()` helper) so the wording is unit-testable and reused by the header
+  control.
+- The header `Window` height grows to the legend's line count.
+- Body (per-language `[N]`/`[X]`/`[ ]` rows) unchanged. Picker row order stays env
+  order — only the *table* reorders the leftover to the top.
+
+## Section 4 — Docs
+
+Update `docs/setters/reference/environment/index.md`: note that the per-group table
+lists the leftover group first, marked with an asterisk and explained in a footer.
+Terminology is already "leftover".
+
+## Section 5 — Tests
+
+- `test_timing_groups.py` — `is_leftover` is `True` on the leftover group from both
+  `build_partition` and `partition_from_assignment`, and `False` on grouped/singleton
+  groups.
+- `test_timing_estimation.py` (or resolve tests) — `isLeftover` propagates from group
+  into the resolved `TimingGroupReport`.
+- `test_limits_table.py` — leftover row is first; Languages cell starts with `* `;
+  `build_limits_table` caption is set when a leftover row exists and absent otherwise;
+  degraded view unaffected; existing ordering tests updated for the new first-position
+  rule.
+- `test_timing_group_picker.py` — the legend constant/text contains all three state
+  descriptions (grouped / singleton / leftover).
+
+## Out of scope
+
+- Reordering the leftover group in the *saved* metadata or in the *picker* (only the
+  rendered table reorders).
+- Marking singleton rows specially (only the leftover is marked).
+- Any change to resolution, `whenEmpty`, or the DEFAULTED warning logic.

--- a/docs/plans/2026-06-02-leftover-group-visibility.md
+++ b/docs/plans/2026-06-02-leftover-group-visibility.md
@@ -1,0 +1,470 @@
+# Leftover-Group Visibility Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the leftover pool obvious — mark it with a persisted flag, render it first in the time-limits table with an asterisk + footer, and teach the three states (grouped / singleton / leftover) via a static legend in the picker.
+
+**Architecture:** Add `is_leftover` to `ResolvedGroup` and `isLeftover` to `TimingGroupReport`; both partition builders set it and `resolve_groups` propagates it into the saved metadata. The table renderer reorders the leftover row first, prefixes its Languages cell with `* `, and adds a caption when present. The picker's header becomes a static legend driven by a module-level constant.
+
+**Tech Stack:** Python 3, Pydantic v2, rich (table), prompt_toolkit (picker), pytest.
+
+**Design:** `docs/plans/2026-06-02-leftover-group-visibility-design.md`
+
+**Conventions:** Single quotes; absolute imports; commit per task with conventional-commit messages + trailer `Co-Authored-By: Claude <noreply@anthropic.com>` (pre-commit runs ruff + commitizen; if ruff-format rewrites a file and aborts the commit, re-stage and commit again). Run tests with `uv run pytest`. Stage files by name, never `git add -A`.
+
+Locked terminology: `[N]` **grouped** · `[X]` **singleton** · `[ ]` **leftover**.
+
+---
+
+## Task 1: Persist the leftover marker
+
+**Files:**
+- Modify: `rbx/box/schema.py` (`TimingGroupReport`)
+- Modify: `rbx/box/timing_groups.py` (`ResolvedGroup`, `build_partition`, `partition_from_assignment`, `resolve_groups`)
+- Test: `tests/rbx/box/test_timing_groups.py`
+
+**Step 1: Write the failing tests**
+
+Append to `tests/rbx/box/test_timing_groups.py`:
+
+```python
+def test_build_partition_marks_leftover():
+    groups = build_partition(
+        env_groups=[LanguageGroup(languages=['c', 'cpp'])],
+        all_languages=['c', 'cpp', 'python', 'go'],
+    )
+    assert groups[0].is_leftover is False  # explicit env group
+    assert groups[1].languages == ['python', 'go']
+    assert groups[1].is_leftover is True  # the leftover pool
+
+
+def test_partition_from_assignment_marks_leftover():
+    groups = partition_from_assignment(
+        assignment={'cpp': 1, 'python': -1, 'go': 0, 'rust': 0},
+        env_groups=[],
+    )
+    leftover = [g for g in groups if g.is_leftover]
+    assert len(leftover) == 1
+    assert leftover[0].languages == ['go', 'rust']
+    # grouped + singleton groups are not marked
+    assert all(not g.is_leftover for g in groups if not g.is_leftover or g is leftover[0])
+    non_leftover = [g for g in groups if not g.is_leftover]
+    assert {tuple(g.languages) for g in non_leftover} == {('cpp',), ('python',)}
+
+
+def test_resolve_propagates_is_leftover():
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(languages=['go', 'java'], is_leftover=True),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=100, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=100, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval)
+    by_leftover = {tuple(r.languages): r.isLeftover for r in result.reports}
+    assert by_leftover[('cpp',)] is False
+    assert by_leftover[('go', 'java')] is True
+```
+
+**Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -k "leftover" -v`
+Expected: FAIL (`ResolvedGroup` has no `is_leftover`; `TimingGroupReport` has no `isLeftover`).
+
+**Step 3: Implement**
+
+(a) In `rbx/box/schema.py`, add a field to `TimingGroupReport` (after `multiplier`, before the closing of the class at line 659):
+
+```python
+    multiplier: Optional[float] = None
+    isLeftover: bool = False
+```
+
+(b) In `rbx/box/timing_groups.py`, add the field to `ResolvedGroup`:
+
+```python
+class ResolvedGroup(BaseModel):
+    languages: List[str]
+    whenEmpty: Optional[LanguageGroupFallback] = None
+    is_leftover: bool = False
+```
+
+(c) In `build_partition`, mark the leftover group:
+
+```python
+    leftover = [lang for lang in all_languages if lang not in grouped]
+    if leftover:
+        result.append(ResolvedGroup(languages=leftover, is_leftover=True))
+    return result
+```
+
+(d) In `partition_from_assignment`, mark the leftover group:
+
+```python
+    if leftover:
+        result.append(ResolvedGroup(languages=leftover, is_leftover=True))
+    return result
+```
+
+(e) In `resolve_groups`, add `isLeftover=group.is_leftover` to ALL THREE `TimingGroupReport(...)` constructors (the ESTIMATED, MULTIPLIER, and DEFAULTED branches). For each, add the keyword argument, e.g.:
+
+```python
+            report = TimingGroupReport(
+                languages=list(group.languages),
+                timeLimit=tl,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=timings.solution_count,
+                fastest=timings.fastest,
+                slowest=timings.slowest,
+                isLeftover=group.is_leftover,
+            )
+```
+
+and the same `isLeftover=group.is_leftover` line in the MULTIPLIER and DEFAULTED `TimingGroupReport(...)` blocks.
+
+**Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: PASS (all tests).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/schema.py rbx/box/timing_groups.py tests/rbx/box/test_timing_groups.py
+git commit -m "$(cat <<'EOF'
+feat(timing): persist a leftover-group marker
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Render the leftover row first, with asterisk + footer
+
+**Files:**
+- Modify: `rbx/box/limits_info.py` (`LimitsTableRow`, `build_limits_table_rows`, `build_limits_table`)
+- Test: `tests/rbx/box/test_limits_table.py`
+
+**Step 1: Write the failing tests**
+
+Append to `tests/rbx/box/test_limits_table.py`:
+
+```python
+def test_leftover_row_is_first_and_marked():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+            TimingGroupReport(
+                languages=['go', 'java'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+                isLeftover=True,
+            ),
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    # leftover pulled to the top, marked with a leading asterisk
+    assert rows[0].is_leftover is True
+    assert rows[0].languages.startswith('* ')
+    assert 'go, java' in rows[0].languages
+    # the rest keep their original order
+    assert rows[1].languages == 'c, cpp'
+
+
+def test_no_asterisk_when_no_leftover():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    assert rows[0].is_leftover is False
+    assert not rows[0].languages.startswith('*')
+
+
+def test_caption_present_only_with_leftover():
+    from rbx.box.limits_info import build_limits_table
+
+    leftover_profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['go', 'java'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+                isLeftover=True,
+            ),
+        ],
+    )
+    plain_profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+        ],
+    )
+    assert 'leftover' in (build_limits_table(leftover_profile).caption or '')
+    assert build_limits_table(plain_profile).caption is None
+```
+
+**Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_limits_table.py -k "leftover or asterisk or caption" -v`
+Expected: FAIL (`LimitsTableRow` has no `is_leftover`; no reorder/asterisk/caption yet).
+
+**Step 3: Implement**
+
+(a) Add the field to `LimitsTableRow` in `rbx/box/limits_info.py`:
+
+```python
+class LimitsTableRow(BaseModel):
+    languages: str
+    solutions: Optional[int]
+    time_limit_ms: int
+    source: str
+    defaulted: bool = False
+    is_leftover: bool = False
+```
+
+(b) In `build_limits_table_rows`, inside the `if profile.groups:` branch, set the asterisk + flag and reorder leftover-first. Replace the existing `rows.append(LimitsTableRow(...))` (the group-metadata one) and the `return rows` after the loop with:
+
+```python
+            languages = ', '.join(report.languages)
+            if report.isLeftover:
+                languages = f'* {languages}'
+            rows.append(
+                LimitsTableRow(
+                    languages=languages,
+                    solutions=report.solutionCount,
+                    time_limit_ms=report.timeLimit,
+                    source=source,
+                    defaulted=report.origin == TimingGroupOrigin.DEFAULTED,
+                    is_leftover=report.isLeftover,
+                )
+            )
+        # Leftover group is shown first; stable sort keeps the rest in order.
+        rows.sort(key=lambda r: not r.is_leftover)
+        return rows
+```
+
+(c) In `build_limits_table`, compute rows once, add a caption when a leftover row exists. Replace the `table = rich.table.Table(...)` construction and the row loop header:
+
+```python
+    rows = build_limits_table_rows(profile)
+    caption = None
+    if any(row.is_leftover for row in rows):
+        caption = (
+            '* leftover: languages not assigned to a group, '
+            'estimated together (default).'
+        )
+    table = rich.table.Table(
+        title=title,
+        title_style='bold bright_white',
+        header_style='bold bright_white',
+        caption=caption,
+        caption_style='bright_black',
+        show_lines=False,
+    )
+```
+
+and change the row loop from `for row in build_limits_table_rows(profile):` to `for row in rows:`.
+
+**Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/rbx/box/test_limits_table.py -v`
+Expected: PASS (all tests, including the pre-existing ones, which have no leftover and so keep their order/asterisk-free cells).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/limits_info.py tests/rbx/box/test_limits_table.py
+git commit -m "$(cat <<'EOF'
+feat(timing): show leftover group first with asterisk and footer
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Static legend in the picker
+
+**Files:**
+- Modify: `rbx/box/timing_group_picker.py`
+- Test: `tests/rbx/box/test_timing_group_picker.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/rbx/box/test_timing_group_picker.py`:
+
+```python
+def test_legend_describes_three_states():
+    from rbx.box.timing_group_picker import LEGEND_LINES
+
+    text = '\n'.join(LEGEND_LINES)
+    assert '[N]' in text and 'grouped' in text
+    assert '[X]' in text and 'singleton' in text
+    assert '[ ]' in text and 'leftover' in text
+    # key hint still present
+    assert 'confirm' in text and 'cancel' in text
+```
+
+The existing picker tests (`test_picker_assigns_and_confirms`, etc.) must continue to pass unchanged.
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -k legend -v`
+Expected: FAIL (`LEGEND_LINES` does not exist).
+
+**Step 3: Implement**
+
+(a) At the top of `rbx/box/timing_group_picker.py`, after the imports, add the module-level constant:
+
+```python
+LEGEND_LINES = [
+    'Assign each language to a time-limit bucket:',
+    '',
+    '  [N] grouped    shares one estimated limit with same-numbered langs',
+    '  [X] singleton  its own estimated limit',
+    '  [ ] leftover   pooled with all other unmarked langs (default)',
+    '',
+    '1-9 group · space/tab [X]/[ ] · 0 clear · enter confirm · q cancel',
+]
+```
+
+(b) Replace the `header = FormattedTextControl(...)` block (currently the title + hint, lines ~73-86) with a legend-driven control:
+
+```python
+    def _header_fragments():
+        fragments = []
+        last = len(LEGEND_LINES) - 1
+        for i, line in enumerate(LEGEND_LINES):
+            if i == 0:
+                style = 'class:header'
+            elif i == last:
+                style = 'class:hint'
+            else:
+                style = 'class:legend'
+            fragments.append((style, line + '\n'))
+        return fragments
+
+    header = FormattedTextControl(_header_fragments)
+```
+
+(c) Update the header `Window` height from `height=2` to the legend's length:
+
+```python
+                Window(
+                    content=header, height=len(LEGEND_LINES), always_hide_cursor=True
+                ),
+```
+
+(d) Add a `legend` style to the `Style.from_dict({...})` mapping (alongside `header`/`hint`):
+
+```python
+            'header': 'bold',
+            'hint': 'ansibrightblack',
+            'legend': '',
+```
+
+**Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -v`
+Expected: PASS (all picker tests, including the unchanged interactive ones).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/timing_group_picker.py tests/rbx/box/test_timing_group_picker.py
+git commit -m "$(cat <<'EOF'
+feat(timing): static three-state legend in the group picker
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Docs
+
+**Files:**
+- Modify: `docs/setters/reference/environment/index.md`
+
+**Step 1: Update the docs**
+
+In the per-group table paragraph of the `### Language groups` section (the part describing the table printed after `rbx time` / `rbx package boca`), add a sentence: the **leftover** group is listed **first**, marked with a leading asterisk (`*`) and explained in a footer beneath the table. Keep terminology "leftover".
+
+**Step 2: Verify the docs build**
+
+Run: `uv run mkdocs build` (non-strict; ignore the ~pre-existing unrelated warnings — see memory). Expected: build succeeds. Do NOT commit any auto-regenerated `docs/setters/reference/cli.md` — if it changes, `git checkout -- docs/setters/reference/cli.md` before committing.
+
+**Step 3: Commit**
+
+```bash
+git add docs/setters/reference/environment/index.md
+git commit -m "$(cat <<'EOF'
+docs: note leftover group is shown first with an asterisk
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Full verification
+
+**Step 1: Run the full relevant suite**
+
+Run:
+```bash
+uv run pytest tests/rbx/box/test_timing_groups.py \
+  tests/rbx/box/test_timing_group_picker.py \
+  tests/rbx/box/test_timing_estimation.py \
+  tests/rbx/box/test_timing.py \
+  tests/rbx/box/test_limits_table.py \
+  tests/rbx/box/test_environment_groups.py \
+  tests/rbx/box/test_limits_profile_groups.py \
+  tests/rbx/box/packaging/test_boca_limits_table.py -v
+```
+Expected: all PASS. (Per memory, checker/validator/sandbox/docker suites fail pre-existingly on this machine and are unrelated.)
+
+**Step 2: Lint & format**
+
+Run: `uv run ruff check rbx/box/schema.py rbx/box/timing_groups.py rbx/box/limits_info.py rbx/box/timing_group_picker.py && uv run ruff format --check rbx/box/schema.py rbx/box/timing_groups.py rbx/box/limits_info.py rbx/box/timing_group_picker.py`
+Expected: clean.
+
+**Step 3: Confirm no stale `.limits` round-trip break** — sanity check `test_limits_profile_groups.py` still passes (it round-trips `groups` through YAML; the new `isLeftover` field must serialize/deserialize cleanly with `extra='forbid'`).
+
+---
+
+## Notes for the implementer
+
+- `TimingGroupReport` has `model_config = ConfigDict(extra='forbid')`; the new `isLeftover` field is a normal model field so old files (without it) still load via the default, and new files serialize it. No migration needed.
+- Only the *table* reorders the leftover to the top; the *picker* keeps env order and the *saved* `groups` metadata keeps partition order.
+- At most one leftover row ever exists, so the stable `sort(key=lambda r: not r.is_leftover)` simply lifts it to the front.

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -203,6 +203,47 @@ timing:
   formula: "step_up(max(fastest * 2, slowest * 1.5), 100)"
 ```
 
+### Language groups
 
+By default, the time limit is estimated once from the pooled timings of all accepted
+solutions and applied to every language. With `timing.groups` you can instead estimate a
+separate time limit per group of languages, which is useful when languages with very
+different performance characteristics (e.g. compiled vs. interpreted) should not share a
+single limit.
 
+```yaml
+timing:
+  formula: "step_up(max(fastest * 3, slowest * 1.5), 100)"
+  groups:
+    - languages: [c, cpp]
+    - languages: [java, kotlin]
+      whenEmpty:          # used only when this group has no solutions
+        relativeTo: cpp   # any language; resolves to the group containing it
+        multiplier: 2.0   # omit relativeTo to multiply the base estimate
+    - languages: [python]
+```
+
+Semantics:
+
+- Groups are **disjoint**. Any language not listed in any group is treated as its own
+  implicit **singleton** group.
+- During estimation, the accepted-solution timings are pooled **per group**, and each
+  group that has at least one solution gets its own estimated time limit from the formula.
+- `whenEmpty` is **optional** and is only used when a group has **no** solutions. It sets
+  the group's time limit to `multiplier ×` the time limit of the group containing
+  `relativeTo` (or `multiplier ×` the base estimate when `relativeTo` is omitted).
+  `multiplier` must be `> 0`.
+- A group that is empty and has no `whenEmpty` falls back to the base time limit, with a
+  **loud warning** (source `DEFAULTED`).
+
+The resolved per-language limits are written into the existing `.limits/{profile}.yml`
+`modifiers`, so nothing else in the pipeline changes; the chosen grouping is also stored as
+presentation-only metadata under a `groups:` key in that profile.
+
+`rbx time` is **interactive**: it prompts you to assign each language a group number
+(prepopulated from `env.rbx.yml`, where `0` means "its own group"). Pass `--auto` to skip
+the prompt and use the env groups as-is. After `rbx time` finishes (and again at the end of
+`rbx package boca`), a per-group table is printed showing the **Languages**, **Solutions**,
+**Time Limit**, and **Source** (estimated / `×N of <lang>` / `DEFAULTED`) for each group,
+with `DEFAULTED` rows highlighted.
 

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -225,8 +225,11 @@ timing:
 
 Semantics:
 
-- Groups are **disjoint**. Any language not listed in any group is treated as its own
-  implicit **singleton** group.
+- Groups are **disjoint**. Any language not listed in any group is left **unbucketed**
+  and joins a single shared **leftover pool**: the pool's accepted-solution timings are
+  estimated together, so an unrepresented language inherits a represented sibling's limit
+  instead of silently falling back to the base time limit. If the whole pool has no
+  solutions it DEFAULTs to the base limit (with a loud warning), like any other empty group.
 - During estimation, the accepted-solution timings are pooled **per group**, and each
   group that has at least one solution gets its own estimated time limit from the formula.
 - `whenEmpty` is **optional** and is only used when a group has **no** solutions. It sets
@@ -240,9 +243,12 @@ The resolved per-language limits are written into the existing `.limits/{profile
 `modifiers`, so nothing else in the pipeline changes; the chosen grouping is also stored as
 presentation-only metadata under a `groups:` key in that profile.
 
-`rbx time` is **interactive**: it prompts you to assign each language a group number
-(prepopulated from `env.rbx.yml`, where `0` means "its own group"). Pass `--auto` to skip
-the prompt and use the env groups as-is. After `rbx time` finishes (and again at the end of
+`rbx time` is **interactive**: it shows every environment language and lets you place each
+one into a numbered group (`1`–`9`), make it a **singleton** `[X]` (its own bucket, via
+`space`/`tab`), or leave it **unbucketed** `[ ]` (the default — joins the leftover pool).
+The picker is prepopulated from `env.rbx.yml` (languages in an env group keep their group
+number; everything else starts unbucketed). Press `Enter` to confirm or `q` to cancel.
+Pass `--auto` to skip the prompt and use the env groups as-is. After `rbx time` finishes (and again at the end of
 `rbx package boca`), a per-group table is printed showing the **Languages**, **Solutions**,
 **Time Limit**, and **Source** (estimated / `×N of <lang>` / `DEFAULTED`) for each group,
 with `DEFAULTED` rows highlighted.

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -251,5 +251,6 @@ number; everything else starts unbucketed). Press `Enter` to confirm or `q` to c
 Pass `--auto` to skip the prompt and use the env groups as-is. After `rbx time` finishes (and again at the end of
 `rbx package boca`), a per-group table is printed showing the **Languages**, **Solutions**,
 **Time Limit**, and **Source** (estimated / `×N of <lang>` / `DEFAULTED`) for each group,
-with `DEFAULTED` rows highlighted.
+with `DEFAULTED` rows highlighted. The **leftover** group is listed **first**, marked with a
+leading asterisk (`*`) on its languages and explained in a footer beneath the table.
 

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -15,8 +15,9 @@ The central Pydantic model hierarchy defining `problem.rbx.yml`:
 - **`Testcase`** -- `inputPath`, `outputPath` (for manual test cases)
 - **`GeneratorCall`** -- `name`, `args` (references a generator program)
 - **`CodeItem`** -- `path`, `language`, `compilationArgs` (reference to any code file)
-- **`LimitsProfile`** -- Per-packager limit overrides with `modifiers` per language, `formula` support
+- **`LimitsProfile`** -- Per-packager limit overrides with `modifiers` per language, `formula` support; also carries optional `groups` metadata (a `TimingGroupReport` list, presentation-only) recording how languages were grouped during estimation
 - **`LimitModifiers`** -- `time`, `timeMultiplier`, `memory` per language
+- **`TimingGroupOrigin` / `TimingGroupReport`** -- presentation-only types describing each language group's resolved time limit and its source (estimated / `whenEmpty` multiple / defaulted)
 
 ### `ExpectedOutcome` (AutoEnum)
 
@@ -144,6 +145,7 @@ Manages language configurations from `env.rbx.yml`:
 - Compiler paths, flags, runtime commands per language
 - Sandbox configuration (memory limits, address space)
 - `VerificationLevel` enum: `NONE`, `VALIDATE`, `FAST_SOLUTIONS`, `ALL_SOLUTIONS`, `FULL`
+- `timing.groups` defines language groups for time-limit estimation; the pure grouping logic lives in `rbx/box/timing_groups.py`
 
 ## Code Compilation (`code.py`)
 

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Annotated, Any, Dict, List, Optional, Type, TypeVar, Union
 
 import typer
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from rbx import config, console
 from rbx.box import presets, safeeval
@@ -273,6 +273,31 @@ for the environment will be used.""",
         return self.get_extension(name, cls) or cls()
 
 
+class LanguageGroupFallback(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    relativeTo: Optional[str] = Field(
+        default=None,
+        description="""A language name whose group's estimated TL this empty group is
+relative to. If omitted, the multiplier is applied to the base estimate.""",
+    )
+    multiplier: float = Field(
+        description="""Multiplier applied when this group has no solutions.""",
+    )
+
+
+class LanguageGroup(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    languages: List[str] = Field(
+        description="""rbx language names that share a single estimated time limit.""",
+    )
+    whenEmpty: Optional[LanguageGroupFallback] = Field(
+        default=None,
+        description="""How to derive a TL for this group when it has no solutions.""",
+    )
+
+
 class TimingConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
@@ -280,6 +305,24 @@ class TimingConfig(BaseModel):
         default='step_up(max(fastest * 3, slowest * 1.5), 100)',
         description="""Formula to use to calculate the time limit for the environment.""",
     )
+
+    groups: List[LanguageGroup] = Field(
+        default_factory=list,
+        description="""Groups of related languages that share an estimated time limit.""",
+    )
+
+    @model_validator(mode='after')
+    def _validate_disjoint_groups(self):
+        seen: set[str] = set()
+        for group in self.groups:
+            for lang in group.languages:
+                if lang in seen:
+                    raise ValueError(
+                        f'Language {lang!r} appears in more than one timing group; '
+                        'groups must be disjoint.'
+                    )
+                seen.add(lang)
+        return self
 
 
 class Environment(BaseModel):

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -282,6 +282,7 @@ class LanguageGroupFallback(BaseModel):
 relative to. If omitted, the multiplier is applied to the base estimate.""",
     )
     multiplier: float = Field(
+        gt=0,
         description="""Multiplier applied when this group has no solutions.""",
     )
 

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -109,6 +109,20 @@ def get_saved_limits_profile(
     return load_yaml_model(limits_path, LimitsProfile)
 
 
+def get_display_limits_profile(
+    profile: str, root: pathlib.Path = pathlib.Path()
+) -> Optional[LimitsProfile]:
+    """Resolved limits profile for presentation: expanded to absolute base +
+    per-language limits (filled from the package when inheriting), with the saved
+    group metadata preserved so the per-group table can be rendered."""
+    saved = get_saved_limits_profile(profile, root=root)
+    if saved is None:
+        return None
+    display = get_limits_profile(profile, root=root)
+    display.groups = saved.groups
+    return display
+
+
 def get_package_limits_profile(root: pathlib.Path = pathlib.Path()) -> LimitsProfile:
     profile = LimitsProfile(inheritFromPackage=True)
     return _expand_limits_profile(profile, root=root)

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -218,6 +218,7 @@ class LimitsTableRow(BaseModel):
     time_limit_ms: int
     source: str
     defaulted: bool = False
+    is_leftover: bool = False
 
 
 def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
@@ -233,15 +234,21 @@ def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
                 source = f'×{report.multiplier} of {ref}'
             else:
                 source = 'DEFAULTED to base'
+            languages = ', '.join(report.languages)
+            if report.isLeftover:
+                languages = f'* {languages}'
             rows.append(
                 LimitsTableRow(
-                    languages=', '.join(report.languages),
+                    languages=languages,
                     solutions=report.solutionCount,
                     time_limit_ms=report.timeLimit,
                     source=source,
                     defaulted=report.origin == TimingGroupOrigin.DEFAULTED,
+                    is_leftover=report.isLeftover,
                 )
             )
+        # Leftover group is shown first; stable sort keeps the rest in order.
+        rows.sort(key=lambda r: not r.is_leftover)
         return rows
     # Degraded view: base row + each per-language modifier override.
     base = profile.timeLimit or 0
@@ -292,17 +299,26 @@ def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
     """
     import rich.table
 
+    rows = build_limits_table_rows(profile)
+    caption = None
+    if any(row.is_leftover for row in rows):
+        caption = (
+            '* leftover: languages not assigned to a group, '
+            'estimated together (default).'
+        )
     table = rich.table.Table(
         title=title,
         title_style='bold bright_white',
         header_style='bold bright_white',
+        caption=caption,
+        caption_style='bright_black',
         show_lines=False,
     )
     table.add_column('Languages', style='bold blue')
     table.add_column('Solutions', justify='right', style='bright_white')
     table.add_column('Time Limit', justify='right', style='bold bright_white')
     table.add_column('Source', style='bright_white')
-    for row in build_limits_table_rows(profile):
+    for row in rows:
         sols = '' if row.solutions is None else str(row.solutions)
         tl = f'{row.time_limit_ms} ms'
         if row.defaulted:

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -1,13 +1,14 @@
 import contextvars
 import pathlib
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, List, Optional
 
 import typer
+from pydantic import BaseModel
 
 from rbx import console
 from rbx.box import package
 from rbx.box.environment import VerificationLevel
-from rbx.box.schema import LimitModifiers, LimitsProfile
+from rbx.box.schema import LimitModifiers, LimitsProfile, TimingGroupOrigin
 from rbx.box.yaml_validation import load_yaml_model
 from rbx.grading.limits import Limits
 
@@ -195,3 +196,77 @@ def pretty_print_profile(profile: LimitsProfile):
     console.console.print(f'[status]Modifiers:[/status] {profile.modifiers}')
     if profile.inheritFromPackage:
         console.console.print('[status]Inherits from package.[/status]')
+
+
+class LimitsTableRow(BaseModel):
+    languages: str
+    solutions: Optional[int]
+    time_limit_ms: int
+    source: str
+    defaulted: bool = False
+
+
+def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
+    rows: List[LimitsTableRow] = []
+    if profile.groups:
+        for report in profile.groups:
+            if report.origin == TimingGroupOrigin.ESTIMATED:
+                source = (
+                    f'estimated (fastest {report.fastest} / slowest {report.slowest})'
+                )
+            elif report.origin == TimingGroupOrigin.MULTIPLIER:
+                ref = report.relativeToLanguage or 'base'
+                source = f'×{report.multiplier} of {ref}'
+            else:
+                source = 'DEFAULTED to base'
+            rows.append(
+                LimitsTableRow(
+                    languages=', '.join(report.languages),
+                    solutions=report.solutionCount,
+                    time_limit_ms=report.timeLimit,
+                    source=source,
+                    defaulted=report.origin == TimingGroupOrigin.DEFAULTED,
+                )
+            )
+        return rows
+    # Degraded view: base row + each per-language modifier override.
+    base = profile.timeLimit or 0
+    rows.append(
+        LimitsTableRow(
+            languages='(base)', solutions=None, time_limit_ms=base, source='base'
+        )
+    )
+    for lang, mod in sorted(profile.modifiers.items()):
+        if mod.time is not None:
+            rows.append(
+                LimitsTableRow(
+                    languages=lang,
+                    solutions=None,
+                    time_limit_ms=mod.time,
+                    source='override',
+                )
+            )
+    return rows
+
+
+def render_limits_table(profile: LimitsProfile, title: str = 'Time limits') -> None:
+    import rich.table
+
+    table = rich.table.Table(title=title, show_lines=False)
+    table.add_column('Languages')
+    table.add_column('Solutions', justify='right')
+    table.add_column('Time Limit', justify='right')
+    table.add_column('Source')
+    for row in build_limits_table_rows(profile):
+        sols = '' if row.solutions is None else str(row.solutions)
+        tl = f'{row.time_limit_ms} ms'
+        if row.defaulted:
+            table.add_row(
+                f'[warning]{row.languages}[/warning]',
+                sols,
+                f'[warning]{tl}[/warning]',
+                f'[warning]⚠ {row.source}[/warning]',
+            )
+        else:
+            table.add_row(row.languages, sols, tl, row.source)
+    console.console.print(table)

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -272,24 +272,50 @@ def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
     return rows
 
 
-def render_limits_table(profile: LimitsProfile, title: str = 'Time limits') -> None:
+def _source_markup(source: str) -> str:
+    if source.startswith('estimated'):
+        return f'[success]{source}[/success]'
+    if source.startswith('×'):
+        return f'[item]{source}[/item]'
+    return source
+
+
+def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
+    """Build a styled rich Table of the resolved per-language/group limits.
+
+    Structural column/header styles use literal rich style strings (the resolved
+    values of the project theme names: ``item`` -> ``bold blue``,
+    ``status`` -> ``bright_white``, ``bstatus`` -> ``bold bright_white``) so the
+    table renders correctly on any console, including non-themed ones used in
+    tests. Cell-level markup still uses theme names (``warning``/``success``/
+    ``item``), which resolve through the markup path.
+    """
     import rich.table
 
-    table = rich.table.Table(title=title, show_lines=False)
-    table.add_column('Languages')
-    table.add_column('Solutions', justify='right')
-    table.add_column('Time Limit', justify='right')
-    table.add_column('Source')
+    table = rich.table.Table(
+        title=title,
+        title_style='bold bright_white',
+        header_style='bold bright_white',
+        show_lines=False,
+    )
+    table.add_column('Languages', style='bold blue')
+    table.add_column('Solutions', justify='right', style='bright_white')
+    table.add_column('Time Limit', justify='right', style='bold bright_white')
+    table.add_column('Source', style='bright_white')
     for row in build_limits_table_rows(profile):
         sols = '' if row.solutions is None else str(row.solutions)
         tl = f'{row.time_limit_ms} ms'
         if row.defaulted:
             table.add_row(
                 f'[warning]{row.languages}[/warning]',
-                sols,
+                f'[warning]{sols}[/warning]',
                 f'[warning]{tl}[/warning]',
                 f'[warning]⚠ {row.source}[/warning]',
             )
         else:
-            table.add_row(row.languages, sols, tl, row.source)
-    console.console.print(table)
+            table.add_row(row.languages, sols, tl, _source_markup(row.source))
+    return table
+
+
+def render_limits_table(profile: LimitsProfile, title: str = 'Time limits') -> None:
+    console.console.print(build_limits_table(profile, title))

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -212,6 +212,11 @@ def pretty_print_profile(profile: LimitsProfile):
         console.console.print('[status]Inherits from package.[/status]')
 
 
+# Prefix marking the leftover group's languages cell; explained in the table
+# caption. Kept as one constant so the marker and its footer can't drift apart.
+LEFTOVER_MARKER = '* '
+
+
 class LimitsTableRow(BaseModel):
     languages: str
     solutions: Optional[int]
@@ -236,7 +241,7 @@ def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
                 source = 'DEFAULTED to base'
             languages = ', '.join(report.languages)
             if report.isLeftover:
-                languages = f'* {languages}'
+                languages = f'{LEFTOVER_MARKER}{languages}'
             rows.append(
                 LimitsTableRow(
                     languages=languages,
@@ -303,8 +308,8 @@ def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
     caption = None
     if any(row.is_leftover for row in rows):
         caption = (
-            '* leftover: languages not assigned to a group, '
-            'estimated together (default).'
+            f'{LEFTOVER_MARKER}leftover: languages not assigned to a group, '
+            'pooled together (default).'
         )
     table = rich.table.Table(
         title=title,

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -246,6 +246,15 @@ def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
                     source='override',
                 )
             )
+        elif mod.timeMultiplier is not None:
+            rows.append(
+                LimitsTableRow(
+                    languages=lang,
+                    solutions=None,
+                    time_limit_ms=int(base * mod.timeMultiplier),
+                    source=f'override (×{mod.timeMultiplier} of base)',
+                )
+            )
     return rows
 
 

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -442,4 +442,10 @@ class BocaPackager(BasePackager):
             str(build_path / self._get_zip_filename()), 'zip', into_path
         )
 
+        boca_profile = limits_info.get_saved_limits_profile('boca')
+        if boca_profile is not None:
+            limits_info.render_limits_table(
+                boca_profile, title='BOCA time limits (per language group)'
+            )
+
         return (build_path / self._get_zip_filename()).with_suffix('.zip')

--- a/rbx/box/packaging/boca/packager.py
+++ b/rbx/box/packaging/boca/packager.py
@@ -19,7 +19,7 @@ from rbx.box.packaging.boca.extension import (
     BocaLanguage,
 )
 from rbx.box.packaging.packager import BasePackager, BuiltStatement
-from rbx.box.schema import TaskType
+from rbx.box.schema import TaskType, TimingGroupOrigin
 from rbx.box.statements.schema import Statement
 from rbx.config import get_default_app_path, get_testlib
 
@@ -442,10 +442,22 @@ class BocaPackager(BasePackager):
             str(build_path / self._get_zip_filename()), 'zip', into_path
         )
 
-        boca_profile = limits_info.get_saved_limits_profile('boca')
+        boca_profile = limits_info.get_display_limits_profile('boca')
         if boca_profile is not None:
             limits_info.render_limits_table(
                 boca_profile, title='BOCA time limits (per language group)'
             )
+            defaulted = [
+                lang
+                for report in (boca_profile.groups or [])
+                if report.origin == TimingGroupOrigin.DEFAULTED
+                for lang in report.languages
+            ]
+            if defaulted:
+                console.console.print(
+                    '[warning]⚠ These languages have no solution and no whenEmpty '
+                    'rule, so they ship the base time limit: '
+                    f'{", ".join(defaulted)}.[/warning]'
+                )
 
         return (build_path / self._get_zip_filename()).with_suffix('.zip')

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -657,6 +657,7 @@ class TimingGroupReport(BaseModel):
     slowest: Optional[int] = None
     relativeToLanguage: Optional[str] = None
     multiplier: Optional[float] = None
+    isLeftover: bool = False
 
 
 class ValidatorTest(BaseModel):

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+import enum
 import pathlib
 import re
 import typing
@@ -639,6 +640,25 @@ class LimitModifiers(BaseModel):
     )
 
 
+class TimingGroupOrigin(str, enum.Enum):
+    ESTIMATED = 'estimated'
+    MULTIPLIER = 'multiplier'
+    DEFAULTED = 'defaulted'
+
+
+class TimingGroupReport(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    languages: List[str]
+    timeLimit: int
+    origin: TimingGroupOrigin
+    solutionCount: int = 0
+    fastest: Optional[int] = None
+    slowest: Optional[int] = None
+    relativeToLanguage: Optional[str] = None
+    multiplier: Optional[float] = None
+
+
 class ValidatorTest(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
@@ -793,6 +813,14 @@ Whether to inherit limits from the package.
         default=None,
         description="""
 A formula to estimate the time limit for the problem.
+""",
+    )
+
+    groups: Optional[List[TimingGroupReport]] = Field(
+        default=None,
+        description="""
+Metadata describing the language grouping used when this profile was estimated.
+Presentation-only; never used for limit resolution.
 """,
     )
 

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -129,13 +129,11 @@ async def _prompt_repartition(
 def relevant_languages_for_estimation(
     env_languages: List[str],
     timing_languages: List[str],
-    env_groups: List[environment.LanguageGroup],
 ) -> List[str]:
     """Languages that participate in the partition during estimation: every
     environment language (so unrepresented ones land in the picker and the
     leftover pool / DEFAULTED warning), followed by any timing language not
     declared in the environment. Ordered by the environment's language order."""
-    del env_groups  # no longer needed; all env languages are in scope
     ordered = list(env_languages)
     for lang in timing_languages:
         if lang not in ordered:
@@ -201,7 +199,6 @@ async def estimate_time_limit(
     all_languages = relevant_languages_for_estimation(
         env_languages=[lang.name for lang in env.languages],
         timing_languages=list(timing_per_solution_per_language.keys()),
-        env_groups=env_groups,
     )
 
     repartition = None

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import questionary
 import rich
@@ -8,7 +8,7 @@ from ordered_set import OrderedSet
 from pydantic import BaseModel, Field
 
 from rbx import console, utils
-from rbx.box import environment, limits_info, package, safeeval, schema
+from rbx.box import environment, limits_info, package, safeeval, schema, timing_groups
 from rbx.box.code import find_language_name
 from rbx.box.environment import VerificationLevel
 from rbx.box.formatting import href
@@ -26,6 +26,7 @@ class TimingProfile(BaseModel):
     timeLimit: int
     formula: Optional[str] = None
     timeLimitPerLanguage: Dict[str, int] = Field(default_factory=dict)
+    groups: Optional[List[schema.TimingGroupReport]] = None
 
     def to_limits(self):
         return schema.LimitsProfile(
@@ -35,6 +36,7 @@ class TimingProfile(BaseModel):
                 lang: schema.LimitModifiers(time=tl)
                 for lang, tl in self.timeLimitPerLanguage.items()
             },
+            groups=self.groups,
         )
 
 
@@ -55,6 +57,81 @@ def step_down(x: Any, step: int) -> int:
 def step_up(x: Any, step: int) -> int:
     x = int(x)
     return (x + step - 1) // step * step
+
+
+def build_timing_profile(
+    timing_per_solution_per_language: Dict[str, Dict[str, int]],
+    formula: str,
+    env_groups: List[environment.LanguageGroup],
+    all_languages: List[str],
+    repartition: Optional[Dict[str, int]] = None,
+) -> TimingProfile:
+    def _eval(fastest: int, slowest: int) -> int:
+        return int(safeeval.eval_int(formula, {'fastest': fastest, 'slowest': slowest}))
+
+    if repartition is not None:
+        groups = timing_groups.partition_from_assignment(repartition, env_groups)
+    else:
+        groups = timing_groups.build_partition(env_groups, all_languages)
+    timing_groups.validate_partition(groups)
+
+    pooled: Dict[int, timing_groups.GroupTimings] = {}
+    all_values: List[int] = []
+    for idx, group in enumerate(groups):
+        values: List[int] = []
+        count = 0
+        for lang in group.languages:
+            per_sol = timing_per_solution_per_language.get(lang, {})
+            values.extend(per_sol.values())
+            count += len(per_sol)
+        if values:
+            pooled[idx] = timing_groups.GroupTimings(
+                fastest=min(values), slowest=max(values), solution_count=count
+            )
+            all_values.extend(values)
+
+    base = timing_groups.GroupTimings(
+        fastest=min(all_values),
+        slowest=max(all_values),
+        solution_count=len(all_values),
+    )
+    result = timing_groups.resolve_groups(groups, pooled, base, _eval)
+    return TimingProfile(
+        timeLimit=result.base_time_limit,
+        formula=formula,
+        timeLimitPerLanguage=result.time_limit_per_language,
+        groups=result.reports,
+    )
+
+
+async def _prompt_repartition(
+    console: rich.console.Console,
+    all_languages: List[str],
+    env_groups: List[environment.LanguageGroup],
+) -> Optional[Dict[str, int]]:
+    # Prepopulate numbers from env groups: env group #1 -> 1, etc.; ungrouped -> 0.
+    default_number: Dict[str, int] = {lang: 0 for lang in all_languages}
+    for i, group in enumerate(env_groups, start=1):
+        for lang in group.languages:
+            if lang in default_number:
+                default_number[lang] = i
+    console.print()
+    console.print(
+        'Assign each language to a group number (same number = shared time limit; '
+        "0 = its own group). A group's languages without solutions inherit the "
+        "group's estimated limit."
+    )
+    assignment: Dict[str, int] = {}
+    for lang in all_languages:
+        answer = await questionary.text(
+            f'Group number for {lang}',
+            default=str(default_number[lang]),
+            validate=lambda x: x.isdigit(),
+        ).ask_async()
+        if answer is None:
+            return None
+        assignment[lang] = int(answer)
+    return assignment
 
 
 async def estimate_time_limit(
@@ -98,87 +175,69 @@ async def estimate_time_limit(
 
     console.rule('[status]Time report[/status]', style='status')
 
+    if not timing_per_solution:
+        console.print('[error]No timings collected from solutions.[/error]')
+        return None
+
     fastest_time = min(timing_per_solution.values())
     slowest_time = max(timing_per_solution.values())
-
     console.print(f'Fastest solution: {fastest_time} ms')
     console.print(f'Slowest solution: {slowest_time} ms')
-
-    def _get_lang_fastest(lang: str) -> int:
-        return min(timing_per_solution_per_language[lang].values())
-
-    def _get_lang_slowest(lang: str) -> int:
-        return max(timing_per_solution_per_language[lang].values())
 
     env = environment.get_environment()
     if formula is None:
         formula = env.timing.formula
+    env_groups = env.timing.groups
 
-    def _eval(fastest_time: int, slowest_time: int) -> int:
-        return int(
-            safeeval.eval_int(
-                formula,
-                {
-                    'fastest': fastest_time,
-                    'slowest': slowest_time,
-                },
-            )
-        )
+    # Scope the partition to languages that matter: those with solutions plus any
+    # language explicitly placed in an env group. Other environment languages are
+    # left out so they don't generate spurious DEFAULTED warnings.
+    grouped_langs = {lang for group in env_groups for lang in group.languages}
+    relevant = set(timing_per_solution_per_language) | grouped_langs
+    all_languages = [lang.name for lang in env.languages if lang.name in relevant]
+    for lang in timing_per_solution_per_language:
+        if lang not in all_languages:
+            all_languages.append(lang)
 
-    if len(timing_per_solution_per_language) > 1:
-        timing_language_list = [
-            (_get_lang_fastest(lang), lang) for lang in timing_per_solution_per_language
-        ]
-        fastest_language_time, fastest_language = min(timing_language_list)
-        slowest_language_time, slowest_language = max(timing_language_list)
-
-        console.print(
-            f'Fastest language: {fastest_language} ({fastest_language_time} ms)'
-        )
-        console.print(
-            f'Slowest language: {slowest_language} ({slowest_language_time} ms)'
-        )
+    repartition = None
+    if not auto and len(all_languages) > 1:
+        repartition = await _prompt_repartition(console, all_languages, env_groups)
+        if repartition is None:
+            console.print('[error]Time limit estimation cancelled.[/error]')
+            return None
 
     console.print()
     console.rule('[status]Time estimation[/status]', style='status')
-
     console.print(f'Using formula: {formula}')
 
-    estimated_tl = _eval(fastest_time, slowest_time)
-    console.print(f'[success]Estimated time limit:[/success] {estimated_tl} ms')
+    try:
+        profile = build_timing_profile(
+            timing_per_solution_per_language=timing_per_solution_per_language,
+            formula=formula,
+            env_groups=env_groups,
+            all_languages=all_languages,
+            repartition=repartition,
+        )
+    except timing_groups.GroupValidationError as e:
+        console.print(f'[error]Invalid language groups: {e}[/error]')
+        return None
 
-    estimated_tl_per_language = {}
-    if len(timing_per_solution_per_language) > 1:
-        for lang in timing_per_solution_per_language:
-            estimated_tl_per_language[lang] = _eval(
-                _get_lang_fastest(lang), _get_lang_slowest(lang)
-            )
+    console.print(f'[success]Estimated time limit:[/success] {profile.timeLimit} ms')
 
-    final_estimated_tls_per_language = {}
-    if estimated_tl_per_language:
-        for lang, tl in estimated_tl_per_language.items():
-            console.print(f'Estimated time limit for {lang}: {tl} ms')
+    defaulted = [
+        lang
+        for report in (profile.groups or [])
+        if report.origin == schema.TimingGroupOrigin.DEFAULTED
+        for lang in report.languages
+    ]
+    if defaulted:
+        console.print(
+            '[warning]⚠ The following languages have no solution and no whenEmpty '
+            f'rule, so they fall back to the base time limit of {profile.timeLimit} '
+            f'ms: {", ".join(defaulted)}.[/warning]'
+        )
 
-        all_distinct_tls = set(estimated_tl_per_language.values())
-        if len(all_distinct_tls) > 1 and not auto:
-            console.print()
-            console.print('It seems your problem has solutions for multiple languages!')
-            selected_langs = await questionary.checkbox(
-                'Please select which languages you want to have a specific time limit for '
-                '(or leave all unselected if you want to use a single global time limit)',
-                choices=list(estimated_tl_per_language.keys()),
-            ).ask_async()
-            if selected_langs:
-                for lang in selected_langs:
-                    final_estimated_tls_per_language[lang] = estimated_tl_per_language[
-                        lang
-                    ]
-
-    return TimingProfile(
-        timeLimit=estimated_tl,
-        formula=formula,
-        timeLimitPerLanguage=final_estimated_tls_per_language,
-    )
+    return profile
 
 
 async def compute_time_limits(

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -316,9 +316,11 @@ async def compute_time_limits(
     console.console.print(
         f'[success]Writing the following timing profile to [item]{href(limits_path)}[/item].[/success]'
     )
-    console.console.print(estimated_tl, highlight=True)
+    limits = estimated_tl.to_limits()
     limits_path.parent.mkdir(parents=True, exist_ok=True)
-    limits_path.write_text(utils.model_to_yaml(estimated_tl.to_limits()))
+    limits_path.write_text(utils.model_to_yaml(limits))
+
+    limits_info.render_limits_table(limits, title=f'Time limits ({profile})')
 
     return estimated_tl
 

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -134,6 +134,28 @@ async def _prompt_repartition(
     return assignment
 
 
+def relevant_languages_for_estimation(
+    env_languages: List[str],
+    timing_languages: List[str],
+    env_groups: List[environment.LanguageGroup],
+) -> List[str]:
+    """Languages that should participate in the partition during estimation:
+    those with solutions, those explicitly placed in a group, and any language
+    referenced by a group's whenEmpty.relativeTo (so the reference resolves).
+    Ordered by the environment's language order, with any leftover timing
+    languages appended."""
+    relevant: set[str] = set(timing_languages)
+    for group in env_groups:
+        relevant.update(group.languages)
+        if group.whenEmpty is not None and group.whenEmpty.relativeTo is not None:
+            relevant.add(group.whenEmpty.relativeTo)
+    ordered = [name for name in env_languages if name in relevant]
+    for lang in timing_languages:
+        if lang not in ordered:
+            ordered.append(lang)
+    return ordered
+
+
 async def estimate_time_limit(
     console: rich.console.Console,
     result: RunSolutionResult,
@@ -189,15 +211,11 @@ async def estimate_time_limit(
         formula = env.timing.formula
     env_groups = env.timing.groups
 
-    # Scope the partition to languages that matter: those with solutions plus any
-    # language explicitly placed in an env group. Other environment languages are
-    # left out so they don't generate spurious DEFAULTED warnings.
-    grouped_langs = {lang for group in env_groups for lang in group.languages}
-    relevant = set(timing_per_solution_per_language) | grouped_langs
-    all_languages = [lang.name for lang in env.languages if lang.name in relevant]
-    for lang in timing_per_solution_per_language:
-        if lang not in all_languages:
-            all_languages.append(lang)
+    all_languages = relevant_languages_for_estimation(
+        env_languages=[lang.name for lang in env.languages],
+        timing_languages=list(timing_per_solution_per_language.keys()),
+        env_groups=env_groups,
+    )
 
     repartition = None
     if not auto and len(all_languages) > 1:

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Optional
 
-import questionary
 import rich
 import rich.console
 import typer
@@ -8,7 +7,15 @@ from ordered_set import OrderedSet
 from pydantic import BaseModel, Field
 
 from rbx import console, utils
-from rbx.box import environment, limits_info, package, safeeval, schema, timing_groups
+from rbx.box import (
+    environment,
+    limits_info,
+    package,
+    safeeval,
+    schema,
+    timing_group_picker,
+    timing_groups,
+)
 from rbx.box.code import find_language_name
 from rbx.box.environment import VerificationLevel
 from rbx.box.formatting import href
@@ -105,7 +112,6 @@ def build_timing_profile(
 
 
 async def _prompt_repartition(
-    console: rich.console.Console,
     all_languages: List[str],
     env_groups: List[environment.LanguageGroup],
 ) -> Optional[Dict[str, int]]:
@@ -115,23 +121,9 @@ async def _prompt_repartition(
         for lang in group.languages:
             if lang in default_number:
                 default_number[lang] = i
-    console.print()
-    console.print(
-        'Assign each language to a group number (same number = shared time limit; '
-        "0 = its own group). A group's languages without solutions inherit the "
-        "group's estimated limit."
+    return await timing_group_picker.prompt_group_assignment(
+        all_languages, default_number
     )
-    assignment: Dict[str, int] = {}
-    for lang in all_languages:
-        answer = await questionary.text(
-            f'Group number for {lang}',
-            default=str(default_number[lang]),
-            validate=lambda x: x.isdigit(),
-        ).ask_async()
-        if answer is None:
-            return None
-        assignment[lang] = int(answer)
-    return assignment
 
 
 def relevant_languages_for_estimation(
@@ -219,7 +211,7 @@ async def estimate_time_limit(
 
     repartition = None
     if not auto and len(all_languages) > 1:
-        repartition = await _prompt_repartition(console, all_languages, env_groups)
+        repartition = await _prompt_repartition(all_languages, env_groups)
         if repartition is None:
             console.print('[error]Time limit estimation cancelled.[/error]')
             return None

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -111,18 +111,28 @@ def build_timing_profile(
     )
 
 
-async def _prompt_repartition(
+def default_assignment(
     all_languages: List[str],
     env_groups: List[environment.LanguageGroup],
-) -> Optional[Dict[str, int]]:
-    # Prepopulate numbers from env groups: env group #1 -> 1, etc.; ungrouped -> 0.
+) -> Dict[str, int]:
+    """Prepopulated picker state from env groups: env group #1 -> 1, etc.;
+    every other language -> 0 (unbucketed). Feeding this straight into
+    partition_from_assignment reproduces the env grouping (so whenEmpty carries
+    over) with all ungrouped languages pooled together."""
     default_number: Dict[str, int] = {lang: 0 for lang in all_languages}
     for i, group in enumerate(env_groups, start=1):
         for lang in group.languages:
             if lang in default_number:
                 default_number[lang] = i
+    return default_number
+
+
+async def _prompt_repartition(
+    all_languages: List[str],
+    env_groups: List[environment.LanguageGroup],
+) -> Optional[Dict[str, int]]:
     return await timing_group_picker.prompt_group_assignment(
-        all_languages, default_number
+        all_languages, default_assignment(all_languages, env_groups)
     )
 
 

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -131,17 +131,12 @@ def relevant_languages_for_estimation(
     timing_languages: List[str],
     env_groups: List[environment.LanguageGroup],
 ) -> List[str]:
-    """Languages that should participate in the partition during estimation:
-    those with solutions, those explicitly placed in a group, and any language
-    referenced by a group's whenEmpty.relativeTo (so the reference resolves).
-    Ordered by the environment's language order, with any leftover timing
-    languages appended."""
-    relevant: set[str] = set(timing_languages)
-    for group in env_groups:
-        relevant.update(group.languages)
-        if group.whenEmpty is not None and group.whenEmpty.relativeTo is not None:
-            relevant.add(group.whenEmpty.relativeTo)
-    ordered = [name for name in env_languages if name in relevant]
+    """Languages that participate in the partition during estimation: every
+    environment language (so unrepresented ones land in the picker and the
+    leftover pool / DEFAULTED warning), followed by any timing language not
+    declared in the environment. Ordered by the environment's language order."""
+    del env_groups  # no longer needed; all env languages are in scope
+    ordered = list(env_languages)
     for lang in timing_languages:
         if lang not in ordered:
             ordered.append(lang)

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -18,6 +18,14 @@ class GroupPickerState:
         if self.languages:
             self.numbers[self.languages[self.cursor]] = number
 
+    def toggle_singleton(self) -> None:
+        if not self.languages:
+            return
+        lang = self.languages[self.cursor]
+        # toggle between singleton (-1) and unbucketed (0); a numbered language
+        # goes to singleton on the first press.
+        self.numbers[lang] = 0 if self.numbers[lang] == -1 else -1
+
     def assignment(self) -> Dict[str, int]:
         return dict(self.numbers)
 
@@ -26,7 +34,12 @@ class GroupPickerState:
         fragments = []
         for i, lang in enumerate(self.languages):
             number = self.numbers[lang]
-            box = str(number) if number > 0 else ' '
+            if number > 0:
+                box = str(number)
+            elif number < 0:
+                box = 'X'
+            else:
+                box = ' '
             selected = i == self.cursor
             pointer = '❯ ' if selected else '  '
             row_style = 'class:current' if selected else 'class:row'
@@ -64,8 +77,8 @@ async def prompt_group_assignment(
             ),
             (
                 'class:hint',
-                '↑/↓ or j/k move · 0-9 set group (0 = own group) · '
-                'Enter confirm · q cancel\n',
+                '↑/↓ or j/k move · 1-9 set group · space/tab toggle '
+                'singleton [X] / unbucketed [ ] · Enter confirm · q cancel\n',
             ),
         ]
     )
@@ -85,11 +98,21 @@ async def prompt_group_assignment(
     def _(event):
         state.move(1)
 
-    for _digit in '0123456789':
+    for _digit in '123456789':
 
         @kb.add(_digit)
         def _(event, _digit=_digit):
             state.set_group(int(_digit))
+
+    @kb.add('0')
+    def _(event):
+        # explicit clear to unbucketed
+        state.set_group(0)
+
+    @kb.add('space')
+    @kb.add('tab')
+    def _(event):
+        state.toggle_singleton()
 
     @kb.add('enter')
     def _(event):

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -57,7 +57,8 @@ async def prompt_group_assignment(
     output=None,
 ) -> Optional[Dict[str, int]]:
     """Interactive single-screen group picker. Returns {language: group_number}
-    (0 = own group) or None if cancelled."""
+    where N>=1 is a shared group, 0 is unbucketed (leftover), and -1 is a
+    singleton (own group); or None if cancelled."""
     if not languages:
         return {}
 

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -1,5 +1,15 @@
 from typing import Dict, List, Optional
 
+LEGEND_LINES = [
+    'Assign each language to a time-limit bucket:',
+    '',
+    '  [N] grouped    shares one estimated limit with same-numbered langs',
+    '  [X] singleton  its own estimated limit',
+    '  [ ] leftover   pooled with all other unmarked langs (default)',
+    '',
+    '1-9 group · space/tab [X]/[ ] · 0 clear · enter confirm · q cancel',
+]
+
 
 class GroupPickerState:
     def __init__(self, languages: List[str], default_number: Dict[str, int]):
@@ -70,20 +80,20 @@ async def prompt_group_assignment(
 
     state = GroupPickerState(languages, default_number)
 
-    header = FormattedTextControl(
-        lambda: [
-            (
-                'class:header',
-                'Assign each language to a group (same number = shared time limit).\n',
-            ),
-            (
-                'class:hint',
-                '↑/↓ or j/k move · 1-9 set group · space/tab toggle '
-                'singleton [X] / unbucketed [ ] · 0 clear · Enter confirm · '
-                'q cancel\n',
-            ),
-        ]
-    )
+    def _header_fragments():
+        fragments = []
+        last = len(LEGEND_LINES) - 1
+        for i, line in enumerate(LEGEND_LINES):
+            if i == 0:
+                style = 'class:header'
+            elif i == last:
+                style = 'class:hint'
+            else:
+                style = 'class:legend'
+            fragments.append((style, line + '\n'))
+        return fragments
+
+    header = FormattedTextControl(_header_fragments)
     body = FormattedTextControl(
         state.render_fragments, focusable=True, show_cursor=False
     )
@@ -128,7 +138,9 @@ async def prompt_group_assignment(
     layout = Layout(
         HSplit(
             [
-                Window(content=header, height=2, always_hide_cursor=True),
+                Window(
+                    content=header, height=len(LEGEND_LINES), always_hide_cursor=True
+                ),
                 Window(
                     content=body,
                     height=len(state.languages),
@@ -141,6 +153,7 @@ async def prompt_group_assignment(
         {
             'header': 'bold',
             'hint': 'ansibrightblack',
+            'legend': '',
             'current': 'bold reverse',
             'row': '',
             'box-current': 'ansiyellow bold',

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -1,0 +1,133 @@
+from typing import Dict, List, Optional
+
+
+class GroupPickerState:
+    def __init__(self, languages: List[str], default_number: Dict[str, int]):
+        self.languages: List[str] = list(languages)
+        self.numbers: Dict[str, int] = {
+            lang: int(default_number.get(lang, 0)) for lang in self.languages
+        }
+        self.cursor: int = 0
+
+    def move(self, delta: int) -> None:
+        if not self.languages:
+            return
+        self.cursor = max(0, min(len(self.languages) - 1, self.cursor + delta))
+
+    def set_group(self, number: int) -> None:
+        if self.languages:
+            self.numbers[self.languages[self.cursor]] = number
+
+    def assignment(self) -> Dict[str, int]:
+        return dict(self.numbers)
+
+    def render_fragments(self):
+        """prompt_toolkit formatted-text fragments: list of (style, text)."""
+        fragments = []
+        for i, lang in enumerate(self.languages):
+            number = self.numbers[lang]
+            box = str(number) if number > 0 else ' '
+            selected = i == self.cursor
+            pointer = '❯ ' if selected else '  '
+            row_style = 'class:current' if selected else 'class:row'
+            box_style = 'class:box-current' if selected else 'class:box'
+            fragments.append((row_style, pointer))
+            fragments.append((box_style, f'[{box}] '))
+            fragments.append((row_style, f'{lang}\n'))
+        return fragments
+
+
+async def prompt_group_assignment(
+    languages: List[str],
+    default_number: Dict[str, int],
+    input=None,
+    output=None,
+) -> Optional[Dict[str, int]]:
+    """Interactive single-screen group picker. Returns {language: group_number}
+    (0 = own group) or None if cancelled."""
+    if not languages:
+        return {}
+
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.layout import HSplit, Layout, Window
+    from prompt_toolkit.layout.controls import FormattedTextControl
+    from prompt_toolkit.styles import Style
+
+    state = GroupPickerState(languages, default_number)
+
+    header = FormattedTextControl(
+        lambda: [
+            (
+                'class:header',
+                'Assign each language to a group (same number = shared time limit).\n',
+            ),
+            (
+                'class:hint',
+                '↑/↓ or j/k move · 0-9 set group (0 = own group) · '
+                'Enter confirm · q cancel\n',
+            ),
+        ]
+    )
+    body = FormattedTextControl(
+        state.render_fragments, focusable=True, show_cursor=False
+    )
+
+    kb = KeyBindings()
+
+    @kb.add('up')
+    @kb.add('k')
+    def _(event):
+        state.move(-1)
+
+    @kb.add('down')
+    @kb.add('j')
+    def _(event):
+        state.move(1)
+
+    for _digit in '0123456789':
+
+        @kb.add(_digit)
+        def _(event, _digit=_digit):
+            state.set_group(int(_digit))
+
+    @kb.add('enter')
+    def _(event):
+        event.app.exit(result=state.assignment())
+
+    @kb.add('c-c')
+    @kb.add('q')
+    def _(event):
+        event.app.exit(result=None)
+
+    layout = Layout(
+        HSplit(
+            [
+                Window(content=header, height=2, always_hide_cursor=True),
+                Window(
+                    content=body,
+                    height=len(state.languages),
+                    always_hide_cursor=True,
+                ),
+            ]
+        )
+    )
+    style = Style.from_dict(
+        {
+            'header': 'bold',
+            'hint': 'ansibrightblack',
+            'current': 'bold reverse',
+            'row': '',
+            'box-current': 'ansiyellow bold',
+            'box': 'ansiyellow',
+        }
+    )
+    app = Application(
+        layout=layout,
+        key_bindings=kb,
+        style=style,
+        full_screen=False,
+        input=input,
+        output=output,
+    )
+    return await app.run_async()

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -24,7 +24,7 @@ class GroupPickerState:
         lang = self.languages[self.cursor]
         # toggle between singleton (-1) and unbucketed (0); a numbered language
         # goes to singleton on the first press.
-        self.numbers[lang] = 0 if self.numbers[lang] == -1 else -1
+        self.numbers[lang] = 0 if self.numbers.get(lang, 0) == -1 else -1
 
     def assignment(self) -> Dict[str, int]:
         return dict(self.numbers)
@@ -79,7 +79,8 @@ async def prompt_group_assignment(
             (
                 'class:hint',
                 '↑/↓ or j/k move · 1-9 set group · space/tab toggle '
-                'singleton [X] / unbucketed [ ] · Enter confirm · q cancel\n',
+                'singleton [X] / unbucketed [ ] · 0 clear · Enter confirm · '
+                'q cancel\n',
             ),
         ]
     )

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -7,7 +7,7 @@ LEGEND_LINES = [
     '  [X] singleton  its own estimated limit',
     '  [ ] leftover   pooled with all other unmarked langs (default)',
     '',
-    '1-9 group · space/tab [X]/[ ] · 0 clear · enter confirm · q cancel',
+    '↑/↓ move · 1-9 group · space/tab [X]/[ ] · 0 clear · enter confirm · q cancel',
 ]
 
 

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -9,6 +9,7 @@ from rbx.box.schema import TimingGroupOrigin, TimingGroupReport
 class ResolvedGroup(BaseModel):
     languages: List[str]
     whenEmpty: Optional[LanguageGroupFallback] = None
+    is_leftover: bool = False
 
 
 def build_partition(
@@ -26,7 +27,7 @@ def build_partition(
         grouped.update(group.languages)
     leftover = [lang for lang in all_languages if lang not in grouped]
     if leftover:
-        result.append(ResolvedGroup(languages=leftover))
+        result.append(ResolvedGroup(languages=leftover, is_leftover=True))
     return result
 
 
@@ -56,7 +57,7 @@ def partition_from_assignment(
         result.append(ResolvedGroup(languages=langs, whenEmpty=when_empty))
     result.extend(ResolvedGroup(languages=s) for s in singletons)
     if leftover:
-        result.append(ResolvedGroup(languages=leftover))
+        result.append(ResolvedGroup(languages=leftover, is_leftover=True))
     return result
 
 
@@ -157,6 +158,7 @@ def resolve_groups(
                 solutionCount=timings.solution_count,
                 fastest=timings.fastest,
                 slowest=timings.slowest,
+                isLeftover=group.is_leftover,
             )
         elif group.whenEmpty is not None:
             ref = group.whenEmpty.relativeTo
@@ -169,6 +171,7 @@ def resolve_groups(
                 solutionCount=0,
                 relativeToLanguage=ref,
                 multiplier=group.whenEmpty.multiplier,
+                isLeftover=group.is_leftover,
             )
         else:
             tl = base_tl
@@ -177,6 +180,7 @@ def resolve_groups(
                 timeLimit=tl,
                 origin=TimingGroupOrigin.DEFAULTED,
                 solutionCount=0,
+                isLeftover=group.is_leftover,
             )
         resolving.discard(idx)
         resolved_tl[idx] = tl

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -55,6 +55,48 @@ def _lang_to_group_index(groups: List[ResolvedGroup]) -> Dict[str, int]:
     return out
 
 
+class GroupValidationError(ValueError):
+    pass
+
+
+def validate_partition(groups: List[ResolvedGroup]) -> None:
+    lang_index = _lang_to_group_index(groups)
+    # reference target existence + not-self
+    for idx, group in enumerate(groups):
+        if group.whenEmpty is None or group.whenEmpty.relativeTo is None:
+            continue
+        ref = group.whenEmpty.relativeTo
+        if ref not in lang_index:
+            raise GroupValidationError(
+                f'whenEmpty.relativeTo references unknown language {ref!r}.'
+            )
+        if lang_index[ref] == idx:
+            raise GroupValidationError(
+                f'whenEmpty.relativeTo {ref!r} points to the same group; it must '
+                'reference a different group.'
+            )
+    # cycle detection over group-to-group reference edges
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = [WHITE] * len(groups)
+
+    def visit(idx: int) -> None:
+        color[idx] = GRAY
+        group = groups[idx]
+        if group.whenEmpty is not None and group.whenEmpty.relativeTo is not None:
+            nxt = lang_index[group.whenEmpty.relativeTo]
+            if color[nxt] == GRAY:
+                raise GroupValidationError(
+                    'whenEmpty.relativeTo forms a cycle between timing groups.'
+                )
+            if color[nxt] == WHITE:
+                visit(nxt)
+        color[idx] = BLACK
+
+    for idx in range(len(groups)):
+        if color[idx] == WHITE:
+            visit(idx)
+
+
 def resolve_groups(
     groups: List[ResolvedGroup],
     pooled: Dict[int, GroupTimings],  # group index -> pooled timings (non-empty only)

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -15,8 +15,8 @@ def build_partition(
     env_groups: List[LanguageGroup],
     all_languages: List[str],
 ) -> List[ResolvedGroup]:
-    """Build a disjoint partition: explicit env groups first (in order), then an
-    implicit singleton for every language not covered by an explicit group."""
+    """Build a disjoint partition: explicit env groups first (in order), then a
+    single leftover pool holding every language not covered by an explicit group."""
     grouped: set[str] = set()
     result: List[ResolvedGroup] = []
     for group in env_groups:
@@ -24,10 +24,9 @@ def build_partition(
             ResolvedGroup(languages=list(group.languages), whenEmpty=group.whenEmpty)
         )
         grouped.update(group.languages)
-    for lang in all_languages:
-        if lang not in grouped:
-            result.append(ResolvedGroup(languages=[lang]))
-            grouped.add(lang)
+    leftover = [lang for lang in all_languages if lang not in grouped]
+    if leftover:
+        result.append(ResolvedGroup(languages=leftover))
     return result
 
 

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -1,8 +1,9 @@
-from typing import List, Optional
+from typing import Callable, Dict, List, Optional
 
 from pydantic import BaseModel
 
 from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+from rbx.box.schema import TimingGroupOrigin, TimingGroupReport
 
 
 class ResolvedGroup(BaseModel):
@@ -28,3 +29,105 @@ def build_partition(
             result.append(ResolvedGroup(languages=[lang]))
             grouped.add(lang)
     return result
+
+
+class GroupTimings(BaseModel):
+    fastest: int
+    slowest: int
+    solution_count: int
+
+
+class ResolutionResult(BaseModel):
+    base_time_limit: int
+    reports: List[TimingGroupReport]
+    time_limit_per_language: Dict[str, int]
+    defaulted_languages: List[str]
+
+
+EvalFn = Callable[[int, int], int]
+
+
+def _lang_to_group_index(groups: List[ResolvedGroup]) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    for idx, group in enumerate(groups):
+        for lang in group.languages:
+            out[lang] = idx
+    return out
+
+
+def resolve_groups(
+    groups: List[ResolvedGroup],
+    pooled: Dict[int, GroupTimings],  # group index -> pooled timings (non-empty only)
+    base: GroupTimings,
+    eval_fn: EvalFn,
+) -> ResolutionResult:
+    base_tl = eval_fn(base.fastest, base.slowest)
+    lang_index = _lang_to_group_index(groups)
+
+    resolved_tl: Dict[int, int] = {}
+    resolved_report: Dict[int, TimingGroupReport] = {}
+    resolving: set[int] = set()  # cycle guard (validation should prevent cycles)
+
+    def resolve(idx: int) -> int:
+        if idx in resolved_tl:
+            return resolved_tl[idx]
+        if idx in resolving:
+            # Acyclic is guaranteed by env validation; fall back defensively.
+            return base_tl
+        resolving.add(idx)
+        group = groups[idx]
+        timings = pooled.get(idx)
+        if timings is not None:
+            tl = eval_fn(timings.fastest, timings.slowest)
+            report = TimingGroupReport(
+                languages=list(group.languages),
+                timeLimit=tl,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=timings.solution_count,
+                fastest=timings.fastest,
+                slowest=timings.slowest,
+            )
+        elif group.whenEmpty is not None:
+            ref = group.whenEmpty.relativeTo
+            ref_tl = base_tl if ref is None else resolve(lang_index[ref])
+            tl = int(ref_tl * group.whenEmpty.multiplier)
+            report = TimingGroupReport(
+                languages=list(group.languages),
+                timeLimit=tl,
+                origin=TimingGroupOrigin.MULTIPLIER,
+                solutionCount=0,
+                relativeToLanguage=ref,
+                multiplier=group.whenEmpty.multiplier,
+            )
+        else:
+            tl = base_tl
+            report = TimingGroupReport(
+                languages=list(group.languages),
+                timeLimit=tl,
+                origin=TimingGroupOrigin.DEFAULTED,
+                solutionCount=0,
+            )
+        resolving.discard(idx)
+        resolved_tl[idx] = tl
+        resolved_report[idx] = report
+        return tl
+
+    for idx in range(len(groups)):
+        resolve(idx)
+
+    reports = [resolved_report[i] for i in range(len(groups))]
+    tl_per_language: Dict[str, int] = {}
+    defaulted: List[str] = []
+    for idx, group in enumerate(groups):
+        report = resolved_report[idx]
+        if report.origin == TimingGroupOrigin.DEFAULTED:
+            defaulted.extend(group.languages)
+            continue  # uses base TL -> no modifier
+        for lang in group.languages:
+            tl_per_language[lang] = report.timeLimit
+    return ResolutionResult(
+        base_time_limit=base_tl,
+        reports=reports,
+        time_limit_per_language=tl_per_language,
+        defaulted_languages=defaulted,
+    )

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -1,0 +1,30 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+
+
+class ResolvedGroup(BaseModel):
+    languages: List[str]
+    whenEmpty: Optional[LanguageGroupFallback] = None
+
+
+def build_partition(
+    env_groups: List[LanguageGroup],
+    all_languages: List[str],
+) -> List[ResolvedGroup]:
+    """Build a disjoint partition: explicit env groups first (in order), then an
+    implicit singleton for every language not covered by an explicit group."""
+    grouped: set[str] = set()
+    result: List[ResolvedGroup] = []
+    for group in env_groups:
+        result.append(
+            ResolvedGroup(languages=list(group.languages), whenEmpty=group.whenEmpty)
+        )
+        grouped.update(group.languages)
+    for lang in all_languages:
+        if lang not in grouped:
+            result.append(ResolvedGroup(languages=[lang]))
+            grouped.add(lang)
+    return result

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -34,16 +34,20 @@ def partition_from_assignment(
     assignment: Dict[str, int],
     env_groups: List[LanguageGroup],
 ) -> List[ResolvedGroup]:
-    """Build groups from a {language: number} map. 0 = own singleton; N>=1 share a
-    bucket. Carries over an env group's whenEmpty only when the resulting membership
-    is identical to that env group."""
+    """Build groups from a {language: state} map. State per language:
+    N>=1 share bucket N; -1 = own singleton group; 0 = the shared leftover pool.
+    Carries over an env group's whenEmpty only when the resulting membership is
+    identical to that env group."""
     buckets: Dict[int, List[str]] = {}
     singletons: List[List[str]] = []
-    for lang, number in assignment.items():
-        if number == 0:
+    leftover: List[str] = []
+    for lang, state in assignment.items():
+        if state == 0:
+            leftover.append(lang)
+        elif state < 0:
             singletons.append([lang])
         else:
-            buckets.setdefault(number, []).append(lang)
+            buckets.setdefault(state, []).append(lang)
 
     env_when_empty = {frozenset(g.languages): g.whenEmpty for g in env_groups}
     result: List[ResolvedGroup] = []
@@ -51,6 +55,8 @@ def partition_from_assignment(
         when_empty = env_when_empty.get(frozenset(langs))
         result.append(ResolvedGroup(languages=langs, whenEmpty=when_empty))
     result.extend(ResolvedGroup(languages=s) for s in singletons)
+    if leftover:
+        result.append(ResolvedGroup(languages=leftover))
     return result
 
 

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -31,6 +31,30 @@ def build_partition(
     return result
 
 
+def partition_from_assignment(
+    assignment: Dict[str, int],
+    env_groups: List[LanguageGroup],
+) -> List[ResolvedGroup]:
+    """Build groups from a {language: number} map. 0 = own singleton; N>=1 share a
+    bucket. Carries over an env group's whenEmpty only when the resulting membership
+    is identical to that env group."""
+    buckets: Dict[int, List[str]] = {}
+    singletons: List[List[str]] = []
+    for lang, number in assignment.items():
+        if number == 0:
+            singletons.append([lang])
+        else:
+            buckets.setdefault(number, []).append(lang)
+
+    env_when_empty = {frozenset(g.languages): g.whenEmpty for g in env_groups}
+    result: List[ResolvedGroup] = []
+    for _, langs in sorted(buckets.items()):
+        when_empty = env_when_empty.get(frozenset(langs))
+        result.append(ResolvedGroup(languages=langs, whenEmpty=when_empty))
+    result.extend(ResolvedGroup(languages=s) for s in singletons)
+    return result
+
+
 class GroupTimings(BaseModel):
     fastest: int
     slowest: int

--- a/tests/rbx/box/packaging/test_boca_limits_table.py
+++ b/tests/rbx/box/packaging/test_boca_limits_table.py
@@ -1,0 +1,17 @@
+from rbx.box.limits_info import build_limits_table_rows
+from rbx.box.schema import LimitsProfile, TimingGroupOrigin, TimingGroupReport
+
+
+def test_boca_table_flags_defaulted_language():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['java'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+            )
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    assert rows[0].defaulted is True

--- a/tests/rbx/box/packaging/test_boca_limits_table.py
+++ b/tests/rbx/box/packaging/test_boca_limits_table.py
@@ -1,5 +1,8 @@
+from rbx.box import limits_info, timing
 from rbx.box.limits_info import build_limits_table_rows
 from rbx.box.schema import LimitsProfile, TimingGroupOrigin, TimingGroupReport
+from rbx.box.testing import testing_package
+from rbx.utils import model_to_yaml
 
 
 def test_boca_table_flags_defaulted_language():
@@ -15,3 +18,57 @@ def test_boca_table_flags_defaulted_language():
     )
     rows = build_limits_table_rows(profile)
     assert rows[0].defaulted is True
+
+
+def test_inherit_display_profile_shows_real_package_base(
+    testing_pkg: testing_package.TestingPackage,
+):
+    # testing_pkg defaults to timeLimit=1000 ms in problem.rbx.yml.
+    assert testing_pkg.yml.timeLimit == 1000
+
+    # Write a boca profile that inherits from the package (raw timeLimit=None).
+    timing.inherit_time_limits(profile='boca')
+
+    saved = limits_info.get_saved_limits_profile('boca')
+    assert saved is not None
+    assert saved.inheritFromPackage is True
+    assert saved.timeLimit is None
+
+    display = limits_info.get_display_limits_profile('boca')
+    assert display is not None
+    # Display profile must resolve to the real package base, not None/0.
+    assert display.timeLimit == 1000
+    # No group metadata when inheriting (degraded view), preserved from saved.
+    assert display.groups is None
+
+    rows = build_limits_table_rows(display)
+    base_row = rows[0]
+    assert base_row.languages == '(base)'
+    assert base_row.time_limit_ms == 1000
+
+
+def test_display_profile_preserves_group_metadata(
+    testing_pkg: testing_package.TestingPackage,
+):
+    estimated = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['cpp'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                fastest=400,
+                slowest=900,
+            )
+        ],
+    )
+    limits_path = testing_pkg.root / '.limits' / 'boca.yml'
+    limits_path.parent.mkdir(parents=True, exist_ok=True)
+    limits_path.write_text(model_to_yaml(estimated))
+
+    display = limits_info.get_display_limits_profile('boca')
+    assert display is not None
+    assert display.timeLimit == 2000
+    assert display.groups is not None
+    assert display.groups[0].languages == ['cpp']
+    assert display.groups[0].origin == TimingGroupOrigin.ESTIMATED

--- a/tests/rbx/box/test_environment_groups.py
+++ b/tests/rbx/box/test_environment_groups.py
@@ -40,3 +40,10 @@ def test_language_cannot_appear_in_two_groups():
 def test_when_empty_requires_multiplier():
     with pytest.raises(ValidationError):
         LanguageGroupFallback.model_validate({'relativeTo': 'cpp'})
+
+
+def test_when_empty_multiplier_must_be_positive():
+    with pytest.raises(ValidationError):
+        LanguageGroupFallback.model_validate({'multiplier': 0})
+    with pytest.raises(ValidationError):
+        LanguageGroupFallback.model_validate({'relativeTo': 'cpp', 'multiplier': -1.0})

--- a/tests/rbx/box/test_environment_groups.py
+++ b/tests/rbx/box/test_environment_groups.py
@@ -1,0 +1,42 @@
+import pytest
+from pydantic import ValidationError
+
+from rbx.box.environment import (
+    LanguageGroupFallback,
+    TimingConfig,
+)
+
+
+def test_timing_config_defaults_to_no_groups():
+    cfg = TimingConfig()
+    assert cfg.groups == []
+
+
+def test_language_group_with_when_empty_parses():
+    cfg = TimingConfig.model_validate(
+        {
+            'groups': [
+                {'languages': ['c', 'cpp']},
+                {
+                    'languages': ['java', 'kotlin'],
+                    'whenEmpty': {'relativeTo': 'cpp', 'multiplier': 2.0},
+                },
+            ]
+        }
+    )
+    assert cfg.groups[0].languages == ['c', 'cpp']
+    assert cfg.groups[1].whenEmpty == LanguageGroupFallback(
+        relativeTo='cpp', multiplier=2.0
+    )
+
+
+def test_language_cannot_appear_in_two_groups():
+    with pytest.raises(ValidationError, match='cpp'):
+        TimingConfig.model_validate(
+            {'groups': [{'languages': ['c', 'cpp']}, {'languages': ['cpp']}]}
+        )
+
+
+def test_when_empty_requires_multiplier():
+    with pytest.raises(ValidationError):
+        LanguageGroupFallback.model_validate({'relativeTo': 'cpp'})

--- a/tests/rbx/box/test_limits_profile_groups.py
+++ b/tests/rbx/box/test_limits_profile_groups.py
@@ -1,0 +1,33 @@
+from rbx.box.schema import LimitsProfile, TimingGroupOrigin, TimingGroupReport
+
+
+def test_limits_profile_groups_defaults_to_none():
+    profile = LimitsProfile(timeLimit=1000)
+    assert profile.groups is None
+
+
+def test_limits_profile_round_trips_group_metadata():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+            TimingGroupReport(
+                languages=['java', 'kotlin'],
+                timeLimit=4000,
+                origin=TimingGroupOrigin.MULTIPLIER,
+                relativeToLanguage='cpp',
+                multiplier=4.0,
+            ),
+        ],
+    )
+    reloaded = LimitsProfile.model_validate(profile.model_dump())
+    assert reloaded.groups is not None
+    assert reloaded.groups[1].origin == TimingGroupOrigin.MULTIPLIER
+    assert reloaded.groups[1].relativeToLanguage == 'cpp'

--- a/tests/rbx/box/test_limits_profile_groups.py
+++ b/tests/rbx/box/test_limits_profile_groups.py
@@ -31,3 +31,38 @@ def test_limits_profile_round_trips_group_metadata():
     assert reloaded.groups is not None
     assert reloaded.groups[1].origin == TimingGroupOrigin.MULTIPLIER
     assert reloaded.groups[1].relativeToLanguage == 'cpp'
+
+
+def test_limits_profile_round_trips_is_leftover():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['go', 'java'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+                isLeftover=True,
+            ),
+        ],
+    )
+    reloaded = LimitsProfile.model_validate(profile.model_dump())
+    assert reloaded.groups is not None
+    assert reloaded.groups[0].isLeftover is True
+
+
+def test_limits_profile_groups_without_is_leftover_default_false():
+    # Old saved files have no isLeftover key -> defaults to False, loads cleanly.
+    raw = {
+        'timeLimit': 2000,
+        'groups': [
+            {
+                'languages': ['c', 'cpp'],
+                'timeLimit': 1000,
+                'origin': 'estimated',
+                'solutionCount': 2,
+            }
+        ],
+    }
+    reloaded = LimitsProfile.model_validate(raw)
+    assert reloaded.groups is not None
+    assert reloaded.groups[0].isLeftover is False

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -131,3 +131,82 @@ def test_source_markup_colors_by_origin():
     assert _source_markup('estimated (fastest 1 / slowest 2)').startswith('[success]')
     assert _source_markup('×4.0 of cpp').startswith('[item]')
     assert _source_markup('base') == 'base'
+
+
+def test_leftover_row_is_first_and_marked():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+            TimingGroupReport(
+                languages=['go', 'java'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+                isLeftover=True,
+            ),
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    # leftover pulled to the top, marked with a leading asterisk
+    assert rows[0].is_leftover is True
+    assert rows[0].languages.startswith('* ')
+    assert 'go, java' in rows[0].languages
+    # the rest keep their original order
+    assert rows[1].languages == 'c, cpp'
+
+
+def test_no_asterisk_when_no_leftover():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    assert rows[0].is_leftover is False
+    assert not rows[0].languages.startswith('*')
+
+
+def test_caption_present_only_with_leftover():
+    from rbx.box.limits_info import build_limits_table
+
+    leftover_profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['go', 'java'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+                isLeftover=True,
+            ),
+        ],
+    )
+    plain_profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+        ],
+    )
+    assert 'leftover' in (build_limits_table(leftover_profile).caption or '')
+    assert build_limits_table(plain_profile).caption is None

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -65,3 +65,33 @@ def test_rows_degrade_without_group_metadata():
     assert 'python' in langs
     # there should be a base row too
     assert any('base' in r.source.lower() for r in rows)
+
+
+def test_degraded_view_includes_time_multiplier_modifier():
+    profile = LimitsProfile(
+        timeLimit=1000,
+        modifiers={'java': LimitModifiers(timeMultiplier=2.0)},
+    )
+    rows = build_limits_table_rows(profile)
+    java_row = next(r for r in rows if r.languages == 'java')
+    assert java_row.time_limit_ms == 2000
+    assert '2.0' in java_row.source
+
+
+def test_render_limits_table_highlights_defaulted(capsys):
+    from rbx.box.limits_info import render_limits_table
+
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['go'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+            )
+        ],
+    )
+    render_limits_table(profile, title='Test limits')
+    out = capsys.readouterr().out
+    assert 'go' in out
+    assert 'Test limits' in out

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -1,0 +1,67 @@
+from rbx.box.limits_info import build_limits_table_rows
+from rbx.box.schema import (
+    LimitModifiers,
+    LimitsProfile,
+    TimingGroupOrigin,
+    TimingGroupReport,
+)
+
+
+def test_rows_from_group_metadata():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        modifiers={'cpp': LimitModifiers(time=1000)},
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+            TimingGroupReport(
+                languages=['go'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+            ),
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    assert rows[0].languages == 'c, cpp'
+    assert rows[0].time_limit_ms == 1000
+    assert rows[0].solutions == 2
+    assert 'estimated' in rows[0].source.lower()
+    assert rows[1].defaulted is True
+    assert 'default' in rows[1].source.lower()
+
+
+def test_multiplier_row_shows_reference():
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['java', 'kotlin'],
+                timeLimit=4000,
+                origin=TimingGroupOrigin.MULTIPLIER,
+                relativeToLanguage='cpp',
+                multiplier=4.0,
+            ),
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    assert rows[0].languages == 'java, kotlin'
+    assert rows[0].time_limit_ms == 4000
+    assert 'cpp' in rows[0].source
+    assert rows[0].defaulted is False
+
+
+def test_rows_degrade_without_group_metadata():
+    profile = LimitsProfile(
+        timeLimit=2000, modifiers={'python': LimitModifiers(time=5000)}
+    )
+    rows = build_limits_table_rows(profile)
+    langs = {r.languages for r in rows}
+    assert 'python' in langs
+    # there should be a base row too
+    assert any('base' in r.source.lower() for r in rows)

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -210,3 +210,26 @@ def test_caption_present_only_with_leftover():
     )
     assert 'leftover' in (build_limits_table(leftover_profile).caption or '')
     assert build_limits_table(plain_profile).caption is None
+
+
+def test_defaulted_leftover_renders_asterisk_and_warning(capsys):
+    from rbx.box.limits_info import render_limits_table
+
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['go', 'java'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+                isLeftover=True,
+            ),
+        ],
+    )
+    render_limits_table(profile, title='Test limits')
+    out = capsys.readouterr().out
+    # asterisk marker and the DEFAULTED warning glyph coexist in the same render
+    assert '*' in out
+    assert '⚠' in out
+    assert 'DEFAULTED' in out
+    assert 'go, java' in out

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -95,3 +95,39 @@ def test_render_limits_table_highlights_defaulted(capsys):
     out = capsys.readouterr().out
     assert 'go' in out
     assert 'Test limits' in out
+
+
+def test_build_limits_table_has_colored_columns():
+    from rbx.box.limits_info import build_limits_table
+
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+        ],
+    )
+    table = build_limits_table(profile)
+    # Columns carry explicit (non-grey) styles. Structural styles use the
+    # resolved literal values of the project theme names so they render on any
+    # console (item -> 'bold blue', bstatus -> 'bold bright_white').
+    styles = [c.style for c in table.columns]
+    assert 'bold blue' in styles  # Languages column (theme: item)
+    assert 'bold bright_white' in styles  # Time Limit column (theme: bstatus)
+    assert table.header_style == 'bold bright_white'
+    # No column is left at the default grey ('info' / bright_black).
+    assert all(s not in (None, '', 'info', 'bright_black') for s in styles)
+
+
+def test_source_markup_colors_by_origin():
+    from rbx.box.limits_info import _source_markup
+
+    assert _source_markup('estimated (fastest 1 / slowest 2)').startswith('[success]')
+    assert _source_markup('×4.0 of cpp').startswith('[item]')
+    assert _source_markup('base') == 'base'

--- a/tests/rbx/box/test_timing.py
+++ b/tests/rbx/box/test_timing.py
@@ -155,10 +155,8 @@ class TestEstimateTimeLimit:
     @mock.patch('rbx.box.timing.consume_and_key_evaluation_items')
     @mock.patch('rbx.box.timing.find_language_name')
     @mock.patch('rbx.box.environment.get_environment')
-    @mock.patch('questionary.checkbox')
     async def test_estimate_time_limit_basic(
         self,
-        mock_checkbox,
         mock_env,
         mock_find_lang,
         mock_consume,
@@ -166,6 +164,8 @@ class TestEstimateTimeLimit:
         sample_solution_result,
     ):
         """Test basic time limit estimation."""
+        from types import SimpleNamespace
+
         # Mock the structured evaluations
         mock_consume.return_value = {
             str(sample_solution_result.skeleton.solutions[0].path): {
@@ -179,14 +179,17 @@ class TestEstimateTimeLimit:
         # Mock find_language_name to avoid language lookup issues
         mock_find_lang.side_effect = lambda sol: sol.language
 
-        # Mock environment
+        # Mock environment so the grouping code works
         mock_env.return_value.timing.formula = 'slowest * 2'
+        mock_env.return_value.timing.groups = []
+        mock_env.return_value.languages = [
+            SimpleNamespace(name='cpp'),
+            SimpleNamespace(name='py'),
+        ]
 
-        # Mock questionary for single language scenario
-        mock_checkbox.return_value.ask_async = mock.AsyncMock(return_value=[])
-
+        # auto=True skips the interactive repartition prompt
         result = await timing.estimate_time_limit(
-            mock_console, sample_solution_result, formula='slowest * 2'
+            mock_console, sample_solution_result, formula='slowest * 2', auto=True
         )
 
         assert result is not None
@@ -230,10 +233,13 @@ class TestEstimateTimeLimit:
         # Mock find_language_name to avoid language lookup issues
         mock_find_lang.side_effect = lambda sol: sol.language
 
-        # The current implementation has a bug where it doesn't handle
-        # the case of no timing data properly and raises ValueError
-        with pytest.raises(ValueError):
-            await timing.estimate_time_limit(mock_console, result)
+        # No timing data: estimation cannot proceed, so it returns None gracefully
+        # (previously this raised ValueError due to min() on an empty sequence).
+        estimate = await timing.estimate_time_limit(mock_console, result)
+        assert estimate is None
+        mock_console.print.assert_any_call(
+            '[error]No timings collected from solutions.[/error]'
+        )
 
     async def test_estimate_time_limit_no_solutions(self, mock_console):
         """Test time limit estimation with no solutions."""

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -32,12 +32,6 @@ def test_relevant_languages_includes_all_env_languages():
     result = relevant_languages_for_estimation(
         env_languages=['c', 'cpp', 'java', 'kotlin', 'python', 'go'],
         timing_languages=['python'],
-        env_groups=[
-            LanguageGroup(
-                languages=['java', 'kotlin'],
-                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
-            ),
-        ],
     )
     # every env language is now in scope, ordered by env order
     assert result == ['c', 'cpp', 'java', 'kotlin', 'python', 'go']
@@ -47,6 +41,5 @@ def test_relevant_languages_appends_unknown_timing_langs():
     result = relevant_languages_for_estimation(
         env_languages=['cpp', 'python'],
         timing_languages=['python', 'rust'],  # rust not in env list
-        env_groups=[],
     )
     assert result == ['cpp', 'python', 'rust']

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -1,0 +1,28 @@
+from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+from rbx.box.schema import TimingGroupOrigin
+from rbx.box.timing import build_timing_profile
+
+
+def test_build_timing_profile_groups_languages():
+    timings = {
+        'cpp': {'a.cpp': 100, 'b.cpp': 150},
+        'python': {'p.py': 500},
+    }
+    profile = build_timing_profile(
+        timing_per_solution_per_language=timings,
+        formula='max(fastest * 3, slowest * 2)',
+        env_groups=[
+            LanguageGroup(languages=['c', 'cpp']),
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=4.0),
+            ),
+        ],
+        all_languages=['c', 'cpp', 'java', 'kotlin', 'python'],
+    )
+    limits = profile.to_limits()
+    assert limits.modifiers['java'].time == limits.modifiers['cpp'].time * 4
+    assert limits.modifiers['c'].time == limits.modifiers['cpp'].time
+    assert limits.groups is not None
+    origins = {tuple(r.languages): r.origin for r in limits.groups}
+    assert origins[('java', 'kotlin')] == TimingGroupOrigin.MULTIPLIER

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -43,3 +43,43 @@ def test_relevant_languages_appends_unknown_timing_langs():
         timing_languages=['python', 'rust'],  # rust not in env list
     )
     assert result == ['cpp', 'python', 'rust']
+
+
+def test_unrepresented_languages_inherit_leftover_pool():
+    # cpp has solutions and is unbucketed; go/java are unbucketed with no
+    # solutions -> they share cpp's pooled estimate via the leftover pool.
+    profile = build_timing_profile(
+        timing_per_solution_per_language={'cpp': {'a.cpp': 100, 'b.cpp': 150}},
+        formula='max(fastest * 3, slowest * 2)',
+        env_groups=[],
+        all_languages=['cpp', 'go', 'java'],
+    )
+    limits = profile.to_limits()
+    # one leftover pool: cpp's estimate applies to all members
+    assert limits.modifiers['cpp'].time == limits.modifiers['go'].time
+    assert limits.modifiers['go'].time == limits.modifiers['java'].time
+    assert profile.groups is not None
+    origins = {tuple(sorted(r.languages)): r.origin for r in profile.groups}
+    assert origins[('cpp', 'go', 'java')] == TimingGroupOrigin.ESTIMATED
+
+
+def test_empty_leftover_pool_defaults_to_base():
+    # No solutions for any leftover language other than the represented one in
+    # its own group; the leftover pool is empty -> DEFAULTED to base, no modifier.
+    profile = build_timing_profile(
+        timing_per_solution_per_language={'cpp': {'a.cpp': 100, 'b.cpp': 150}},
+        formula='max(fastest * 3, slowest * 2)',
+        env_groups=[LanguageGroup(languages=['cpp'])],
+        all_languages=['cpp', 'go', 'java'],
+    )
+    limits = profile.to_limits()
+    # leftover pool (go, java) has no solutions -> DEFAULTED, no modifiers
+    assert 'go' not in limits.modifiers
+    assert 'java' not in limits.modifiers
+    assert profile.groups is not None
+    defaulted = {
+        tuple(sorted(r.languages)): r
+        for r in profile.groups
+        if r.origin == TimingGroupOrigin.DEFAULTED
+    }
+    assert ('go', 'java') in defaulted

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -1,6 +1,11 @@
 from rbx.box.environment import LanguageGroup, LanguageGroupFallback
 from rbx.box.schema import TimingGroupOrigin
-from rbx.box.timing import build_timing_profile, relevant_languages_for_estimation
+from rbx.box.timing import (
+    build_timing_profile,
+    default_assignment,
+    relevant_languages_for_estimation,
+)
+from rbx.box.timing_groups import partition_from_assignment
 
 
 def test_build_timing_profile_groups_languages():
@@ -83,3 +88,34 @@ def test_empty_leftover_pool_defaults_to_base():
         if r.origin == TimingGroupOrigin.DEFAULTED
     }
     assert ('go', 'java') in defaulted
+
+
+def test_default_assignment_round_trip_preserves_when_empty():
+    # The picker's prepopulated default, fed straight into the partition builder,
+    # must reproduce the env grouping (so whenEmpty carries over) and pool every
+    # ungrouped language into one leftover pool.
+    env_groups = [
+        LanguageGroup(languages=['c', 'cpp']),
+        LanguageGroup(
+            languages=['java', 'kotlin'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        ),
+    ]
+    all_languages = ['c', 'cpp', 'java', 'kotlin', 'python', 'go']
+
+    default = default_assignment(all_languages, env_groups)
+    assert default == {
+        'c': 1,
+        'cpp': 1,
+        'java': 2,
+        'kotlin': 2,
+        'python': 0,
+        'go': 0,
+    }
+
+    groups = partition_from_assignment(default, env_groups)
+    jk = next(g for g in groups if set(g.languages) == {'java', 'kotlin'})
+    assert jk.whenEmpty is not None
+    assert jk.whenEmpty.multiplier == 2.0
+    # python + go are unbucketed -> a single leftover pool
+    assert ['python', 'go'] in [g.languages for g in groups]

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -28,9 +28,7 @@ def test_build_timing_profile_groups_languages():
     assert origins[('java', 'kotlin')] == TimingGroupOrigin.MULTIPLIER
 
 
-def test_relevant_languages_includes_relative_to_target():
-    # 'cpp' is referenced by java's whenEmpty but has no solution and is in no
-    # group of its own; it must still be pulled into scope.
+def test_relevant_languages_includes_all_env_languages():
     result = relevant_languages_for_estimation(
         env_languages=['c', 'cpp', 'java', 'kotlin', 'python', 'go'],
         timing_languages=['python'],
@@ -41,22 +39,14 @@ def test_relevant_languages_includes_relative_to_target():
             ),
         ],
     )
-    assert 'cpp' in result  # relativeTo target pulled in
-    assert 'python' in result  # has solution
-    assert 'java' in result and 'kotlin' in result  # grouped
-    assert 'go' not in result  # irrelevant, excluded
-    # ordering follows env_languages
-    assert result == [
-        name
-        for name in ['c', 'cpp', 'java', 'kotlin', 'python', 'go']
-        if name in result
-    ]
+    # every env language is now in scope, ordered by env order
+    assert result == ['c', 'cpp', 'java', 'kotlin', 'python', 'go']
 
 
-def test_relevant_languages_orders_by_env_then_appends_unknown_timing_langs():
+def test_relevant_languages_appends_unknown_timing_langs():
     result = relevant_languages_for_estimation(
         env_languages=['cpp', 'python'],
         timing_languages=['python', 'rust'],  # rust not in env list
         env_groups=[],
     )
-    assert result == ['python', 'rust']
+    assert result == ['cpp', 'python', 'rust']

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -1,6 +1,6 @@
 from rbx.box.environment import LanguageGroup, LanguageGroupFallback
 from rbx.box.schema import TimingGroupOrigin
-from rbx.box.timing import build_timing_profile
+from rbx.box.timing import build_timing_profile, relevant_languages_for_estimation
 
 
 def test_build_timing_profile_groups_languages():
@@ -26,3 +26,37 @@ def test_build_timing_profile_groups_languages():
     assert limits.groups is not None
     origins = {tuple(r.languages): r.origin for r in limits.groups}
     assert origins[('java', 'kotlin')] == TimingGroupOrigin.MULTIPLIER
+
+
+def test_relevant_languages_includes_relative_to_target():
+    # 'cpp' is referenced by java's whenEmpty but has no solution and is in no
+    # group of its own; it must still be pulled into scope.
+    result = relevant_languages_for_estimation(
+        env_languages=['c', 'cpp', 'java', 'kotlin', 'python', 'go'],
+        timing_languages=['python'],
+        env_groups=[
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            ),
+        ],
+    )
+    assert 'cpp' in result  # relativeTo target pulled in
+    assert 'python' in result  # has solution
+    assert 'java' in result and 'kotlin' in result  # grouped
+    assert 'go' not in result  # irrelevant, excluded
+    # ordering follows env_languages
+    assert result == [
+        name
+        for name in ['c', 'cpp', 'java', 'kotlin', 'python', 'go']
+        if name in result
+    ]
+
+
+def test_relevant_languages_orders_by_env_then_appends_unknown_timing_langs():
+    result = relevant_languages_for_estimation(
+        env_languages=['cpp', 'python'],
+        timing_languages=['python', 'rust'],  # rust not in env list
+        env_groups=[],
+    )
+    assert result == ['python', 'rust']

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -82,3 +82,14 @@ async def test_picker_cancel_returns_none():
             ['cpp', 'java'], {}, input=inp, output=DummyOutput()
         )
     assert result is None
+
+
+def test_legend_describes_three_states():
+    from rbx.box.timing_group_picker import LEGEND_LINES
+
+    text = '\n'.join(LEGEND_LINES)
+    assert '[N]' in text and 'grouped' in text
+    assert '[X]' in text and 'singleton' in text
+    assert '[ ]' in text and 'leftover' in text
+    # key hint still present
+    assert 'confirm' in text and 'cancel' in text

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -23,13 +23,44 @@ def test_state_set_group_and_assignment():
     assert s.assignment() == {'cpp': 1, 'java': 2}
 
 
-def test_render_fragments_marks_cursor_and_numbers():
-    s = GroupPickerState(['cpp', 'java'], {'cpp': 3})
+def test_render_fragments_shows_three_states():
+    # cpp -> group 3, java -> unbucketed (0), python -> singleton (-1)
+    s = GroupPickerState(['cpp', 'java', 'python'], {'cpp': 3, 'python': -1})
     text = ''.join(t for _, t in s.render_fragments())
     assert '[3] cpp' in text
     assert '[ ] java' in text
-    # the cursor pointer appears once for the selected (first) row
+    assert '[X] python' in text
     assert text.count('❯') == 1
+
+
+def test_toggle_singleton_cycles():
+    s = GroupPickerState(['cpp'], {'cpp': 0})
+    s.toggle_singleton()
+    assert s.assignment() == {'cpp': -1}  # unbucketed -> singleton
+    s.toggle_singleton()
+    assert s.assignment() == {'cpp': 0}  # singleton -> unbucketed
+
+
+def test_toggle_singleton_from_group_goes_to_singleton():
+    s = GroupPickerState(['cpp'], {'cpp': 2})
+    s.toggle_singleton()
+    assert s.assignment() == {'cpp': -1}
+
+
+async def test_picker_toggle_and_group_then_confirm():
+    with create_pipe_input() as inp:
+        inp.send_text('1')  # cpp -> group 1
+        inp.send_text('\x1b[B')  # down -> java
+        inp.send_text(' ')  # space -> java singleton [X]
+        inp.send_text('\x1b[B')  # down -> python (stays unbucketed [ ])
+        inp.send_text('\r')  # enter -> confirm
+        result = await prompt_group_assignment(
+            ['cpp', 'java', 'python'],
+            {'cpp': 0, 'java': 0, 'python': 0},
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert result == {'cpp': 1, 'java': -1, 'python': 0}
 
 
 async def test_picker_assigns_and_confirms():

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -1,0 +1,53 @@
+from prompt_toolkit.input.defaults import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+
+from rbx.box.timing_group_picker import GroupPickerState, prompt_group_assignment
+
+
+def test_state_move_clamps():
+    s = GroupPickerState(['a', 'b', 'c'], {})
+    s.move(-1)
+    assert s.cursor == 0
+    s.move(1)
+    s.move(1)
+    s.move(1)
+    s.move(1)
+    assert s.cursor == 2
+
+
+def test_state_set_group_and_assignment():
+    s = GroupPickerState(['cpp', 'java'], {'cpp': 1})
+    assert s.assignment() == {'cpp': 1, 'java': 0}
+    s.move(1)
+    s.set_group(2)
+    assert s.assignment() == {'cpp': 1, 'java': 2}
+
+
+def test_render_fragments_marks_cursor_and_numbers():
+    s = GroupPickerState(['cpp', 'java'], {'cpp': 3})
+    text = ''.join(t for _, t in s.render_fragments())
+    assert '[3] cpp' in text
+    assert '[ ] java' in text
+    # the cursor pointer appears once for the selected (first) row
+    assert text.count('❯') == 1
+
+
+async def test_picker_assigns_and_confirms():
+    with create_pipe_input() as inp:
+        inp.send_text('2')  # set first lang (cpp) -> group 2
+        inp.send_text('\x1b[B')  # down arrow -> cursor to java
+        inp.send_text('2')  # set java -> group 2
+        inp.send_text('\r')  # enter -> confirm
+        result = await prompt_group_assignment(
+            ['cpp', 'java'], {'cpp': 0, 'java': 0}, input=inp, output=DummyOutput()
+        )
+    assert result == {'cpp': 2, 'java': 2}
+
+
+async def test_picker_cancel_returns_none():
+    with create_pipe_input() as inp:
+        inp.send_text('q')
+        result = await prompt_group_assignment(
+            ['cpp', 'java'], {}, input=inp, output=DummyOutput()
+        )
+    assert result is None

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -1,10 +1,14 @@
+import pytest
+
 from rbx.box.environment import LanguageGroup, LanguageGroupFallback
 from rbx.box.schema import TimingGroupOrigin
 from rbx.box.timing_groups import (
     GroupTimings,
+    GroupValidationError,
     ResolvedGroup,
     build_partition,
     resolve_groups,
+    validate_partition,
 )
 
 
@@ -107,3 +111,63 @@ def test_multiplier_chain_through_another_empty_group():
     cpp_tl = result.time_limit_per_language['cpp']
     assert result.time_limit_per_language['java'] == cpp_tl * 2
     assert result.time_limit_per_language['dart'] == cpp_tl * 2 * 2
+
+
+def test_relative_to_unknown_language_errors():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(
+                languages=['java'],
+                whenEmpty=LanguageGroupFallback(relativeTo='rust', multiplier=2.0),
+            )
+        ],
+        all_languages=['java'],
+    )
+    with pytest.raises(GroupValidationError, match='rust'):
+        validate_partition(groups)
+
+
+def test_relative_to_same_group_errors():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='kotlin', multiplier=2.0),
+            )
+        ],
+        all_languages=['java', 'kotlin'],
+    )
+    with pytest.raises(GroupValidationError, match='same group'):
+        validate_partition(groups)
+
+
+def test_cyclic_when_empty_errors():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(
+                languages=['a'],
+                whenEmpty=LanguageGroupFallback(relativeTo='b', multiplier=2.0),
+            ),
+            LanguageGroup(
+                languages=['b'],
+                whenEmpty=LanguageGroupFallback(relativeTo='a', multiplier=2.0),
+            ),
+        ],
+        all_languages=['a', 'b'],
+    )
+    with pytest.raises(GroupValidationError, match='cycle'):
+        validate_partition(groups)
+
+
+def test_valid_partition_passes():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(languages=['cpp']),
+            LanguageGroup(
+                languages=['java'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            ),
+        ],
+        all_languages=['cpp', 'java'],
+    )
+    validate_partition(groups)  # no raise

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -7,6 +7,7 @@ from rbx.box.timing_groups import (
     GroupValidationError,
     ResolvedGroup,
     build_partition,
+    partition_from_assignment,
     resolve_groups,
     validate_partition,
 )
@@ -171,3 +172,42 @@ def test_valid_partition_passes():
         all_languages=['cpp', 'java'],
     )
     validate_partition(groups)  # no raise
+
+
+def test_assignment_zero_makes_singletons():
+    env_groups = [LanguageGroup(languages=['c', 'cpp'])]
+    groups = partition_from_assignment(
+        assignment={'c': 0, 'cpp': 0, 'python': 0},
+        env_groups=env_groups,
+    )
+    assert sorted(g.languages for g in groups) == [['c'], ['cpp'], ['python']]
+
+
+def test_identical_membership_preserves_when_empty():
+    env_groups = [
+        LanguageGroup(
+            languages=['java', 'kotlin'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        )
+    ]
+    groups = partition_from_assignment(
+        assignment={'java': 1, 'kotlin': 1, 'cpp': 2},
+        env_groups=env_groups,
+    )
+    jvm = next(g for g in groups if set(g.languages) == {'java', 'kotlin'})
+    assert jvm.whenEmpty is not None and jvm.whenEmpty.multiplier == 2.0
+
+
+def test_changed_membership_drops_when_empty():
+    env_groups = [
+        LanguageGroup(
+            languages=['java', 'kotlin'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        )
+    ]
+    groups = partition_from_assignment(
+        assignment={'java': 1, 'kotlin': 1, 'scala': 1},
+        env_groups=env_groups,
+    )
+    jvm = next(g for g in groups if 'java' in g.languages)
+    assert jvm.whenEmpty is None

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -265,3 +265,38 @@ def test_partition_from_assignment_preserves_when_empty_on_exact_match():
     )
     assert groups[0].whenEmpty is not None
     assert groups[0].whenEmpty.multiplier == 2.0
+
+
+def test_build_partition_marks_leftover():
+    groups = build_partition(
+        env_groups=[LanguageGroup(languages=['c', 'cpp'])],
+        all_languages=['c', 'cpp', 'python', 'go'],
+    )
+    assert groups[0].is_leftover is False  # explicit env group
+    assert groups[1].languages == ['python', 'go']
+    assert groups[1].is_leftover is True  # the leftover pool
+
+
+def test_partition_from_assignment_marks_leftover():
+    groups = partition_from_assignment(
+        assignment={'cpp': 1, 'python': -1, 'go': 0, 'rust': 0},
+        env_groups=[],
+    )
+    leftover = [g for g in groups if g.is_leftover]
+    assert len(leftover) == 1
+    assert leftover[0].languages == ['go', 'rust']
+    non_leftover = [g for g in groups if not g.is_leftover]
+    assert {tuple(g.languages) for g in non_leftover} == {('cpp',), ('python',)}
+
+
+def test_resolve_propagates_is_leftover():
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(languages=['go', 'java'], is_leftover=True),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=100, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=100, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval)
+    by_leftover = {tuple(r.languages): r.isLeftover for r in result.reports}
+    assert by_leftover[('cpp',)] is False
+    assert by_leftover[('go', 'java')] is True

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -183,10 +183,10 @@ def test_valid_partition_passes():
     validate_partition(groups)  # no raise
 
 
-def test_assignment_zero_makes_singletons():
+def test_assignment_singleton_state_makes_singletons():
     env_groups = [LanguageGroup(languages=['c', 'cpp'])]
     groups = partition_from_assignment(
-        assignment={'c': 0, 'cpp': 0, 'python': 0},
+        assignment={'c': -1, 'cpp': -1, 'python': -1},
         env_groups=env_groups,
     )
     assert sorted(g.languages for g in groups) == [['c'], ['cpp'], ['python']]
@@ -220,3 +220,48 @@ def test_changed_membership_drops_when_empty():
     )
     jvm = next(g for g in groups if 'java' in g.languages)
     assert jvm.whenEmpty is None
+
+
+def test_partition_from_assignment_three_states():
+    # 1/2 = shared groups, -1 = singleton, 0 = unbucketed leftover pool
+    groups = partition_from_assignment(
+        assignment={
+            'c': 1,
+            'cpp': 1,
+            'java': 2,
+            'kotlin': 2,
+            'python': -1,
+            'go': 0,
+            'rust': 0,
+        },
+        env_groups=[],
+    )
+    langs = [g.languages for g in groups]
+    assert ['c', 'cpp'] in langs
+    assert ['java', 'kotlin'] in langs
+    assert ['python'] in langs  # singleton -> own group
+    assert ['go', 'rust'] in langs  # unbucketed -> ONE leftover pool
+    # numbered groups first (sorted), then singletons, then the leftover pool
+    assert langs[-1] == ['go', 'rust']
+
+
+def test_partition_from_assignment_no_leftover_group_when_none_unbucketed():
+    groups = partition_from_assignment(
+        assignment={'cpp': 1, 'python': -1},
+        env_groups=[],
+    )
+    assert [g.languages for g in groups] == [['cpp'], ['python']]
+
+
+def test_partition_from_assignment_preserves_when_empty_on_exact_match():
+    groups = partition_from_assignment(
+        assignment={'java': 1, 'kotlin': 1},
+        env_groups=[
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            ),
+        ],
+    )
+    assert groups[0].whenEmpty is not None
+    assert groups[0].whenEmpty.multiplier == 2.0

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -13,14 +13,15 @@ from rbx.box.timing_groups import (
 )
 
 
-def test_implicit_singletons_for_unlisted_languages():
+def test_leftover_pool_for_unlisted_languages():
     groups = build_partition(
         env_groups=[LanguageGroup(languages=['c', 'cpp'])],
-        all_languages=['c', 'cpp', 'python'],
+        all_languages=['c', 'cpp', 'python', 'go'],
     )
-    # one explicit group + one implicit singleton, order preserved
-    assert [g.languages for g in groups] == [['c', 'cpp'], ['python']]
+    # one explicit group + ONE leftover pool of all unlisted languages, in order
+    assert [g.languages for g in groups] == [['c', 'cpp'], ['python', 'go']]
     assert groups[0].whenEmpty is None
+    assert groups[1].whenEmpty is None
 
 
 def test_partition_preserves_when_empty():
@@ -36,9 +37,17 @@ def test_partition_preserves_when_empty():
     assert groups[0].whenEmpty.multiplier == 2.0
 
 
-def test_build_partition_with_no_env_groups_makes_all_singletons():
+def test_build_partition_with_no_env_groups_makes_one_leftover_pool():
     groups = build_partition(env_groups=[], all_languages=['c', 'cpp', 'python'])
-    assert [g.languages for g in groups] == [['c'], ['cpp'], ['python']]
+    assert [g.languages for g in groups] == [['c', 'cpp', 'python']]
+
+
+def test_build_partition_no_leftover_when_all_grouped():
+    groups = build_partition(
+        env_groups=[LanguageGroup(languages=['c', 'cpp'])],
+        all_languages=['c', 'cpp'],
+    )
+    assert [g.languages for g in groups] == [['c', 'cpp']]
 
 
 def _eval(fastest, slowest):

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -1,5 +1,11 @@
 from rbx.box.environment import LanguageGroup, LanguageGroupFallback
-from rbx.box.timing_groups import build_partition
+from rbx.box.schema import TimingGroupOrigin
+from rbx.box.timing_groups import (
+    GroupTimings,
+    ResolvedGroup,
+    build_partition,
+    resolve_groups,
+)
 
 
 def test_implicit_singletons_for_unlisted_languages():
@@ -23,3 +29,81 @@ def test_partition_preserves_when_empty():
         all_languages=['java', 'kotlin'],
     )
     assert groups[0].whenEmpty.multiplier == 2.0
+
+
+def test_build_partition_with_no_env_groups_makes_all_singletons():
+    groups = build_partition(env_groups=[], all_languages=['c', 'cpp', 'python'])
+    assert [g.languages for g in groups] == [['c'], ['cpp'], ['python']]
+
+
+def _eval(fastest, slowest):
+    # simple deterministic formula for tests: max(fastest*3, slowest*2)
+    return max(fastest * 3, slowest * 2)
+
+
+def test_resolves_estimated_and_multiplier_and_default_groups():
+    groups = [
+        ResolvedGroup(languages=['c', 'cpp']),
+        ResolvedGroup(
+            languages=['java', 'kotlin'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=4.0),
+        ),
+        ResolvedGroup(languages=['go']),  # empty, no whenEmpty -> DEFAULTED
+        ResolvedGroup(languages=['python']),
+    ]
+    pooled = {
+        0: GroupTimings(fastest=100, slowest=200, solution_count=2),
+        3: GroupTimings(fastest=500, slowest=500, solution_count=1),
+    }
+    base = GroupTimings(fastest=100, slowest=500, solution_count=3)
+
+    result = resolve_groups(groups, pooled, base, _eval)
+
+    assert result.base_time_limit == _eval(100, 500)  # 1000
+    by_lang = result.time_limit_per_language
+    assert by_lang['cpp'] == _eval(100, 200)  # 400
+    assert by_lang['c'] == 400
+    assert by_lang['java'] == int(400 * 4.0)
+    assert by_lang['kotlin'] == int(400 * 4.0)
+    assert 'go' not in by_lang  # DEFAULTED -> uses base, no modifier
+    assert by_lang['python'] == _eval(500, 500)  # 1500
+
+    origins = {tuple(r.languages): r.origin for r in result.reports}
+    assert origins[('c', 'cpp')] == TimingGroupOrigin.ESTIMATED
+    assert origins[('java', 'kotlin')] == TimingGroupOrigin.MULTIPLIER
+    assert origins[('go',)] == TimingGroupOrigin.DEFAULTED
+    assert result.defaulted_languages == ['go']
+
+
+def test_multiplier_relative_to_base_when_relative_to_omitted():
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['java'],
+            whenEmpty=LanguageGroupFallback(multiplier=3.0),
+        ),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=100, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=100, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval)
+    assert result.time_limit_per_language['java'] == int(result.base_time_limit * 3.0)
+
+
+def test_multiplier_chain_through_another_empty_group():
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['java'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        ),
+        ResolvedGroup(
+            languages=['dart'],
+            whenEmpty=LanguageGroupFallback(relativeTo='java', multiplier=2.0),
+        ),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=100, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=100, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval)
+    cpp_tl = result.time_limit_per_language['cpp']
+    assert result.time_limit_per_language['java'] == cpp_tl * 2
+    assert result.time_limit_per_language['dart'] == cpp_tl * 2 * 2

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -1,0 +1,25 @@
+from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+from rbx.box.timing_groups import build_partition
+
+
+def test_implicit_singletons_for_unlisted_languages():
+    groups = build_partition(
+        env_groups=[LanguageGroup(languages=['c', 'cpp'])],
+        all_languages=['c', 'cpp', 'python'],
+    )
+    # one explicit group + one implicit singleton, order preserved
+    assert [g.languages for g in groups] == [['c', 'cpp'], ['python']]
+    assert groups[0].whenEmpty is None
+
+
+def test_partition_preserves_when_empty():
+    groups = build_partition(
+        env_groups=[
+            LanguageGroup(
+                languages=['java', 'kotlin'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            )
+        ],
+        all_languages=['java', 'kotlin'],
+    )
+    assert groups[0].whenEmpty.multiplier == 2.0


### PR DESCRIPTION
## Summary

Fixes #497 — languages without a solution silently defaulted to a (potentially tight) base time limit, invisibly, because setting per-language limits masked the fallback.

This introduces **language groups** for time-limit estimation (Approach A: groups are an estimation-time abstraction that compiles down to the existing per-language `modifiers`, so no consumer's resolution path changes):

- **`env.rbx.yml` `timing.groups`** — anonymous, disjoint groups of related languages (e.g. `[c, cpp]`, `[java, kotlin]`); unlisted languages are implicit singletons. Each group may declare `whenEmpty: {relativeTo: <language>, multiplier: >0}`, used only when the group has no solutions (multiplies the referenced group's TL, transitively; or the base estimate if `relativeTo` is omitted).
- **`rbx time`** pools accepted-solution timings per group, estimates a TL per non-empty group, resolves empty groups via `whenEmpty` (or falls back to the base TL with a **loud DEFAULTED warning**), and expands everything into `modifiers[lang].time`. An interactive group-number prompt (prepopulated from `env.rbx.yml`; `--auto` skips it) lets you repartition per run.
- **Presentation** — a shared per-group table (Languages / Solutions / Time Limit / Source) is shown after `rbx time` and at the end of `rbx package boca` (rendered from the resolved profile so inherit/custom profiles show real limits, not `0 ms`). DEFAULTED rows are highlighted.
- **Metadata** — an optional, presentation-only `groups` field on `LimitsProfile` records the grouping so the table is reconstructable from a saved profile; old `.limits/*.yml` files load unchanged.

Pure grouping logic lives in `rbx/box/timing_groups.py` (partition / resolve / validate / repartition), fully unit-tested without the sandbox.

Design & plan: `docs/plans/2026-06-01-language-groups-timing-design.md`, `docs/plans/2026-06-01-language-groups-timing.md`.

## Test Plan

- [x] New unit tests: `test_timing_groups.py`, `test_environment_groups.py`, `test_limits_profile_groups.py`, `test_limits_table.py`, `test_timing_estimation.py`, `packaging/test_boca_limits_table.py`
- [x] Updated existing `test_timing.py` for the new estimation flow
- [x] All directly-relevant suites pass (108 tests); `ruff check`/`format` clean repo-wide; `mkdocs build` succeeds
- [x] Disjoint-group validation, `whenEmpty` ref/self/cycle rejection, `multiplier > 0`, transitive multiplier chains, DEFAULTED fallback, and degraded (no-metadata) table rendering all covered
- [ ] Manual: run `rbx time -p boca` then `rbx package boca` on a multi-language problem with `timing.groups` configured and confirm the per-group table + DEFAULTED highlighting

> Note: broad `tests/rbx/box` sweep shows pre-existing failures confined to checker/validator/generator/sandbox suites (require a working C++ toolchain/sandbox); none are in the modules changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)