### PR TITLE
feat(timing): add increment to group relative timings (#511)

### DIFF
--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -220,6 +220,7 @@ timing:
       whenEmpty:          # used only when this group has no solutions
         relativeTo: cpp   # any language; resolves to the group containing it
         multiplier: 2.0   # omit relativeTo to multiply the base estimate
+        increment: 500    # optional constant offset, in ms, added on top
     - languages: [python]
 ```
 
@@ -233,9 +234,11 @@ Semantics:
 - During estimation, the accepted-solution timings are pooled **per group**, and each
   group that has at least one solution gets its own estimated time limit from the formula.
 - `whenEmpty` is **optional** and is only used when a group has **no** solutions. It sets
-  the group's time limit to `multiplier ×` the time limit of the group containing
-  `relativeTo` (or `multiplier ×` the base estimate when `relativeTo` is omitted).
-  `multiplier` must be `> 0`.
+  the group's time limit to `multiplier × reference + increment`, where `reference` is the
+  time limit of the group containing `relativeTo` (or the base estimate when `relativeTo`
+  is omitted). `multiplier` is the slope and must be `> 0`; `increment` is an optional
+  constant offset in milliseconds (default `0`). For example, `multiplier: 2.0` with
+  `increment: 500` resolves to `2 × reference + 500 ms`.
 - A group that is empty and has no `whenEmpty` falls back to the base time limit, with a
   **loud warning** (source `DEFAULTED`).
 

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -304,7 +304,14 @@ relative to. If omitted, the multiplier is applied to the base estimate.""",
     )
     multiplier: float = Field(
         gt=0,
-        description="""Multiplier applied when this group has no solutions.""",
+        description="""Slope applied to the reference TL when this group has no
+solutions. The resolved TL is ``multiplier * reference + increment``.""",
+    )
+    increment: Optional[int] = Field(
+        default=None,
+        description="""Constant offset (in milliseconds) added on top of the
+multiplied reference TL when this group has no solutions. The resolved TL is
+``multiplier * reference + increment``.""",
     )
 
 

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -231,7 +231,10 @@ def _report_source(report: TimingGroupReport) -> str:
         return f'estimated (fastest {report.fastest} ms / slowest {report.slowest} ms)'
     if report.origin == TimingGroupOrigin.MULTIPLIER:
         ref = report.relativeToLanguage or 'base'
-        return f'×{report.multiplier} of {ref}'
+        source = f'×{report.multiplier} of {ref}'
+        if report.increment is not None:
+            source += f' + {report.increment} ms'
+        return source
     return 'DEFAULTED to base'
 
 

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -657,6 +657,7 @@ class TimingGroupReport(BaseModel):
     slowest: Optional[int] = None
     relativeToLanguage: Optional[str] = None
     multiplier: Optional[float] = None
+    increment: Optional[int] = None
     isLeftover: bool = False
 
 

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -172,7 +172,8 @@ def resolve_groups(
         elif group.whenEmpty is not None:
             ref = group.whenEmpty.relativeTo
             ref_tl = base_tl if ref is None else resolve(lang_index[ref])
-            tl = int(ref_tl * group.whenEmpty.multiplier)
+            increment = group.whenEmpty.increment or 0
+            tl = int(ref_tl * group.whenEmpty.multiplier + increment)
             report = TimingGroupReport(
                 languages=list(group.languages),
                 timeLimit=tl,
@@ -180,6 +181,7 @@ def resolve_groups(
                 solutionCount=0,
                 relativeToLanguage=ref,
                 multiplier=group.whenEmpty.multiplier,
+                increment=group.whenEmpty.increment,
                 isLeftover=group.is_leftover,
             )
         else:

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -228,6 +228,33 @@ def test_report_source_estimated_includes_ms_unit():
     assert _report_source(report) == 'estimated (fastest 280 ms / slowest 600 ms)'
 
 
+def test_report_source_multiplier_renders_increment_when_present():
+    from rbx.box.limits_info import _report_source
+
+    report = TimingGroupReport(
+        languages=['java'],
+        timeLimit=2500,
+        origin=TimingGroupOrigin.MULTIPLIER,
+        relativeToLanguage='cpp',
+        multiplier=2.0,
+        increment=500,
+    )
+    assert _report_source(report) == '×2.0 of cpp + 500 ms'
+
+
+def test_report_source_multiplier_omits_increment_when_null():
+    from rbx.box.limits_info import _report_source
+
+    report = TimingGroupReport(
+        languages=['java'],
+        timeLimit=2000,
+        origin=TimingGroupOrigin.MULTIPLIER,
+        relativeToLanguage='cpp',
+        multiplier=2.0,
+    )
+    assert _report_source(report) == '×2.0 of cpp'
+
+
 def test_highlight_ms_colors_number_and_dims_unit():
     from rbx.box.limits_info import _highlight_ms
 

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -111,6 +111,44 @@ def test_multiplier_relative_to_base_when_relative_to_omitted():
     assert result.time_limit_per_language['java'] == int(result.base_time_limit * 3.0)
 
 
+def test_increment_added_on_top_of_multiplier():
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['java'],
+            whenEmpty=LanguageGroupFallback(
+                relativeTo='cpp', multiplier=2.0, increment=500
+            ),
+        ),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=100, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=100, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval)
+    cpp_tl = result.time_limit_per_language['cpp']
+    assert result.time_limit_per_language['java'] == int(cpp_tl * 2.0 + 500)
+
+    report = next(r for r in result.reports if r.languages == ['java'])
+    assert report.multiplier == 2.0
+    assert report.increment == 500
+
+
+def test_increment_relative_to_base_when_relative_to_omitted():
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['java'],
+            whenEmpty=LanguageGroupFallback(multiplier=1.0, increment=300),
+        ),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=100, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=100, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval)
+    # multiplier 1.0 against the base estimate, plus the increment.
+    assert result.time_limit_per_language['java'] == int(
+        result.base_time_limit * 1.0 + 300
+    )
+
+
 def test_multiplier_chain_through_another_empty_group():
     groups = [
         ResolvedGroup(languages=['cpp']),


### PR DESCRIPTION
Closes #511.

## What

Adds an `increment` parameter to the `whenEmpty` group-relative timing fallback. Previously an empty language group's time limit was derived as `multiplier × reference`. Now it resolves as:

```
multiplier × reference + increment
```

where `multiplier` is the slope and `increment` is the constant term of a line (`y = mx + b`), expressed in milliseconds. `increment` is optional (defaults to `0`); `multiplier` remains required and `> 0`.

## Changes

- `rbx/box/environment.py` — added `increment: Optional[int]` to `LanguageGroupFallback`; clarified `multiplier` as the slope.
- `rbx/box/timing_groups.py` — resolution now computes `int(ref_tl * multiplier + increment)` and records `increment` in the report.
- `rbx/box/schema.py` — added `increment` to the presentation-only `TimingGroupReport`.
- `rbx/box/limits_info.py` — the limits table renders ` + N ms` after the multiplier when `increment` is non-null (flows through the existing `ms` highlighter).
- Tests for resolution and table rendering (present/absent increment).
- Documented the new field in `docs/setters/reference/environment/index.md`.

## Testing

- 90 related timing/limits/environment tests pass.
- `ruff check` + `ruff format` clean; pre-commit hooks pass.
- One pre-existing unrelated failure (`walltime_test::test_compute_walltime_uses_active_environment`) fails identically with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)