### PR TITLE
docs(timing): document #492 timing/BOCA work + default preset language groups

### DIFF
--- a/docs/setters/packaging-walkthrough.md
+++ b/docs/setters/packaging-walkthrough.md
@@ -102,8 +102,9 @@ modifiers:
 ```
 
 !!! tip
-    When `rbx time` detects accepted solutions in multiple languages, it will
-    automatically prompt you to set per-language limits. You can also edit the profile
+    You normally don't write `modifiers` by hand. When you run `rbx time`, the interactive
+    [language groups](/setters/profiling#language-groups) picker estimates a limit per group of
+    languages and writes the per-language modifiers for you. You can also edit the profile
     manually or through the TUI (`rbx ui` > **Edit limits profiles**).
 
 ### Verify with the profile active

--- a/docs/setters/packaging/boca.md
+++ b/docs/setters/packaging/boca.md
@@ -16,6 +16,45 @@ rbx each package boca
 
 Both **batch** problems and **interactive** problems are supported.
 
+The BOCA packager uses the `boca` [limits profile](../profiling/index.md), so create it with
+`rbx time -p boca` before packaging.
+
+## Time limits
+
+{{rbx}} emits the **exact** time limit for each language into the BOCA package — fractional
+seconds included (e.g. a `1234 ms` limit becomes `1.234`). There is no rounding or approximation:
+the limit a solution gets in BOCA matches the one you estimated.
+
+### Minimum running time
+
+By default each solution runs **once** against the exact time limit. Some setups prefer a larger
+per-run budget (for instance, to absorb startup jitter on a loaded autojudge). You can set a
+**minimum total running time** under the BOCA extension in `env.rbx.yml`; {{rbx}} then runs the
+solution enough times to reach it (`ceil(minRunningTime / timeLimit)` runs), keeping each run's
+limit exact:
+
+```yaml
+extensions:
+  boca:
+    minRunningTime: 1000   # milliseconds; e.g. a 300ms problem runs 4x for a 1.2s budget
+```
+
+The number of runs is capped at 10; if the minimum can't be reached within that cap, {{rbx}}
+prints a warning and uses 10 runs.
+
+### Wall time
+
+BOCA solutions are also given a **wall (real) time** limit, computed from the CPU time limit with
+the same configurable `a * x + b` formula used during local judging — useful for slow languages
+that pay JVM/interpreter startup costs. See
+[Wall time limits](../reference/environment/index.md#wall-time-limits).
+
+### C++ language variants
+
+Older BOCA versions call the C++ language `cc` while newer ones call it `cpp`. {{rbx}} packages
+both variants, and both inherit the time and memory limits of the rbx `cpp` language, so the two
+always get identical limits regardless of which name your BOCA server uses.
+
 ## Interactive problems
 
 Interactive problems can be easily packaged for BOCA with {{rbx}}. There are some limitations to it, though:

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -42,8 +42,8 @@ solutions and applying a formula to their timings.
 3. **Solution execution** -- For formula-based strategies, all accepted solutions are run against all testcases with no time limit enforced, so that the true execution times can be measured.
 4. **Time report** -- The fastest and slowest solution times are shown, along with per-language breakdowns if solutions in multiple languages exist.
 5. **Formula evaluation** -- The formula is applied to compute the estimated time limit.
-6. **Per-language limits** -- If solutions exist in multiple languages and their estimated limits differ, you are prompted to select which languages should have language-specific time limits.
-7. **Profile persistence** -- The result is written to `.limits/<profile>.yml`.
+6. **Language groups** -- You are shown every environment language and can place each one into a group, so related languages (e.g. `c`/`cpp`, or `java`/`kotlin`) share a single estimated limit and unrepresented languages inherit a sensible limit instead of falling back to the base. See [Language groups](#language-groups).
+7. **Profile persistence** -- The result is written to `.limits/<profile>.yml`, together with the chosen grouping as metadata.
 
 ### Strategies
 
@@ -173,6 +173,51 @@ step_up(slowest * 1.5, 100)
 step_up(fastest * 4, 100)
 ```
 
