### PR TITLE
feat(timing): render current limits as a table in rbx time

### DIFF
--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -513,13 +513,13 @@ async def time(
         help='Integrate the given limits profile into the package.',
     ),
 ):
-    current_profile = limits_info.get_limits_profile(profile)
-    if current_profile is not None:
-        console.console.print(
-            f'[status]Current limits for profile [item]{profile}[/item]:[/status]'
-        )
-        limits_info.pretty_print_profile(current_profile)
-        console.console.print()
+    current_profile = limits_info.get_display_limits_profile(profile)
+    if current_profile is None:
+        current_profile = limits_info.get_limits_profile(profile)
+    limits_info.render_limits_table(
+        current_profile, title=f'Current limits ({profile})'
+    )
+    console.console.print()
     if integrate:
         timing.integrate(profile)
         return

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -205,13 +205,6 @@ def get_limits(
     return res
 
 
-def pretty_print_profile(profile: LimitsProfile):
-    console.console.print(f'[status]Time limit:[/status] {profile.timeLimit} ms')
-    console.console.print(f'[status]Modifiers:[/status] {profile.modifiers}')
-    if profile.inheritFromPackage:
-        console.console.print('[status]Inherits from package.[/status]')
-
-
 # Prefix marking the leftover group's languages cell; explained in the table
 # caption. Kept as one constant so the marker and its footer can't drift apart.
 LEFTOVER_MARKER = '* '


### PR DESCRIPTION
## Summary

Fixes #504.

When running `rbx time`, the current time-limit snapshot shown at the start was rendered in a raw, ugly way — a bare `Time limit: 2000 ms` line plus a Python `dict` of modifiers. This now renders the **same** rich per-language/group limits table that is shown at the end of estimation, for a consistent and readable display.

## Changes

- `rbx/box/cli.py` — `rbx time` now resolves the snapshot via `limits_info.get_display_limits_profile(profile)` (which preserves saved group metadata for the grouped table), falling back to the resolved package profile + degraded table when no profile is saved, then renders it with `render_limits_table(...)`. Mirrors the established pattern already used in the BOCA packager.
- `rbx/box/limits_info.py` — removed the now-dead `pretty_print_profile`.

## Verification

- `ruff check` / `ruff format` clean; pre-commit hooks pass.
- 17 existing table tests pass (`test_limits_table.py` + `test_boca_limits_table.py`).
- Smoke-tested both render paths: degraded snapshot (no groups → base + per-language overrides) and grouped snapshot (estimated / multiplier rows) — both render the styled table correctly.

No new test added: the change is pure wiring of already well-tested table machinery, and no test asserted on the removed raw-dump strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)