### PR TITLE
feat(irun): show solution stderr in irun (#266)

### DIFF
--- a/docs/plans/2026-06-03-irun-stderr-design.md
+++ b/docs/plans/2026-06-03-irun-stderr-design.md
@@ -1,0 +1,103 @@
+# Show stderr in `rbx irun` (issue #266)
+
+## Goal
+
+Let problem setters see a solution's `stderr` when running it interactively via
+`rbx irun`. Two presentation modes:
+
+- **Default (separate section):** print `stderr` in its own distinctly-colored
+  "Stderr" section, right after the Output / Interaction section.
+- **Interleaved (`--merge-stderr` / `-e`):** weave `stderr` into the Output
+  (batch) or Interaction (communication) view in **true line order**, with
+  `stderr` lines rendered in a distinct color so they are easy to tell apart
+  from `stdout`.
+
+Both modes render **only when `-p` / `--print` is set**. Without `-p`, behavior
+is unchanged: `irun` just prints the `stderr` file path link
+(`solutions.py:969`).
+
+Scope is **`irun` only** (per the issue), not the full `rbx run` report.
+
+## Background
+
+The interactive interaction system already interleaves streams in true write
+order:
+
+- `rbx/grading/judge/sandboxes/line_tee.py` / `tee.py` tee each stream into a
+  shared `merged_capture` file, tagging each line with a prefix marker:
+  `<` = interactor (pipe 0), `>` = solution (pipe 1).
+- `rbx/box/testcase_utils.py`:
+  - `parse_interaction()` reads the marked lines into
+    `TestcaseInteractionEntry(data, pipe)`.
+  - `print_interaction()` colors each entry by `pipe` (0 = `status`,
+    1 = `info`).
+- `irun`'s `run_and_print_interactive_solutions()` (`rbx/box/solutions.py`)
+  already prints the interaction for COMMUNICATION problems and the output for
+  BATCH problems when `-p` is set.
+
+This design extends that machinery with a third stream: **stderr = pipe 2,
+marker `!`, its own color.**
+
+## Approach (reuse the tee / merged-capture machinery)
+
+### Capture
+
+`stderr` is already captured to a file by `run_item` (exposed via
+`eval.log.stderr_absolute_path`). The default separate-section view just reads
+that file. No sandbox change is needed for the default mode.
+
+The interleaved mode needs a merged capture:
+
+1. **Communication problems:** the solution's `stderr` is tee'd to *both* its
+   normal `stderr` file *and* appended to the existing `merged_capture` with
+   marker `!`. Result: interactor ↔ solution exchange **and** stderr in one
+   true-ordered, 3-color view.
+2. **Batch problems:** the plain `run()` path does not tee today. When
+   interleave is on, add optional teeing so:
+   - `stdout` → (clean stdout file *for the checker*) + (merged-capture, marker `>`)
+   - `stderr` → (stderr file) + (merged-capture, marker `!`)
+
+   **Clean stdout is preserved**, so the checker is unaffected.
+
+### Threading the flag
+
+The interleave flag threads through `SolutionReportSkeleton` (next to the
+existing `capture_pipes` field) so it reaches the run functions. `irun` only
+caches when an explicit `--testcase` is given; making the flag part of the run
+skeleton ensures toggling it never serves a stale merged capture.
+
+### Parsing / rendering changes
+
+- `parse_interaction()`: support a third prefix / pipe. For `.interaction` /
+  `.pio` files, recognize the `!` prefix → pipe 2.
+- `print_interaction()`: add a color for pipe 2 (stderr) — an `error` / red
+  style.
+- `solutions.py` `run_and_print_interactive_solutions()`: when `-p`, branch on
+  the flag:
+  - interleave on → render the merged capture (now includes stderr lines).
+  - interleave off (default) → render the Output section as today, then a
+    colored "Stderr" section reading `stderr_absolute_path`.
+
+## Error handling / edge cases
+
+- **Empty stderr:** default mode skips the section; interleave mode shows no
+  stderr lines.
+- **Non-UTF8 / large stderr:** reuse existing file reads and capture limits.
+- **Checker correctness:** stdout fed to the checker stays clean in both modes.
+
+## Testing
+
+- Unit: `parse_interaction` with the 3rd prefix; `print_interaction` color for
+  pipe 2.
+- A fixture solution that writes to stderr → assert the default section prints
+  it, and that the interleaved merged-file ordering is correct.
+
+## CLI
+
+New option on `irun`:
+
+```
+--merge-stderr / -e    Interleave stderr with the solution output in true line
+                       order (colored distinctly). Requires -p. Default off:
+                       stderr is shown in a separate colored section.
+```

--- a/docs/plans/2026-06-03-irun-stderr.md
+++ b/docs/plans/2026-06-03-irun-stderr.md
@@ -1,0 +1,352 @@
+# Show stderr in `rbx irun` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let problem setters see a solution's `stderr` in `rbx irun` — in a separate colored section by default, or interleaved in true line order with the solution output via a `--merge-stderr` / `-e` flag.
+
+**Architecture:** Reuse the existing interaction-capture machinery (`line_tee.py` → `merged_capture` file → `parse_interaction` → `print_interaction`). Add `stderr` as a third stream: pipe id `2`, prefix marker `!`, its own color. The default view reads the already-captured `stderr` file and prints it in a section; the interleaved view tees `stderr` (and, for batch problems, `stdout`) into a merged-capture file so streams render in true write order. The clean `stdout` file the checker reads is never polluted.
+
+**Tech Stack:** Python 3, Typer (CLI), Pydantic v2, Rich (terminal rendering), pytest. Design doc: `docs/plans/2026-06-03-irun-stderr-design.md`.
+
+**Phasing (value-first, risk-isolated):**
+- **Phase 1** — parsing/rendering primitives for a 3rd stream (pure, fully unit-tested).
+- **Phase 2** — default separate "Stderr" section in `irun` (delivers the core ask, no sandbox changes).
+- **Phase 3** — `--merge-stderr` / `-e` flag + true line-order interleave (the sandbox teeing work).
+
+Each phase is independently shippable. Stop after Phase 2 if Phase 3 proves too costly.
+
+---
+
+## Conventions for this repo (read first)
+
+- **Single quotes** for strings; absolute imports only (ruff `TID`). Run `uv run ruff format .` and `uv run ruff check --fix .` before committing.
+- **Commits:** MUST follow Conventional Commits via commitizen. Use the `/commit` workflow in `.claude/skills/commit.md`. Stage files by name. Append the `Co-Authored-By:` trailer. Never amend; on hook rejection, make a new commit.
+- **Tests:** `uv run pytest <path>`. Reuse fixtures from `tests/rbx/conftest.py` and `tests/rbx/box/conftest.py`. Note (from memory): some C++/sandbox/docker tests fail pre-existingly on this machine — that is NOT your change.
+- **Test isolation rule:** any new module-level `@functools.cache` in `rbx/box/` must be added to `rbx.testing_utils.clear_all_functools_cache`. (This plan does not add any.)
+
+---
+
+## Phase 1 — Parsing & rendering a third stream (stderr)
+
+The interaction model lives in `rbx/box/testcase_utils.py`:
+- `TestcaseInteractionEntry(data: str, pipe: int)` — `pipe` is `0` = interactor, `1` = solution.
+- `parse_interaction(file)` — `.interaction` files use hardcoded prefixes `<` (pipe 0) / `>` (pipe 1); other suffixes (`.pio`) read the two prefixes from the first two lines.
+- `print_interaction(interaction)` — colors entries: pipe `0` → `status`, else → `info`.
+
+We add **pipe `2` = stderr, prefix `!`**, colored with the `error` style (red). The 2-element `prefixes` tuple and the first-two-lines `.pio` header format are kept backward-compatible: `!` is a fixed, predetermined stderr prefix recognized in addition to whatever the header declares.
+
+### Task 1.1: stderr lines parse to pipe 2
+
+**Files:**
+- Modify: `rbx/box/testcase_utils.py` (`parse_interaction`, ~163-202)
+- Test: `tests/rbx/box/testcase_utils_test.py` (create if absent; check first with `ls tests/rbx/box/ | grep testcase`)
+
+**Step 1: Write the failing test**
+
+```python
+import pathlib
+
+from rbx.box import testcase_utils
+
+
+def test_parse_interaction_recognizes_stderr_prefix(tmp_path: pathlib.Path):
+    f = tmp_path / 'sample.interaction'
+    f.write_text('< 3\n! reading n\n> 1 2 3\n! done\n')
+
+    interaction = testcase_utils.parse_interaction(f)
+
+    assert [(e.pipe, e.data) for e in interaction.entries] == [
+        (0, '3'),
+        (2, 'reading n'),
+        (1, '1 2 3'),
+        (2, 'done'),
+    ]
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/testcase_utils_test.py::test_parse_interaction_recognizes_stderr_prefix -v`
+Expected: FAIL — currently raises `TestcaseInteractionParsingError` on the `!` line.
+
+**Step 3: Implement**
+
+In `parse_interaction`, define a fixed stderr prefix and branch on it BEFORE the error case. Keep it independent of the interactor/solution prefixes so it works for both `.interaction` and `.pio`:
+
+```python
+STDERR_PREFIX = '!'
+```
+(module-level constant near the top of `testcase_utils.py`)
+
+Inside the `while line := f.readline().strip():` loop, add a branch:
+
+```python
+        while line := f.readline().strip():
+            if line.startswith(interactor_prefix):
+                stripped = line[len(interactor_prefix):].rstrip()
+                entries.append(TestcaseInteractionEntry(data=stripped, pipe=0))
+            elif line.startswith(solution_prefix):
+                stripped = line[len(solution_prefix):].rstrip()
+                entries.append(TestcaseInteractionEntry(data=stripped, pipe=1))
+            elif line.startswith(STDERR_PREFIX):
+                stripped = line[len(STDERR_PREFIX):].rstrip()
+                entries.append(TestcaseInteractionEntry(data=stripped, pipe=2))
+            else:
+                raise TestcaseInteractionParsingError(...)  # unchanged
+```
+
+Note: order the `STDERR_PREFIX` branch so it cannot be shadowed if a caller ever sets `solution_prefix='!'` — in practice the comm tees use `<`/`>`, so `!` is free. If `interactor_prefix`/`solution_prefix` could equal `!`, keep the stderr branch last (as above) so explicit interactor/solution prefixes win.
+
+Also update the docstring to mention the `!` stderr prefix.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/testcase_utils_test.py::test_parse_interaction_recognizes_stderr_prefix -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+uv run ruff format rbx/box/testcase_utils.py tests/rbx/box/testcase_utils_test.py
+git add rbx/box/testcase_utils.py tests/rbx/box/testcase_utils_test.py
+git commit  # feat(irun): parse stderr lines (prefix '!') as interaction pipe 2
+```
+
+### Task 1.2: stderr entries render in a distinct color
+
+**Files:**
+- Modify: `rbx/box/testcase_utils.py` (`print_interaction`, ~220-227)
+- Test: `tests/rbx/box/testcase_utils_test.py`
+
+**Step 1: Write the failing test** — assert the stderr entry is styled with the error color. `print_interaction` builds `rich.text.Text(entry.data)` then `.stylize(...)`. Capture style via a Rich console recording or by refactoring the style choice into a small pure helper (preferred — easier to test):
+
+```python
+from rbx.box import testcase_utils
+from rbx.box.testcase_utils import TestcaseInteractionEntry
+
+
+def test_interaction_entry_style_per_pipe():
+    assert testcase_utils.interaction_entry_style(0) == 'status'
+    assert testcase_utils.interaction_entry_style(1) == 'info'
+    assert testcase_utils.interaction_entry_style(2) == 'error'
+```
+
+**Step 2: Run** — FAIL (`interaction_entry_style` not defined).
+
+**Step 3: Implement** — add the pure helper and use it in `print_interaction`:
+
+```python
+def interaction_entry_style(pipe: int) -> str:
+    if pipe == 0:
+        return 'status'
+    if pipe == 2:
+        return 'error'
+    return 'info'
+
+
+def print_interaction(interaction: TestcaseInteraction):
+    for entry in interaction.entries:
+        text = rich.text.Text(entry.data)
+        text.stylize(interaction_entry_style(entry.pipe))
+        console.console.print(text)
+```
+
+Verify `error` exists in the Rich theme: `grep -n "error" rbx/box/console.py`. If not present, use an explicit `'red'`.
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit** — `feat(irun): color stderr interaction lines distinctly`.
+
+---
+
+## Phase 2 — Default separate "Stderr" section in `irun`
+
+Delivers the core ask with no sandbox changes: when `-p` is set, print the already-captured `stderr` in its own colored section after Output/Interaction.
+
+Relevant code in `rbx/box/solutions.py`, `run_and_print_interactive_solutions` (~872-973):
+- With `print` set, it prints the Output (and Interaction for COMMUNICATION) section (~939-955).
+- `eval.log.stderr_absolute_path` already points to the captured stderr file (used at ~969 to print the *path* when `-p` is NOT set).
+
+### Task 2.1: helper that prints a stderr section
+
+**Files:**
+- Modify: `rbx/box/testcase_utils.py` (new `print_stderr_section`)
+- Test: `tests/rbx/box/testcase_utils_test.py`
+
+**Step 1: Write the failing test**
+
+```python
+import pathlib
+
+import rich.console
+
+from rbx.box import testcase_utils
+
+
+def test_print_stderr_section_prints_contents(tmp_path, monkeypatch):
+    err = tmp_path / 'run.stderr'
+    err.write_text('debug: hello\n')
+
+    rec = rich.console.Console(record=True, force_terminal=False, width=80)
+    monkeypatch.setattr(testcase_utils.console, 'console', rec)
+
+    printed = testcase_utils.print_stderr_section(err)
+
+    assert printed is True
+    out = rec.export_text()
+    assert 'debug: hello' in out
+
+
+def test_print_stderr_section_skips_empty(tmp_path, monkeypatch):
+    err = tmp_path / 'run.stderr'
+    err.write_text('')
+    rec = rich.console.Console(record=True, width=80)
+    monkeypatch.setattr(testcase_utils.console, 'console', rec)
+
+    assert testcase_utils.print_stderr_section(err) is False
+```
+
+(Confirm the console import path: in `testcase_utils.py` look for `from rbx.box import console` / `console.console`. Adjust `monkeypatch.setattr` target accordingly.)
+
+**Step 2: Run** — FAIL (`print_stderr_section` not defined).
+
+**Step 3: Implement** in `testcase_utils.py`:
+
+```python
+def print_stderr_section(stderr_path: Optional[pathlib.Path]) -> bool:
+    """Print captured stderr in its own section. Returns True if anything printed."""
+    if stderr_path is None or not stderr_path.is_file():
+        return False
+    content = stderr_path.read_text()
+    if not content.strip():
+        return False
+    console.console.rule('Stderr', style='error')
+    console.console.print(rich.text.Text(content.rstrip('\n'), style='error'))
+    return True
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit** — `feat(irun): add helper to print captured stderr section`.
+
+### Task 2.2: call the stderr section from `irun` when `-p`
+
+**Files:**
+- Modify: `rbx/box/solutions.py` (`run_and_print_interactive_solutions`, in the `if print and stdout_path is not None:` block, ~940-955)
+- Test: an `irun`-level test. First check existing coverage: `grep -rn "run_and_print_interactive_solutions\|def test.*irun" tests/`. If a direct unit test is impractical (it drives sandbox runs), rely on the Phase-1/2.1 unit tests plus a manual smoke test, and add an e2e case in Task 2.3.
+
+**Step 1:** After the existing Output rendering inside the `if print ...` branch, add:
+
+```python
+            # After the Output / Interaction sections:
+            if eval.log.stderr_absolute_path is not None:
+                testcase_utils.print_stderr_section(eval.log.stderr_absolute_path)
+```
+
+Confirm `testcase_utils` is imported in `solutions.py` (`grep -n "import testcase_utils\|from rbx.box.testcase_utils" rbx/box/solutions.py`); `print_best_output` is already imported from it, so add `print_stderr_section` to that import or call via the module.
+
+**Step 2:** Manual smoke test — create/throwaway a problem where a solution writes to stderr, run:
+`uv run rbx irun <sol> -t 0/0 -p -v4` and confirm a red "Stderr" section appears under the output.
+
+**Step 3: Commit** — `feat(irun): show captured stderr section when printing (#266)`.
+
+### Task 2.3: e2e coverage (if the e2e harness fits)
+
+**Files:**
+- Read: `tests/e2e/README.md` for the YAML DSL.
+- Add/extend: an `e2e.rbx.yml` fixture with a solution that writes to stderr, asserting the printed output contains the stderr text when run with `-p`.
+
+Run: `mise run test-e2e` (or the documented single-fixture invocation). If the DSL can't assert on `irun -p` output, skip this task and note it in the commit/PR. Commit — `test(irun): e2e for stderr section in irun`.
+
+---
+
+## Phase 3 — `--merge-stderr` / `-e` flag (true line-order interleave)
+
+The heavy part: tee streams into a `merged_capture` file so stderr and stdout render in true write order. Render via the Phase-1 parser/printer.
+
+### Task 3.1: add the CLI flag (off by default), thread to the runner
+
+**Files:**
+- Modify: `rbx/box/cli.py` (`irun`, ~610-741) — add the option and pass it through.
+- Modify: `rbx/box/solutions.py` (`run_and_print_interactive_solutions` signature, ~872-884) — accept `merge_stderr: bool = False`.
+
+**Step 1:** In `irun`, add after the `print` option (~665-667):
+
+```python
+    merge_stderr: bool = typer.Option(
+        False,
+        '--merge-stderr',
+        '-e',
+        help='Interleave stderr with the solution output in true line order '
+        '(colored distinctly). Requires -p. Default: stderr is shown in a '
+        'separate section.',
+    ),
+```
+
+Pass `merge_stderr=merge_stderr` into `run_and_print_interactive_solutions(...)` (~727-741). If `merge_stderr and not print`, print a `[warning]` that `--merge-stderr` requires `-p` and fall back to the default section (do not error).
+
+**Step 2:** No automated test for arg wiring alone; verified via Task 3.4. Commit — `feat(irun): add --merge-stderr/-e flag (#266)`.
+
+### Task 3.2: capture stderr into the merged file — COMMUNICATION path
+
+For interactive problems, `run_coordinated` (`rbx/grading/steps.py:873`) already produces a `merged_capture` via `sandbox.run_communication` + the tees (`stupid_sandbox.py:209-309`). The solution's stderr currently goes to `subprocess.DEVNULL`/its stderr file. We route the solution's stderr through a tee that appends to `merged_capture` with the `!` marker.
+
+**Files:**
+- Modify: `rbx/grading/judge/sandboxes/stupid_sandbox.py` (`run_communication`, the teeing setup ~284-309; `_get_tee_program` ~209-230) so the solution's stderr is tee'd into `merged_capture` with prefix `!` while still writing the solution's own stderr file.
+- Modify: `rbx/grading/judge/sandboxes/line_tee.py` (and/or `tee.py`) only if the marker char isn't already parameterized — it is passed as `char` in `_get_tee_command` (`stupid_sandbox.py:196-207`), so reuse with `char='!'`.
+
+**Investigation step (do first):** read `line_tee.py` / `tee.py` end-to-end and `run_communication` (`stupid_sandbox.py:253-360+`) to confirm exactly how `merged_capture` lines get their `<`/`>` prefixes, then mirror that for a stderr tee with `!`.
+
+**Step 1 (test):** A grading-level test under `tests/rbx/grading/` that runs a tiny program writing to both stdout and stderr through the communication path with `merged_capture` set, then asserts the merged file contains a `!`-prefixed line with the stderr text and a `>`-prefixed line with stdout, and that the standalone stdout file is clean (no stderr). Model it on existing `run_communication`/`run_coordinated` tests (`grep -rln "run_coordinated\|run_communication\|merged_capture" tests/`).
+
+**Step 2:** Run — FAIL.
+
+**Step 3:** Implement the stderr tee wiring. Keep clean stdout intact (checker correctness).
+
+**Step 4:** Run — PASS.
+
+**Step 5: Commit** — `feat(grading): tee solution stderr into merged capture (#266)`.
+
+### Task 3.3: capture into a merged file — BATCH path
+
+Batch problems use `steps.run` (`steps.py:833`) → `sandbox.run` (`stupid_sandbox.py:237`), which does **no teeing**. Add an opt-in path: when a `merged_capture` is requested, tee `stdout` → (clean stdout file + merged, marker `>`) and `stderr` → (stderr file + merged, marker `!`).
+
+**Files:**
+- Modify: `rbx/grading/judge/sandbox.py` — extend `SandboxParams` (or add a param) to carry an optional `merged_capture: Optional[pathlib.Path]` and `tee_mode` for the simple run, mirroring `CommunicationParams`.
+- Modify: `rbx/grading/judge/sandboxes/stupid_sandbox.py` (`run`, ~237-251) — when `merged_capture` is set, spawn line-tees for stdout and stderr (reuse `_get_tee_program`/`_get_tee_command` with chars `>` and `!`), preserving the clean stdout/stderr files.
+- Modify: `rbx/grading/steps.py` (`run`, ~833-863) — accept and forward `merged_capture`/`line_capture`, analogous to `run_coordinated`.
+
+**Investigation step (do first):** confirm whether `sandbox.run`'s output redirection can be combined with tee processes the same way `run_communication` composes them. This is the riskiest task; budget time to read `_get_io`, `_get_program_params`, and how `stdout_file` is honored. If composing tees into `run` proves disproportionately complex, fall back: for BATCH, capture stdout and stderr to their two files (already available) and produce the merged file post-run by **best-effort timestamp-free concatenation is NOT acceptable** (loses ordering) — instead, document that batch interleave is deferred and keep batch on the Phase-2 separate-section path. Record this decision in the PR.
+
+**Steps:** TDD as in 3.2 — a `tests/rbx/grading/` test that runs a program interleaving stdout/stderr writes and asserts the merged file ordering, plus clean stdout. FAIL → implement → PASS. Commit — `feat(grading): support merged stdout/stderr capture for batch runs (#266)`.
+
+### Task 3.4: wire the merged capture through `irun` and render it
+
+**Files:**
+- Modify: `rbx/box/solutions.py`:
+  - `SolutionReportSkeleton` — add a `merge_stderr: bool = False` field (near `capture_pipes`, ~128) so the flag rides with the run skeleton (prevents stale cached merged captures; `irun` only caches with explicit `--testcase`).
+  - `_get_interactive_skeleton` (~826-869) — set `merge_stderr` from the new param.
+  - `run_solution_on_testcase` / `_run_solution` / `_run_interactive_solutions` — thread `merge_stderr` and pass a `merged_capture` path (e.g. `output_dir / 'merged.interaction'`) into the run calls when set. (Search the run plumbing: `grep -n "merged_capture\|capture_pipes\|run_coordinated\|steps.run(" rbx/box/solutions.py`.)
+  - In `run_and_print_interactive_solutions` (~939-973): when `print and merge_stderr` and a merged-capture file exists, render it with `print_interaction(parse_interaction(merged_path))` under an `Output`/`Interaction` rule INSTEAD of the plain output + separate stderr section. Otherwise keep the Phase-2 behavior.
+
+**Step 1 (manual smoke):** With a batch solution that writes interleaved stdout/stderr:
+- `uv run rbx irun <sol> -t 0/0 -p -v4` → separate red Stderr section (default).
+- `uv run rbx irun <sol> -t 0/0 -p -e -v4` → interleaved view, stderr lines red, in true order; checker still runs on clean output.
+- Repeat for a COMMUNICATION problem; confirm stderr folds into the interaction as a 3rd color.
+
+**Step 2: Commit** — `feat(irun): render interleaved stderr with --merge-stderr (#266)`.
+
+### Task 3.5: full verification
+
+- `uv run pytest tests/rbx/box/testcase_utils_test.py -v`
+- `uv run pytest --ignore=tests/rbx/box/cli` (note pre-existing C++/sandbox/docker failures per memory — confirm only those fail).
+- `uv run ruff check . && uv run ruff format --check .`
+- Update docs: search for `irun` in `docs/` and add the `--merge-stderr`/`-e` option; verify with a non-strict mkdocs build (per memory, ignore the ~9 pre-existing `--strict` warnings).
+- Commit docs — `docs(irun): document --merge-stderr/-e option`.
+
+---
+
+## Out of scope (YAGNI)
+
+- Applying stderr display to the full `rbx run` report (issue is `irun`-only).
+- Configurable colors or per-stream filtering.
+- Timestamped interleave (line-tee ordering is sufficient).

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -76,6 +76,7 @@ from rbx.box.testcase_utils import (
     get_all_interaction_files,
     get_best_interaction_file,
     print_best_output,
+    print_stderr_section,
 )
 from rbx.grading import grading_context, steps
 from rbx.grading.async_executor import AsyncStreamer
@@ -953,6 +954,9 @@ async def run_and_print_interactive_solutions(
             console.console.rule('Output', style='status')
             output_files = [stdout_path]
             print_best_output(output_files, pkg.type, empty_warning=True)
+
+            if eval.log.stderr_absolute_path is not None:
+                print_stderr_section(eval.log.stderr_absolute_path)
         elif stdout_path is not None:
             if stdout_path.with_suffix('.pout').is_file():
                 stdout_path = stdout_path.with_suffix('.pout')

--- a/rbx/box/testcase_utils.py
+++ b/rbx/box/testcase_utils.py
@@ -243,6 +243,18 @@ def print_interaction(interaction: TestcaseInteraction):
         console.console.print(text)
 
 
+def print_stderr_section(stderr_path: Optional[pathlib.Path]) -> bool:
+    """Print captured stderr in its own section. Returns True if anything printed."""
+    if stderr_path is None or not stderr_path.is_file():
+        return False
+    content = stderr_path.read_text()
+    if not content.strip():
+        return False
+    console.console.rule('Stderr', style='error')
+    console.console.print(rich.text.Text(content.rstrip('\n'), style='error'))
+    return True
+
+
 def valid_interaction_suffixes() -> List[str]:
     return ['.interaction', '.pio']
 

--- a/rbx/box/testcase_utils.py
+++ b/rbx/box/testcase_utils.py
@@ -99,7 +99,8 @@ class TestcaseInteractionEntry(BaseModel):
 
     # The text exchanged on this line (participant prefix already stripped).
     data: str
-    # Which participant produced this line: 0 = interactor, 1 = solution.
+    # Which participant produced this line: 0 = interactor, 1 = solution,
+    # 2 = solution's stderr.
     pipe: int
 
 
@@ -214,6 +215,10 @@ def get_alternate_interaction_texts(
     interactor_entries = []
     solution_entries = []
     for entry in interaction.entries:
+        if entry.pipe == 2:
+            # stderr is not part of the two-column interactor/solution dialogue
+            # shown in statements; skip it here.
+            continue
         if entry.pipe == 1:
             solution_entries.append(entry.data + '\n')
             interactor_entries.extend(['\n'] * (entry.data.count('\n') + 1))

--- a/rbx/box/testcase_utils.py
+++ b/rbx/box/testcase_utils.py
@@ -223,6 +223,7 @@ def get_alternate_interaction_texts(
             solution_entries.append(entry.data + '\n')
             interactor_entries.extend(['\n'] * (entry.data.count('\n') + 1))
         else:
+            # entry.pipe == 0 (interactor); pipe 2 (stderr) was skipped above.
             interactor_entries.append(entry.data + '\n')
             solution_entries.extend(['\n'] * (entry.data.count('\n') + 1))
     return ''.join(interactor_entries), ''.join(solution_entries)

--- a/rbx/box/testcase_utils.py
+++ b/rbx/box/testcase_utils.py
@@ -11,6 +11,8 @@ from rbx.box.package import get_build_tests_path
 from rbx.box.schema import TaskType, Testcase
 from rbx.box.testcase_schema import TestcaseEntry
 
+STDERR_PREFIX = '!'
+
 
 class TestcasePattern(BaseModel):
     __test__ = False
@@ -165,9 +167,10 @@ def parse_interaction(file: pathlib.Path) -> TestcaseInteraction:
 
     ``.interaction`` files use the predetermined prefixes ``<`` (interactor)
     and ``>`` (solution); any other suffix (e.g. ``.pio``) reads the two
-    prefixes from the first two lines of the file. Each remaining non-empty
-    line becomes one :class:`TestcaseInteractionEntry` (no merging is done
-    here -- see :func:`merge_interaction_entries` for the chunked view).
+    prefixes from the first two lines of the file. Lines starting with ``!``
+    (the stderr prefix) become pipe 2 entries. Each remaining non-empty line
+    becomes one :class:`TestcaseInteractionEntry` (no merging is done here --
+    see :func:`merge_interaction_entries` for the chunked view).
     """
     entries = []
     with file.open('r') as f:
@@ -191,6 +194,9 @@ def parse_interaction(file: pathlib.Path) -> TestcaseInteraction:
             elif line.startswith(solution_prefix):
                 stripped = line[len(solution_prefix) :].rstrip()
                 entries.append(TestcaseInteractionEntry(data=stripped, pipe=1))
+            elif line.startswith(STDERR_PREFIX):
+                stripped = line[len(STDERR_PREFIX) :].rstrip()
+                entries.append(TestcaseInteractionEntry(data=stripped, pipe=2))
             else:
                 raise TestcaseInteractionParsingError(
                     f'Invalid line in interaction file {file}. Expected the line to start with the interactor or solution prefix ({interactor_prefix} or {solution_prefix}).'
@@ -217,13 +223,18 @@ def get_alternate_interaction_texts(
     return ''.join(interactor_entries), ''.join(solution_entries)
 
 
+def interaction_entry_style(pipe: int) -> str:
+    if pipe == 0:
+        return 'status'
+    if pipe == 2:
+        return 'error'
+    return 'info'
+
+
 def print_interaction(interaction: TestcaseInteraction):
     for entry in interaction.entries:
         text = rich.text.Text(entry.data)
-        if entry.pipe == 0:
-            text.stylize('status')
-        else:
-            text.stylize('info')
+        text.stylize(interaction_entry_style(entry.pipe))
         console.console.print(text)
 
 

--- a/rbx/box/ui/widgets/interaction_box.py
+++ b/rbx/box/ui/widgets/interaction_box.py
@@ -57,6 +57,9 @@ class InteractionBox(RichLogBox):
         for entry in interaction.entries:
             if entry.pipe == 0:
                 self.write(rich.text.Text(entry.data.rstrip(), style='green'))
+            elif entry.pipe == 2:
+                # stderr: render distinctly from the solution's stdout.
+                self.write(rich.text.Text(entry.data.rstrip(), style='red'))
             else:
                 self.write(rich.text.Text(entry.data.rstrip()))
 

--- a/tests/e2e/testdata/irun-stderr/e2e.rbx.yml
+++ b/tests/e2e/testdata/irun-stderr/e2e.rbx.yml
@@ -1,0 +1,9 @@
+scenarios:
+  - name: stderr-section
+    steps:
+      - cmd: build
+      - cmd: irun sols/main.cpp -t main/0 -p -v4
+        expect:
+          stdout_contains:
+            - "Stderr"
+            - "DBG_STDERR_MARKER"

--- a/tests/e2e/testdata/irun-stderr/gens/gen.cpp
+++ b/tests/e2e/testdata/irun-stderr/gens/gen.cpp
@@ -1,0 +1,14 @@
+#include <cstdio>
+#include <cstdlib>
+
+// Minimal generator: takes two integers as args and prints them as the input.
+// Usage: gen <a> <b>
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        return 1;
+    }
+    int a = atoi(argv[1]);
+    int b = atoi(argv[2]);
+    printf("%d %d\n", a, b);
+    return 0;
+}

--- a/tests/e2e/testdata/irun-stderr/problem.rbx.yml
+++ b/tests/e2e/testdata/irun-stderr/problem.rbx.yml
@@ -1,0 +1,21 @@
+name: irun-stderr
+timeLimit: 1000
+memoryLimit: 256
+
+generators:
+  - name: gen
+    path: gens/gen.cpp
+
+solutions:
+  - path: sols/main.cpp
+    outcome: ac
+
+testcases:
+  - name: main
+    subgroups:
+      - name: gen
+        generators:
+          - name: gen
+            args: 1 2
+          - name: gen
+            args: 3 4

--- a/tests/e2e/testdata/irun-stderr/sols/main.cpp
+++ b/tests/e2e/testdata/irun-stderr/sols/main.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+using namespace std;
+
+int main() {
+    int a, b;
+    cin >> a >> b;
+    // Distinctive debug line written to stderr; irun -p should surface it
+    // under its own "Stderr" section on stdout.
+    cerr << "DBG_STDERR_MARKER a=" << a << endl;
+    cout << a + b << endl;
+    return 0;
+}

--- a/tests/rbx/box/testcase_utils_test.py
+++ b/tests/rbx/box/testcase_utils_test.py
@@ -423,6 +423,19 @@ class TestMergeInteractionEntries:
         assert result[0].data == 'line1\nline2\nline3'
         assert result[0].pipe == 0
 
+    def test_consecutive_stderr_pipe_merged(self):
+        # Forward-compat: stderr (pipe 2) entries merge like any other pipe.
+        entries = [
+            TestcaseInteractionEntry(data='err1', pipe=2),
+            TestcaseInteractionEntry(data='err2', pipe=2),
+            TestcaseInteractionEntry(data='out1', pipe=1),
+        ]
+        result = merge_interaction_entries(entries)
+        assert len(result) == 2
+        assert result[0].data == 'err1\nerr2'
+        assert result[0].pipe == 2
+        assert result[1].pipe == 1
+
     def test_merge_then_alternate(self):
         entries = [
             TestcaseInteractionEntry(data='a1', pipe=0),

--- a/tests/rbx/box/testcase_utils_test.py
+++ b/tests/rbx/box/testcase_utils_test.py
@@ -491,6 +491,25 @@ class TestGetAlternateInteractionTexts:
         assert interactor_text == expected_interactor
         assert solution_text == expected_solution
 
+    def test_get_alternate_interaction_texts_skips_stderr(self):
+        """stderr (pipe 2) is excluded from both interactor and solution columns."""
+        entries = [
+            TestcaseInteractionEntry(data='Hello', pipe=0),
+            TestcaseInteractionEntry(data='noise', pipe=2),
+            TestcaseInteractionEntry(data='Hi', pipe=1),
+        ]
+
+        interaction = TestcaseInteraction(
+            entries=entries, prefixes=('INTERACTOR:', 'SOLUTION:')
+        )
+
+        interactor_text, solution_text = get_alternate_interaction_texts(interaction)
+
+        assert 'noise' not in interactor_text
+        assert 'noise' not in solution_text
+        assert interactor_text == 'Hello\n\n'
+        assert solution_text == '\nHi\n'
+
     def test_get_alternate_interaction_texts_with_multiline(self):
         """Test with multiline entries."""
         entries = [

--- a/tests/rbx/box/testcase_utils_test.py
+++ b/tests/rbx/box/testcase_utils_test.py
@@ -2,6 +2,7 @@ import pathlib
 from unittest import mock
 
 import pytest
+import rich.console
 import typer
 
 from rbx.box import package, testcase_utils
@@ -575,3 +576,32 @@ def test_interaction_entry_style_per_pipe():
     assert testcase_utils.interaction_entry_style(0) == 'status'
     assert testcase_utils.interaction_entry_style(1) == 'info'
     assert testcase_utils.interaction_entry_style(2) == 'error'
+
+
+def test_print_stderr_section_prints_contents(tmp_path, monkeypatch):
+    err = tmp_path / 'run.stderr'
+    err.write_text('debug: hello\n')
+
+    rec = rich.console.Console(record=True, force_terminal=False, width=80)
+    monkeypatch.setattr(testcase_utils.console, 'console', rec)
+
+    printed = testcase_utils.print_stderr_section(err)
+
+    assert printed is True
+    assert 'debug: hello' in rec.export_text()
+
+
+def test_print_stderr_section_skips_empty(tmp_path, monkeypatch):
+    err = tmp_path / 'run.stderr'
+    err.write_text('')
+    rec = rich.console.Console(record=True, width=80)
+    monkeypatch.setattr(testcase_utils.console, 'console', rec)
+
+    assert testcase_utils.print_stderr_section(err) is False
+
+
+def test_print_stderr_section_handles_missing_file(tmp_path, monkeypatch):
+    rec = rich.console.Console(record=True, width=80)
+    monkeypatch.setattr(testcase_utils.console, 'console', rec)
+    assert testcase_utils.print_stderr_section(tmp_path / 'nope.stderr') is False
+    assert testcase_utils.print_stderr_section(None) is False

--- a/tests/rbx/box/testcase_utils_test.py
+++ b/tests/rbx/box/testcase_utils_test.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 import typer
 
-from rbx.box import package
+from rbx.box import package, testcase_utils
 from rbx.box.schema import Testcase
 from rbx.box.testcase_schema import TestcaseEntry
 from rbx.box.testcase_utils import (
@@ -536,3 +536,23 @@ class TestPrintInteraction:
         # Check that both entries are printed
         assert 'Hello from interactor' in captured.out
         assert 'Hello from solution' in captured.out
+
+
+def test_parse_interaction_recognizes_stderr_prefix(tmp_path: pathlib.Path):
+    f = tmp_path / 'sample.interaction'
+    f.write_text('< 3\n! reading n\n> 1 2 3\n! done\n')
+
+    interaction = testcase_utils.parse_interaction(f)
+
+    assert [(e.pipe, e.data) for e in interaction.entries] == [
+        (0, ' 3'),
+        (2, ' reading n'),
+        (1, ' 1 2 3'),
+        (2, ' done'),
+    ]
+
+
+def test_interaction_entry_style_per_pipe():
+    assert testcase_utils.interaction_entry_style(0) == 'status'
+    assert testcase_utils.interaction_entry_style(1) == 'info'
+    assert testcase_utils.interaction_entry_style(2) == 'error'


### PR DESCRIPTION
## Summary

Adds visibility of a solution's **stderr** in `rbx irun` (#266). When `-p`/`--print` is set, the solution's captured stderr is now printed in its own distinctly-colored **"Stderr"** section right after the Output/Interaction section. This works for both batch and interactive problems with no sandbox changes.

This is **Phases 1–2** of the design. The opt-in `--merge-stderr`/`-e` flag for *true line-order interleave* (which requires refactoring the sandbox `run()` path) is tracked separately to be reviewed in pieces — see the follow-up issue.

## What's included

- **stderr as a third interaction stream** in `testcase_utils.py`: prefix marker `!` → pipe `2`, parsed by `parse_interaction`, colored via a new pure `interaction_entry_style(pipe)` helper (`error`/red). Excluded from the two-column statement view (`get_alternate_interaction_texts`).
- **`print_stderr_section(stderr_path)`** helper: prints captured stderr under a `Stderr` rule in the `error` style; returns `False` (prints nothing) for `None`/missing/whitespace-only.
- **Wiring in `irun`** (`run_and_print_interactive_solutions`): the section is shown when printing (`-p`), after Output/Interaction. The non-print path (file-path links) is unchanged.
- **Design + implementation plan docs** under `docs/plans/`.

## Testing

- `uv run pytest tests/rbx/box/testcase_utils_test.py` → **57 passed** (new tests cover parsing the `!` prefix, the per-pipe style helper, the stderr-skip in the statement view, and `print_stderr_section` for content/empty/missing/None).
- New **e2e fixture** `tests/e2e/testdata/irun-stderr/`: builds a package whose solution writes a marker to stderr, runs `irun sols/main.cpp -t main/0 -p -v4`, and asserts the `Stderr` section + marker appear in stdout. → **1 passed**.
- `uv run ruff check` / `ruff format --check` on changed files → clean.

## Follow-up

Phase 3 (`--merge-stderr`/`-e` true line-order interleave, incl. the batch sandbox `run()` tee refactor) is filed as a separate issue for staged review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
