### PR TITLE
feat(timing): always show base time limit as leading table row

### DIFF
--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -219,6 +219,16 @@ class LimitsTableRow(BaseModel):
     is_leftover: bool = False
 
 
+def _base_row(profile: LimitsProfile) -> LimitsTableRow:
+    """The fallback row: the base time limit applied when nothing else does."""
+    return LimitsTableRow(
+        languages='(base)',
+        solutions=None,
+        time_limit_ms=profile.timeLimit or 0,
+        source='base',
+    )
+
+
 def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
     rows: List[LimitsTableRow] = []
     if profile.groups:
@@ -247,14 +257,11 @@ def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
             )
         # Leftover group is shown first; stable sort keeps the rest in order.
         rows.sort(key=lambda r: not r.is_leftover)
-        return rows
+        # Base (fallback) row always leads the table.
+        return [_base_row(profile), *rows]
     # Degraded view: base row + each per-language modifier override.
     base = profile.timeLimit or 0
-    rows.append(
-        LimitsTableRow(
-            languages='(base)', solutions=None, time_limit_ms=base, source='base'
-        )
-    )
+    rows.append(_base_row(profile))
     for lang, mod in sorted(profile.modifiers.items()):
         if mod.time is not None:
             rows.append(

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -8,7 +8,12 @@ from pydantic import BaseModel
 from rbx import console
 from rbx.box import package
 from rbx.box.environment import VerificationLevel
-from rbx.box.schema import LimitModifiers, LimitsProfile, TimingGroupOrigin
+from rbx.box.schema import (
+    LimitModifiers,
+    LimitsProfile,
+    TimingGroupOrigin,
+    TimingGroupReport,
+)
 from rbx.box.yaml_validation import load_yaml_model
 from rbx.grading.limits import Limits
 
@@ -120,6 +125,7 @@ def get_display_limits_profile(
         return None
     display = get_limits_profile(profile, root=root)
     display.groups = saved.groups
+    display.baseEstimate = saved.baseEstimate
     return display
 
 
@@ -219,13 +225,32 @@ class LimitsTableRow(BaseModel):
     is_leftover: bool = False
 
 
+def _report_source(report: TimingGroupReport) -> str:
+    if report.origin == TimingGroupOrigin.ESTIMATED:
+        return f'estimated (fastest {report.fastest} / slowest {report.slowest})'
+    if report.origin == TimingGroupOrigin.MULTIPLIER:
+        ref = report.relativeToLanguage or 'base'
+        return f'×{report.multiplier} of {ref}'
+    return 'DEFAULTED to base'
+
+
 def _base_row(profile: LimitsProfile) -> LimitsTableRow:
-    """The fallback row: the base time limit applied when nothing else does."""
+    """The fallback row: the base time limit applied when nothing else does.
+
+    When the profile was estimated, the base is itself pooled across every
+    solution, so it carries the same ``estimated (fastest / slowest)`` provenance
+    as the group rows; otherwise it is just the configured base.
+    """
+    source = 'base'
+    solutions = None
+    if profile.baseEstimate is not None:
+        source = _report_source(profile.baseEstimate)
+        solutions = profile.baseEstimate.solutionCount
     return LimitsTableRow(
         languages='(base)',
-        solutions=None,
+        solutions=solutions,
         time_limit_ms=profile.timeLimit or 0,
-        source='base',
+        source=source,
     )
 
 
@@ -233,15 +258,7 @@ def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
     rows: List[LimitsTableRow] = []
     if profile.groups:
         for report in profile.groups:
-            if report.origin == TimingGroupOrigin.ESTIMATED:
-                source = (
-                    f'estimated (fastest {report.fastest} / slowest {report.slowest})'
-                )
-            elif report.origin == TimingGroupOrigin.MULTIPLIER:
-                ref = report.relativeToLanguage or 'base'
-                source = f'×{report.multiplier} of {ref}'
-            else:
-                source = 'DEFAULTED to base'
+            source = _report_source(report)
             languages = ', '.join(report.languages)
             if report.isLeftover:
                 languages = f'{LEFTOVER_MARKER}{languages}'

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -825,6 +825,14 @@ Presentation-only; never used for limit resolution.
 """,
     )
 
+    baseEstimate: Optional[TimingGroupReport] = Field(
+        default=None,
+        description="""
+Metadata describing how the base (fallback) time limit was estimated, pooled
+across every solution. Presentation-only; never used for limit resolution.
+""",
+    )
+
     def timelimit_for_language(self, language: Optional[str] = None) -> int:
         assert self.timeLimit is not None
         res = self.timeLimit

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -36,6 +36,7 @@ class TimingProfile(BaseModel):
     formula: Optional[str] = None
     timeLimitPerLanguage: Dict[str, int] = Field(default_factory=dict)
     groups: Optional[List[schema.TimingGroupReport]] = None
+    baseEstimate: Optional[schema.TimingGroupReport] = None
 
     def to_limits(self):
         return schema.LimitsProfile(
@@ -46,6 +47,7 @@ class TimingProfile(BaseModel):
                 for lang, tl in self.timeLimitPerLanguage.items()
             },
             groups=self.groups,
+            baseEstimate=self.baseEstimate,
         )
 
 
@@ -110,6 +112,7 @@ def build_timing_profile(
         formula=formula,
         timeLimitPerLanguage=result.time_limit_per_language,
         groups=result.reports,
+        baseEstimate=result.base_report,
     )
 
 

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -69,6 +69,7 @@ class GroupTimings(BaseModel):
 
 class ResolutionResult(BaseModel):
     base_time_limit: int
+    base_report: TimingGroupReport
     reports: List[TimingGroupReport]
     time_limit_per_language: Dict[str, int]
     defaulted_languages: List[str]
@@ -134,6 +135,14 @@ def resolve_groups(
     eval_fn: EvalFn,
 ) -> ResolutionResult:
     base_tl = eval_fn(base.fastest, base.slowest)
+    base_report = TimingGroupReport(
+        languages=[],
+        timeLimit=base_tl,
+        origin=TimingGroupOrigin.ESTIMATED,
+        solutionCount=base.solution_count,
+        fastest=base.fastest,
+        slowest=base.slowest,
+    )
     lang_index = _lang_to_group_index(groups)
 
     resolved_tl: Dict[int, int] = {}
@@ -202,6 +211,7 @@ def resolve_groups(
             tl_per_language[lang] = report.timeLimit
     return ResolutionResult(
         base_time_limit=base_tl,
+        base_report=base_report,
         reports=reports,
         time_limit_per_language=tl_per_language,
         defaulted_languages=defaulted,

--- a/tests/rbx/box/packaging/test_boca_limits_table.py
+++ b/tests/rbx/box/packaging/test_boca_limits_table.py
@@ -17,7 +17,10 @@ def test_boca_table_flags_defaulted_language():
         ],
     )
     rows = build_limits_table_rows(profile)
-    assert rows[0].defaulted is True
+    # Base (fallback) row leads; the java group below it is flagged as defaulted.
+    assert rows[0].languages == '(base)'
+    java_row = next(r for r in rows if r.languages == 'java')
+    assert java_row.defaulted is True
 
 
 def test_inherit_display_profile_shows_real_package_base(

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -28,12 +28,39 @@ def test_rows_from_group_metadata():
         ],
     )
     rows = build_limits_table_rows(profile)
-    assert rows[0].languages == 'c, cpp'
-    assert rows[0].time_limit_ms == 1000
-    assert rows[0].solutions == 2
-    assert 'estimated' in rows[0].source.lower()
-    assert rows[1].defaulted is True
-    assert 'default' in rows[1].source.lower()
+    # Base (fallback) row always leads.
+    assert rows[0].languages == '(base)'
+    assert rows[0].time_limit_ms == 2000
+    assert rows[0].source == 'base'
+    assert rows[1].languages == 'c, cpp'
+    assert rows[1].time_limit_ms == 1000
+    assert rows[1].solutions == 2
+    assert 'estimated' in rows[1].source.lower()
+    assert rows[2].defaulted is True
+    assert 'default' in rows[2].source.lower()
+
+
+def test_grouped_view_leads_with_base_row():
+    profile = LimitsProfile(
+        timeLimit=1500,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    # The base (fallback) row is always present and leads the table, even when
+    # no group defaulted to it.
+    assert rows[0].languages == '(base)'
+    assert rows[0].time_limit_ms == 1500
+    assert rows[0].source == 'base'
+    assert rows[0].solutions is None
 
 
 def test_multiplier_row_shows_reference():
@@ -50,10 +77,11 @@ def test_multiplier_row_shows_reference():
         ],
     )
     rows = build_limits_table_rows(profile)
-    assert rows[0].languages == 'java, kotlin'
-    assert rows[0].time_limit_ms == 4000
-    assert 'cpp' in rows[0].source
-    assert rows[0].defaulted is False
+    assert rows[0].languages == '(base)'
+    assert rows[1].languages == 'java, kotlin'
+    assert rows[1].time_limit_ms == 4000
+    assert 'cpp' in rows[1].source
+    assert rows[1].defaulted is False
 
 
 def test_rows_degrade_without_group_metadata():
@@ -154,12 +182,14 @@ def test_leftover_row_is_first_and_marked():
         ],
     )
     rows = build_limits_table_rows(profile)
-    # leftover pulled to the top, marked with a leading asterisk
-    assert rows[0].is_leftover is True
-    assert rows[0].languages.startswith('* ')
-    assert 'go, java' in rows[0].languages
+    # base row leads; leftover group is pulled to the top of the group rows,
+    # marked with a leading asterisk
+    assert rows[0].languages == '(base)'
+    assert rows[1].is_leftover is True
+    assert rows[1].languages.startswith('* ')
+    assert 'go, java' in rows[1].languages
     # the rest keep their original order
-    assert rows[1].languages == 'c, cpp'
+    assert rows[2].languages == 'c, cpp'
 
 
 def test_no_asterisk_when_no_leftover():
@@ -177,8 +207,9 @@ def test_no_asterisk_when_no_leftover():
         ],
     )
     rows = build_limits_table_rows(profile)
-    assert rows[0].is_leftover is False
-    assert not rows[0].languages.startswith('*')
+    assert rows[0].languages == '(base)'
+    assert rows[1].is_leftover is False
+    assert not rows[1].languages.startswith('*')
 
 
 def test_caption_present_only_with_leftover():

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -63,6 +63,55 @@ def test_grouped_view_leads_with_base_row():
     assert rows[0].solutions is None
 
 
+def test_base_row_shows_estimated_provenance():
+    profile = LimitsProfile(
+        timeLimit=1000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=400,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=100,
+                slowest=200,
+            ),
+        ],
+        baseEstimate=TimingGroupReport(
+            languages=[],
+            timeLimit=1000,
+            origin=TimingGroupOrigin.ESTIMATED,
+            solutionCount=3,
+            fastest=100,
+            slowest=500,
+        ),
+    )
+    rows = build_limits_table_rows(profile)
+    assert rows[0].languages == '(base)'
+    assert rows[0].time_limit_ms == 1000
+    # When estimated, the base row reports the same provenance as group rows,
+    # pooled across every solution.
+    assert rows[0].source == 'estimated (fastest 100 / slowest 500)'
+    assert rows[0].solutions == 3
+
+
+def test_base_row_plain_without_estimate():
+    # No baseEstimate (e.g. a fixed/inherited limit) -> the base row stays plain.
+    profile = LimitsProfile(
+        timeLimit=1000,
+        groups=[
+            TimingGroupReport(
+                languages=['cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.DEFAULTED,
+            ),
+        ],
+    )
+    rows = build_limits_table_rows(profile)
+    assert rows[0].languages == '(base)'
+    assert rows[0].source == 'base'
+    assert rows[0].solutions is None
+
+
 def test_multiplier_row_shows_reference():
     profile = LimitsProfile(
         timeLimit=2000,

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -31,6 +31,12 @@ def test_build_timing_profile_groups_languages():
     assert limits.groups is not None
     origins = {tuple(r.languages): r.origin for r in limits.groups}
     assert origins[('java', 'kotlin')] == TimingGroupOrigin.MULTIPLIER
+    # The base estimate is pooled across every solution timing (100..500).
+    assert limits.baseEstimate is not None
+    assert limits.baseEstimate.origin == TimingGroupOrigin.ESTIMATED
+    assert limits.baseEstimate.fastest == 100
+    assert limits.baseEstimate.slowest == 500
+    assert limits.baseEstimate.solutionCount == 3
 
 
 def test_relevant_languages_includes_all_env_languages():

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -88,6 +88,14 @@ def test_resolves_estimated_and_multiplier_and_default_groups():
     assert origins[('go',)] == TimingGroupOrigin.DEFAULTED
     assert result.defaulted_languages == ['go']
 
+    # The base (fallback) carries its own estimation provenance, pooled across
+    # every solution.
+    assert result.base_report.origin == TimingGroupOrigin.ESTIMATED
+    assert result.base_report.timeLimit == result.base_time_limit
+    assert result.base_report.fastest == 100
+    assert result.base_report.slowest == 500
+    assert result.base_report.solutionCount == 3
+
 
 def test_multiplier_relative_to_base_when_relative_to_omitted():
     groups = [


### PR DESCRIPTION
## Summary

Closes #506.

The base time limit is the fallback applied when no language group or per-language override matches. Two improvements:

1. **Always visible** — every limits table now leads with an explicit **`(base)`** row, in both the grouped (estimated) view and the degraded (no-group-metadata) view. Previously the base was only surfaced implicitly, buried inside a `DEFAULTED to base` row.
2. **Proper provenance** — when a profile is *estimated*, the base TL is itself `formula(fastest, slowest)` pooled across **every** solution, so the base row now reports the same `estimated (fastest / slowest)` source and solution count as the group rows. A fixed or inherited base (no estimate) still shows a plain `base`.

All three render sites — the live `rbx time` picker preview, post-`rbx time`, and `rbx package boca` — go through `build_limits_table_rows()`, so the base row appears everywhere with no call-site changes.

### Example (estimated, grouped view)

```
 Languages │ Solutions │ Time Limit │ Source
 (base)    │     3     │  1000 ms   │ estimated (fastest 100 / slowest 500)   <- pooled across all solutions
 c, cpp    │     2     │   400 ms   │ estimated (fastest 100 / slowest 200)
 go        │           │  1000 ms   │ DEFAULTED to base
```

## Changes

- `rbx/box/limits_info.py`: add a `_base_row(profile)` helper that leads every table; extract `_report_source(report)` shared by group and base rows; the base row uses estimation provenance when `LimitsProfile.baseEstimate` is set. Preserve `baseEstimate` in the boca display profile.
- `rbx/box/timing_groups.py`: `resolve_groups` returns a `base_report` (origin `ESTIMATED`, overall `fastest`/`slowest`/`solutionCount`).
- `rbx/box/schema.py`: add presentation-only `LimitsProfile.baseEstimate` (mirrors `groups`; old `.limits/*.yml` load unchanged as `None`).
- `rbx/box/timing.py`: thread `baseEstimate` through `TimingProfile` and `to_limits()`.

## Test Plan

- [x] `test_limits_table.py`: base row leads in both views; shows estimated provenance when `baseEstimate` present, plain `base` otherwise.
- [x] `test_timing_groups.py`: `resolve_groups` returns a pooled `base_report`.
- [x] `test_timing_estimation.py`: `build_timing_profile` populates `baseEstimate`.
- [x] `test_boca_limits_table.py` defaulted-flag test locates the row by language instead of index.
- [x] All touched suites pass (table, boca table, timing estimation, groups, picker, preview, schema); `ruff check`/`format` clean.
- [x] Visually confirmed the rendered table leads with an `(base)` row labeled `estimated (...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
