### PR TITLE
feat(timing): explain DEFAULTED below limits table (#502)

### DIFF
--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -305,12 +305,18 @@ def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
     import rich.table
 
     rows = build_limits_table_rows(profile)
-    caption = None
+    caption_lines: List[str] = []
     if any(row.is_leftover for row in rows):
-        caption = (
+        caption_lines.append(
             f'{LEFTOVER_MARKER}leftover: languages not assigned to a group, '
             'pooled together (default).'
         )
+    if any(row.defaulted for row in rows):
+        caption_lines.append(
+            '[warning]⚠ DEFAULTED: no accepted solutions and no whenEmpty rule; '
+            'fell back to the base time limit.[/warning]'
+        )
+    caption = '\n'.join(caption_lines) if caption_lines else None
     table = rich.table.Table(
         title=title,
         title_style='bold bright_white',

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -212,6 +212,71 @@ def test_caption_present_only_with_leftover():
     assert build_limits_table(plain_profile).caption is None
 
 
+def test_caption_explains_defaulted_when_present():
+    from rbx.box.limits_info import build_limits_table
+
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+            TimingGroupReport(
+                languages=['go'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+            ),
+        ],
+    )
+    caption = build_limits_table(profile).caption or ''
+    assert 'DEFAULTED' in caption
+    # styled as a warning so it renders yellow, like the defaulted rows
+    assert '[warning]' in caption
+
+
+def test_no_defaulted_caption_without_defaulted_row():
+    from rbx.box.limits_info import build_limits_table
+
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+        ],
+    )
+    assert 'DEFAULTED' not in (build_limits_table(profile).caption or '')
+
+
+def test_render_includes_defaulted_caption(capsys):
+    from rbx.box.limits_info import render_limits_table
+
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['go'],
+                timeLimit=2000,
+                origin=TimingGroupOrigin.DEFAULTED,
+            )
+        ],
+    )
+    render_limits_table(profile, title='Test limits')
+    out = capsys.readouterr().out
+    # the footer explanation appears below the table, not just the row glyph
+    assert 'fell back to the base time limit' in out
+
+
 def test_defaulted_leftover_renders_asterisk_and_warning(capsys):
     from rbx.box.limits_info import render_limits_table
 


### PR DESCRIPTION
Fixes #502.

## Summary

When a limits table contains a `DEFAULTED` row, a yellow footer now appears below the table explaining what DEFAULTED means: *"no accepted solutions and no whenEmpty rule; fell back to the base time limit."* Previously only the `⚠` glyph in the row hinted at it, which left the meaning unclear (per #499's presentation work).

## Changes

- `rbx/box/limits_info.py`: `build_limits_table` now accumulates caption lines, appending a `[warning]`-styled DEFAULTED explanation whenever any row is defaulted. Coexists with the existing leftover (`*`) footer.
- `tests/rbx/box/test_limits_table.py`: 3 new tests — caption present & `[warning]`-styled when a defaulted row exists, absent otherwise, and the rendered output includes the footer text.

## Test Plan

- [x] All 17 tests in `test_limits_table.py` + `packaging/test_boca_limits_table.py` pass
- [x] `ruff check` / `ruff format` clean
- [x] Manual render confirms the yellow footer shows below the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)