### PR TITLE
feat(timing): highlight time figures in the limits table (#508)

### DIFF
--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -1,5 +1,6 @@
 import contextvars
 import pathlib
+import re
 from typing import Callable, Dict, List, Optional
 
 import typer
@@ -227,7 +228,7 @@ class LimitsTableRow(BaseModel):
 
 def _report_source(report: TimingGroupReport) -> str:
     if report.origin == TimingGroupOrigin.ESTIMATED:
-        return f'estimated (fastest {report.fastest} / slowest {report.slowest})'
+        return f'estimated (fastest {report.fastest} ms / slowest {report.slowest} ms)'
     if report.origin == TimingGroupOrigin.MULTIPLIER:
         ref = report.relativeToLanguage or 'base'
         return f'×{report.multiplier} of {ref}'
@@ -309,6 +310,18 @@ def _source_markup(source: str) -> str:
     return source
 
 
+# Matches a time figure like "1000 ms" so the number can be highlighted while
+# the unit is dimmed; applied uniformly to the Time Limit column and to the
+# fastest/slowest figures inside the Source column.
+_MS_PATTERN = re.compile(r'(\d+)\s*ms')
+
+
+def _highlight_ms(text: str) -> str:
+    """Colorize every "<number> ms" in ``text``: the figure pops in the
+    ``timelimit`` color, the unit is dimmed so the number stands out beside it."""
+    return _MS_PATTERN.sub(r'[timelimit]\1[/timelimit] [dim]ms[/dim]', text)
+
+
 def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
     """Build a styled rich Table of the resolved per-language/group limits.
 
@@ -350,6 +363,8 @@ def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
         sols = '' if row.solutions is None else str(row.solutions)
         tl = f'{row.time_limit_ms} ms'
         if row.defaulted:
+            # Defaulted rows are warnings: the yellow signals the fallback and
+            # deliberately overrides the per-figure time highlight.
             table.add_row(
                 f'[warning]{row.languages}[/warning]',
                 f'[warning]{sols}[/warning]',
@@ -357,7 +372,12 @@ def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
                 f'[warning]⚠ {row.source}[/warning]',
             )
         else:
-            table.add_row(row.languages, sols, tl, _source_markup(row.source))
+            table.add_row(
+                row.languages,
+                sols,
+                _highlight_ms(tl),
+                _highlight_ms(_source_markup(row.source)),
+            )
     return table
 
 

--- a/rbx/console.py
+++ b/rbx/console.py
@@ -18,6 +18,7 @@ theme = Theme(
         'status': 'bright_white',
         'bstatus': 'bold bright_white',
         'item': 'bold blue',
+        'timelimit': 'bold cyan',
         'error': 'bold red',
         'success': 'bold green',
         'lnumber': 'dim cyan',

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -90,7 +90,7 @@ def test_base_row_shows_estimated_provenance():
     assert rows[0].time_limit_ms == 1000
     # When estimated, the base row reports the same provenance as group rows,
     # pooled across every solution.
-    assert rows[0].source == 'estimated (fastest 100 / slowest 500)'
+    assert rows[0].source == 'estimated (fastest 100 ms / slowest 500 ms)'
     assert rows[0].solutions == 3
 
 
@@ -205,9 +205,79 @@ def test_build_limits_table_has_colored_columns():
 def test_source_markup_colors_by_origin():
     from rbx.box.limits_info import _source_markup
 
-    assert _source_markup('estimated (fastest 1 / slowest 2)').startswith('[success]')
+    assert _source_markup('estimated (fastest 1 ms / slowest 2 ms)').startswith(
+        '[success]'
+    )
     assert _source_markup('×4.0 of cpp').startswith('[item]')
     assert _source_markup('base') == 'base'
+
+
+def test_report_source_estimated_includes_ms_unit():
+    from rbx.box.limits_info import _report_source
+
+    report = TimingGroupReport(
+        languages=['c', 'cpp'],
+        timeLimit=1000,
+        origin=TimingGroupOrigin.ESTIMATED,
+        solutionCount=2,
+        fastest=280,
+        slowest=600,
+    )
+    # The fastest/slowest figures are times, so they carry the same "ms" unit
+    # shown in the Time Limit column.
+    assert _report_source(report) == 'estimated (fastest 280 ms / slowest 600 ms)'
+
+
+def test_highlight_ms_colors_number_and_dims_unit():
+    from rbx.box.limits_info import _highlight_ms
+
+    # The numeric value is highlighted (theme: timelimit) and the unit is dimmed
+    # so the figure stands out beside it.
+    assert _highlight_ms('1000 ms') == '[timelimit]1000[/timelimit] [dim]ms[/dim]'
+
+
+def test_highlight_ms_colors_every_time_in_a_string():
+    from rbx.box.limits_info import _highlight_ms
+
+    # Times embedded in the Source column (fastest/slowest) get the same
+    # treatment, so the figures match the Time Limit column.
+    out = _highlight_ms('estimated (fastest 280 ms / slowest 600 ms)')
+    assert out == (
+        'estimated (fastest [timelimit]280[/timelimit] [dim]ms[/dim] / '
+        'slowest [timelimit]600[/timelimit] [dim]ms[/dim])'
+    )
+
+
+def test_highlight_ms_leaves_non_time_text_untouched():
+    from rbx.box.limits_info import _highlight_ms
+
+    assert _highlight_ms('×4.0 of cpp') == '×4.0 of cpp'
+    assert _highlight_ms('DEFAULTED to base') == 'DEFAULTED to base'
+
+
+def test_estimated_time_renders_cyan_with_ms():
+    import rbx.console as console_module
+    from rbx.box.limits_info import build_limits_table
+
+    profile = LimitsProfile(
+        timeLimit=2000,
+        groups=[
+            TimingGroupReport(
+                languages=['c', 'cpp'],
+                timeLimit=1000,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=2,
+                fastest=280,
+                slowest=600,
+            ),
+        ],
+    )
+    out = console_module.capture_ansi(build_limits_table(profile), width=200)
+    # 'ms' unit is present and the time value carries the cyan (ANSI 36) color.
+    assert 'ms' in out
+    assert '\x1b[1;36m1000' in out
+    # the fastest/slowest figures in the Source column are colored the same way.
+    assert '\x1b[1;36m280' in out
 
 
 def test_leftover_row_is_first_and_marked():


### PR DESCRIPTION
Closes #508.

## What

The timing/limits table (`rbx time`, the group-picker preview, and the BOCA packaging table) rendered time values in plain white, and the `fastest / slowest` figures in the **Source** column had no unit at all.

This PR makes every time figure pop:
- Adds a `timelimit` theme color (`bold cyan`).
- Adds a single `_highlight_ms` helper (regex `(\d+)\s*ms`) that colorizes the number in cyan and dims the `ms` unit.
- Applies it uniformly to **both** the Time Limit cell and the Source string, so the estimated `fastest X ms / slowest Y ms` figures get the exact same treatment as the Time Limit column (`_report_source` now includes the `ms` unit on those figures).
- **Defaulted** rows stay fully yellow on purpose — the fallback warning still dominates and overrides the per-figure highlight.

## Result

```
Languages      Solutions   Time Limit   Source
(base)                 3      2000 ms    estimated (fastest 300 ms / slowest 900 ms)
* go, rust             0      2000 ms    ⚠ DEFAULTED to base          (all yellow)
c, cpp                 2      1000 ms    estimated (fastest 280 ms / slowest 600 ms)
java, kotlin           0      4000 ms    ×4.0 of cpp
```
(numbers cyan, `ms` dimmed; multiplier source blue, defaulted row yellow)

## Tests

- TDD: added unit tests for `_highlight_ms`, `_report_source` (ms unit), and an ANSI render assertion that the time renders cyan (`\x1b[1;36m`) with the `ms` unit.
- `tests/rbx/box/test_limits_table.py`: 22 passed; timing/boca/picker suites: 67 passed.
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)