### PR TITLE
feat(timing): force relative time limits in the rbx time picker (#512)

### DIFF
--- a/docs/plans/2026-06-03-rbx-time-forced-relative-design.md
+++ b/docs/plans/2026-06-03-rbx-time-forced-relative-design.md
@@ -1,0 +1,155 @@
+# `rbx time`: forced relative time limits in the interactive picker
+
+**Issue:** [#512](https://github.com/rsalesc/rbx/issues/512)
+**Date:** 2026-06-03
+
+## Problem
+
+After #499/#511, an env group may declare `whenEmpty` so that an *empty* group's
+time limit is derived from another group as `A·t + B` (`multiplier *
+reference + increment`). But this only works through `env.rbx.yml`, and only when
+the group has no solutions.
+
+Inside the `rbx time` interactive picker (`timing_group_picker.py`) the user can
+re-bucket languages, but:
+
+- They have **no way** to author or edit a relative spec.
+- The relative spec from env survives only by accident: `partition_from_assignment`
+  re-derives `whenEmpty` by matching the resulting group membership against the
+  env groups. Any edit to a group silently drops its relative spec.
+
+We want the user to be able to **force** a relative assignment on a group — and
+to edit its `A` and `B` — directly in the picker, with the relative formula
+**always** taking precedence over estimation (the user sees solution counts in the
+live preview and decides informed).
+
+## Design
+
+### 1. Resolve layer — a *forced* relative spec
+
+A group may carry a **forced** relative spec that **always** wins over estimation,
+even when the group has measured solutions.
+
+Resolution priority in `resolve_groups` (per group):
+
+1. **forced relative** present → `A · reference + B`
+2. else group has pooled timings → estimate from the formula
+3. else env `whenEmpty` present (empty-only, unchanged) → relative
+4. else → base time limit (`DEFAULTED`)
+
+The forced spec lives **only on `ResolvedGroup`**, via a new field
+`forced_relative: Optional[LanguageGroupFallback]`. The user-facing env schema
+(`environment.LanguageGroupFallback` / `LanguageGroup`) is **untouched**, and the
+existing empty-only `whenEmpty` behavior on the non-interactive (`auto`) path is
+unchanged.
+
+The two paths never collide:
+
+- Non-interactive / `auto` path (`build_partition`, `repartition=None`) sets
+  `whenEmpty` on `ResolvedGroup`; never sets `forced_relative`.
+- Picker path (`partition_from_assignment`) sets `forced_relative`; never sets
+  `whenEmpty`.
+
+The emitted `TimingGroupReport.origin` for a forced group reuses `MULTIPLIER`, but
+`solutionCount` is preserved so the table can convey "had N solutions, forced
+relative." `relativeToLanguage` / `multiplier` / `increment` are populated as today.
+
+### 2. Drop the env-crossing; bake `whenEmpty` at picker init
+
+`partition_from_assignment` **loses** its `env_groups` whenEmpty-matching logic. It
+just builds buckets from the `{language: state}` numbers and stamps any supplied
+relative overrides as `forced_relative` on the matching `ResolvedGroup`.
+
+The env `whenEmpty` specs are instead **baked into the picker state at
+initialization**:
+
+- For each env group that has **no measured solutions** at init time, seed the
+  picker's `relatives` map with that group's `whenEmpty` (as a forced spec).
+- Groups that have solutions are not seeded (matching today's empty-only semantics
+  at the moment of init).
+
+After init, the picker's `{numbers, relatives}` is the **single source of truth**.
+No re-crossing with env. If the user later moves a solution-bearing language into a
+baked-relative group, the forced spec now overrides that group's estimate — this is
+the user's responsibility, and the live preview shows the solution counts so the
+decision is informed.
+
+### 3. Picker interaction (UX)
+
+Entry point: press **`r`** on a language → an **inline editor** expands under that
+row, scoped to *the group that language currently belongs to*:
+
+```
+  [1] cpp
+❯ [2] python   relative-to: [cpp]  A:[2.0]  B:[100]
+      editing: Tab cycles ref · type A/B · enter ok · esc cancel · c clear
+  [ ] java
+```
+
+- **Tab** cycles the reference through the *other groups* (shown by a representative
+  language) plus **`(base estimate)`** (`relativeTo: None`, relative to the base TL).
+- Type to edit **A** (slope, must be `> 0`) and **B** (increment in ms, optional).
+- **Enter** commits, **Esc** cancels the edit, **`c`** (or clearing the reference)
+  removes the spec.
+
+In the normal list view, a forced-relative group's rows show a persistent
+annotation so the relationship is visible without opening the editor:
+
+```
+❯ [2] python  → cpp ×2.0 +100
+  [1] cpp
+  [ ] java
+```
+
+**Reset:** a **`R`** (capital, distinct from `r` = edit) hotkey restores the full
+initial env-derived state — both `numbers` *and* `relatives` — from a snapshot the
+picker stashes at init. The legend documents it.
+
+The **live preview table** already re-renders on every change and surfaces
+`GroupValidationError` (self-reference, cycles) inline. Forced specs flow through the
+same `validate_partition`, so a bad reference shows an error immediately and blocks
+confirm.
+
+Legend (updated):
+
+```
+↑/↓ move · 1-9 group · space/tab [X]/[ ] · 0 clear · r relative · R reset env
+· enter confirm · q cancel
+```
+
+### 4. Data flow
+
+- `prompt_group_assignment` return type grows from `Dict[str, int]` to a small
+  struct, e.g. `GroupAssignment{ numbers: Dict[str, int], relatives: Dict[GroupKey,
+  ForcedRelative] }`.
+- `relatives` is keyed per **group** — numbered bucket `1..9`, the leftover pool,
+  and each singleton keyed by its language — so a spec survives membership edits and
+  is pruned when its group disappears at confirm time.
+- `default_assignment` (or a sibling helper) grows a **per-group solution presence**
+  argument (derived from the already-collected `timing_per_solution_per_language`)
+  so init can decide which env `whenEmpty` specs to seed.
+- `partition_from_assignment` accepts the `relatives` overrides and stamps
+  `forced_relative` onto matching `ResolvedGroup`s. Everything downstream
+  (`resolve_groups`, `build_limits_table`, the written `timeLimitPerLanguage`) already
+  handles relative limits — the resolved profile stores **concrete numbers**, so the
+  forced spec is a one-shot computation that never round-trips to `env.rbx.yml`.
+
+## Out of scope
+
+- Persisting forced specs back to `env.rbx.yml` (the resolved profile holds concrete
+  numbers; this is a one-shot estimation aid).
+- Changing the env schema or the non-interactive `auto` resolution path.
+
+## Testing
+
+- `tests/rbx/box/test_timing_groups.py`: `partition_from_assignment` with relative
+  overrides → `forced_relative` stamped; forced relative wins over pooled timings in
+  `resolve_groups`; forced vs. empty-only `whenEmpty` priority; validation errors
+  (self-reference, cycle) still raised through forced specs.
+- New picker-state unit tests (mirroring `GroupPickerState`): `r` edit lifecycle,
+  reference cycling incl. `(base estimate)`, A/B parsing/validation, clear, and `R`
+  reset to the init snapshot.
+- `tests/rbx/box/test_timing_preview.py`: preview reflects a forced relative and
+  shows inline validation errors for bad references.
+- Init seeding: env `whenEmpty` seeded only for empty groups; not seeded when the
+  group has solutions.

--- a/docs/plans/2026-06-03-rbx-time-forced-relative-plan.md
+++ b/docs/plans/2026-06-03-rbx-time-forced-relative-plan.md
@@ -1,0 +1,1093 @@
+# Forced Relative Time Limits in `rbx time` Picker — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let `rbx time` users force a group's time limit to be relative to another group (`A·t + B`) directly in the interactive picker, always overriding estimation, with an inline editor and an env-reset hotkey.
+
+**Architecture:** A new `forced_relative` field on `ResolvedGroup` (pure layer in `timing_groups.py`) takes top priority during resolution. The picker (`timing_group_picker.py`) gains a `relatives` map keyed by a string group-key, an inline `r` editor, and an `R` reset. `partition_from_assignment` drops its env-crossing and instead applies picker-supplied relatives; env `whenEmpty` is baked into picker state at init only for groups with no solutions. The resolved profile stores concrete numbers, so nothing round-trips to `env.rbx.yml`.
+
+**Tech Stack:** Python 3.14, Pydantic v2, `prompt_toolkit` (picker UI), pytest (`create_pipe_input`/`DummyOutput` for picker tests). Single quotes, absolute imports, ruff.
+
+**Design doc:** `docs/plans/2026-06-03-rbx-time-forced-relative-design.md`
+
+**Reference — group-key encoding (used everywhere `relatives` is keyed):**
+Given the picker `numbers: Dict[str,int]` (N≥1 bucket, 0 leftover, -1 singleton):
+- bucket `N≥1` → `f'g{N}'`  (e.g. `'g2'`)
+- leftover (`0`) → `'leftover'`
+- singleton (`-1`) of language `L` → `f's:{L}'`
+
+The relative spec value type is the existing `environment.LanguageGroupFallback`
+(`relativeTo`, `multiplier`, `increment`). `relativeTo` holds a representative
+language of the target group, or `None` for "(base estimate)".
+
+---
+
+## Task 1: `forced_relative` field + resolution priority (pure layer)
+
+**Files:**
+- Modify: `rbx/box/timing_groups.py` (`ResolvedGroup`, `validate_partition`, `resolve_groups`)
+- Test: `tests/rbx/box/test_timing_groups.py`
+
+**Step 1: Write failing tests**
+
+Add to `tests/rbx/box/test_timing_groups.py`:
+
+```python
+from rbx.box.environment import LanguageGroupFallback
+
+
+def _eval(fastest, slowest):
+    # simple deterministic formula for tests: just the slowest
+    return slowest
+
+
+def test_forced_relative_wins_over_pooled_timings():
+    # group 0 has solutions; group 1 forced relative to group 0
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['python'],
+            forced_relative=LanguageGroupFallback(
+                relativeTo='cpp', multiplier=2.0, increment=100
+            ),
+        ),
+    ]
+    pooled = {
+        0: GroupTimings(fastest=100, slowest=200, solution_count=1),
+        1: GroupTimings(fastest=500, slowest=900, solution_count=1),
+    }
+    base = GroupTimings(fastest=100, slowest=900, solution_count=2)
+    result = resolve_groups(groups, pooled, base, _eval)
+    # group 1 ignores its own timings (would be 900) -> 2.0*200 + 100 = 500
+    assert result.reports[1].timeLimit == 500
+    assert result.reports[1].origin == TimingGroupOrigin.MULTIPLIER
+    assert result.reports[1].relativeToLanguage == 'cpp'
+    # solution count of the overridden group is preserved for display
+    assert result.reports[1].solutionCount == 1
+
+
+def test_forced_relative_validates_self_reference():
+    groups = [
+        ResolvedGroup(
+            languages=['cpp'],
+            forced_relative=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        )
+    ]
+    with pytest.raises(GroupValidationError):
+        validate_partition(groups)
+
+
+def test_forced_relative_to_base_estimate():
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['python'],
+            forced_relative=LanguageGroupFallback(relativeTo=None, multiplier=3.0),
+        ),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=200, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=200, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval)
+    # base_tl = _eval(100, 200) = 200; forced -> 3.0*200 = 600
+    assert result.reports[1].timeLimit == 600
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -k forced -v`
+Expected: FAIL (`ResolvedGroup` has no `forced_relative`).
+
+**Step 3: Add the field**
+
+In `rbx/box/timing_groups.py`, import is already `from rbx.box.environment import LanguageGroup, LanguageGroupFallback`. Update `ResolvedGroup`:
+
+```python
+class ResolvedGroup(BaseModel):
+    languages: List[str]
+    whenEmpty: Optional[LanguageGroupFallback] = None
+    forced_relative: Optional[LanguageGroupFallback] = None
+    is_leftover: bool = False
+```
+
+**Step 4: Add a fallback-edge helper and update `validate_partition`**
+
+Add near the top of `validate_partition`'s module scope:
+
+```python
+def _effective_fallback(group: ResolvedGroup) -> Optional[LanguageGroupFallback]:
+    """The fallback whose reference edge matters for validation: a forced
+    relative (picker path) takes precedence, else the env whenEmpty."""
+    return group.forced_relative or group.whenEmpty
+```
+
+In `validate_partition`, replace both `group.whenEmpty` accesses (the reference-existence loop and the `visit` cycle walk) with `_effective_fallback(group)`. Concretely:
+
+```python
+    for idx, group in enumerate(groups):
+        fb = _effective_fallback(group)
+        if fb is None or fb.relativeTo is None:
+            continue
+        ref = fb.relativeTo
+        if ref not in lang_index:
+            raise GroupValidationError(
+                f'whenEmpty.relativeTo references unknown language {ref!r}.'
+            )
+        if lang_index[ref] == idx:
+            raise GroupValidationError(
+                f'whenEmpty.relativeTo {ref!r} points to the same group; it must '
+                'reference a different group.'
+            )
+    ...
+    def visit(idx: int) -> None:
+        color[idx] = GRAY
+        fb = _effective_fallback(groups[idx])
+        if fb is not None and fb.relativeTo is not None:
+            nxt = lang_index[fb.relativeTo]
+            ...
+```
+
+**Step 5: Add the forced branch in `resolve_groups`**
+
+In the `resolve(idx)` inner function, insert a new FIRST branch (before `if timings is not None:`). Keep the existing `timings` and `whenEmpty` branches after it:
+
+```python
+        group = groups[idx]
+        timings = pooled.get(idx)
+        if group.forced_relative is not None:
+            fb = group.forced_relative
+            ref = fb.relativeTo
+            ref_tl = base_tl if ref is None else resolve(lang_index[ref])
+            increment = fb.increment or 0
+            tl = int(ref_tl * fb.multiplier + increment)
+            report = TimingGroupReport(
+                languages=list(group.languages),
+                timeLimit=tl,
+                origin=TimingGroupOrigin.MULTIPLIER,
+                solutionCount=timings.solution_count if timings else 0,
+                fastest=timings.fastest if timings else None,
+                slowest=timings.slowest if timings else None,
+                relativeToLanguage=ref,
+                multiplier=fb.multiplier,
+                increment=fb.increment,
+                isLeftover=group.is_leftover,
+            )
+        elif timings is not None:
+            ...  # unchanged
+```
+
+**Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: PASS (new + all existing).
+
+**Step 7: Commit**
+
+```bash
+git add rbx/box/timing_groups.py tests/rbx/box/test_timing_groups.py
+git commit -m "feat(timing): forced relative spec wins over estimation in resolve_groups"
+```
+
+---
+
+## Task 2: `partition_from_assignment` drops env-crossing, applies relatives
+
+**Files:**
+- Modify: `rbx/box/timing_groups.py` (`partition_from_assignment`)
+- Test: `tests/rbx/box/test_timing_groups.py`
+
+**Step 1: Write failing tests**
+
+```python
+def test_partition_applies_forced_relatives_by_group_key():
+    groups = partition_from_assignment(
+        {'cpp': 1, 'python': 2, 'go': 0, 'rust': -1},
+        relatives={
+            'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            's:rust': LanguageGroupFallback(relativeTo='cpp', multiplier=3.0),
+            'leftover': LanguageGroupFallback(relativeTo='cpp', multiplier=4.0),
+        },
+    )
+    by_lang = {g.languages[0]: g for g in groups}
+    assert by_lang['python'].forced_relative.multiplier == 2.0
+    assert by_lang['rust'].forced_relative.multiplier == 3.0
+    assert by_lang['go'].forced_relative.multiplier == 4.0
+    assert by_lang['cpp'].forced_relative is None
+
+
+def test_partition_no_longer_derives_when_empty_from_env():
+    # membership matches an env group, but partition_from_assignment must NOT
+    # re-derive whenEmpty anymore (env-crossing dropped).
+    groups = partition_from_assignment({'java': 1, 'kotlin': 1})
+    assert groups[0].whenEmpty is None
+    assert groups[0].forced_relative is None
+```
+
+**Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -k "partition_applies or no_longer" -v`
+Expected: FAIL (`partition_from_assignment` still requires `env_groups`).
+
+**Step 3: Rewrite `partition_from_assignment`**
+
+Replace the signature and body. Add a module-level key helper:
+
+```python
+def group_key(state: int, lang: str) -> str:
+    """Stable key for the group a language currently belongs to."""
+    if state > 0:
+        return f'g{state}'
+    if state < 0:
+        return f's:{lang}'
+    return 'leftover'
+
+
+def partition_from_assignment(
+    assignment: Dict[str, int],
+    relatives: Optional[Dict[str, LanguageGroupFallback]] = None,
+) -> List[ResolvedGroup]:
+    """Build groups from a {language: state} map. State per language:
+    N>=1 share bucket N; -1 = own singleton group; 0 = the shared leftover pool.
+    Optional ``relatives`` maps a group-key (see group_key) to a forced relative
+    spec, stamped onto the matching group as ``forced_relative``."""
+    relatives = relatives or {}
+    buckets: Dict[int, List[str]] = {}
+    singletons: List[tuple[str, List[str]]] = []
+    leftover: List[str] = []
+    for lang, state in assignment.items():
+        if state == 0:
+            leftover.append(lang)
+        elif state < 0:
+            singletons.append((f's:{lang}', [lang]))
+        else:
+            buckets.setdefault(state, []).append(lang)
+
+    result: List[ResolvedGroup] = []
+    for number, langs in sorted(buckets.items()):
+        result.append(
+            ResolvedGroup(
+                languages=langs, forced_relative=relatives.get(f'g{number}')
+            )
+        )
+    for key, langs in singletons:
+        result.append(
+            ResolvedGroup(languages=langs, forced_relative=relatives.get(key))
+        )
+    if leftover:
+        result.append(
+            ResolvedGroup(
+                languages=leftover,
+                is_leftover=True,
+                forced_relative=relatives.get('leftover'),
+            )
+        )
+    return result
+```
+
+Remove the now-unused `env_when_empty` logic. (The `LanguageGroup` import stays — still used by `build_partition`.)
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py -v`
+Expected: PASS.
+
+**Step 5: Find and fix callers**
+
+Run: `uv run python -c "import rbx.box.timing"` then
+`grep -rn "partition_from_assignment" rbx tests`.
+The only non-test caller is `rbx/box/timing.py:build_timing_profile` (fixed in Task 3). Any existing test passing `env_groups=` positionally must be updated to the new signature.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/timing_groups.py tests/rbx/box/test_timing_groups.py
+git commit -m "refactor(timing): partition_from_assignment applies picker relatives, drops env-crossing"
+```
+
+---
+
+## Task 3: Thread `relatives` through `build_timing_profile` + preview
+
+**Files:**
+- Modify: `rbx/box/timing.py` (`build_timing_profile`, `build_preview_renderer`)
+- Test: `tests/rbx/box/test_timing_preview.py`, `tests/rbx/box/test_timing_estimation.py`
+
+**Step 1: Write a failing preview test**
+
+In `tests/rbx/box/test_timing_preview.py`, add a test that a forced relative changes the previewed table. Mirror the existing tests in that file for fixture shape; assert the rendered ANSI contains the forced group's relative-derived limit (or a `×`/`relative` marker the table emits). Example skeleton:
+
+```python
+def test_preview_reflects_forced_relative():
+    render = build_preview_renderer(
+        timing_per_solution_per_language={'cpp': {'sol.cpp': 200}},
+        formula='slowest',
+        env_groups=[],
+        all_languages=['cpp', 'python'],
+    )
+    # python forced relative to cpp, x2 -> 400ms must appear
+    out = render({'cpp': 1, 'python': 2}, {'g2': LanguageGroupFallback(
+        relativeTo='cpp', multiplier=2.0)})
+    assert '400' in str(out.value)
+```
+
+(Adjust `formula`/assertions to match how `build_limits_table` renders; read the existing passing tests in this file first.)
+
+**Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/rbx/box/test_timing_preview.py -k forced -v`
+Expected: FAIL (`render` takes one arg; `build_timing_profile` has no `relatives`).
+
+**Step 3: Update `build_timing_profile`**
+
+Add a `relatives` parameter and pass it through:
+
+```python
+def build_timing_profile(
+    timing_per_solution_per_language: Dict[str, Dict[str, int]],
+    formula: str,
+    env_groups: List[environment.LanguageGroup],
+    all_languages: List[str],
+    repartition: Optional[Dict[str, int]] = None,
+    relatives: Optional[Dict[str, environment.LanguageGroupFallback]] = None,
+) -> TimingProfile:
+    ...
+    if repartition is not None:
+        groups = timing_groups.partition_from_assignment(repartition, relatives)
+    else:
+        groups = timing_groups.build_partition(env_groups, all_languages)
+```
+
+**Step 4: Update `build_preview_renderer`**
+
+The memoized render must key on relatives too. Change the inner cache + outer `render`:
+
+```python
+    @functools.lru_cache(maxsize=None)
+    def _render(assignment_items: tuple, relative_items: tuple) -> ANSI:
+        assignment = dict(assignment_items)
+        relatives = {k: v for k, v in relative_items}
+        try:
+            profile = build_timing_profile(
+                ...,
+                repartition=assignment,
+                relatives=relatives,
+            )
+        ...
+
+    def render(
+        assignment: Dict[str, int],
+        relatives: Optional[Dict[str, environment.LanguageGroupFallback]] = None,
+    ) -> ANSI:
+        relatives = relatives or {}
+        return _render(
+            tuple(sorted(assignment.items())),
+            tuple(sorted(relatives.items(), key=lambda kv: kv[0])),
+        )
+```
+
+Note: `LanguageGroupFallback` is a Pydantic model; it is hashable only if frozen. Confirm by running the test — if `lru_cache` raises `unhashable type`, set `model_config = ConfigDict(frozen=True)` on `LanguageGroupFallback` in `environment.py` (it is `extra='forbid'` already and only ever constructed, never mutated). Add that to the same commit if needed.
+
+**Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_preview.py tests/rbx/box/test_timing_estimation.py -v`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/timing.py rbx/box/environment.py tests/rbx/box/test_timing_preview.py
+git commit -m "feat(timing): thread forced relatives through profile build and preview"
+```
+
+---
+
+## Task 4: Picker state — relatives, group-key, edit lifecycle (pure)
+
+**Files:**
+- Modify: `rbx/box/timing_group_picker.py` (`GroupPickerState`)
+- Test: `tests/rbx/box/test_timing_group_picker.py`
+
+This task is pure state logic (no `prompt_toolkit` app). All methods are unit-tested directly.
+
+**Step 1: Write failing tests**
+
+```python
+from rbx.box.environment import LanguageGroupFallback
+
+
+def test_group_key_per_state():
+    s = GroupPickerState(['cpp', 'py', 'go'], {'cpp': 2, 'py': -1, 'go': 0})
+    assert s.group_key('cpp') == 'g2'
+    assert s.group_key('py') == 's:py'
+    assert s.group_key('go') == 'leftover'
+
+
+def test_start_edit_seeds_defaults_and_commit():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)  # cursor -> py
+    s.start_edit()
+    assert s.editing
+    s.set_ref('cpp')
+    s.set_a('2.5')
+    s.set_b('100')
+    s.commit_edit()
+    assert not s.editing
+    assert s.relatives['g2'] == LanguageGroupFallback(
+        relativeTo='cpp', multiplier=2.5, increment=100
+    )
+
+
+def test_cancel_edit_discards():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_a('9')
+    s.cancel_edit()
+    assert not s.editing
+    assert 'g2' not in s.relatives
+
+
+def test_clear_relative_removes_spec():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2},
+                         relatives={'g2': LanguageGroupFallback(
+                             relativeTo='cpp', multiplier=2.0)})
+    s.move(1)
+    s.start_edit()
+    s.clear_relative()
+    assert 'g2' not in s.relatives
+    assert not s.editing
+
+
+def test_invalid_a_keeps_editing(monkeypatch=None):
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_ref('cpp')
+    s.set_a('abc')  # not a positive float
+    assert s.commit_edit() is False  # rejected
+    assert s.editing  # stays in editor
+
+
+def test_reference_options_exclude_own_group_and_include_base():
+    s = GroupPickerState(['cpp', 'py', 'go'], {'cpp': 1, 'py': 2, 'go': 2})
+    s.move(1)  # cursor on py (group g2)
+    refs = s.reference_options()
+    # representative langs of OTHER groups + None for base estimate
+    assert None in refs
+    assert 'cpp' in refs
+    assert 'py' not in refs and 'go' not in refs  # own group excluded
+
+
+def test_reset_restores_initial_numbers_and_relatives():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2},
+                         relatives={'g2': LanguageGroupFallback(
+                             relativeTo='cpp', multiplier=2.0)})
+    s.set_group(5)  # mutate cpp
+    s.move(1)
+    s.start_edit(); s.clear_relative()
+    s.reset_to_initial()
+    assert s.assignment() == {'cpp': 1, 'py': 2}
+    assert s.relatives == {'g2': LanguageGroupFallback(
+        relativeTo='cpp', multiplier=2.0)}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -k "group_key or edit or relative or reference_options or reset" -v`
+Expected: FAIL.
+
+**Step 3: Extend `GroupPickerState.__init__`**
+
+```python
+    def __init__(self, languages, default_number, relatives=None):
+        self.languages = list(languages)
+        self.numbers = {lang: int(default_number.get(lang, 0)) for lang in self.languages}
+        self.cursor = 0
+        self.done = False
+        self.relatives: Dict[str, LanguageGroupFallback] = dict(relatives or {})
+        # immutable snapshot for reset_to_initial
+        self._initial_numbers = dict(self.numbers)
+        self._initial_relatives = dict(self.relatives)
+        # edit-mode scratch state
+        self.editing = False
+        self._edit_ref: Optional[str] = None
+        self._edit_a: str = ''
+        self._edit_b: str = ''
+```
+
+Add `from typing import ... ` already present; add `from rbx.box.environment import LanguageGroupFallback` at top.
+
+**Step 4: Add the methods**
+
+```python
+    def group_key(self, lang: str) -> str:
+        state = self.numbers[lang]
+        if state > 0:
+            return f'g{state}'
+        if state < 0:
+            return f's:{lang}'
+        return 'leftover'
+
+    def current_lang(self) -> Optional[str]:
+        return self.languages[self.cursor] if self.languages else None
+
+    def reference_options(self) -> List[Optional[str]]:
+        """None (base estimate) + one representative language per OTHER group,
+        in language order."""
+        own = self.group_key(self.current_lang())
+        opts: List[Optional[str]] = [None]
+        seen: set = set()
+        for lang in self.languages:
+            key = self.group_key(lang)
+            if key == own or key in seen:
+                continue
+            seen.add(key)
+            opts.append(lang)
+        return opts
+
+    def start_edit(self) -> None:
+        if not self.languages:
+            return
+        key = self.group_key(self.current_lang())
+        existing = self.relatives.get(key)
+        self.editing = True
+        self._edit_ref = existing.relativeTo if existing else None
+        self._edit_a = str(existing.multiplier) if existing else '1.0'
+        self._edit_b = (
+            str(existing.increment) if existing and existing.increment else ''
+        )
+
+    def set_ref(self, ref: Optional[str]) -> None:
+        self._edit_ref = ref
+
+    def cycle_ref(self, delta: int) -> None:
+        opts = self.reference_options()
+        try:
+            i = opts.index(self._edit_ref)
+        except ValueError:
+            i = 0
+        self._edit_ref = opts[(i + delta) % len(opts)]
+
+    def set_a(self, text: str) -> None:
+        self._edit_a = text
+
+    def set_b(self, text: str) -> None:
+        self._edit_b = text
+
+    def commit_edit(self) -> bool:
+        """Validate buffers; on success store the spec and exit edit mode.
+        Returns False (and stays editing) on invalid A/B."""
+        try:
+            a = float(self._edit_a)
+        except ValueError:
+            return False
+        if a <= 0:
+            return False
+        b: Optional[int] = None
+        if self._edit_b.strip():
+            try:
+                b = int(self._edit_b)
+            except ValueError:
+                return False
+        key = self.group_key(self.current_lang())
+        self.relatives[key] = LanguageGroupFallback(
+            relativeTo=self._edit_ref, multiplier=a, increment=b
+        )
+        self.editing = False
+        return True
+
+    def cancel_edit(self) -> None:
+        self.editing = False
+
+    def clear_relative(self) -> None:
+        self.relatives.pop(self.group_key(self.current_lang()), None)
+        self.editing = False
+
+    def reset_to_initial(self) -> None:
+        self.numbers = dict(self._initial_numbers)
+        self.relatives = dict(self._initial_relatives)
+        self.editing = False
+
+    def prune_relatives(self) -> Dict[str, LanguageGroupFallback]:
+        """Drop specs whose group-key no longer maps to any language."""
+        live = {self.group_key(lang) for lang in self.languages}
+        return {k: v for k, v in self.relatives.items() if k in live}
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -v`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/timing_group_picker.py tests/rbx/box/test_timing_group_picker.py
+git commit -m "feat(timing): picker state for forced relative specs (edit/clear/reset)"
+```
+
+---
+
+## Task 5: Picker rendering — annotation + inline editor
+
+**Files:**
+- Modify: `rbx/box/timing_group_picker.py` (`render_fragments`, `LEGEND_LINES`)
+- Test: `tests/rbx/box/test_timing_group_picker.py`
+
+**Step 1: Write failing tests**
+
+```python
+def test_render_annotates_relative_group():
+    s = GroupPickerState(
+        ['cpp', 'py'], {'cpp': 1, 'py': 2},
+        relatives={'g2': LanguageGroupFallback(
+            relativeTo='cpp', multiplier=2.0, increment=100)},
+    )
+    text = ''.join(t for _, t in s.render_fragments())
+    assert 'py' in text
+    # annotation shows reference + A + B
+    assert '→ cpp' in text or '-> cpp' in text
+    assert '2.0' in text
+    assert '100' in text
+
+
+def test_render_shows_inline_editor_when_editing():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_ref('cpp')
+    text = ''.join(t for _, t in s.render_fragments())
+    assert 'relative-to' in text
+    assert 'A:' in text and 'B:' in text
+
+
+def test_legend_mentions_relative_and_reset():
+    from rbx.box.timing_group_picker import LEGEND_LINES
+    text = '\n'.join(LEGEND_LINES)
+    assert 'relative' in text
+    assert 'reset' in text
+```
+
+**Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -k "annotat or inline_editor or legend_mentions" -v`
+Expected: FAIL.
+
+**Step 3: Update `LEGEND_LINES`**
+
+Replace the last hint line:
+
+```python
+    '↑/↓ move · 1-9 group · space/tab [X]/[ ] · 0 clear · r relative · R reset env'
+    ' · enter confirm · q cancel',
+```
+
+**Step 4: Update `render_fragments`**
+
+After building each language row, append a relative annotation when the language's group carries a spec, and render the inline editor under the cursor row when `self.editing`:
+
+```python
+    def _relative_suffix(self, lang: str) -> str:
+        spec = self.relatives.get(self.group_key(lang))
+        if spec is None:
+            return ''
+        ref = spec.relativeTo if spec.relativeTo is not None else 'base'
+        suffix = f'  → {ref} ×{spec.multiplier:g}'
+        if spec.increment:
+            suffix += f' +{spec.increment}'
+        return suffix
+
+    def _editor_fragments(self):
+        ref = self._edit_ref if self._edit_ref is not None else '(base estimate)'
+        return [(
+            'class:editor',
+            f'      relative-to: [{ref}]  A:[{self._edit_a}]  B:[{self._edit_b}]\n'
+            '      Tab cycles ref · type A/B · enter ok · esc cancel · c clear\n',
+        )]
+
+    def render_fragments(self):
+        fragments = []
+        for i, lang in enumerate(self.languages):
+            number = self.numbers[lang]
+            box = str(number) if number > 0 else ('X' if number < 0 else ' ')
+            selected = i == self.cursor
+            pointer = '❯ ' if selected else '  '
+            row_style = 'class:current' if selected else 'class:row'
+            box_style = 'class:box-current' if selected else 'class:box'
+            fragments.append((row_style, pointer))
+            fragments.append((box_style, f'[{box}] '))
+            fragments.append((row_style, f'{lang}'))
+            fragments.append(('class:relative', self._relative_suffix(lang)))
+            fragments.append((row_style, '\n'))
+            if selected and self.editing:
+                fragments.extend(self._editor_fragments())
+        return fragments
+```
+
+Add `'editor': 'ansicyan'` and `'relative': 'ansigreen'` to the `Style.from_dict` map in `prompt_group_assignment` (Task 6 touches that function; if not yet present, add the styles there).
+
+**Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -k "annotat or inline_editor or legend" -v`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/timing_group_picker.py tests/rbx/box/test_timing_group_picker.py
+git commit -m "feat(timing): render relative annotations and inline editor in picker"
+```
+
+---
+
+## Task 6: Picker key bindings, edit-mode routing, new return struct
+
+**Files:**
+- Modify: `rbx/box/timing_group_picker.py` (`prompt_group_assignment`)
+- Modify: `rbx/box/timing.py` (`_prompt_repartition` to consume new return)
+- Test: `tests/rbx/box/test_timing_group_picker.py`
+
+**Decision — return type:** `prompt_group_assignment` now returns
+`Optional[GroupAssignment]` where `GroupAssignment` is a small Pydantic model:
+
+```python
+class GroupAssignment(BaseModel):
+    numbers: Dict[str, int]
+    relatives: Dict[str, LanguageGroupFallback] = {}
+```
+
+This breaks existing assertions like `result == {'cpp': 1}`; update those tests to
+`result.numbers == {...}`.
+
+**Step 1: Update existing picker integration tests + add new ones**
+
+Change the three existing `prompt_group_assignment` integration tests to assert on
+`result.numbers`. Then add:
+
+```python
+async def test_picker_force_relative_flow():
+    with create_pipe_input() as inp:
+        inp.send_text('1')          # cpp -> group 1
+        inp.send_text('\x1b[B')     # down -> py
+        inp.send_text('2')          # py -> group 2
+        inp.send_text('r')          # open editor on py (g2)
+        inp.send_text('\t')         # Tab: ref None -> cpp
+        inp.send_text('2.0')        # type A
+        # move focus to B is implicit in editor; send Tab? -> see Step 3 routing
+        inp.send_text('\r')         # commit edit
+        inp.send_text('\r')         # confirm picker
+        result = await prompt_group_assignment(
+            ['cpp', 'py'], {'cpp': 0, 'py': 0},
+            input=inp, output=DummyOutput(),
+        )
+    assert result.numbers == {'cpp': 1, 'py': 2}
+    assert result.relatives['g2'].relativeTo == 'cpp'
+    assert result.relatives['g2'].multiplier == 2.0
+
+
+async def test_picker_reset_restores_env():
+    with create_pipe_input() as inp:
+        inp.send_text('5')          # mutate cpp -> 5
+        inp.send_text('R')          # reset to initial
+        inp.send_text('\r')         # confirm
+        result = await prompt_group_assignment(
+            ['cpp', 'py'], {'cpp': 1, 'py': 2},
+            input=inp, output=DummyOutput(),
+        )
+    assert result.numbers == {'cpp': 1, 'py': 2}
+```
+
+(The exact A/B keystroke routing depends on Step 3; adjust the `send_text`
+sequence to match the implemented editor input model. Keep the editor input model
+SIMPLE: a single focused buffer that A and B share is error-prone — prefer
+separate `a`/`b` sub-fields toggled by Tab, or commit A then B via two Enter
+presses. Pick one and make the test match.)
+
+**Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -v`
+Expected: FAIL (no `GroupAssignment`, no `r`/`R`/editor bindings).
+
+**Step 3: Implement edit-mode key routing**
+
+Editor input model (chosen for testability): when `state.editing`, keystrokes are
+routed to the editor instead of the list. Fields cycle with **Tab**:
+`ref → A → B → ref …`. Reuse a `self._edit_field` cursor (`'ref' | 'a' | 'b'`).
+- On `ref`: Tab/Left/Right cycle `cycle_ref`.
+- On `a`/`b`: digit/`.`/`-` keys append to the buffer; backspace pops.
+- **Enter**: `commit_edit()`; if it returns False, stay (invalid).
+- **Esc**: `cancel_edit()`. **c** (only meaningful on ref field): `clear_relative()`.
+
+In `prompt_group_assignment`, gate the existing list bindings on
+`not state.editing`, and add an editor key handler. `prompt_toolkit` allows a
+`filter=Condition(lambda: state.editing)` on bindings. Sketch:
+
+```python
+    from prompt_toolkit.filters import Condition
+    editing = Condition(lambda: state.editing)
+    not_editing = ~editing
+
+    @kb.add('up', filter=not_editing)
+    @kb.add('k', filter=not_editing)
+    def _(event):
+        state.move(-1)
+    # ... wrap every existing list binding with filter=not_editing ...
+
+    @kb.add('r', filter=not_editing)
+    def _(event):
+        state.start_edit()
+
+    @kb.add('R', filter=not_editing)
+    def _(event):
+        state.reset_to_initial()
+
+    # editor bindings
+    @kb.add('tab', filter=editing)
+    def _(event):
+        state.edit_tab()         # advance _edit_field; on ref, also cycle? keep simple: advance field
+
+    @kb.add('enter', filter=editing)
+    def _(event):
+        state.commit_edit()      # stays editing if invalid
+
+    @kb.add('escape', filter=editing)
+    def _(event):
+        state.cancel_edit()
+
+    @kb.add('c', filter=editing)
+    def _(event):
+        state.clear_relative()
+
+    @kb.add('<any>', filter=editing)
+    def _(event):
+        state.edit_key(event.data)  # append/cycle based on _edit_field
+```
+
+Add the small helpers `edit_tab`, `edit_key` to `GroupPickerState` (with unit
+tests in Task 4's file — add them there if you prefer strict TDD ordering; it is
+acceptable to add these two helpers here with their own tests since they are
+input-routing glue). `edit_key` on the `ref` field maps arrow-like data to
+`cycle_ref`; on `a`/`b` appends printable chars / handles backspace.
+
+Update `enter` (confirm) binding (now `filter=not_editing`) to return the struct:
+
+```python
+    @kb.add('enter', filter=not_editing)
+    def _(event):
+        state.done = True
+        event.app.exit(result=GroupAssignment(
+            numbers=state.assignment(),
+            relatives=state.prune_relatives(),
+        ))
+```
+
+Update the `preview` window call to pass relatives:
+`state.preview_text(preview)` → ensure `preview_text` forwards both
+`assignment()` and `relatives` to the preview callback. Update `preview_text`:
+
+```python
+    def preview_text(self, preview):
+        if self.done or preview is None:
+            return ''
+        return preview(self.assignment(), self.prune_relatives())
+```
+
+And in `timing.py` the `preview` passed in is `build_preview_renderer`'s
+`render(assignment, relatives)` — already 2-arg after Task 3.
+
+**Step 4: Update `_prompt_repartition` / `estimate_time_limit` (timing.py)**
+
+`_prompt_repartition` returns the picker result. Change its return type to
+`Optional[GroupAssignment]` and update `estimate_time_limit`:
+
+```python
+    repartition = None
+    relatives = None
+    if not auto and len(all_languages) > 1:
+        picked = await _prompt_repartition(...)
+        if picked is None:
+            console.print('[error]Time limit estimation cancelled.[/error]')
+            return None
+        repartition = picked.numbers
+        relatives = picked.relatives
+    ...
+    profile = build_timing_profile(
+        ...,
+        repartition=repartition,
+        relatives=relatives,
+    )
+```
+
+**Step 5: Run the full picker + timing suite**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py tests/rbx/box/test_timing.py tests/rbx/box/test_timing_estimation.py tests/rbx/box/test_timing_preview.py -v`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/timing_group_picker.py rbx/box/timing.py tests/rbx/box/test_timing_group_picker.py
+git commit -m "feat(timing): wire forced-relative editor keys and GroupAssignment return"
+```
+
+---
+
+## Task 7: Init seeding from env `whenEmpty` for empty groups
+
+**Files:**
+- Modify: `rbx/box/timing.py` (`default_assignment` → add `default_relatives`, `_prompt_repartition`)
+- Test: `tests/rbx/box/test_timing.py` (or `test_timing_estimation.py`)
+
+**Step 1: Write failing tests**
+
+```python
+def test_default_relatives_seeds_only_empty_groups():
+    from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+    from rbx.box.timing import default_relatives
+
+    env_groups = [
+        LanguageGroup(languages=['cpp']),  # has solutions
+        LanguageGroup(
+            languages=['py'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        ),  # empty -> seed
+        LanguageGroup(
+            languages=['go'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=3.0),
+        ),  # has solutions -> do NOT seed
+    ]
+    langs_with_solutions = {'cpp', 'go'}
+    seeded = default_relatives(env_groups, langs_with_solutions)
+    assert set(seeded) == {'g2'}  # only the empty py group (env group #2)
+    assert seeded['g2'].multiplier == 2.0
+```
+
+**Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/rbx/box/test_timing.py -k default_relatives -v`
+Expected: FAIL (`default_relatives` undefined).
+
+**Step 3: Implement `default_relatives`**
+
+In `timing.py`, alongside `default_assignment`:
+
+```python
+def default_relatives(
+    env_groups: List[environment.LanguageGroup],
+    langs_with_solutions: set,
+) -> Dict[str, environment.LanguageGroupFallback]:
+    """Seed picker relatives from env whenEmpty, but only for groups that have
+    NO measured solutions (matching env whenEmpty's empty-only semantics at the
+    moment of init). Keyed by the picker group-key the env group maps to
+    (env group i -> bucket i -> 'g{i}')."""
+    seeded: Dict[str, environment.LanguageGroupFallback] = {}
+    for i, group in enumerate(env_groups, start=1):
+        if group.whenEmpty is None:
+            continue
+        if any(lang in langs_with_solutions for lang in group.languages):
+            continue
+        seeded[f'g{i}'] = group.whenEmpty
+    return seeded
+```
+
+**Step 4: Pass seeds into the picker**
+
+In `_prompt_repartition`, compute and forward:
+
+```python
+async def _prompt_repartition(
+    all_languages,
+    env_groups,
+    timing_per_solution_per_language,
+    formula,
+):
+    preview = build_preview_renderer(...)
+    langs_with_solutions = {
+        lang for lang, per_sol in timing_per_solution_per_language.items() if per_sol
+    }
+    return await timing_group_picker.prompt_group_assignment(
+        all_languages,
+        default_assignment(all_languages, env_groups),
+        relatives=default_relatives(env_groups, langs_with_solutions),
+        preview=preview,
+    )
+```
+
+Add a `relatives` parameter to `prompt_group_assignment` (defaults to `None`) and
+pass it into `GroupPickerState(..., relatives=relatives)`.
+
+**Step 5: Run tests**
+
+Run: `uv run pytest tests/rbx/box/test_timing.py tests/rbx/box/test_timing_group_picker.py -v`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/timing.py rbx/box/timing_group_picker.py tests/rbx/box/test_timing.py
+git commit -m "feat(timing): seed picker relatives from env whenEmpty for empty groups"
+```
+
+---
+
+## Task 8: Docs + full verification
+
+**Files:**
+- Modify: `docs/setters/reference/environment/index.md` (note picker can now force a relative limit), and any `rbx time` walkthrough doc that lists picker hotkeys (search `grep -rn "leftover\|singleton\|rbx time" docs`).
+- Test: full suite.
+
+**Step 1: Update docs**
+
+In the timing/`whenEmpty` reference section, add a short paragraph: in `rbx time`
+the picker lets you force any group's limit to be relative to another group
+(`A·t + B`) with `r`, and reset to the env grouping with `R`. Keep it to a few
+sentences; mirror surrounding doc tone.
+
+**Step 2: Lint + format**
+
+Run: `uv run ruff check --fix . && uv run ruff format .`
+Expected: clean.
+
+**Step 3: Run the full timing-related suite**
+
+Run: `uv run pytest tests/rbx/box/test_timing_groups.py tests/rbx/box/test_timing_group_picker.py tests/rbx/box/test_timing.py tests/rbx/box/test_timing_estimation.py tests/rbx/box/test_timing_preview.py tests/rbx/box/test_limits_table.py -v`
+Expected: all PASS.
+
+**Step 4: Run the broader box suite (catch fallout)**
+
+Run: `uv run pytest --ignore=tests/rbx/box/cli -n auto`
+Expected: PASS (modulo the pre-existing C++/sandbox/docker failures noted in
+project memory — confirm any failures match that known set, not new ones).
+
+**Step 5: Verify docs build**
+
+Run: `uv run mkdocs build` (non-strict; ~9 pre-existing strict warnings are known
+and unrelated per project memory).
+Expected: build succeeds.
+
+**Step 6: Commit**
+
+```bash
+git add docs
+git commit -m "docs(timing): document forced relative limits in rbx time picker"
+```
+
+---
+
+## Notes & Edge Cases
+
+- **Hashability for `lru_cache`**: if threading `LanguageGroupFallback` through the
+  memoized preview raises `unhashable type`, mark the model `frozen=True`
+  (Task 3, Step 4). It is constructed-once, never mutated.
+- **Group-key churn**: moving a language out of a relative group changes its
+  group-key; `prune_relatives()` drops orphaned specs at confirm/preview time.
+  This is the intended "user's responsibility" behavior — `R` reset recovers the
+  env grouping.
+- **`relativeTo` drift**: the reference stores a representative language; if that
+  language is later re-bucketed, the reference follows it. `validate_partition`
+  still rejects self-reference and cycles, and the live preview surfaces the error
+  inline and blocks confirm.
+- **Singletons share state `-1`** in `numbers` but get distinct `s:{lang}` keys —
+  this is why relatives are keyed by `group_key`, not by the raw state int.
+- **`auto` path unchanged**: `build_partition` + env `whenEmpty` (empty-only) still
+  governs non-interactive estimation; forced relatives only exist on the picker path.
+```

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -196,6 +196,22 @@ The picker is **prepopulated from `env.rbx.yml`**: any groups you configure ther
 preselected. After estimation, a per-group table is printed showing the estimated time limit
 for each group.
 
+### Forcing a relative limit
+
+While in the picker you can **force** a group's time limit to be computed relative to another
+group instead of from its own measured timings:
+
+- Press <kbd>r</kbd> on a language to open an inline editor and force its group's limit to
+  `A·t + B`, where `t` is the reference's limit, `A` is the multiplier, and `B` is an optional
+  increment in milliseconds. The reference can be another group or the **base estimate**. In the
+  editor, <kbd>Tab</kbd> cycles between the reference, `A`, and `B`; type to set `A`/`B`;
+  <kbd>Enter</kbd> commits, <kbd>Esc</kbd> cancels, and <kbd>c</kbd> clears the rule.
+- Press <kbd>R</kbd> to reset the whole grouping and all relative rules back to what
+  `env.rbx.yml` defines.
+
+Unlike the env `whenEmpty` fallback (which only applies to groups that have **no** solutions),
+a forced relative **always overrides** the group's measured estimate.
+
 Press <kbd>Enter</kbd> to confirm, or pass `--auto` to skip the prompt and use the configured
 env groups as-is.
 

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -201,11 +201,13 @@ for each group.
 While in the picker you can **force** a group's time limit to be computed relative to another
 group instead of from its own measured timings:
 
-- Press <kbd>r</kbd> on a language to open an inline editor and force its group's limit to
-  `A·t + B`, where `t` is the reference's limit, `A` is the multiplier, and `B` is an optional
-  increment in milliseconds. The reference can be another group or the **base estimate**. In the
-  editor, <kbd>Tab</kbd> cycles between the reference, `A`, and `B`; type to set `A`/`B`;
-  <kbd>Enter</kbd> commits, <kbd>Esc</kbd> cancels, and <kbd>c</kbd> clears the rule.
+- Press <kbd>r</kbd> on a language to open an inline editor and derive its group's limit from
+  another group as `multiplier × reference + increment` (the formula is shown in the editor).
+  The reference can be another group or the **base estimate**; the increment is an optional
+  constant in milliseconds. In the editor, <kbd>Tab</kbd> switches the focused field
+  (reference / multiplier / increment), <kbd>←</kbd>/<kbd>→</kbd> (or <kbd>h</kbd>/<kbd>l</kbd>)
+  change the reference, you type to set the multiplier and increment, <kbd>Enter</kbd> commits,
+  <kbd>Esc</kbd> cancels, and <kbd>c</kbd> clears the rule.
 - Press <kbd>R</kbd> to reset the whole grouping and all relative rules back to what
   `env.rbx.yml` defines.
 

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -250,7 +250,12 @@ presentation-only metadata under a `groups:` key in that profile.
 one into a numbered group (`1`–`9`), make it a **singleton** `[X]` (its own bucket, via
 `space`/`tab`), or leave it **unbucketed** `[ ]` (the default — joins the leftover pool).
 The picker is prepopulated from `env.rbx.yml` (languages in an env group keep their group
-number; everything else starts unbucketed). Press `Enter` to confirm or `q` to cancel.
+number; everything else starts unbucketed). Press `r` to force a group's limit to be relative
+to another group as `A × reference + B` (`A` is the multiplier, `B` an optional increment in
+ms, and the reference may be another group or the base estimate), or `R` to reset the grouping
+and all relative rules back to what `env.rbx.yml` defines. A forced relative **always**
+overrides the group's measured estimate, unlike `whenEmpty`, which applies only to empty
+groups. Press `Enter` to confirm or `q` to cancel.
 Pass `--auto` to skip the prompt and use the env groups as-is. After `rbx time` finishes (and again at the end of
 `rbx package boca`), a per-group table is printed showing the **Languages**, **Solutions**,
 **Time Limit**, and **Source** (estimated / `×N of <lang>` / `DEFAULTED`) for each group,

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -250,9 +250,10 @@ presentation-only metadata under a `groups:` key in that profile.
 one into a numbered group (`1`–`9`), make it a **singleton** `[X]` (its own bucket, via
 `space`/`tab`), or leave it **unbucketed** `[ ]` (the default — joins the leftover pool).
 The picker is prepopulated from `env.rbx.yml` (languages in an env group keep their group
-number; everything else starts unbucketed). Press `r` to force a group's limit to be relative
-to another group as `A × reference + B` (`A` is the multiplier, `B` an optional increment in
-ms, and the reference may be another group or the base estimate), or `R` to reset the grouping
+number; everything else starts unbucketed). Press `r` to derive a group's limit from
+another group as `multiplier × reference + increment` (the reference may be another group or the
+base estimate; the increment is an optional constant in ms) — `Tab` switches the focused field,
+`←`/`→` (or `h`/`l`) change the reference — or `R` to reset the grouping
 and all relative rules back to what `env.rbx.yml` defines. A forced relative **always**
 overrides the group's measured estimate, unlike `whenEmpty`, which applies only to empty
 groups. Press `Enter` to confirm or `q` to cancel.

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -295,7 +295,7 @@ for the environment will be used.""",
 
 
 class LanguageGroupFallback(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra='forbid', frozen=True)
 
     relativeTo: Optional[str] = Field(
         default=None,

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -76,12 +76,13 @@ def build_timing_profile(
     env_groups: List[environment.LanguageGroup],
     all_languages: List[str],
     repartition: Optional[Dict[str, int]] = None,
+    relatives: Optional[Dict[str, environment.LanguageGroupFallback]] = None,
 ) -> TimingProfile:
     def _eval(fastest: int, slowest: int) -> int:
         return int(safeeval.eval_int(formula, {'fastest': fastest, 'slowest': slowest}))
 
     if repartition is not None:
-        groups = timing_groups.partition_from_assignment(repartition)
+        groups = timing_groups.partition_from_assignment(repartition, relatives)
     else:
         groups = timing_groups.build_partition(env_groups, all_languages)
     timing_groups.validate_partition(groups)
@@ -120,10 +121,11 @@ def default_assignment(
     all_languages: List[str],
     env_groups: List[environment.LanguageGroup],
 ) -> Dict[str, int]:
-    """Prepopulated picker state from env groups: env group #1 -> 1, etc.;
-    every other language -> 0 (unbucketed). Feeding this straight into
-    partition_from_assignment reproduces the env grouping (so whenEmpty carries
-    over) with all ungrouped languages pooled together."""
+    """Prepopulated picker buckets from env groups: env group #i -> bucket i;
+    every other language -> 0 (the shared leftover pool). This reproduces the env
+    grouping's membership in the picker only. Forced-relative specs (env
+    ``whenEmpty``) no longer flow through ``partition_from_assignment``; they are
+    seeded separately (see ``default_relatives``)."""
     default_number: Dict[str, int] = {lang: 0 for lang in all_languages}
     for i, group in enumerate(env_groups, start=1):
         for lang in group.languages:
@@ -138,14 +140,16 @@ def build_preview_renderer(
     env_groups: List[environment.LanguageGroup],
     all_languages: List[str],
     width: Optional[int] = None,
-) -> Callable[[Dict[str, int]], ANSI]:
-    """Return a memoized callback mapping a picker assignment to an ``ANSI``
-    preview: the resolved limits table, or an inline error for invalid groupings.
-    Pure -- reuses the already-collected timings, never re-runs solutions."""
+) -> Callable[..., ANSI]:
+    """Return a memoized callback mapping a picker assignment (and optional
+    forced-relative specs) to an ``ANSI`` preview: the resolved limits table, or
+    an inline error for invalid groupings. Pure -- reuses the already-collected
+    timings, never re-runs solutions."""
 
     @functools.lru_cache(maxsize=None)
-    def _render(assignment_items: tuple) -> ANSI:
+    def _render(assignment_items: tuple, relative_items: tuple) -> ANSI:
         assignment = dict(assignment_items)
+        relatives = dict(relative_items)
         try:
             profile = build_timing_profile(
                 timing_per_solution_per_language=timing_per_solution_per_language,
@@ -153,6 +157,7 @@ def build_preview_renderer(
                 env_groups=env_groups,
                 all_languages=all_languages,
                 repartition=assignment,
+                relatives=relatives,
             )
         except timing_groups.GroupValidationError as e:
             return ANSI(
@@ -163,8 +168,15 @@ def build_preview_renderer(
         table = limits_info.build_limits_table(profile.to_limits(), title='Preview')
         return ANSI(console.capture_ansi(table, width=width))
 
-    def render(assignment: Dict[str, int]) -> ANSI:
-        return _render(tuple(sorted(assignment.items())))
+    def render(
+        assignment: Dict[str, int],
+        relatives: Optional[Dict[str, environment.LanguageGroupFallback]] = None,
+    ) -> ANSI:
+        relatives = relatives or {}
+        return _render(
+            tuple(sorted(assignment.items())),
+            tuple(sorted(relatives.items(), key=lambda kv: kv[0])),
+        )
 
     return render
 

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -134,6 +134,24 @@ def default_assignment(
     return default_number
 
 
+def default_relatives(
+    env_groups: List[environment.LanguageGroup],
+    langs_with_solutions: set,
+) -> Dict[str, environment.LanguageGroupFallback]:
+    """Seed picker relatives from env whenEmpty, but only for groups that have
+    NO measured solutions (matching env whenEmpty's empty-only semantics at the
+    moment of init). Keyed by the picker group-key the env group maps to
+    (env group i -> bucket i -> 'g{i}')."""
+    seeded: Dict[str, environment.LanguageGroupFallback] = {}
+    for i, group in enumerate(env_groups, start=1):
+        if group.whenEmpty is None:
+            continue
+        if any(lang in langs_with_solutions for lang in group.languages):
+            continue
+        seeded[f'g{i}'] = group.whenEmpty
+    return seeded
+
+
 def build_preview_renderer(
     timing_per_solution_per_language: Dict[str, Dict[str, int]],
     formula: str,
@@ -186,7 +204,7 @@ async def _prompt_repartition(
     env_groups: List[environment.LanguageGroup],
     timing_per_solution_per_language: Dict[str, Dict[str, int]],
     formula: str,
-) -> Optional[Dict[str, int]]:
+) -> Optional[timing_group_picker.GroupAssignment]:
     preview = build_preview_renderer(
         timing_per_solution_per_language=timing_per_solution_per_language,
         formula=formula,
@@ -194,9 +212,13 @@ async def _prompt_repartition(
         all_languages=all_languages,
         width=console.console.size.width,
     )
+    langs_with_solutions = {
+        lang for lang, per_sol in timing_per_solution_per_language.items() if per_sol
+    }
     return await timing_group_picker.prompt_group_assignment(
         all_languages,
         default_assignment(all_languages, env_groups),
+        relatives=default_relatives(env_groups, langs_with_solutions),
         preview=preview,
     )
 
@@ -277,16 +299,19 @@ async def estimate_time_limit(
     )
 
     repartition = None
+    relatives = None
     if not auto and len(all_languages) > 1:
-        repartition = await _prompt_repartition(
+        picked = await _prompt_repartition(
             all_languages,
             env_groups,
             timing_per_solution_per_language,
             formula,
         )
-        if repartition is None:
+        if picked is None:
             console.print('[error]Time limit estimation cancelled.[/error]')
             return None
+        repartition = picked.numbers
+        relatives = picked.relatives
 
     console.print()
     console.rule('[status]Time estimation[/status]', style='status')
@@ -299,6 +324,7 @@ async def estimate_time_limit(
             env_groups=env_groups,
             all_languages=all_languages,
             repartition=repartition,
+            relatives=relatives,
         )
     except timing_groups.GroupValidationError as e:
         console.print(f'[error]Invalid language groups: {e}[/error]')

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -81,7 +81,7 @@ def build_timing_profile(
         return int(safeeval.eval_int(formula, {'fastest': fastest, 'slowest': slowest}))
 
     if repartition is not None:
-        groups = timing_groups.partition_from_assignment(repartition, env_groups)
+        groups = timing_groups.partition_from_assignment(repartition)
     else:
         groups = timing_groups.build_partition(env_groups, all_languages)
     timing_groups.validate_partition(groups)

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -52,6 +52,7 @@ class GroupPickerState:
         self._edit_a: str = ''
         self._edit_b: str = ''
         self._edit_field: str = 'ref'
+        self._edit_error: str = ''
 
     def group_key(self, lang: str) -> str:
         return timing_groups.group_key(self.numbers[lang], lang)
@@ -79,6 +80,7 @@ class GroupPickerState:
         existing = self.relatives.get(self.group_key(self.current_lang()))
         self.editing = True
         self._edit_field = 'ref'
+        self._edit_error = ''
         self._edit_ref = existing.relativeTo if existing else None
         self._edit_a = str(existing.multiplier) if existing else '1.0'
         self._edit_b = (
@@ -125,36 +127,56 @@ class GroupPickerState:
     def edit_field(self) -> str:
         return self._edit_field
 
+    @property
+    def edit_error(self) -> str:
+        return self._edit_error
+
+    def _accepts_char(self, buf: str, data: str) -> bool:
+        """Whether ``data`` is a valid next character for the focused field.
+        Multiplier accepts digits and a single decimal point; increment accepts
+        digits only."""
+        if self._edit_field == 'a':
+            return data.isdigit() or (data == '.' and '.' not in buf)
+        return data.isdigit()  # 'b'
+
     def edit_key(self, data: str) -> None:
-        """Route a raw key press to the focused editor field."""
+        """Route a raw key press to the focused editor field, ignoring any
+        character that would make the multiplier/increment non-numeric."""
         if self._edit_field == 'ref':
             return  # ref is changed via cycle_ref / edit_tab, not typed
         buf = self._edit_a if self._edit_field == 'a' else self._edit_b
         if data == '\x7f' or data == '\b':  # backspace
             buf = buf[:-1]
-        elif data.isprintable():
+        elif self._accepts_char(buf, data):
             buf += data
+        else:
+            return  # reject invalid character; leave the buffer untouched
         if self._edit_field == 'a':
             self._edit_a = buf
         else:
             self._edit_b = buf
+        self._edit_error = ''  # any successful edit clears a stale error
 
     def commit_edit(self) -> bool:
         try:
             a = float(self._edit_a)
         except ValueError:
+            self._edit_error = 'multiplier must be a number greater than 0'
             return False
         if a <= 0:
+            self._edit_error = 'multiplier must be greater than 0'
             return False
         b: Optional[int] = None
         if self._edit_b.strip():
             try:
                 b = int(self._edit_b)
             except ValueError:
+                self._edit_error = 'increment must be a whole number of milliseconds'
                 return False
         self.relatives[self.group_key(self.current_lang())] = LanguageGroupFallback(
             relativeTo=self._edit_ref, multiplier=a, increment=b
         )
+        self._edit_error = ''
         self.editing = False
         return True
 
@@ -243,7 +265,13 @@ class GroupPickerState:
                 'enter: ok · esc: cancel · c: clear\n',
             )
         )
+        if self._edit_error:
+            frags.append(('class:editor-error', f'      ⚠ {self._edit_error}\n'))
         return frags
+
+    def editor_height(self) -> int:
+        """Number of lines the inline editor draws (grows for an error line)."""
+        return EDITOR_HEIGHT + (1 if self._edit_error else 0)
 
     def render_fragments(self):
         """prompt_toolkit formatted-text fragments: list of (style, text)."""
@@ -404,7 +432,7 @@ async def prompt_group_assignment(
 
     def _body_height():
         # Grow to fit the inline editor's extra lines while it is open.
-        return len(state.languages) + (EDITOR_HEIGHT if state.editing else 0)
+        return len(state.languages) + (state.editor_height() if state.editing else 0)
 
     windows = [
         Window(content=header, height=len(LEGEND_LINES), always_hide_cursor=True),
@@ -435,6 +463,7 @@ async def prompt_group_assignment(
             'editor': 'ansicyan',
             'editor-focus': 'ansicyan bold reverse',
             'editor-hint': 'ansibrightblack',
+            'editor-error': 'ansired bold',
             'relative': 'ansigreen',
         }
     )

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -1,9 +1,16 @@
 from typing import Callable, Dict, List, Optional
 
 from prompt_toolkit.formatted_text import AnyFormattedText
+from pydantic import BaseModel
 
 from rbx.box import timing_groups
 from rbx.box.environment import LanguageGroupFallback
+
+
+class GroupAssignment(BaseModel):
+    numbers: Dict[str, int]
+    relatives: Dict[str, LanguageGroupFallback] = {}
+
 
 LEGEND_LINES = [
     'Assign each language to a time-limit bucket:',
@@ -41,6 +48,7 @@ class GroupPickerState:
         self._edit_ref: Optional[str] = None
         self._edit_a: str = ''
         self._edit_b: str = ''
+        self._edit_field: str = 'ref'
 
     def group_key(self, lang: str) -> str:
         return timing_groups.group_key(self.numbers[lang], lang)
@@ -67,6 +75,7 @@ class GroupPickerState:
             return
         existing = self.relatives.get(self.group_key(self.current_lang()))
         self.editing = True
+        self._edit_field = 'ref'
         self._edit_ref = existing.relativeTo if existing else None
         self._edit_a = str(existing.multiplier) if existing else '1.0'
         self._edit_b = (
@@ -96,6 +105,36 @@ class GroupPickerState:
 
     def set_b(self, text: str) -> None:
         self._edit_b = text
+
+    @property
+    def edit_a(self) -> str:
+        return self._edit_a
+
+    @property
+    def edit_b(self) -> str:
+        return self._edit_b
+
+    def edit_tab(self) -> None:
+        order = ['ref', 'a', 'b']
+        self._edit_field = order[(order.index(self._edit_field) + 1) % len(order)]
+
+    @property
+    def edit_field(self) -> str:
+        return self._edit_field
+
+    def edit_key(self, data: str) -> None:
+        """Route a raw key press to the focused editor field."""
+        if self._edit_field == 'ref':
+            return  # ref is changed via cycle_ref / edit_tab, not typed
+        buf = self._edit_a if self._edit_field == 'a' else self._edit_b
+        if data == '\x7f' or data == '\b':  # backspace
+            buf = buf[:-1]
+        elif data.isprintable():
+            buf += data
+        if self._edit_field == 'a':
+            self._edit_a = buf
+        else:
+            self._edit_b = buf
 
     def commit_edit(self) -> bool:
         try:
@@ -136,7 +175,7 @@ class GroupPickerState:
         """The live preview's content, or empty once the picker is confirmed."""
         if self.done or preview is None:
             return ''
