### PR TITLE
feat(timing): live timing-table preview during group selection (#500)

### DIFF
--- a/docs/plans/2026-06-02-timing-preview-design.md
+++ b/docs/plans/2026-06-02-timing-preview-design.md
@@ -1,0 +1,67 @@
+# Live timing-table preview during group selection
+
+Issue: [#500](https://github.com/rsalesc/rbx/issues/500). Builds on the language-groups
+estimation work from [#499](https://github.com/rsalesc/rbx/pull/499).
+
+## Goal
+
+While the user regroups languages in the interactive `rbx time` picker, render the
+resolved timing table directly below the language list, updating as the grouping
+changes. The final table after confirmation is already rendered by
+`compute_time_limits`, so this work is purely the *live preview during selection*.
+
+## Constraints / context
+
+- The picker is a `prompt_toolkit.Application` (`timing_group_picker.prompt_group_assignment`)
+  with its own redraw loop that repaints on every key event.
+- The table is a single rich renderable built by `limits_info.build_limits_table()`.
+- The issue suggests `rich.live`, but `rich.live` and prompt_toolkit both own the
+  terminal screen and conflict. The clean path is to render the preview *inside* the
+  existing prompt_toolkit app, which already repaints on every keystroke.
+
+## Approach (chosen)
+
+**Reuse the one rich renderer via ANSI.** prompt_toolkit's renderer cannot accept a
+rich renderable directly, so we render the existing `build_limits_table()` Table to an
+ANSI string and wrap it in `prompt_toolkit.formatted_text.ANSI`. There is exactly one
+table renderer; the picker only captures its output. No second renderer, no drift.
+
+### Keep the picker UI-only
+
+`timing_group_picker` stays free of timing/estimation logic. It gains one optional
+parameter:
+
+```python
+preview: Optional[Callable[[Dict[str, int]], AnyFormattedText]] = None
+```
+
+When provided, the layout adds a `Window` below the language-list body whose
+`FormattedTextControl` calls `preview(state.assignment())`. Because prompt_toolkit
+repaints on every key event, the preview is live for free.
+
+### The preview callback (owned by `timing.py`)
+
+`timing.py` already has everything needed *before* the prompt
+(`timing_per_solution_per_language`, `formula`, `env_groups`, `all_languages`) — no
+re-running solutions. The callback, given the current `assignment` dict:
+
+1. `build_timing_profile(..., repartition=assignment)`, catching `GroupValidationError`.
+2. On error → return a styled inline message (e.g. `⚠ Invalid grouping: <reason>`),
+   so the user sees immediately why no table renders.
+3. On success → `profile.to_limits()` → `build_limits_table(limits)` (the existing
+   renderer) → capture to an ANSI string via a
+   `rich.console.Console(file=StringIO, force_terminal=True, width=…)` → wrap in `ANSI`.
+
+Memoize by assignment so pure cursor moves don't rebuild the profile.
+
+## Testing
+
+- The callback is pure and unit-testable: valid assignment → table text contains the
+  expected per-group limits; cyclic/invalid grouping → inline error string.
+- The picker gets a test feeding piped keystrokes (existing prompt_toolkit test
+  pattern) and asserting the preview Window reflects the current assignment.
+
+## Out of scope
+
+- Final-table rendering after confirmation (already done in `compute_time_limits`).
+- The `--auto` path (no prompt → no preview).

--- a/docs/plans/2026-06-02-timing-preview.md
+++ b/docs/plans/2026-06-02-timing-preview.md
@@ -1,0 +1,453 @@
+# Live Timing-Table Preview During Group Selection — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Render the resolved timing table live below the language list in the interactive `rbx time` group picker, updating as the user regroups languages.
+
+**Architecture:** Reuse the single rich renderer `limits_info.build_limits_table()`. Add a generic `console.capture_ansi()` helper that renders any themed rich renderable to an ANSI string. `timing.py` builds a pure preview callback (assignment → ANSI table, or an inline error for invalid groupings) and passes it to the UI-only picker, which adds a content-sized Window below the list. prompt_toolkit repaints on every keystroke, so the preview is live without `rich.live`.
+
+**Tech Stack:** Python, prompt_toolkit (`FormattedTextControl`, `ANSI`), rich (`Console`, `Table`), pytest (`create_pipe_input`/`DummyOutput`).
+
+Design doc: `docs/plans/2026-06-02-timing-preview-design.md`.
+
+---
+
+### Task 1: `console.capture_ansi()` — render a themed renderable to ANSI
+
+**Files:**
+- Modify: `rbx/console.py`
+- Test: `tests/rbx/test_console_capture.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+import rich.table
+
+from rbx import console
+
+
+def test_capture_ansi_contains_text_and_escape_codes():
+    table = rich.table.Table('Col')
+    table.add_row('hello')
+    out = console.capture_ansi(table, width=40)
+    assert 'hello' in out
+    assert '\x1b[' in out  # SGR / box-drawing escapes emitted
+
+
+def test_capture_ansi_resolves_theme_markup():
+    # 'warning' is a project theme style; markup must resolve, not error.
+    out = console.capture_ansi('[warning]careful[/warning]', width=40)
+    assert 'careful' in out
+    assert '\x1b[' in out
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/test_console_capture.py -v`
+Expected: FAIL with `AttributeError: module 'rbx.console' has no attribute 'capture_ansi'`
+
+**Step 3: Write minimal implementation**
+
+Add to `rbx/console.py` (it already defines `theme` and imports `Console`):
+
+```python
+def capture_ansi(renderable, width: Optional[int] = None) -> str:
+    """Render a rich renderable (or markup string) to an ANSI string using the
+    project theme, suitable for embedding in a prompt_toolkit ``ANSI`` fragment."""
+    import io
+
+    buf = io.StringIO()
+    cap = Console(
+        theme=theme,
+        style='info',
+        highlight=False,
+        file=buf,
+        force_terminal=True,
+        color_system='standard',
+        width=width,
+    )
+    cap.print(renderable)
+    return buf.getvalue()
+```
+
+Add `from typing import Optional` if not already imported.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/test_console_capture.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add rbx/console.py tests/rbx/test_console_capture.py
+git commit  # use the /commit skill: feat(console): add capture_ansi helper for embedding rich output
+```
+
+---
+
+### Task 2: Preview callback factory in `timing.py`
+
+The callback maps a picker assignment to an `ANSI` renderable: the resolved limits table on success, or an inline themed error for an invalid grouping. It is pure (no solution re-runs) and memoized so cursor moves don't rebuild the profile.
+
+**Files:**
+- Modify: `rbx/box/timing.py`
+- Test: `tests/rbx/box/test_timing_preview.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+from prompt_toolkit.formatted_text import ANSI, to_formatted_text
+
+from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+from rbx.box.timing import build_preview_renderer
+
+
+def _text(ansi: ANSI) -> str:
+    return ''.join(t for _, t in to_formatted_text(ansi))
+
+
+def test_preview_renders_estimated_table():
+    render = build_preview_renderer(
+        timing_per_solution_per_language={
+            'cpp': {'a.cpp': 100, 'b.cpp': 200},
+            'python': {'p.py': 900},
+        },
+        formula='slowest * 3',
+        env_groups=[],
+        all_languages=['cpp', 'python'],
+        width=80,
+    )
+    out = _text(render({'cpp': 1, 'python': 2}))
+    assert 'Time Limit' in out  # the table header
+    assert 'cpp' in out and 'python' in out
+
+
+def test_preview_reports_invalid_grouping_inline():
+    # Two env groups whose whenEmpty rules reference each other -> cycle.
+    env_groups = [
+        LanguageGroup(
+            languages=['a'],
+            whenEmpty=LanguageGroupFallback(relativeTo='b', multiplier=2.0),
+        ),
+        LanguageGroup(
+            languages=['b'],
+            whenEmpty=LanguageGroupFallback(relativeTo='a', multiplier=2.0),
+        ),
+    ]
+    render = build_preview_renderer(
+        timing_per_solution_per_language={},  # both groups empty -> resolve via cycle
+        formula='slowest * 3',
+        env_groups=env_groups,
+        all_languages=['a', 'b'],
+        width=80,
+    )
+    # assignment reproduces the two env groups exactly, carrying their whenEmpty
+    out = _text(render({'a': 1, 'b': 2}))
+    assert 'Invalid grouping' in out
+
+
+def test_preview_memoizes_by_assignment():
+    calls = {'n': 0}
+    real = build_preview_renderer(
+        timing_per_solution_per_language={'cpp': {'a.cpp': 100}},
+        formula='slowest * 3',
+        env_groups=[],
+        all_languages=['cpp'],
+        width=80,
+    )
+
+    # Same assignment dict (different identity) must hit the cache.
+    first = real({'cpp': 1})
+    second = real({'cpp': 1})
+    assert first is second
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_preview.py -v`
+Expected: FAIL with `ImportError: cannot import name 'build_preview_renderer'`
+
+**Step 3: Write minimal implementation**
+
+Add to `rbx/box/timing.py`. Add imports at top:
+
+```python
+import functools
+
+from prompt_toolkit.formatted_text import ANSI
+
+from rbx.box.environment import LanguageGroup
+```
+
+(`environment`, `limits_info`, `timing_groups`, `console` are already imported.)
+
+Then:
+
+```python
+def build_preview_renderer(
+    timing_per_solution_per_language: Dict[str, Dict[str, int]],
+    formula: str,
+    env_groups: List[LanguageGroup],
+    all_languages: List[str],
+    width: Optional[int] = None,
+) -> Callable[[Dict[str, int]], ANSI]:
+    """Return a memoized callback mapping a picker assignment to an ``ANSI``
+    preview: the resolved limits table, or an inline error for invalid groupings.
+    Pure — reuses the already-collected timings, never re-runs solutions."""
+
+    @functools.lru_cache(maxsize=None)
+    def _render(assignment_items: tuple) -> ANSI:
+        assignment = dict(assignment_items)
+        try:
+            profile = build_timing_profile(
+                timing_per_solution_per_language=timing_per_solution_per_language,
+                formula=formula,
+                env_groups=env_groups,
+                all_languages=all_languages,
+                repartition=assignment,
+            )
+        except timing_groups.GroupValidationError as e:
+            return ANSI(console.capture_ansi(f'[warning]⚠ Invalid grouping: {e}[/warning]', width=width))
+        table = limits_info.build_limits_table(profile.to_limits(), title='Preview')
+        return ANSI(console.capture_ansi(table, width=width))
+
+    def render(assignment: Dict[str, int]) -> ANSI:
+        return _render(tuple(sorted(assignment.items())))
+
+    return render
+```
+
+Add `Callable` to the `typing` import line at the top of the file.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_preview.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/timing.py tests/rbx/box/test_timing_preview.py
+git commit  # /commit skill: feat(timing): add memoized preview renderer for the group picker
+```
+
+---
+
+### Task 3: Render the preview Window in the picker
+
+**Files:**
+- Modify: `rbx/box/timing_group_picker.py`
+- Test: `tests/rbx/box/test_timing_group_picker.py:` (append)
+
+**Step 1: Write the failing test**
+
+Append to `tests/rbx/box/test_timing_group_picker.py`:
+
+```python
+async def test_picker_invokes_preview_with_current_assignment():
+    from prompt_toolkit.formatted_text import ANSI
+    from prompt_toolkit.input.defaults import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    seen = []
+
+    def preview(assignment):
+        seen.append(dict(assignment))
+        return ANSI('preview')
+
+    with create_pipe_input() as inp:
+        inp.send_text('1')  # cpp -> group 1
+        inp.send_text('\r')  # confirm
+        result = await prompt_group_assignment(
+            ['cpp', 'java'],
+            {'cpp': 0, 'java': 0},
+            input=inp,
+            output=DummyOutput(),
+            preview=preview,
+        )
+    assert result == {'cpp': 1, 'java': 0}
+    # The picker rendered at least once and the final state reached the preview.
+    assert seen
+    assert {'cpp': 1, 'java': 0} in seen
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py::test_picker_invokes_preview_with_current_assignment -v`
+Expected: FAIL with `TypeError: prompt_group_assignment() got an unexpected keyword argument 'preview'`
+
+**Step 3: Write minimal implementation**
+
+In `rbx/box/timing_group_picker.py`:
+
+1. Update imports at top of file:
+
+```python
+from typing import Callable, Dict, List, Optional
+
+from prompt_toolkit.formatted_text import AnyFormattedText
+```
+
+2. Extend the signature:
+
+```python
+async def prompt_group_assignment(
+    languages: List[str],
+    default_number: Dict[str, int],
+    input=None,
+    output=None,
+    preview: Optional[Callable[[Dict[str, int]], AnyFormattedText]] = None,
+) -> Optional[Dict[str, int]]:
+```
+
+3. Build the layout's window list and conditionally append the preview window. Replace the existing `layout = Layout(HSplit([...]))` block with:
+
+```python
+windows = [
+    Window(content=header, height=len(LEGEND_LINES), always_hide_cursor=True),
+    Window(content=body, height=len(state.languages), always_hide_cursor=True),
+]
+if preview is not None:
+
+    def _preview_fragments():
+        return preview(state.assignment())
+
+    windows.append(
+        Window(
+            content=FormattedTextControl(_preview_fragments),
+            always_hide_cursor=True,
+            dont_extend_height=True,
+        )
+    )
+layout = Layout(HSplit(windows))
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -v`
+Expected: PASS (new test plus all existing picker tests)
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/timing_group_picker.py tests/rbx/box/test_timing_group_picker.py
+git commit  # /commit skill: feat(timing): render live preview window in the group picker
+```
+
+---
+
+### Task 4: Wire the preview into `_prompt_repartition`
+
+**Files:**
+- Modify: `rbx/box/timing.py` (`_prompt_repartition`, `estimate_time_limit` call site)
+- Test: `tests/rbx/box/test_timing_preview.py` (append)
+
+**Step 1: Write the failing test**
+
+Append to `tests/rbx/box/test_timing_preview.py`:
+
+```python
+import inspect
+
+from rbx.box import timing
+
+
+def test_prompt_repartition_passes_preview_to_picker():
+    # _prompt_repartition must accept the timing data needed to build a preview.
+    sig = inspect.signature(timing._prompt_repartition)
+    assert 'timing_per_solution_per_language' in sig.parameters
+    assert 'formula' in sig.parameters
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_preview.py::test_prompt_repartition_passes_preview_to_picker -v`
+Expected: FAIL on the missing-parameter assertions.
+
+**Step 3: Write minimal implementation**
+
+In `rbx/box/timing.py`, replace `_prompt_repartition`:
+
+```python
+async def _prompt_repartition(
+    all_languages: List[str],
+    env_groups: List[environment.LanguageGroup],
+    timing_per_solution_per_language: Dict[str, Dict[str, int]],
+    formula: str,
+) -> Optional[Dict[str, int]]:
+    preview = build_preview_renderer(
+        timing_per_solution_per_language=timing_per_solution_per_language,
+        formula=formula,
+        env_groups=env_groups,
+        all_languages=all_languages,
+        width=console.console.size.width,
+    )
+    return await timing_group_picker.prompt_group_assignment(
+        all_languages,
+        default_assignment(all_languages, env_groups),
+        preview=preview,
+    )
+```
+
+Update the call site in `estimate_time_limit` (currently around line 216). Note `formula` is resolved just above the call (lines 205-206), so pass it:
+
+```python
+    repartition = None
+    if not auto and len(all_languages) > 1:
+        repartition = await _prompt_repartition(
+            all_languages,
+            env_groups,
+            timing_per_solution_per_language,
+            formula,
+        )
+        if repartition is None:
+            console.print('[error]Time limit estimation cancelled.[/error]')
+            return None
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_preview.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/timing.py tests/rbx/box/test_timing_preview.py
+git commit  # /commit skill: feat(timing): wire live preview into the repartition prompt
+```
+
+---
+
+### Task 5: Full verification
+
+**Step 1: Run the directly-related suites**
+
+Run:
+```bash
+uv run pytest tests/rbx/test_console_capture.py tests/rbx/box/test_timing_preview.py \
+  tests/rbx/box/test_timing_group_picker.py tests/rbx/box/test_timing_groups.py \
+  tests/rbx/box/test_timing_estimation.py tests/rbx/box/test_timing.py -v
+```
+Expected: all PASS.
+
+**Step 2: Lint & format**
+
+Run: `uv run ruff check rbx/box/timing.py rbx/box/timing_group_picker.py rbx/console.py && uv run ruff format --check .`
+Expected: clean.
+
+**Step 3: Manual smoke (optional, needs a multi-language package)**
+
+Run `rbx time -p boca` in a package with ≥2 languages; confirm the table renders below the picker and updates as groups change. (Skip if no sandbox/toolchain available locally.)
+
+**Step 4: Final commit if any fixups were needed.**
+
+---
+
+## Notes for the implementer
+
+- **Why ANSI, not `rich.live`:** the picker is already a `prompt_toolkit.Application` that repaints every keystroke; a second screen-owner (`rich.live`) would conflict. Capturing the existing table to ANSI keeps one renderer.
+- **Memoization key** is `tuple(sorted(assignment.items()))` — cursor-only moves don't change the assignment, so they reuse the cached `ANSI`.
+- **Width** is captured once from `console.console.size.width`; the table is compact, so static width is acceptable.
+- Keep `timing_group_picker.py` free of timing/rich-theme knowledge — it only invokes the opaque `preview` callback.

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Optional
+import functools
+from typing import Any, Callable, Dict, List, Optional
 
 import rich
 import rich.console
 import typer
 from ordered_set import OrderedSet
+from prompt_toolkit.formatted_text import ANSI
 from pydantic import BaseModel, Field
 
 from rbx import console, utils
@@ -125,6 +127,43 @@ def default_assignment(
             if lang in default_number:
                 default_number[lang] = i
     return default_number
+
+
+def build_preview_renderer(
+    timing_per_solution_per_language: Dict[str, Dict[str, int]],
+    formula: str,
+    env_groups: List[environment.LanguageGroup],
+    all_languages: List[str],
+    width: Optional[int] = None,
+) -> Callable[[Dict[str, int]], ANSI]:
+    """Return a memoized callback mapping a picker assignment to an ``ANSI``
+    preview: the resolved limits table, or an inline error for invalid groupings.
+    Pure -- reuses the already-collected timings, never re-runs solutions."""
+
+    @functools.lru_cache(maxsize=None)
+    def _render(assignment_items: tuple) -> ANSI:
+        assignment = dict(assignment_items)
+        try:
+            profile = build_timing_profile(
+                timing_per_solution_per_language=timing_per_solution_per_language,
+                formula=formula,
+                env_groups=env_groups,
+                all_languages=all_languages,
+                repartition=assignment,
+            )
+        except timing_groups.GroupValidationError as e:
+            return ANSI(
+                console.capture_ansi(
+                    f'[warning]⚠ Invalid grouping: {e}[/warning]', width=width
+                )
+            )
+        table = limits_info.build_limits_table(profile.to_limits(), title='Preview')
+        return ANSI(console.capture_ansi(table, width=width))
+
+    def render(assignment: Dict[str, int]) -> ANSI:
+        return _render(tuple(sorted(assignment.items())))
+
+    return render
 
 
 async def _prompt_repartition(

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -169,9 +169,20 @@ def build_preview_renderer(
 async def _prompt_repartition(
     all_languages: List[str],
     env_groups: List[environment.LanguageGroup],
+    timing_per_solution_per_language: Dict[str, Dict[str, int]],
+    formula: str,
 ) -> Optional[Dict[str, int]]:
+    preview = build_preview_renderer(
+        timing_per_solution_per_language=timing_per_solution_per_language,
+        formula=formula,
+        env_groups=env_groups,
+        all_languages=all_languages,
+        width=console.console.size.width,
+    )
     return await timing_group_picker.prompt_group_assignment(
-        all_languages, default_assignment(all_languages, env_groups)
+        all_languages,
+        default_assignment(all_languages, env_groups),
+        preview=preview,
     )
 
 
@@ -252,7 +263,12 @@ async def estimate_time_limit(
 
     repartition = None
     if not auto and len(all_languages) > 1:
-        repartition = await _prompt_repartition(all_languages, env_groups)
+        repartition = await _prompt_repartition(
+            all_languages,
+            env_groups,
+            timing_per_solution_per_language,
+            formula,
+        )
         if repartition is None:
             console.print('[error]Time limit estimation cancelled.[/error]')
             return None

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -20,6 +20,15 @@ class GroupPickerState:
             lang: int(default_number.get(lang, 0)) for lang in self.languages
         }
         self.cursor: int = 0
+        # Set once the user confirms; suppresses the live preview on the final
+        # paint so only the official table (printed afterwards) remains.
+        self.done: bool = False
+
+    def preview_text(self, preview):
+        """The live preview's content, or empty once the picker is confirmed."""
+        if self.done or preview is None:
+            return ''
+        return preview(self.assignment())
 
     def move(self, delta: int) -> None:
         if not self.languages:
@@ -131,6 +140,9 @@ async def prompt_group_assignment(
 
     @kb.add('enter')
     def _(event):
+        # Hide the live preview on the final paint; the official table is
+        # printed by the caller right after the picker returns.
+        state.done = True
         event.app.exit(result=state.assignment())
 
     @kb.add('c-c')
@@ -145,7 +157,7 @@ async def prompt_group_assignment(
     if preview is not None:
 
         def _preview_fragments():
-            return preview(state.assignment())
+            return state.preview_text(preview)
 
         windows.append(
             Window(

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -1,4 +1,6 @@
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
+
+from prompt_toolkit.formatted_text import AnyFormattedText
 
 LEGEND_LINES = [
     'Assign each language to a time-limit bucket:',
@@ -65,6 +67,7 @@ async def prompt_group_assignment(
     default_number: Dict[str, int],
     input=None,
     output=None,
+    preview: Optional[Callable[[Dict[str, int]], AnyFormattedText]] = None,
 ) -> Optional[Dict[str, int]]:
     """Interactive single-screen group picker. Returns {language: group_number}
     where N>=1 is a shared group, 0 is unbucketed (leftover), and -1 is a
@@ -135,20 +138,23 @@ async def prompt_group_assignment(
     def _(event):
         event.app.exit(result=None)
 
-    layout = Layout(
-        HSplit(
-            [
-                Window(
-                    content=header, height=len(LEGEND_LINES), always_hide_cursor=True
-                ),
-                Window(
-                    content=body,
-                    height=len(state.languages),
-                    always_hide_cursor=True,
-                ),
-            ]
+    windows = [
+        Window(content=header, height=len(LEGEND_LINES), always_hide_cursor=True),
+        Window(content=body, height=len(state.languages), always_hide_cursor=True),
+    ]
+    if preview is not None:
+
+        def _preview_fragments():
+            return preview(state.assignment())
+
+        windows.append(
+            Window(
+                content=FormattedTextControl(_preview_fragments),
+                always_hide_cursor=True,
+                dont_extend_height=True,
+            )
         )
-    )
+    layout = Layout(HSplit(windows))
     style = Style.from_dict(
         {
             'header': 'bold',

--- a/rbx/console.py
+++ b/rbx/console.py
@@ -1,4 +1,6 @@
+import io
 import sys
+from typing import Optional
 
 import rich
 import rich.markup
@@ -33,6 +35,23 @@ stderr_console = Console(theme=theme, style='info', highlight=False, stderr=True
 
 def new_console():
     return Console(theme=theme, style='info', highlight=False)
+
+
+def capture_ansi(renderable, width: Optional[int] = None) -> str:
+    """Render a rich renderable (or markup string) to an ANSI string using the
+    project theme, suitable for embedding in a prompt_toolkit ``ANSI`` fragment."""
+    buf = io.StringIO()
+    cap = Console(
+        theme=theme,
+        style='info',
+        highlight=False,
+        file=buf,
+        force_terminal=True,
+        color_system='standard',
+        width=width,
+    )
+    cap.print(renderable)
+    return buf.getvalue()
 
 
 def multiline_prompt(text: str) -> str:

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -84,6 +84,31 @@ async def test_picker_cancel_returns_none():
     assert result is None
 
 
+async def test_picker_invokes_preview_with_current_assignment():
+    from prompt_toolkit.formatted_text import ANSI
+
+    seen = []
+
+    def preview(assignment):
+        seen.append(dict(assignment))
+        return ANSI('preview')
+
+    with create_pipe_input() as inp:
+        inp.send_text('1')  # cpp -> group 1
+        inp.send_text('\r')  # confirm
+        result = await prompt_group_assignment(
+            ['cpp', 'java'],
+            {'cpp': 0, 'java': 0},
+            input=inp,
+            output=DummyOutput(),
+            preview=preview,
+        )
+    assert result == {'cpp': 1, 'java': 0}
+    # The picker rendered at least once and the final state reached the preview.
+    assert seen
+    assert {'cpp': 1, 'java': 0} in seen
+
+
 def test_legend_describes_three_states():
     from rbx.box.timing_group_picker import LEGEND_LINES
 

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -84,6 +84,18 @@ async def test_picker_cancel_returns_none():
     assert result is None
 
 
+def test_preview_text_suppressed_once_done():
+    s = GroupPickerState(['cpp'], {})
+    assert s.preview_text(lambda a: 'TABLE') == 'TABLE'
+    s.done = True
+    assert s.preview_text(lambda a: 'TABLE') == ''
+
+
+def test_preview_text_empty_without_callback():
+    s = GroupPickerState(['cpp'], {})
+    assert s.preview_text(None) == ''
+
+
 async def test_picker_invokes_preview_with_current_assignment():
     from prompt_toolkit.formatted_text import ANSI
 
@@ -104,9 +116,11 @@ async def test_picker_invokes_preview_with_current_assignment():
             preview=preview,
         )
     assert result == {'cpp': 1, 'java': 0}
-    # The picker rendered at least once and the final state reached the preview.
-    assert seen
-    assert {'cpp': 1, 'java': 0} in seen
+    # The picker rendered the live preview from the current assignment...
+    assert {'cpp': 0, 'java': 0} in seen
+    # ...but suppressed it on the confirming (final) paint, so the post-enter
+    # assignment never reaches the preview.
+    assert {'cpp': 1, 'java': 0} not in seen
 
 
 def test_legend_describes_three_states():

--- a/tests/rbx/box/test_timing_preview.py
+++ b/tests/rbx/box/test_timing_preview.py
@@ -1,0 +1,63 @@
+from prompt_toolkit.formatted_text import ANSI, to_formatted_text
+
+from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+from rbx.box.timing import build_preview_renderer
+
+
+def _text(ansi: ANSI) -> str:
+    return ''.join(t for _, t in to_formatted_text(ansi))
+
+
+def test_preview_renders_estimated_table():
+    render = build_preview_renderer(
+        timing_per_solution_per_language={
+            'cpp': {'a.cpp': 100, 'b.cpp': 200},
+            'python': {'p.py': 900},
+        },
+        formula='slowest * 3',
+        env_groups=[],
+        all_languages=['cpp', 'python'],
+        width=80,
+    )
+    out = _text(render({'cpp': 1, 'python': 2}))
+    assert 'Time Limit' in out  # the table header
+    assert 'cpp' in out and 'python' in out
+
+
+def test_preview_reports_invalid_grouping_inline():
+    # Two env groups whose whenEmpty rules reference each other -> cycle.
+    env_groups = [
+        LanguageGroup(
+            languages=['a'],
+            whenEmpty=LanguageGroupFallback(relativeTo='b', multiplier=2.0),
+        ),
+        LanguageGroup(
+            languages=['b'],
+            whenEmpty=LanguageGroupFallback(relativeTo='a', multiplier=2.0),
+        ),
+    ]
+    render = build_preview_renderer(
+        timing_per_solution_per_language={},  # both groups empty -> resolve via cycle
+        formula='slowest * 3',
+        env_groups=env_groups,
+        all_languages=['a', 'b'],
+        width=80,
+    )
+    # assignment reproduces the two env groups exactly, carrying their whenEmpty
+    out = _text(render({'a': 1, 'b': 2}))
+    assert 'Invalid grouping' in out
+
+
+def test_preview_memoizes_by_assignment():
+    real = build_preview_renderer(
+        timing_per_solution_per_language={'cpp': {'a.cpp': 100}},
+        formula='slowest * 3',
+        env_groups=[],
+        all_languages=['cpp'],
+        width=80,
+    )
+
+    # Same assignment dict (different identity) must hit the cache.
+    first = real({'cpp': 1})
+    second = real({'cpp': 1})
+    assert first is second

--- a/tests/rbx/box/test_timing_preview.py
+++ b/tests/rbx/box/test_timing_preview.py
@@ -48,6 +48,33 @@ def test_preview_reports_invalid_grouping_inline():
     assert 'Invalid grouping' in out
 
 
+async def test_prompt_repartition_wires_a_working_preview(monkeypatch):
+    from rbx.box import timing, timing_group_picker
+
+    captured = {}
+
+    async def fake_picker(languages, default_number, preview=None, **kwargs):
+        captured['preview'] = preview
+        return default_number
+
+    monkeypatch.setattr(timing_group_picker, 'prompt_group_assignment', fake_picker)
+
+    await timing._prompt_repartition(  # noqa: SLF001
+        all_languages=['cpp', 'python'],
+        env_groups=[],
+        timing_per_solution_per_language={
+            'cpp': {'a.cpp': 100},
+            'python': {'p.py': 900},
+        },
+        formula='slowest * 3',
+    )
+
+    # The picker received a preview callback that renders the resolved table.
+    out = _text(captured['preview']({'cpp': 1, 'python': 2}))
+    assert 'Time Limit' in out
+    assert 'cpp' in out and 'python' in out
+
+
 def test_preview_memoizes_by_assignment():
     real = build_preview_renderer(
         timing_per_solution_per_language={'cpp': {'a.cpp': 100}},

--- a/tests/rbx/test_console_capture.py
+++ b/tests/rbx/test_console_capture.py
@@ -1,0 +1,18 @@
+import rich.table
+
+from rbx import console
+
+
+def test_capture_ansi_contains_text_and_escape_codes():
+    table = rich.table.Table('Col')
+    table.add_row('hello')
+    out = console.capture_ansi(table, width=40)
+    assert 'hello' in out
+    assert '\x1b[' in out  # SGR / box-drawing escapes emitted
+
+
+def test_capture_ansi_resolves_theme_markup():
+    # 'warning' is a project theme style; markup must resolve, not error.
+    out = console.capture_ansi('[warning]careful[/warning]', width=40)
+    assert 'careful' in out
+    assert '\x1b[' in out


### PR DESCRIPTION
Closes #500. Builds on the language-groups estimation work from #499.

## Summary

While the user regroups languages in the interactive `rbx time` picker, the resolved timing table now renders **live below the language list**, updating on every keystroke. The final table after confirmation is unchanged.

## Approach

The issue suggested `rich.live`, but the picker is already a `prompt_toolkit.Application` with its own redraw loop — a second screen-owner would conflict. Instead this **reuses the single existing renderer** (`limits_info.build_limits_table()`): the table is captured to an ANSI string and embedded in a prompt_toolkit `Window`. prompt_toolkit repaints on every key event, so the preview is live for free. One table renderer, no duplication, no drift.

## Changes

- **`console.capture_ansi()`** — generic helper rendering any themed rich renderable (or markup) to an ANSI string.
- **`timing.build_preview_renderer()`** — pure, memoized callback mapping a picker assignment to an `ANSI` preview: the resolved limits table, or an inline `⚠ Invalid grouping: …` message for cyclic/invalid groupings. Reuses already-collected timings; never re-runs solutions.
- **`timing_group_picker.prompt_group_assignment()`** — gains an optional `preview` callback and a content-sized preview `Window`; stays UI-only (no timing/theme knowledge).
- **`timing._prompt_repartition()`** — wires the preview in, passing the live terminal width.

Design & plan: `docs/plans/2026-06-02-timing-preview-design.md`, `docs/plans/2026-06-02-timing-preview.md`.

## Test Plan

- [x] New tests: `test_console_capture.py`, `test_timing_preview.py`, plus a picker integration test in `test_timing_group_picker.py` — cover the table render, the inline-error path, memoization by assignment, the picker preview Window, and the `_prompt_repartition` wiring seam.
- [x] 60 tests pass across all timing/picker/console suites; `ruff check`/`format` clean on changed files; all modules import cleanly through the CLI.
- [x] Eyeballed actual rendered output: table with estimated / ×multiplier / leftover sources, and the inline error for invalid groupings.
- [ ] Manual `rbx time` on a multi-language package — skipped here (needs a working C++ sandbox/toolchain, fails locally; pre-existing/unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)