+## Language groups
+
+By default, a single time limit is estimated from the pooled timings of all accepted solutions
+and applied to every language. This is a problem when your accepted solutions don't cover every
+language your contest accepts: a language with no solutions (say, Java in a problem solved only in
+C++ and Python) would simply inherit the base limit, which may be far too tight for it.
+
+**Language groups** solve this. When you run `rbx time`, you are shown every environment language
+and can bucket related languages together. Each group gets its own estimated time limit from the
+formula, computed from the pooled timings of the accepted solutions in that group:
+
+- **Grouped** `[N]` -- the language belongs to numbered group `N` (`1`–`9`). Languages in the
+  same group share one estimated limit. Place compiled languages like `c`/`cpp` together, and
+  `java`/`kotlin` together.
+- **Singleton** `[X]` -- the language gets its own bucket (toggle with `space`/`tab`).
+- **Unbucketed** `[ ]` -- the default. All unbucketed languages join a single **leftover pool**
+  that is estimated together, so an unrepresented language inherits a represented sibling's limit
+  instead of the base limit. The leftover row is listed **first** in the table, marked with a `*`.
+
+The picker is **prepopulated from `env.rbx.yml`**: any groups you configure there appear
+preselected. After estimation, a per-group table is printed showing the **Languages**,
+**Solutions**, **Time Limit**, and **Source** of each group, where the source is one of
+`estimated`, `×N of <lang>` (inherited from another group), or `DEFAULTED` (the group had no
+solutions and no fallback, so it fell back to the base limit — highlighted as a warning).
+
+Press <kbd>Enter</kbd> to confirm, or pass `--auto` to skip the prompt and use the configured
+env groups as-is. The resolved per-language limits are written into the profile's `modifiers`,
+and the chosen grouping is stored as presentation-only metadata under a `groups:` key.
+
+Groups are configured (and given empty-group fallbacks via `whenEmpty`) in `env.rbx.yml`. See the
+[Environment reference](../reference/environment/#language-groups) for the full schema and
+semantics.
+
+## Wall time limits
+
+In addition to the CPU time limit estimated above, every solution is bounded by a **wall (real)
+time** limit. Slow languages (Java, Kotlin, Python) spend significant wall-clock time on JVM /
+interpreter startup before doing any real work, so a wall limit derived too tightly from the CPU
+limit produces spurious time-limit verdicts.
+
+{{rbx}} computes the wall time limit from the CPU time limit with a configurable `a * x + b`
+formula (`wallTimeMultiplier` and `wallTimeIncrement`), configurable environment-wide and
+overridable per language. The same formula is used both when judging locally and when packaging
+for BOCA. See the [Environment reference](../reference/environment/#wall-time-limits) for details.
+
 ## Limits profiles
 
 Profiles are the mechanism {{rbx}} uses to store and manage time/memory limits independently of
@@ -215,6 +260,14 @@ modifiers:
 
 # The formula that was used to estimate the time limit (informational)
 formula: "step_up(max(fastest * 3, slowest * 1.5), 100)"
+
+# How languages were grouped during estimation (presentation-only metadata,
+# written automatically by `rbx time`; never used for limit resolution).
+groups:
+  - languages: [c, cpp]
+    timeLimit: 2000
+  - languages: [py]
+    timeLimit: 6000
 ```
 
 ### Per-language modifiers
@@ -235,8 +288,9 @@ The effective time limit for a language is computed as:
 3. If the language has a `timeMultiplier`, multiply the result by it.
 
 !!! tip
-    When `rbx time` detects that your accepted solutions are written in multiple languages with different
-    performance characteristics, it will prompt you to set per-language time limits automatically.
+    You don't usually edit `modifiers` by hand. When you run `rbx time`, the interactive
+    [language groups](#language-groups) picker estimates a limit per group of languages and writes
+    the resulting per-language modifiers for you.
 
 ### The `local` profile
 

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -193,14 +193,11 @@ formula, computed from the pooled timings of the accepted solutions in that grou
   instead of the base limit. The leftover row is listed **first** in the table, marked with a `*`.
 
 The picker is **prepopulated from `env.rbx.yml`**: any groups you configure there appear
-preselected. After estimation, a per-group table is printed showing the **Languages**,
-**Solutions**, **Time Limit**, and **Source** of each group, where the source is one of
-`estimated`, `×N of <lang>` (inherited from another group), or `DEFAULTED` (the group had no
-solutions and no fallback, so it fell back to the base limit — highlighted as a warning).
+preselected. After estimation, a per-group table is printed showing the estimated time limit
+for each group.
 
 Press <kbd>Enter</kbd> to confirm, or pass `--auto` to skip the prompt and use the configured
-env groups as-is. The resolved per-language limits are written into the profile's `modifiers`,
-and the chosen grouping is stored as presentation-only metadata under a `groups:` key.
+env groups as-is.
 
 Groups are configured (and given empty-group fallbacks via `whenEmpty`) in `env.rbx.yml`. See the
 [Environment reference](../reference/environment/#language-groups) for the full schema and

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -161,7 +161,7 @@ rbx time [OPTIONS]
 | `--check` | BOOLEAN | Whether to not build outputs for tests and run checker. | `True` |
 | `--validate` | BOOLEAN | Whether to not validate outputs for tests. | `True` |
 | `--detailed`, `-d` | BOOLEAN | Whether to print a detailed view of the tests using tables. | `False` |
-| `--strategy`, `-s` | TEXT | Strategy to use for time limit estimation (estimate, inherit). | - |
+| `--strategy`, `-s` | TEXT | Strategy to use for time limit estimation (estimate, inherit, estimate_custom, custom). | - |
 | `--auto`, `-a` | BOOLEAN | Whether to automatically estimate the time limit. | `False` |
 | `--runs`, `-r` | INTEGER | Number of runs to perform for each solution. Zero means the config default. | `0` |
 | `--profile`, `-p` | TEXT | Profile to use for time limit estimation. | `local` |

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -254,6 +254,11 @@ Pass `--auto` to skip the prompt and use the env groups as-is. After `rbx time` 
 with `DEFAULTED` rows highlighted. The **leftover** group is listed **first**, marked with a
 leading asterisk (`*`) on its languages and explained in a footer beneath the table.
 
+!!! note
+    The shipped default preset groups `python` on its own and `java`/`kotlin` together, while
+    leaving `c`/`cpp` ungrouped (the leftover pool). Both groups fall back relative to `cpp`
+    when they have no solutions: `python` at `3×` and `java`/`kotlin` at `2×` the C++ limit.
+
 ## Wall time limits
 
 Solutions are also bounded by a **wall (real) time** limit, in addition to the

--- a/docs/setters/running/index.md
+++ b/docs/setters/running/index.md
@@ -46,6 +46,8 @@ You can read more about each verification level [here](/setters/verification/#ve
 By default, {{rbx}} will run solutions with the maximum verification level. This means tests will be built
 and verified, and that all solutions will be run with twice the time limit, and a warning will show up if a TLE solution passed in `2*TL`.
 
+Solutions are also bounded by a configurable **wall (real) time** limit, derived from the CPU time limit — see [Wall time limits](/setters/reference/environment/#wall-time-limits).
+
 The results of a `rbx run` command can be inspected through the `rbx ui` command, as shown in the
 animation below.
 

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -486,7 +486,7 @@ async def time(
         None,
         '--strategy',
         '-s',
-        help='Strategy to use for time limit estimation (estimate, inherit).',
+        help='Strategy to use for time limit estimation (estimate, inherit, estimate_custom, custom).',
     ),
     auto: bool = typer.Option(
         False,

--- a/rbx/resources/presets/default/env.rbx.yml
+++ b/rbx/resources/presets/default/env.rbx.yml
@@ -3,6 +3,17 @@ sandbox: "stupid"
 timing:
   wallTimeMultiplier: 2.0
   wallTimeIncrement: 1000
+  groups:
+    # c and cpp are left ungrouped: they share the leftover pool and are
+    # estimated together from their accepted-solution timings.
+    - languages: ["py"]
+      whenEmpty:
+        relativeTo: "cpp"
+        multiplier: 3.0
+    - languages: ["java", "kt"]
+      whenEmpty:
+        relativeTo: "cpp"
+        multiplier: 2.0
 defaultCompilation:
   sandbox:
     maxProcesses: 1000


### PR DESCRIPTION
## Summary

Documents the timing/BOCA improvements shipped for the **Maratona Mineira** umbrella issue (#492), and adds the missing piece of default-preset configuration so the new language-group machinery is useful out of the box.

### Default preset language groups (`feat`)
Pre-buckets time-limit estimation in the default `env.rbx.yml`:
- `c`/`cpp` — left **ungrouped** (leftover pool), estimated together.
- `[py]` — own group, falls back to **3× cpp** when no Python solutions exist.
- `[java, kt]` — grouped, falls back to **2× cpp** when no Java/Kotlin solutions exist.

### Documentation (`docs`)
The reference (`reference/environment/`) already covered groups & wall time, but the guide pages users actually read did not. Updated:
- **`profiling/index.md`** — new *Language groups* and *Wall time limits* sections; fixed the stale "How it works" step and per-language tip (old two-language prompt → group picker); added the `groups:` metadata key to the profile schema example.
- **`packaging/boca.md`** — new *Time limits* section: exact fractional limits, optional `minRunningTime`, wall-time cross-link, and the cc/cpp variant note.
- **`packaging-walkthrough.md`** / **`running/index.md`** — replaced stale prompt prose and added wall-time cross-references.
- **`reference/environment/index.md`** — note describing the shipped default grouping.
- **`cli.py` help + `cli.md`** — corrected `rbx time --strategy` to list all four strategies (`estimate, inherit, estimate_custom, custom`).

Per the project convention, the auto-regenerated `cli.md` is kept to a clean one-line hand-edit.

## Background: what shipped for #492
| Sub-problem | Issue→PR |
|---|---|
| Configurable per-language wall time (`WT = a·T + b`) | #490→#498 |
| Language groups / bucketing in `rbx time` | #497→#499 |
| BOCA cc/cpp alias TL lookup | #493→#495 |
| Exact fractional BOCA TLs (rounding dropped) | #494→#496 |

Still unimplemented from #492 (out of scope here): a Maratona/BOCA-tuned preset, and refusing a BOCA time sheet without `.limits/boca.yml`.

## Testing
- `uv run mkdocs build` — passes (exit 0, no errors).
- Default preset validates against the `Environment` schema (disjoint groups).
- Timing/group/wall-time/BOCA-table suites: **72 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)