-        return preview(self.assignment())
+        return preview(self.assignment(), self.prune_relatives())
 
     def move(self, delta: int) -> None:
         if not self.languages:
@@ -208,15 +247,17 @@ async def prompt_group_assignment(
     default_number: Dict[str, int],
     input=None,
     output=None,
-    preview: Optional[Callable[[Dict[str, int]], AnyFormattedText]] = None,
-) -> Optional[Dict[str, int]]:
-    """Interactive single-screen group picker. Returns {language: group_number}
-    where N>=1 is a shared group, 0 is unbucketed (leftover), and -1 is a
-    singleton (own group); or None if cancelled."""
+    preview: Optional[Callable[..., AnyFormattedText]] = None,
+) -> Optional[GroupAssignment]:
+    """Interactive single-screen group picker. Returns a ``GroupAssignment``
+    whose ``numbers`` maps {language: group_number} (N>=1 shared group, 0
+    unbucketed/leftover, -1 singleton) and whose ``relatives`` carries any
+    forced-relative specs; or None if cancelled."""
     if not languages:
-        return {}
+        return GroupAssignment(numbers={})
 
     from prompt_toolkit.application import Application
+    from prompt_toolkit.filters import Condition
     from prompt_toolkit.key_binding import KeyBindings
     from prompt_toolkit.layout import HSplit, Layout, Window
     from prompt_toolkit.layout.controls import FormattedTextControl
@@ -244,43 +285,91 @@ async def prompt_group_assignment(
 
     kb = KeyBindings()
 
-    @kb.add('up')
-    @kb.add('k')
+    editing = Condition(lambda: state.editing)
+    not_editing = ~editing
+
+    @kb.add('up', filter=not_editing)
+    @kb.add('k', filter=not_editing)
     def _(event):
         state.move(-1)
 
-    @kb.add('down')
-    @kb.add('j')
+    @kb.add('down', filter=not_editing)
+    @kb.add('j', filter=not_editing)
     def _(event):
         state.move(1)
 
     for _digit in '123456789':
 
-        @kb.add(_digit)
+        @kb.add(_digit, filter=not_editing)
         def _(event, _digit=_digit):
             state.set_group(int(_digit))
 
-    @kb.add('0')
+    @kb.add('0', filter=not_editing)
     def _(event):
         # explicit clear to unbucketed
         state.set_group(0)
 
-    @kb.add('space')
-    @kb.add('tab')
+    @kb.add('space', filter=not_editing)
+    @kb.add('tab', filter=not_editing)
     def _(event):
         state.toggle_singleton()
 
-    @kb.add('enter')
+    @kb.add('r', filter=not_editing)
+    def _(event):
+        state.start_edit()
+
+    @kb.add('R', filter=not_editing)
+    def _(event):
+        state.reset_to_initial()
+
+    @kb.add('enter', filter=not_editing)
     def _(event):
         # Hide the live preview on the final paint; the official table is
         # printed by the caller right after the picker returns.
         state.done = True
-        event.app.exit(result=state.assignment())
+        event.app.exit(
+            result=GroupAssignment(
+                numbers=state.assignment(),
+                relatives=state.prune_relatives(),
+            )
+        )
 
-    @kb.add('c-c')
-    @kb.add('q')
+    @kb.add('c-c', filter=not_editing)
+    @kb.add('q', filter=not_editing)
     def _(event):
         event.app.exit(result=None)
+
+    # Edit-mode bindings: active only while the inline relative editor is open.
+    @kb.add('tab', filter=editing)
+    def _(event):
+        state.edit_tab()
+
+    @kb.add('left', filter=editing)
+    def _(event):
+        if state.edit_field == 'ref':
+            state.cycle_ref(-1)
+
+    @kb.add('right', filter=editing)
+    def _(event):
+        if state.edit_field == 'ref':
+            state.cycle_ref(1)
+
+    @kb.add('enter', filter=editing)
+    def _(event):
+        # commit_edit flips editing=False on success; stay editing if invalid.
+        state.commit_edit()
+
+    @kb.add('escape', filter=editing)
+    def _(event):
+        state.cancel_edit()
+
+    @kb.add('c', filter=editing)
+    def _(event):
+        state.clear_relative()
+
+    @kb.add('<any>', filter=editing)
+    def _(event):
+        state.edit_key(event.data)
 
     windows = [
         Window(content=header, height=len(LEGEND_LINES), always_hide_cursor=True),

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -245,6 +245,7 @@ class GroupPickerState:
 async def prompt_group_assignment(
     languages: List[str],
     default_number: Dict[str, int],
+    relatives: Optional[Dict[str, LanguageGroupFallback]] = None,
     input=None,
     output=None,
     preview: Optional[Callable[..., AnyFormattedText]] = None,
@@ -254,7 +255,7 @@ async def prompt_group_assignment(
     unbucketed/leftover, -1 singleton) and whose ``relatives`` carries any
     forced-relative specs; or None if cancelled."""
     if not languages:
-        return GroupAssignment(numbers={})
+        return GroupAssignment(numbers={}, relatives={})
 
     from prompt_toolkit.application import Application
     from prompt_toolkit.filters import Condition
@@ -263,7 +264,7 @@ async def prompt_group_assignment(
     from prompt_toolkit.layout.controls import FormattedTextControl
     from prompt_toolkit.styles import Style
 
-    state = GroupPickerState(languages, default_number)
+    state = GroupPickerState(languages, default_number, relatives=relatives)
 
     def _header_fragments():
         fragments = []

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -19,9 +19,12 @@ LEGEND_LINES = [
     '  [X] singleton  its own estimated limit',
     '  [ ] leftover   pooled with all other unmarked langs (default)',
     '',
-    '↑/↓ move · 1-9 group · space/tab [X]/[ ] · 0 clear · r relative · R reset env'
-    ' · enter confirm · q cancel',
+    '↑/↓ or k/j move · 1-9 group · space/tab [X]/[ ] · 0 leftover'
+    ' · r derive limit from a group · R reset to env · enter confirm · q cancel',
 ]
+
+# Number of extra lines the inline relative editor draws under the cursor row.
+EDITOR_HEIGHT = 3
 
 
 class GroupPickerState:
@@ -208,14 +211,39 @@ class GroupPickerState:
         return suffix
 
     def _editor_fragments(self):
-        ref = self._edit_ref if self._edit_ref is not None else '(base estimate)'
-        return [
-            (
-                'class:editor',
-                f'      relative-to: [{ref}]  A:[{self._edit_a}]  B:[{self._edit_b}]\n'
-                '      Tab cycles ref · type A/B · enter ok · esc cancel · c clear\n',
-            )
+        ref = self._edit_ref if self._edit_ref is not None else 'base estimate'
+        increment = self._edit_b if self._edit_b else '0'
+        fields = [
+            ('reference', ref, 'ref'),
+            ('multiplier', self._edit_a, 'a'),
+            ('increment', increment, 'b'),
         ]
+        # Field row: the focused field is marked with a pointer and highlighted,
+        # so it is clear which of reference/multiplier/increment is being edited.
+        frags = [('class:editor', '      ')]
+        for idx, (label, value, key) in enumerate(fields):
+            if idx:
+                frags.append(('class:editor', '    '))
+            focused = self._edit_field == key
+            marker = '▸ ' if focused else '  '
+            field_style = 'class:editor-focus' if focused else 'class:editor'
+            frags.append((field_style, f'{marker}{label}: [{value}]'))
+        frags.append(('class:editor', '\n'))
+        # Explain what the parameters mean and how the limit is computed.
+        frags.append(
+            (
+                'class:editor-hint',
+                '      time limit = multiplier × reference + increment\n',
+            )
+        )
+        frags.append(
+            (
+                'class:editor-hint',
+                '      Tab: switch field · ←/→ or h/l: change reference · '
+                'enter: ok · esc: cancel · c: clear\n',
+            )
+        )
+        return frags
 
     def render_fragments(self):
         """prompt_toolkit formatted-text fragments: list of (style, text)."""
@@ -345,15 +373,17 @@ async def prompt_group_assignment(
     def _(event):
         state.edit_tab()
 
+    # Left/right (and vim h/l) cycle the reference group regardless of which
+    # field is focused; Tab switches the focused field.
     @kb.add('left', filter=editing)
+    @kb.add('h', filter=editing)
     def _(event):
-        if state.edit_field == 'ref':
-            state.cycle_ref(-1)
+        state.cycle_ref(-1)
 
     @kb.add('right', filter=editing)
+    @kb.add('l', filter=editing)
     def _(event):
-        if state.edit_field == 'ref':
-            state.cycle_ref(1)
+        state.cycle_ref(1)
 
     @kb.add('enter', filter=editing)
     def _(event):
@@ -372,9 +402,13 @@ async def prompt_group_assignment(
     def _(event):
         state.edit_key(event.data)
 
+    def _body_height():
+        # Grow to fit the inline editor's extra lines while it is open.
+        return len(state.languages) + (EDITOR_HEIGHT if state.editing else 0)
+
     windows = [
         Window(content=header, height=len(LEGEND_LINES), always_hide_cursor=True),
-        Window(content=body, height=len(state.languages), always_hide_cursor=True),
+        Window(content=body, height=_body_height, always_hide_cursor=True),
     ]
     if preview is not None:
 
@@ -399,6 +433,8 @@ async def prompt_group_assignment(
             'box-current': 'ansiyellow bold',
             'box': 'ansiyellow',
             'editor': 'ansicyan',
+            'editor-focus': 'ansicyan bold reverse',
+            'editor-hint': 'ansibrightblack',
             'relative': 'ansigreen',
         }
     )

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -2,6 +2,9 @@ from typing import Callable, Dict, List, Optional
 
 from prompt_toolkit.formatted_text import AnyFormattedText
 
+from rbx.box import timing_groups
+from rbx.box.environment import LanguageGroupFallback
+
 LEGEND_LINES = [
     'Assign each language to a time-limit bucket:',
     '',
@@ -14,7 +17,12 @@ LEGEND_LINES = [
 
 
 class GroupPickerState:
-    def __init__(self, languages: List[str], default_number: Dict[str, int]):
+    def __init__(
+        self,
+        languages: List[str],
+        default_number: Dict[str, int],
+        relatives: Optional[Dict[str, LanguageGroupFallback]] = None,
+    ):
         self.languages: List[str] = list(languages)
         self.numbers: Dict[str, int] = {
             lang: int(default_number.get(lang, 0)) for lang in self.languages
@@ -23,6 +31,105 @@ class GroupPickerState:
         # Set once the user confirms; suppresses the live preview on the final
         # paint so only the official table (printed afterwards) remains.
         self.done: bool = False
+        # Forced relative specs keyed by group-key (see timing_groups.group_key).
+        self.relatives: Dict[str, LanguageGroupFallback] = dict(relatives or {})
+        self._initial_numbers = dict(self.numbers)
+        self._initial_relatives = dict(self.relatives)
+        # Edit-mode scratch state for the relative-spec editor.
+        self.editing = False
+        self._edit_ref: Optional[str] = None
+        self._edit_a: str = ''
+        self._edit_b: str = ''
+
+    def group_key(self, lang: str) -> str:
+        return timing_groups.group_key(self.numbers[lang], lang)
+
+    def current_lang(self) -> Optional[str]:
+        return self.languages[self.cursor] if self.languages else None
+
+    def reference_options(self) -> List[Optional[str]]:
+        """None (base estimate) + one representative language per OTHER group,
+        in language order."""
+        own = self.group_key(self.current_lang())
+        opts: List[Optional[str]] = [None]
+        seen: set = set()
+        for lang in self.languages:
+            key = self.group_key(lang)
+            if key == own or key in seen:
+                continue
+            seen.add(key)
+            opts.append(lang)
+        return opts
+
+    def start_edit(self) -> None:
+        if not self.languages:
+            return
+        existing = self.relatives.get(self.group_key(self.current_lang()))
+        self.editing = True
+        self._edit_ref = existing.relativeTo if existing else None
+        self._edit_a = str(existing.multiplier) if existing else '1.0'
+        self._edit_b = (
+            str(existing.increment)
+            if existing and existing.increment is not None
+            else ''
+        )
+
+    @property
+    def edit_ref(self) -> Optional[str]:
+        """The reference language currently selected in the inline editor."""
+        return self._edit_ref
+
+    def set_ref(self, ref: Optional[str]) -> None:
+        self._edit_ref = ref
+
+    def cycle_ref(self, delta: int) -> None:
+        opts = self.reference_options()
+        try:
+            i = opts.index(self._edit_ref)
+        except ValueError:
+            i = 0
+        self._edit_ref = opts[(i + delta) % len(opts)]
+
+    def set_a(self, text: str) -> None:
+        self._edit_a = text
+
+    def set_b(self, text: str) -> None:
+        self._edit_b = text
+
+    def commit_edit(self) -> bool:
+        try:
+            a = float(self._edit_a)
+        except ValueError:
+            return False
+        if a <= 0:
+            return False
+        b: Optional[int] = None
+        if self._edit_b.strip():
+            try:
+                b = int(self._edit_b)
+            except ValueError:
+                return False
+        self.relatives[self.group_key(self.current_lang())] = LanguageGroupFallback(
+            relativeTo=self._edit_ref, multiplier=a, increment=b
+        )
+        self.editing = False
+        return True
+
+    def cancel_edit(self) -> None:
+        self.editing = False
+
+    def clear_relative(self) -> None:
+        self.relatives.pop(self.group_key(self.current_lang()), None)
+        self.editing = False
+
+    def reset_to_initial(self) -> None:
+        self.numbers = dict(self._initial_numbers)
+        self.relatives = dict(self._initial_relatives)
+        self.editing = False
+
+    def prune_relatives(self) -> Dict[str, LanguageGroupFallback]:
+        live = {self.group_key(lang) for lang in self.languages}
+        return {k: v for k, v in self.relatives.items() if k in live}
 
     def preview_text(self, preview):
         """The live preview's content, or empty once the picker is confirmed."""

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -12,7 +12,8 @@ LEGEND_LINES = [
     '  [X] singleton  its own estimated limit',
     '  [ ] leftover   pooled with all other unmarked langs (default)',
     '',
-    '↑/↓ move · 1-9 group · space/tab [X]/[ ] · 0 clear · enter confirm · q cancel',
+    '↑/↓ move · 1-9 group · space/tab [X]/[ ] · 0 clear · r relative · R reset env'
+    ' · enter confirm · q cancel',
 ]
 
 
@@ -157,6 +158,26 @@ class GroupPickerState:
     def assignment(self) -> Dict[str, int]:
         return dict(self.numbers)
 
+    def _relative_suffix(self, lang: str) -> str:
+        spec = self.relatives.get(self.group_key(lang))
+        if spec is None:
+            return ''
+        ref = spec.relativeTo if spec.relativeTo is not None else 'base'
+        suffix = f'  → {ref} ×{spec.multiplier:g}'
+        if spec.increment:
+            suffix += f' +{spec.increment}'
+        return suffix
+
+    def _editor_fragments(self):
+        ref = self._edit_ref if self._edit_ref is not None else '(base estimate)'
+        return [
+            (
+                'class:editor',
+                f'      relative-to: [{ref}]  A:[{self._edit_a}]  B:[{self._edit_b}]\n'
+                '      Tab cycles ref · type A/B · enter ok · esc cancel · c clear\n',
+            )
+        ]
+
     def render_fragments(self):
         """prompt_toolkit formatted-text fragments: list of (style, text)."""
         fragments = []
@@ -174,7 +195,11 @@ class GroupPickerState:
             box_style = 'class:box-current' if selected else 'class:box'
             fragments.append((row_style, pointer))
             fragments.append((box_style, f'[{box}] '))
-            fragments.append((row_style, f'{lang}\n'))
+            fragments.append((row_style, lang))
+            fragments.append(('class:relative', self._relative_suffix(lang)))
+            fragments.append((row_style, '\n'))
+            if i == self.cursor and self.editing:
+                fragments.extend(self._editor_fragments())
         return fragments
 
 
@@ -283,6 +308,8 @@ async def prompt_group_assignment(
             'row': '',
             'box-current': 'ansiyellow bold',
             'box': 'ansiyellow',
+            'editor': 'ansicyan',
+            'relative': 'ansigreen',
         }
     )
     app = Application(

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -9,7 +9,14 @@ from rbx.box.schema import TimingGroupOrigin, TimingGroupReport
 class ResolvedGroup(BaseModel):
     languages: List[str]
     whenEmpty: Optional[LanguageGroupFallback] = None
+    forced_relative: Optional[LanguageGroupFallback] = None
     is_leftover: bool = False
+
+
+def _effective_fallback(group: 'ResolvedGroup') -> Optional[LanguageGroupFallback]:
+    """The fallback whose reference edge matters for validation: a forced
+    relative (picker path) takes precedence, else the env whenEmpty."""
+    return group.forced_relative or group.whenEmpty
 
 
 def build_partition(
@@ -94,9 +101,10 @@ def validate_partition(groups: List[ResolvedGroup]) -> None:
     lang_index = _lang_to_group_index(groups)
     # reference target existence + not-self
     for idx, group in enumerate(groups):
-        if group.whenEmpty is None or group.whenEmpty.relativeTo is None:
+        fallback = _effective_fallback(group)
+        if fallback is None or fallback.relativeTo is None:
             continue
-        ref = group.whenEmpty.relativeTo
+        ref = fallback.relativeTo
         if ref not in lang_index:
             raise GroupValidationError(
                 f'whenEmpty.relativeTo references unknown language {ref!r}.'
@@ -112,9 +120,9 @@ def validate_partition(groups: List[ResolvedGroup]) -> None:
 
     def visit(idx: int) -> None:
         color[idx] = GRAY
-        group = groups[idx]
-        if group.whenEmpty is not None and group.whenEmpty.relativeTo is not None:
-            nxt = lang_index[group.whenEmpty.relativeTo]
+        fallback = _effective_fallback(groups[idx])
+        if fallback is not None and fallback.relativeTo is not None:
+            nxt = lang_index[fallback.relativeTo]
             if color[nxt] == GRAY:
                 raise GroupValidationError(
                     'whenEmpty.relativeTo forms a cycle between timing groups.'
@@ -158,7 +166,25 @@ def resolve_groups(
         resolving.add(idx)
         group = groups[idx]
         timings = pooled.get(idx)
-        if timings is not None:
+        if group.forced_relative is not None:
+            fb = group.forced_relative
+            ref = fb.relativeTo
+            ref_tl = base_tl if ref is None else resolve(lang_index[ref])
+            increment = fb.increment or 0
+            tl = int(ref_tl * fb.multiplier + increment)
+            report = TimingGroupReport(
+                languages=list(group.languages),
+                timeLimit=tl,
+                origin=TimingGroupOrigin.MULTIPLIER,
+                solutionCount=timings.solution_count if timings else 0,
+                fastest=timings.fastest if timings else None,
+                slowest=timings.slowest if timings else None,
+                relativeToLanguage=ref,
+                multiplier=fb.multiplier,
+                increment=fb.increment,
+                isLeftover=group.is_leftover,
+            )
+        elif timings is not None:
             tl = eval_fn(timings.fastest, timings.slowest)
             report = TimingGroupReport(
                 languages=list(group.languages),

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel
 
@@ -57,7 +57,7 @@ def partition_from_assignment(
     spec, stamped onto the matching group as ``forced_relative``."""
     relatives = relatives or {}
     buckets: Dict[int, List[str]] = {}
-    singletons: List[tuple[str, List[str]]] = []
+    singletons: List[Tuple[str, List[str]]] = []
     leftover: List[str] = []
     for lang, state in assignment.items():
         if state == 0:
@@ -70,7 +70,10 @@ def partition_from_assignment(
     result: List[ResolvedGroup] = []
     for number, langs in sorted(buckets.items()):
         result.append(
-            ResolvedGroup(languages=langs, forced_relative=relatives.get(f'g{number}'))
+            ResolvedGroup(
+                languages=langs,
+                forced_relative=relatives.get(group_key(number, langs[0])),
+            )
         )
     for key, langs in singletons:
         result.append(
@@ -81,7 +84,7 @@ def partition_from_assignment(
             ResolvedGroup(
                 languages=leftover,
                 is_leftover=True,
-                forced_relative=relatives.get('leftover'),
+                forced_relative=relatives.get(group_key(0, '')),
             )
         )
     return result

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -107,11 +107,11 @@ def validate_partition(groups: List[ResolvedGroup]) -> None:
         ref = fallback.relativeTo
         if ref not in lang_index:
             raise GroupValidationError(
-                f'whenEmpty.relativeTo references unknown language {ref!r}.'
+                f'relative reference points to unknown language {ref!r}.'
             )
         if lang_index[ref] == idx:
             raise GroupValidationError(
-                f'whenEmpty.relativeTo {ref!r} points to the same group; it must '
+                f'relative reference {ref!r} points to the same group; it must '
                 'reference a different group.'
             )
     # cycle detection over group-to-group reference edges
@@ -125,7 +125,7 @@ def validate_partition(groups: List[ResolvedGroup]) -> None:
             nxt = lang_index[fallback.relativeTo]
             if color[nxt] == GRAY:
                 raise GroupValidationError(
-                    'whenEmpty.relativeTo forms a cycle between timing groups.'
+                    'relative references form a cycle between timing groups.'
                 )
             if color[nxt] == WHITE:
                 visit(nxt)

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -38,33 +38,52 @@ def build_partition(
     return result
 
 
+def group_key(state: int, lang: str) -> str:
+    """Stable key for the group a language currently belongs to."""
+    if state > 0:
+        return f'g{state}'
+    if state < 0:
+        return f's:{lang}'
+    return 'leftover'
+
+
 def partition_from_assignment(
     assignment: Dict[str, int],
-    env_groups: List[LanguageGroup],
+    relatives: Optional[Dict[str, LanguageGroupFallback]] = None,
 ) -> List[ResolvedGroup]:
     """Build groups from a {language: state} map. State per language:
     N>=1 share bucket N; -1 = own singleton group; 0 = the shared leftover pool.
-    Carries over an env group's whenEmpty only when the resulting membership is
-    identical to that env group."""
+    Optional ``relatives`` maps a group-key (see group_key) to a forced relative
+    spec, stamped onto the matching group as ``forced_relative``."""
+    relatives = relatives or {}
     buckets: Dict[int, List[str]] = {}
-    singletons: List[List[str]] = []
+    singletons: List[tuple[str, List[str]]] = []
     leftover: List[str] = []
     for lang, state in assignment.items():
         if state == 0:
             leftover.append(lang)
         elif state < 0:
-            singletons.append([lang])
+            singletons.append((group_key(state, lang), [lang]))
         else:
             buckets.setdefault(state, []).append(lang)
 
-    env_when_empty = {frozenset(g.languages): g.whenEmpty for g in env_groups}
     result: List[ResolvedGroup] = []
-    for _, langs in sorted(buckets.items()):
-        when_empty = env_when_empty.get(frozenset(langs))
-        result.append(ResolvedGroup(languages=langs, whenEmpty=when_empty))
-    result.extend(ResolvedGroup(languages=s) for s in singletons)
+    for number, langs in sorted(buckets.items()):
+        result.append(
+            ResolvedGroup(languages=langs, forced_relative=relatives.get(f'g{number}'))
+        )
+    for key, langs in singletons:
+        result.append(
+            ResolvedGroup(languages=langs, forced_relative=relatives.get(key))
+        )
     if leftover:
-        result.append(ResolvedGroup(languages=leftover, is_leftover=True))
+        result.append(
+            ResolvedGroup(
+                languages=leftover,
+                is_leftover=True,
+                forced_relative=relatives.get('leftover'),
+            )
+        )
     return result
 
 

--- a/tests/rbx/box/test_timing.py
+++ b/tests/rbx/box/test_timing.py
@@ -10,6 +10,7 @@ import yaml
 
 from rbx.box import schema, timing
 from rbx.box.deferred import Deferred
+from rbx.box.environment import LanguageGroupFallback
 from rbx.box.schema import ExpectedOutcome, Solution
 from rbx.box.solutions import EvaluationItem, RunSolutionResult
 from rbx.box.testcase_schema import TestcaseEntry
@@ -426,3 +427,57 @@ class TestTimingIntegration:
         assert result is not None
         assert isinstance(result, timing.TimingProfile)
         assert result.timeLimit == 1000
+
+
+class TestForcedRelativeIntegration:
+    """Integration tests for the forced-relative override through the public
+    build_timing_profile path."""
+
+    def test_forced_relative_overrides_group_with_own_timings(self):
+        """The headline behavior: a forced relative spec overrides a group's OWN
+        measured timings, not just an empty group.
+
+        Setup (formula='slowest', so _eval(fastest, slowest) == slowest):
+          - repartition puts cpp in bucket 1, python in bucket 2.
+          - Both groups HAVE their own measured solutions:
+              cpp:    a.cpp = 100ms  -> estimated limit = slowest(100) = 100
+              python: b.py  = 900ms  -> estimated limit would be 900
+          - python's bucket (group key 'g2') carries a forced relative spec
+            relativeTo='cpp', multiplier=2.0, increment=50.
+
+        Expected python limit = multiplier * cpp_estimate + increment
+                              = 2.0 * 100 + 50 = 250
+        and explicitly NOT python's own 900ms estimate -- proving the forced
+        relative wins over the group's own measured timings.
+        """
+        profile = timing.build_timing_profile(
+            timing_per_solution_per_language={
+                'cpp': {'a.cpp': 100},
+                'python': {'b.py': 900},
+            },
+            formula='slowest',
+            env_groups=[],
+            all_languages=['cpp', 'python'],
+            repartition={'cpp': 1, 'python': 2},
+            relatives={
+                'g2': LanguageGroupFallback(
+                    relativeTo='cpp', multiplier=2.0, increment=50
+                )
+            },
+        )
+
+        # python's resolved limit is the forced relative value, not its own 900.
+        assert profile.timeLimitPerLanguage['python'] == 250
+        assert profile.timeLimitPerLanguage['python'] != 900
+        # cpp is still estimated from its own (only) measurement.
+        assert profile.timeLimitPerLanguage['cpp'] == 100
+
+        # The overridden group report keeps the measured solution count for
+        # display and is flagged as MULTIPLIER origin.
+        python_group = next(
+            report for report in profile.groups if 'python' in report.languages
+        )
+        assert python_group.origin == schema.TimingGroupOrigin.MULTIPLIER
+        assert python_group.solutionCount == 1
+        assert python_group.relativeToLanguage == 'cpp'
+        assert python_group.timeLimit == 250

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -96,10 +96,11 @@ def test_empty_leftover_pool_defaults_to_base():
     assert ('go', 'java') in defaulted
 
 
-def test_default_assignment_round_trip_preserves_when_empty():
+def test_default_assignment_round_trip_reproduces_env_grouping():
     # The picker's prepopulated default, fed straight into the partition builder,
-    # must reproduce the env grouping (so whenEmpty carries over) and pool every
-    # ungrouped language into one leftover pool.
+    # must reproduce the env grouping (membership) and pool every ungrouped
+    # language into one leftover pool. (whenEmpty is no longer re-derived here;
+    # env-crossing was dropped from partition_from_assignment.)
     env_groups = [
         LanguageGroup(languages=['c', 'cpp']),
         LanguageGroup(
@@ -119,9 +120,9 @@ def test_default_assignment_round_trip_preserves_when_empty():
         'go': 0,
     }
 
-    groups = partition_from_assignment(default, env_groups)
+    groups = partition_from_assignment(default)
     jk = next(g for g in groups if set(g.languages) == {'java', 'kotlin'})
-    assert jk.whenEmpty is not None
-    assert jk.whenEmpty.multiplier == 2.0
+    assert jk.whenEmpty is None
+    assert jk.forced_relative is None
     # python + go are unbucketed -> a single leftover pool
     assert ['python', 'go'] in [g.languages for g in groups]

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -126,3 +126,32 @@ def test_default_assignment_round_trip_reproduces_env_grouping():
     assert jk.forced_relative is None
     # python + go are unbucketed -> a single leftover pool
     assert ['python', 'go'] in [g.languages for g in groups]
+
+
+def test_default_relatives_seeds_only_empty_groups():
+    from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+    from rbx.box.timing import default_relatives
+
+    env_groups = [
+        LanguageGroup(languages=['cpp']),  # has solutions
+        LanguageGroup(
+            languages=['py'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        ),  # empty -> seed
+        LanguageGroup(
+            languages=['go'],
+            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=3.0),
+        ),  # has solutions -> do NOT seed
+    ]
+    langs_with_solutions = {'cpp', 'go'}
+    seeded = default_relatives(env_groups, langs_with_solutions)
+    assert set(seeded) == {'g2'}  # only the empty py group (env group #2)
+    assert seeded['g2'].multiplier == 2.0
+
+
+def test_default_relatives_skips_groups_without_when_empty():
+    from rbx.box.environment import LanguageGroup
+    from rbx.box.timing import default_relatives
+
+    env_groups = [LanguageGroup(languages=['py'])]  # empty but no whenEmpty
+    assert default_relatives(env_groups, set()) == {}

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -254,6 +254,55 @@ def test_prune_relatives_drops_orphans():
     assert 's:rust' not in pruned
 
 
+def test_render_annotates_relative_group():
+    s = GroupPickerState(
+        ['cpp', 'py'],
+        {'cpp': 1, 'py': 2},
+        relatives={
+            'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=2.0, increment=100)
+        },
+    )
+    text = ''.join(t for _, t in s.render_fragments())
+    assert 'py' in text
+    assert '→ cpp' in text or '-> cpp' in text  # reference shown
+    assert '2' in text  # multiplier shown
+    assert '100' in text  # increment shown
+
+
+def test_render_annotates_relative_to_base():
+    s = GroupPickerState(
+        ['cpp', 'py'],
+        {'cpp': 1, 'py': 2},
+        relatives={'g2': LanguageGroupFallback(relativeTo=None, multiplier=3.0)},
+    )
+    text = ''.join(t for _, t in s.render_fragments())
+    assert 'base' in text  # relativeTo=None shown as 'base'
+
+
+def test_render_shows_inline_editor_when_editing():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_ref('cpp')
+    text = ''.join(t for _, t in s.render_fragments())
+    assert 'relative-to' in text
+    assert 'A:' in text and 'B:' in text
+
+
+def test_render_no_editor_when_not_editing():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    text = ''.join(t for _, t in s.render_fragments())
+    assert 'relative-to' not in text
+
+
+def test_legend_mentions_relative_and_reset():
+    from rbx.box.timing_group_picker import LEGEND_LINES
+
+    text = '\n'.join(LEGEND_LINES)
+    assert 'relative' in text
+    assert 'reset' in text
+
+
 def test_legend_describes_three_states():
     from rbx.box.timing_group_picker import LEGEND_LINES
 

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -289,21 +289,37 @@ def test_render_shows_inline_editor_when_editing():
     s.start_edit()
     s.set_ref('cpp')
     text = ''.join(t for _, t in s.render_fragments())
-    assert 'relative-to' in text
-    assert 'A:' in text and 'B:' in text
+    # named fields instead of terse A/B
+    assert 'reference' in text
+    assert 'multiplier' in text and 'increment' in text
+    # the formula is spelled out for the user
+    assert 'multiplier × reference + increment' in text
+
+
+def test_render_marks_focused_editor_field():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()  # starts focused on the reference field
+    text = ''.join(t for _, t in s.render_fragments())
+    assert '▸ reference' in text
+    s.edit_tab()  # -> multiplier
+    text = ''.join(t for _, t in s.render_fragments())
+    assert '▸ multiplier' in text
+    assert '▸ reference' not in text
 
 
 def test_render_no_editor_when_not_editing():
     s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
     text = ''.join(t for _, t in s.render_fragments())
-    assert 'relative-to' not in text
+    assert 'multiplier' not in text
 
 
-def test_legend_mentions_relative_and_reset():
+def test_legend_mentions_derive_and_reset():
     from rbx.box.timing_group_picker import LEGEND_LINES
 
     text = '\n'.join(LEGEND_LINES)
-    assert 'relative' in text
+    # the 'r' action is described meaningfully, and reset is mentioned
+    assert 'derive' in text
     assert 'reset' in text
 
 
@@ -382,6 +398,32 @@ async def test_picker_force_relative_flow():
         inp.send_text('0')
         inp.send_text('\r')  # commit edit
         inp.send_text('\r')  # confirm picker
+        result = await prompt_group_assignment(
+            ['cpp', 'py'],
+            {'cpp': 0, 'py': 0},
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert result.numbers == {'cpp': 1, 'py': 2}
+    assert result.relatives['g2'].relativeTo == 'cpp'
+    assert result.relatives['g2'].multiplier == 2.0
+
+
+async def test_picker_vim_keys_navigate_and_cycle_reference():
+    # j moves down the list; in the editor, l cycles the reference (vim h/l).
+    with create_pipe_input() as inp:
+        inp.send_text('1')  # cpp -> group 1
+        inp.send_text('j')  # vim down -> py
+        inp.send_text('2')  # py -> group 2
+        inp.send_text('r')  # open editor on py (g2), field=ref
+        inp.send_text('l')  # vim right: cycle ref None -> 'cpp'
+        inp.send_text('\t')  # Tab -> multiplier
+        inp.send_text('\x7f')  # clear seeded '1.0'
+        inp.send_text('\x7f')
+        inp.send_text('\x7f')
+        inp.send_text('2')  # multiplier = '2'
+        inp.send_text('\r')  # commit
+        inp.send_text('\r')  # confirm
         result = await prompt_group_assignment(
             ['cpp', 'py'],
             {'cpp': 0, 'py': 0},

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -2,7 +2,11 @@ from prompt_toolkit.input.defaults import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 
 from rbx.box.environment import LanguageGroupFallback
-from rbx.box.timing_group_picker import GroupPickerState, prompt_group_assignment
+from rbx.box.timing_group_picker import (
+    GroupAssignment,
+    GroupPickerState,
+    prompt_group_assignment,
+)
 
 
 def test_state_move_clamps():
@@ -61,7 +65,7 @@ async def test_picker_toggle_and_group_then_confirm():
             input=inp,
             output=DummyOutput(),
         )
-    assert result == {'cpp': 1, 'java': -1, 'python': 0}
+    assert result.numbers == {'cpp': 1, 'java': -1, 'python': 0}
 
 
 async def test_picker_assigns_and_confirms():
@@ -73,7 +77,7 @@ async def test_picker_assigns_and_confirms():
         result = await prompt_group_assignment(
             ['cpp', 'java'], {'cpp': 0, 'java': 0}, input=inp, output=DummyOutput()
         )
-    assert result == {'cpp': 2, 'java': 2}
+    assert result.numbers == {'cpp': 2, 'java': 2}
 
 
 async def test_picker_cancel_returns_none():
@@ -87,9 +91,9 @@ async def test_picker_cancel_returns_none():
 
 def test_preview_text_suppressed_once_done():
     s = GroupPickerState(['cpp'], {})
-    assert s.preview_text(lambda a: 'TABLE') == 'TABLE'
+    assert s.preview_text(lambda a, r: 'TABLE') == 'TABLE'
     s.done = True
-    assert s.preview_text(lambda a: 'TABLE') == ''
+    assert s.preview_text(lambda a, r: 'TABLE') == ''
 
 
 def test_preview_text_empty_without_callback():
@@ -102,7 +106,7 @@ async def test_picker_invokes_preview_with_current_assignment():
 
     seen = []
 
-    def preview(assignment):
+    def preview(assignment, relatives=None):
         seen.append(dict(assignment))
         return ANSI('preview')
 
@@ -116,7 +120,7 @@ async def test_picker_invokes_preview_with_current_assignment():
             output=DummyOutput(),
             preview=preview,
         )
-    assert result == {'cpp': 1, 'java': 0}
+    assert result.numbers == {'cpp': 1, 'java': 0}
     # The picker rendered the live preview from the current assignment...
     assert {'cpp': 0, 'java': 0} in seen
     # ...but suppressed it on the confirming (final) paint, so the post-enter
@@ -301,6 +305,145 @@ def test_legend_mentions_relative_and_reset():
     text = '\n'.join(LEGEND_LINES)
     assert 'relative' in text
     assert 'reset' in text
+
+
+def test_edit_tab_cycles_fields():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    assert s.edit_field == 'ref'
+    s.edit_tab()
+    assert s.edit_field == 'a'
+    s.edit_tab()
+    assert s.edit_field == 'b'
+    s.edit_tab()
+    assert s.edit_field == 'ref'
+
+
+def test_start_edit_resets_field_to_ref():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.edit_tab()  # -> 'a'
+    s.cancel_edit()
+    s.start_edit()
+    assert s.edit_field == 'ref'
+
+
+def test_edit_key_types_into_focused_field():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.edit_tab()  # focus 'a'
+    s.set_a('')  # clear seeded default
+    s.edit_key('2')
+    s.edit_key('.')
+    s.edit_key('5')
+    assert s.edit_a == '2.5'
+    s.edit_key('\x7f')  # backspace
+    assert s.edit_a == '2.'
+
+
+def test_edit_key_ref_field_is_noop():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    assert s.edit_field == 'ref'
+    s.edit_key('9')  # typing on ref does nothing
+    assert s.edit_a == '1.0'
+    assert s.edit_b == ''
+
+
+def test_edit_key_types_into_b_field():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.edit_tab()  # 'a'
+    s.edit_tab()  # 'b'
+    s.edit_key('1')
+    s.edit_key('0')
+    s.edit_key('0')
+    assert s.edit_b == '100'
+
+
+async def test_picker_force_relative_flow():
+    with create_pipe_input() as inp:
+        inp.send_text('1')  # cpp -> group 1
+        inp.send_text('\x1b[B')  # down -> py
+        inp.send_text('2')  # py -> group 2
+        inp.send_text('r')  # open editor on py (g2), field=ref
+        inp.send_text('\x1b[C')  # right: cycle ref None -> 'cpp'
+        inp.send_text('\t')  # Tab: ref -> a
+        inp.send_text('\x7f')  # backspace seeded '1.0'
+        inp.send_text('\x7f')
+        inp.send_text('\x7f')
+        inp.send_text('2')  # type '2.0'
+        inp.send_text('.')
+        inp.send_text('0')
+        inp.send_text('\r')  # commit edit
+        inp.send_text('\r')  # confirm picker
+        result = await prompt_group_assignment(
+            ['cpp', 'py'],
+            {'cpp': 0, 'py': 0},
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert result.numbers == {'cpp': 1, 'py': 2}
+    assert result.relatives['g2'].relativeTo == 'cpp'
+    assert result.relatives['g2'].multiplier == 2.0
+
+
+async def test_picker_digit_routes_into_editor_not_group():
+    # While editing, a digit must land in the A buffer, not call set_group.
+    with create_pipe_input() as inp:
+        inp.send_text('\x1b[B')  # down -> py
+        inp.send_text('2')  # py -> group 2
+        inp.send_text('r')  # editor on py, field=ref
+        inp.send_text('\x1b[C')  # ref -> cpp
+        inp.send_text('\t')  # -> field 'a'
+        inp.send_text('\x7f')  # clear seeded '1.0'
+        inp.send_text('\x7f')
+        inp.send_text('\x7f')
+        inp.send_text('3')  # A = '3'
+        inp.send_text('\r')  # commit
+        inp.send_text('\r')  # confirm
+        result = await prompt_group_assignment(
+            ['cpp', 'py'],
+            {'cpp': 1, 'py': 0},
+            input=inp,
+            output=DummyOutput(),
+        )
+    # py stayed in group 2 (the '3' did not re-group it); spec multiplier is 3.
+    assert result.numbers == {'cpp': 1, 'py': 2}
+    assert result.relatives['g2'].multiplier == 3.0
+
+
+async def test_picker_reset_restores_env():
+    with create_pipe_input() as inp:
+        inp.send_text('5')  # mutate cpp -> 5
+        inp.send_text('R')  # reset to initial
+        inp.send_text('\r')  # confirm
+        result = await prompt_group_assignment(
+            ['cpp', 'py'],
+            {'cpp': 1, 'py': 2},
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert result.numbers == {'cpp': 1, 'py': 2}
+
+
+async def test_picker_returns_group_assignment_struct():
+    with create_pipe_input() as inp:
+        inp.send_text('\r')
+        result = await prompt_group_assignment(
+            ['cpp', 'py'],
+            {'cpp': 1, 'py': 2},
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert isinstance(result, GroupAssignment)
+    assert result.numbers == {'cpp': 1, 'py': 2}
+    assert result.relatives == {}
 
 
 def test_legend_describes_three_states():

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -1,6 +1,7 @@
 from prompt_toolkit.input.defaults import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 
+from rbx.box.environment import LanguageGroupFallback
 from rbx.box.timing_group_picker import GroupPickerState, prompt_group_assignment
 
 
@@ -121,6 +122,136 @@ async def test_picker_invokes_preview_with_current_assignment():
     # ...but suppressed it on the confirming (final) paint, so the post-enter
     # assignment never reaches the preview.
     assert {'cpp': 1, 'java': 0} not in seen
+
+
+def test_group_key_per_state():
+    s = GroupPickerState(['cpp', 'py', 'go'], {'cpp': 2, 'py': -1, 'go': 0})
+    assert s.group_key('cpp') == 'g2'
+    assert s.group_key('py') == 's:py'
+    assert s.group_key('go') == 'leftover'
+
+
+def test_start_edit_seeds_defaults_and_commit():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)  # cursor -> py
+    s.start_edit()
+    assert s.editing
+    s.set_ref('cpp')
+    s.set_a('2.5')
+    s.set_b('100')
+    assert s.commit_edit() is True
+    assert not s.editing
+    assert s.relatives['g2'] == LanguageGroupFallback(
+        relativeTo='cpp', multiplier=2.5, increment=100
+    )
+
+
+def test_cancel_edit_discards():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_a('9')
+    s.cancel_edit()
+    assert not s.editing
+    assert 'g2' not in s.relatives
+
+
+def test_clear_relative_removes_spec():
+    s = GroupPickerState(
+        ['cpp', 'py'],
+        {'cpp': 1, 'py': 2},
+        relatives={'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=2.0)},
+    )
+    s.move(1)
+    s.start_edit()
+    s.clear_relative()
+    assert 'g2' not in s.relatives
+    assert not s.editing
+
+
+def test_invalid_a_keeps_editing():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_ref('cpp')
+    s.set_a('abc')  # not a positive float
+    assert s.commit_edit() is False  # rejected
+    assert s.editing  # stays in editor
+
+
+def test_nonpositive_a_rejected():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_a('0')
+    assert s.commit_edit() is False
+    s.set_a('-3')
+    assert s.commit_edit() is False
+    assert s.editing
+
+
+def test_invalid_b_rejected_but_empty_ok():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_ref('cpp')
+    s.set_a('2.0')
+    s.set_b('xx')
+    assert s.commit_edit() is False
+    s.set_b('')  # empty increment is allowed (None)
+    assert s.commit_edit() is True
+    assert s.relatives['g2'].increment is None
+
+
+def test_reference_options_exclude_own_group_and_include_base():
+    s = GroupPickerState(['cpp', 'py', 'go'], {'cpp': 1, 'py': 2, 'go': 2})
+    s.move(1)  # cursor on py (group g2)
+    refs = s.reference_options()
+    assert None in refs  # base estimate
+    assert 'cpp' in refs  # representative of the other group
+    assert 'py' not in refs and 'go' not in refs  # own group excluded
+
+
+def test_cycle_ref_wraps():
+    s = GroupPickerState(['cpp', 'py', 'go'], {'cpp': 1, 'py': 2, 'go': 3})
+    s.move(1)  # py
+    s.start_edit()
+    opts = s.reference_options()  # e.g. [None, 'cpp', 'go']
+    start = s.edit_ref
+    s.cycle_ref(1)
+    assert s.edit_ref == opts[(opts.index(start) + 1) % len(opts)]
+
+
+def test_reset_restores_initial_numbers_and_relatives():
+    s = GroupPickerState(
+        ['cpp', 'py'],
+        {'cpp': 1, 'py': 2},
+        relatives={'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=2.0)},
+    )
+    s.set_group(5)  # mutate cpp
+    s.move(1)
+    s.start_edit()
+    s.clear_relative()
+    s.reset_to_initial()
+    assert s.assignment() == {'cpp': 1, 'py': 2}
+    assert s.relatives == {
+        'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=2.0)
+    }
+
+
+def test_prune_relatives_drops_orphans():
+    s = GroupPickerState(
+        ['cpp', 'py'],
+        {'cpp': 1, 'py': 2},
+        relatives={
+            'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            's:rust': LanguageGroupFallback(relativeTo='cpp', multiplier=3.0),
+        },
+    )
+    # 's:rust' has no corresponding language/group -> pruned; 'g2' kept (py in bucket 2)
+    pruned = s.prune_relatives()
+    assert 'g2' in pruned
+    assert 's:rust' not in pruned
 
 
 def test_legend_describes_three_states():

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -455,3 +455,18 @@ def test_legend_describes_three_states():
     assert '[ ]' in text and 'leftover' in text
     # key hint still present
     assert 'confirm' in text and 'cancel' in text
+
+
+async def test_prompt_seeds_relatives_into_state():
+    from rbx.box.environment import LanguageGroupFallback
+
+    with create_pipe_input() as inp:
+        inp.send_text('\r')  # immediately confirm
+        result = await prompt_group_assignment(
+            ['cpp', 'py'],
+            {'cpp': 1, 'py': 2},
+            relatives={'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=2.0)},
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert result.relatives['g2'].multiplier == 2.0

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -382,6 +382,92 @@ def test_edit_key_types_into_b_field():
     assert s.edit_b == '100'
 
 
+def test_edit_key_rejects_non_numeric_multiplier():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.edit_tab()  # focus multiplier
+    s.set_a('')
+    s.edit_key('x')  # letter rejected
+    s.edit_key('2')
+    s.edit_key('.')
+    s.edit_key('.')  # a second decimal point is rejected
+    s.edit_key('5')
+    assert s.edit_a == '2.5'
+
+
+def test_edit_key_rejects_non_digit_increment():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.edit_tab()
+    s.edit_tab()  # focus increment
+    s.edit_key('1')
+    s.edit_key('.')  # increment is integer-only -> rejected
+    s.edit_key('a')  # rejected
+    s.edit_key('0')
+    assert s.edit_b == '10'
+
+
+def test_commit_sets_error_message_when_invalid():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_a('')  # empty multiplier
+    assert s.commit_edit() is False
+    assert 'multiplier' in s.edit_error
+
+
+def test_edit_key_clears_error():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_a('0')
+    assert s.commit_edit() is False
+    assert s.edit_error
+    s.edit_tab()  # focus multiplier
+    s.set_a('')
+    s.edit_key('2')  # a valid edit clears the stale error
+    assert s.edit_error == ''
+
+
+def test_render_shows_validation_error():
+    s = GroupPickerState(['cpp', 'py'], {'cpp': 1, 'py': 2})
+    s.move(1)
+    s.start_edit()
+    s.set_a('abc')
+    s.commit_edit()
+    text = ''.join(t for _, t in s.render_fragments())
+    assert '⚠' in text and 'multiplier' in text
+
+
+async def test_picker_invalid_commit_keeps_editing_then_recovers():
+    # Pressing enter with an empty multiplier must not commit/exit; the user
+    # can then type a valid value and commit successfully.
+    with create_pipe_input() as inp:
+        inp.send_text('1')  # cpp -> group 1
+        inp.send_text('\x1b[B')  # down -> py
+        inp.send_text('2')  # py -> group 2
+        inp.send_text('r')  # editor on py, field=ref
+        inp.send_text('\x1b[C')  # ref -> cpp
+        inp.send_text('\t')  # -> multiplier
+        inp.send_text('\x7f')  # clear seeded '1.0'
+        inp.send_text('\x7f')
+        inp.send_text('\x7f')
+        inp.send_text('\r')  # commit EMPTY multiplier -> invalid, stays editing
+        inp.send_text('2')  # type a valid multiplier
+        inp.send_text('\r')  # commit succeeds
+        inp.send_text('\r')  # confirm picker
+        result = await prompt_group_assignment(
+            ['cpp', 'py'],
+            {'cpp': 0, 'py': 0},
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert result.numbers == {'cpp': 1, 'py': 2}
+    assert result.relatives['g2'].multiplier == 2.0
+
+
 async def test_picker_force_relative_flow():
     with create_pipe_input() as inp:
         inp.send_text('1')  # cpp -> group 1

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -230,42 +230,10 @@ def test_valid_partition_passes():
 
 
 def test_assignment_singleton_state_makes_singletons():
-    env_groups = [LanguageGroup(languages=['c', 'cpp'])]
     groups = partition_from_assignment(
         assignment={'c': -1, 'cpp': -1, 'python': -1},
-        env_groups=env_groups,
     )
     assert sorted(g.languages for g in groups) == [['c'], ['cpp'], ['python']]
-
-
-def test_identical_membership_preserves_when_empty():
-    env_groups = [
-        LanguageGroup(
-            languages=['java', 'kotlin'],
-            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
-        )
-    ]
-    groups = partition_from_assignment(
-        assignment={'java': 1, 'kotlin': 1, 'cpp': 2},
-        env_groups=env_groups,
-    )
-    jvm = next(g for g in groups if set(g.languages) == {'java', 'kotlin'})
-    assert jvm.whenEmpty is not None and jvm.whenEmpty.multiplier == 2.0
-
-
-def test_changed_membership_drops_when_empty():
-    env_groups = [
-        LanguageGroup(
-            languages=['java', 'kotlin'],
-            whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
-        )
-    ]
-    groups = partition_from_assignment(
-        assignment={'java': 1, 'kotlin': 1, 'scala': 1},
-        env_groups=env_groups,
-    )
-    jvm = next(g for g in groups if 'java' in g.languages)
-    assert jvm.whenEmpty is None
 
 
 def test_partition_from_assignment_three_states():
@@ -280,7 +248,6 @@ def test_partition_from_assignment_three_states():
             'go': 0,
             'rust': 0,
         },
-        env_groups=[],
     )
     langs = [g.languages for g in groups]
     assert ['c', 'cpp'] in langs
@@ -294,23 +261,32 @@ def test_partition_from_assignment_three_states():
 def test_partition_from_assignment_no_leftover_group_when_none_unbucketed():
     groups = partition_from_assignment(
         assignment={'cpp': 1, 'python': -1},
-        env_groups=[],
     )
     assert [g.languages for g in groups] == [['cpp'], ['python']]
 
 
-def test_partition_from_assignment_preserves_when_empty_on_exact_match():
+def test_partition_applies_forced_relatives_by_group_key():
     groups = partition_from_assignment(
-        assignment={'java': 1, 'kotlin': 1},
-        env_groups=[
-            LanguageGroup(
-                languages=['java', 'kotlin'],
-                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
-            ),
-        ],
+        {'cpp': 1, 'python': 2, 'go': 0, 'rust': -1},
+        relatives={
+            'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+            's:rust': LanguageGroupFallback(relativeTo='cpp', multiplier=3.0),
+            'leftover': LanguageGroupFallback(relativeTo='cpp', multiplier=4.0),
+        },
     )
-    assert groups[0].whenEmpty is not None
-    assert groups[0].whenEmpty.multiplier == 2.0
+    by_lang = {g.languages[0]: g for g in groups}
+    assert by_lang['python'].forced_relative.multiplier == 2.0
+    assert by_lang['rust'].forced_relative.multiplier == 3.0
+    assert by_lang['go'].forced_relative.multiplier == 4.0
+    assert by_lang['cpp'].forced_relative is None
+
+
+def test_partition_no_longer_derives_when_empty_from_env():
+    # membership matches an env group, but partition_from_assignment must NOT
+    # re-derive whenEmpty anymore (env-crossing dropped).
+    groups = partition_from_assignment({'java': 1, 'kotlin': 1})
+    assert groups[0].whenEmpty is None
+    assert groups[0].forced_relative is None
 
 
 def test_build_partition_marks_leftover():
@@ -326,7 +302,6 @@ def test_build_partition_marks_leftover():
 def test_partition_from_assignment_marks_leftover():
     groups = partition_from_assignment(
         assignment={'cpp': 1, 'python': -1, 'go': 0, 'rust': 0},
-        env_groups=[],
     )
     leftover = [g for g in groups if g.is_leftover]
     assert len(leftover) == 1

--- a/tests/rbx/box/test_timing_groups.py
+++ b/tests/rbx/box/test_timing_groups.py
@@ -346,3 +346,59 @@ def test_resolve_propagates_is_leftover():
     by_leftover = {tuple(r.languages): r.isLeftover for r in result.reports}
     assert by_leftover[('cpp',)] is False
     assert by_leftover[('go', 'java')] is True
+
+
+def _eval_slowest(fastest, slowest):
+    # simple deterministic formula for tests: just the slowest
+    return slowest
+
+
+def test_forced_relative_wins_over_pooled_timings():
+    # group 0 has solutions; group 1 forced relative to group 0
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['python'],
+            forced_relative=LanguageGroupFallback(
+                relativeTo='cpp', multiplier=2.0, increment=100
+            ),
+        ),
+    ]
+    pooled = {
+        0: GroupTimings(fastest=100, slowest=200, solution_count=1),
+        1: GroupTimings(fastest=500, slowest=900, solution_count=1),
+    }
+    base = GroupTimings(fastest=100, slowest=900, solution_count=2)
+    result = resolve_groups(groups, pooled, base, _eval_slowest)
+    # group 1 ignores its own timings (would be 900) -> 2.0*200 + 100 = 500
+    assert result.reports[1].timeLimit == 500
+    assert result.reports[1].origin == TimingGroupOrigin.MULTIPLIER
+    assert result.reports[1].relativeToLanguage == 'cpp'
+    # solution count of the overridden group is preserved for display
+    assert result.reports[1].solutionCount == 1
+
+
+def test_forced_relative_validates_self_reference():
+    groups = [
+        ResolvedGroup(
+            languages=['cpp'],
+            forced_relative=LanguageGroupFallback(relativeTo='cpp', multiplier=2.0),
+        )
+    ]
+    with pytest.raises(GroupValidationError):
+        validate_partition(groups)
+
+
+def test_forced_relative_to_base_estimate():
+    groups = [
+        ResolvedGroup(languages=['cpp']),
+        ResolvedGroup(
+            languages=['python'],
+            forced_relative=LanguageGroupFallback(relativeTo=None, multiplier=3.0),
+        ),
+    ]
+    pooled = {0: GroupTimings(fastest=100, slowest=200, solution_count=1)}
+    base = GroupTimings(fastest=100, slowest=200, solution_count=1)
+    result = resolve_groups(groups, pooled, base, _eval_slowest)
+    # base_tl = _eval(100, 200) = 200; forced -> 3.0*200 = 600
+    assert result.reports[1].timeLimit == 600

--- a/tests/rbx/box/test_timing_preview.py
+++ b/tests/rbx/box/test_timing_preview.py
@@ -1,7 +1,6 @@
-import pytest
 from prompt_toolkit.formatted_text import ANSI, to_formatted_text
 
-from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+from rbx.box.environment import LanguageGroupFallback
 from rbx.box.timing import build_preview_renderer
 
 
@@ -25,32 +24,45 @@ def test_preview_renders_estimated_table():
     assert 'cpp' in out and 'python' in out
 
 
-@pytest.mark.xfail(
-    reason='Picker-driven cycles flow through relatives, wired in Task 3; '
-    'partition_from_assignment no longer carries env whenEmpty over (Task 2).',
-    strict=True,
-)
-def test_preview_reports_invalid_grouping_inline():
-    # Two env groups whose whenEmpty rules reference each other -> cycle.
-    env_groups = [
-        LanguageGroup(
-            languages=['a'],
-            whenEmpty=LanguageGroupFallback(relativeTo='b', multiplier=2.0),
-        ),
-        LanguageGroup(
-            languages=['b'],
-            whenEmpty=LanguageGroupFallback(relativeTo='a', multiplier=2.0),
-        ),
-    ]
+def test_preview_reflects_forced_relative():
     render = build_preview_renderer(
-        timing_per_solution_per_language={},  # both groups empty -> resolve via cycle
+        timing_per_solution_per_language={'cpp': {'sol.cpp': 200}},
+        formula='slowest',
+        env_groups=[],
+        all_languages=['cpp', 'python'],
+        width=80,
+    )
+    out = _text(
+        render(
+            {'cpp': 1, 'python': 2},
+            {'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=2.0)},
+        )
+    )
+    # python's group (g2) is forced relative to cpp x2.0; cpp estimate = 200 ->
+    # python = 400ms must appear in the rendered table.
+    assert '400' in out
+
+
+def test_preview_reports_invalid_grouping_inline():
+    # Two picker groups whose forced relatives reference each other -> cycle.
+    render = build_preview_renderer(
+        timing_per_solution_per_language={},
         formula='slowest * 3',
-        env_groups=env_groups,
+        env_groups=[],
         all_languages=['a', 'b'],
         width=80,
     )
-    # assignment reproduces the two env groups exactly, carrying their whenEmpty
-    out = _text(render({'a': 1, 'b': 2}))
+    # The forced relatives make g1 -> b and g2 -> a, forming a cycle, so
+    # validate_partition raises and the preview renders the inline warning.
+    out = _text(
+        render(
+            {'a': 1, 'b': 2},
+            {
+                'g1': LanguageGroupFallback(relativeTo='b', multiplier=2.0),
+                'g2': LanguageGroupFallback(relativeTo='a', multiplier=2.0),
+            },
+        )
+    )
     assert 'Invalid grouping' in out
 
 

--- a/tests/rbx/box/test_timing_preview.py
+++ b/tests/rbx/box/test_timing_preview.py
@@ -1,3 +1,4 @@
+import pytest
 from prompt_toolkit.formatted_text import ANSI, to_formatted_text
 
 from rbx.box.environment import LanguageGroup, LanguageGroupFallback
@@ -24,6 +25,11 @@ def test_preview_renders_estimated_table():
     assert 'cpp' in out and 'python' in out
 
 
+@pytest.mark.xfail(
+    reason='Picker-driven cycles flow through relatives, wired in Task 3; '
+    'partition_from_assignment no longer carries env whenEmpty over (Task 2).',
+    strict=True,
+)
 def test_preview_reports_invalid_grouping_inline():
     # Two env groups whose whenEmpty rules reference each other -> cycle.
     env_groups = [


### PR DESCRIPTION
Closes #512.

## What

Lets `rbx time` users **force** a language group's time limit to be computed relative to another group as `A·t + B` (`multiplier × reference + increment`), directly in the interactive picker. Unlike env `whenEmpty` (which only fires for groups with no solutions), a forced relative **always overrides** the group's measured estimate — the live preview shows solution counts so the choice is informed.

## Picker UX

- **`r`** on a language opens an inline editor for its group: `relative-to: [ref]  A:[..]  B:[..]`. `Tab` cycles the focused field (ref → A → B), `←/→` cycles the reference group (including a **base estimate** option), type to set A/B, `Enter` commits, `Esc` cancels, `c` clears.
- A persistent `→ ref ×A +B` annotation marks relative groups in the list.
- **`R`** resets the whole grouping + relative rules back to what `env.rbx.yml` defines.
- The live preview validates references inline (self-reference / cycles) and blocks confirm.

## Design / approach

- New `ResolvedGroup.forced_relative` takes top priority in `resolve_groups` (forced → measured timings → env `whenEmpty` empty-only → base). The env schema is untouched; the forced spec lives only on the resolved layer.
- `partition_from_assignment` **drops the old env-crossing** (it no longer re-derives `whenEmpty` by matching membership). Instead env `whenEmpty` is **seeded into picker state at init**, only for groups with no solutions. After init, the picker's `{numbers, relatives}` is the single source of truth — membership edits are the user's responsibility, and `R` recovers the env grouping.
- The picker return grew from a raw dict to a `GroupAssignment{numbers, relatives}`; relatives are keyed by a stable group-key (`g{N}`/`s:{lang}`/`leftover`) and pruned when a group disappears.
- Resolved profiles store concrete numbers, so nothing round-trips to `env.rbx.yml`.

Design + plan docs: `docs/plans/2026-06-03-rbx-time-forced-relative-design.md`, `docs/plans/2026-06-03-rbx-time-forced-relative-plan.md`.

## Testing

- Full timing suite green (118 tests): `test_timing_groups`, `test_timing_group_picker`, `test_timing`, `test_timing_estimation`, `test_timing_preview`, `test_limits_table`.
- Covers: forced relative winning over a group's own timings (unit **and** end-to-end through `build_timing_profile`), base-estimate reference, validation (self/cycle) reachable from the picker path, editor key routing (digit routing, field cycling, ref cycling, clear/cancel/commit), reset-to-env, init-seeding only for empty groups, and prune of orphaned specs.
- Broader box suite: no new regressions (remaining failures are pre-existing, unrelated C++/sandbox/docker/walltime env issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)