### PR TITLE
feat(timing): share run/time reports to clipboard (#388)

### DIFF
--- a/docs/plans/2026-06-03-shareable-reports-design.md
+++ b/docs/plans/2026-06-03-shareable-reports-design.md
@@ -1,0 +1,127 @@
+# Design: Shareable run & time reports (#388)
+
+## Problem
+
+It is currently difficult to share a run report (`rbx run`) or a time report
+(`rbx time`) with another person. Both are rendered with [Rich] to the terminal
+and there is no export/share path. Issue #388 asks for an easy way to produce a
+shareable artifact (image, HTML, table — "anything shareable").
+
+## Decisions
+
+- **Formats:** PNG image + plain text.
+- **Delivery:** copy to the system clipboard.
+- **Platforms (image clipboard):** macOS + Linux. Text clipboard is
+  cross-platform. Windows / unsupported environments degrade gracefully.
+- **PNG generation:** shell out to a runtime-detected SVG→PNG converter
+  (`rsvg-convert` → ImageMagick `magick`/`convert` → macOS `qlmanage`). No new
+  Python dependency.
+- **CLI surface:** a `--share[=FORMAT]` flag on the two commands that already
+  produce these reports — `rbx run` and `rbx time`. `FORMAT ∈ {png, text}`,
+  default `png`.
+
+## UX
+
+```
+rbx run … --share         # capture report → PNG → clipboard
+rbx run … --share=text    # capture report → text → clipboard
+rbx time … --share        # same, for the estimation report
+```
+
+1. The command runs exactly as today; the live terminal output is unchanged.
+2. After the report prints, if `--share` is set, the report is re-rendered
+   statically into a recording console, converted to the chosen format, and
+   copied to the clipboard.
+3. On success: `✓ Report copied to clipboard (PNG)`.
+4. On any unsupported step (no converter, no clipboard tool, Windows image):
+   gracefully fall back to **writing a file** and printing its path. `--share`
+   never hard-fails.
+
+## What gets shared
+
+### `rbx run --share`
+The full run report, top to bottom:
+
+1. **Limits header** (`_print_limits`) — per-language time & memory limits.
+2. **Verdict view** — single-solution verbose listing, or the multi-solution
+   per-group testcase grid (captured as its final settled frame, not the live
+   animation). With `-d`, the detailed per-group tables.
+3. **Timing summary** (`_print_timing`, multi-solution) — `Time limit`,
+   `Slowest AC`, `Slowest AC-or-TLE`, `Fastest slow`, per-language when limits
+   differ.
+
+### `rbx time --share`
+A superset — the estimation report (timing.py `compute_time_limits`):
+
+1. **Run report (for time estimation)** — the run report above (verdicts +
+   timing summary; detailed tables when `-d`). Limits header suppressed.
+2. **Estimation summary** — `Fastest solution`, `Slowest solution`, the chosen
+   **formula**, and the resulting base time limit.
+3. **Final limits table** (`render_limits_table` → `build_limits_table`) — the
+   per-language-group breakdown: each row = a language group with solution
+   count, resolved time limit, and source/origin (estimated / inherited /
+   defaulted / override). This is the "detailed timing breakdown".
+
+Scope notes:
+- The pre-prompt **"Current limits"** table (cli.py, before strategy selection)
+  is **excluded** from the share — it is pre-state and redundant with the final
+  table.
+- `--share` captures whatever the command prints at the current `-d` level; it
+  does not force extra detail.
+
+## Architecture
+
+### New module: `rbx/box/sharing.py`
+The only new file. Small hooks added in `cli.py`, `solutions.py`, `timing.py`.
+
+#### Capture
+The multi-solution run report is drawn with `rich.live.Live`, so the live
+session cannot be recorded directly. Instead:
+
+- Build a `rich.console.Console(record=True)` with a fixed width.
+- **Re-render the report statically** into it after the run finishes — every
+  renderable derives from the final `RunSolutionResult` / estimation result, so
+  the report-builder functions just need to accept a target console and render
+  their final state (no `Live`). Refactor report bodies so "build renderables"
+  is separable from "print live".
+- For `time`, render the run report + estimation summary + limits table into the
+  **same** recording console so they stack into one artifact.
+
+#### Convert
+- **Text:** `record_console.export_text()`.
+- **PNG:** `record_console.export_svg(title=…)` → SVG string → shell out to the
+  first available converter (`rsvg-convert` → `magick`/`convert` → `qlmanage`).
+  If none found: save the `.svg`, print its path, hint to install a converter.
+
+#### Clipboard — `copy_to_clipboard(data, kind)`
+Platform dispatch via subprocess, no new Python deps:
+
+| | Text | PNG image |
+|---|---|---|
+| macOS | `pbcopy` | `osascript` set clipboard to `«class PNGf»` |
+| Linux (X11) | `xclip -selection clipboard` | `xclip -selection clipboard -t image/png` |
+| Linux (Wayland) | `wl-copy` | `wl-copy --type image/png` |
+| Windows / none | write file, print path | write file, print path |
+
+Detection: `sys.platform`, then `$WAYLAND_DISPLAY` vs `$DISPLAY`, then
+`shutil.which` for the tool. Every failure path degrades to writing a file.
+
+#### Flag wiring
+`--share` parsed in `cli.py` for both commands. After the normal (live) report
+prints, if set, run the static capture path and copy.
+
+## Testing
+
+- **Capture/export:** render a known report into a `record=True` console; assert
+  `export_text()` contains the expected lines (limits, verdicts, timing summary,
+  group table rows). No subprocess needed.
+- **Converter detection:** `mock.patch` `shutil.which` to simulate each
+  converter present/absent; assert the right command is built; assert SVG
+  fallback when none.
+- **Clipboard dispatch:** `mock.patch` `sys.platform`, env vars, and
+  `subprocess.run`; assert the correct tool + args per (platform, kind); assert
+  file fallback on Windows / missing tool.
+- Reuse existing pytest fixtures (`cleandir_with_testdata`, `pkg_from_testdata`)
+  for an end-to-end `--share=text` smoke test asserting clipboard content.
+
+[Rich]: https://rich.readthedocs.io/

--- a/docs/plans/2026-06-03-shareable-reports.md
+++ b/docs/plans/2026-06-03-shareable-reports.md
@@ -1,0 +1,570 @@
+# Shareable run & time reports Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `--share[=FORMAT]` flag to `rbx run` and `rbx time` that captures the rendered report and copies it to the clipboard as a PNG image or plain text (#388).
+
+**Architecture:** A new `rbx/box/sharing.py` module owns three concerns: (1) *capture* — re-render a report into a `rich.console.Console(record=True)` and export it as text or SVG; (2) *convert* — turn SVG into PNG by shelling out to a runtime-detected converter; (3) *clipboard* — copy text/image via platform-specific CLI tools, falling back to writing a file. The two CLI commands re-render their final report into a recording console after the normal live output, then hand off to `sharing`.
+
+**Tech Stack:** Python, Rich (`Console(record=True)`, `export_text`/`export_svg`), `subprocess`/`shutil.which`, Typer, pytest + `unittest.mock`.
+
+**Key insight:** `rich.live.Live` only animates when `console.is_terminal` is true. A recording `Console` built without `force_terminal` is **not** a terminal, so re-rendering the existing report functions into it yields a clean final frame — no reporter rewrite needed.
+
+---
+
+### Background: design
+
+Read `docs/plans/2026-06-03-shareable-reports-design.md` first. It defines exactly what each command shares. Summary:
+- `rbx run --share` → limits header + verdict view (+ `-d` detailed tables) + timing summary.
+- `rbx time --share` → the "Run report (for time estimation)" + the final per-language-group limits table (`build_limits_table`). (Optional: the fastest/slowest/formula estimation lines.)
+
+Key existing symbols:
+- `rbx/console.py`: `theme`, `console.console` (global), `new_console()`, `capture_ansi()`.
+- `rbx/box/solutions.py`: `async print_run_report(result, console, verification, detailed=False, timing=True, skip_printing_limits=False)`.
+- `rbx/box/limits_info.py`: `build_limits_table(profile, title=...) -> rich.table.Table`, `render_limits_table(profile, title=...)`.
+- `rbx/box/cli.py`: the `run` command (~line 303) and `time` command (~line 463).
+
+Run tests with `uv run pytest <path> -v`. Lint with `uv run ruff check rbx/box/sharing.py`.
+
+---
+
+### Task 1: Converter detection + SVG→PNG
+
+**Files:**
+- Create: `rbx/box/sharing.py`
+- Test: `tests/rbx/box/test_sharing.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/rbx/box/test_sharing.py
+from unittest import mock
+
+from rbx.box import sharing
+
+
+def test_detect_png_converter_prefers_rsvg(monkeypatch):
+    monkeypatch.setattr(
+        sharing.shutil, 'which',
+        lambda name: f'/usr/bin/{name}' if name == 'rsvg-convert' else None,
+    )
+    conv = sharing.detect_png_converter()
+    assert conv is not None
+    assert conv.tool == 'rsvg-convert'
+
+
+def test_detect_png_converter_none_available(monkeypatch):
+    monkeypatch.setattr(sharing.shutil, 'which', lambda name: None)
+    assert sharing.detect_png_converter() is None
+
+
+def test_svg_to_png_invokes_converter(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sharing.shutil, 'which',
+        lambda name: f'/usr/bin/{name}' if name == 'magick' else None,
+    )
+    calls = []
+    monkeypatch.setattr(
+        sharing.subprocess, 'run',
+        lambda *a, **k: calls.append((a, k)) or mock.Mock(returncode=0),
+    )
+    out = sharing.svg_to_png('<svg/>', tmp_path / 'r.png')
+    assert out == tmp_path / 'r.png'
+    assert calls, 'converter should have been invoked'
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_sharing.py -v`
+Expected: FAIL — `ModuleNotFoundError: rbx.box.sharing`.
+
+**Step 3: Write minimal implementation**
+
+```python
+# rbx/box/sharing.py
+import dataclasses
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+# Ordered preference of SVG->PNG converters. Each entry builds the argv given
+# (svg_path, png_path).
+_CONVERTERS = [
+    ('rsvg-convert', lambda svg, png: ['rsvg-convert', str(svg), '-o', str(png)]),
+    ('magick', lambda svg, png: ['magick', str(svg), str(png)]),
+    ('convert', lambda svg, png: ['convert', str(svg), str(png)]),
+    ('qlmanage', lambda svg, png: ['qlmanage', '-t', '-o', str(png.parent), str(svg)]),
+]
+
+
+@dataclasses.dataclass
+class PngConverter:
+    tool: str
+    build_argv: object  # Callable[[Path, Path], List[str]]
+
+
+def detect_png_converter() -> Optional[PngConverter]:
+    for tool, build in _CONVERTERS:
+        if shutil.which(tool) is not None:
+            return PngConverter(tool=tool, build_argv=build)
+    return None
+
+
+def svg_to_png(svg: str, png_path: Path) -> Optional[Path]:
+    """Convert SVG text to a PNG file. Returns the path on success, None if no
+    converter is available."""
+    converter = detect_png_converter()
+    if converter is None:
+        return None
+    with tempfile.NamedTemporaryFile('w', suffix='.svg', delete=False) as f:
+        f.write(svg)
+        svg_path = Path(f.name)
+    try:
+        argv = converter.build_argv(svg_path, png_path)
+        subprocess.run(argv, check=True, capture_output=True)
+    finally:
+        svg_path.unlink(missing_ok=True)
+    return png_path
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_sharing.py -v`
+Expected: PASS (3 tests).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/sharing.py tests/rbx/box/test_sharing.py
+git commit -m "feat(sharing): detect svg-to-png converter and convert"
+```
+
+> Note: `qlmanage` names its output `<svg-stem>.png` in the target dir, not the exact `png_path`. Handle in Task 1b if you choose to support it; otherwise the `rsvg-convert`/`magick` paths are primary. Keep `qlmanage` last.
+
+---
+
+### Task 2: Clipboard dispatch with file fallback
+
+**Files:**
+- Modify: `rbx/box/sharing.py`
+- Test: `tests/rbx/box/test_sharing.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_copy_text_macos_uses_pbcopy(monkeypatch):
+    monkeypatch.setattr(sharing.sys, 'platform', 'darwin')
+    captured = {}
+    def fake_run(argv, input=None, **k):
+        captured['argv'] = argv
+        captured['input'] = input
+        return mock.Mock(returncode=0)
+    monkeypatch.setattr(sharing.subprocess, 'run', fake_run)
+    monkeypatch.setattr(sharing.shutil, 'which', lambda n: '/usr/bin/pbcopy')
+    assert sharing.copy_text_to_clipboard('hello') is True
+    assert captured['argv'] == ['pbcopy']
+    assert captured['input'] == b'hello'
+
+
+def test_copy_text_linux_wayland_uses_wl_copy(monkeypatch):
+    monkeypatch.setattr(sharing.sys, 'platform', 'linux')
+    monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-0')
+    monkeypatch.setattr(sharing.shutil, 'which',
+                        lambda n: '/usr/bin/wl-copy' if n == 'wl-copy' else None)
+    seen = {}
+    monkeypatch.setattr(sharing.subprocess, 'run',
+                        lambda argv, input=None, **k: seen.update(argv=argv) or mock.Mock(returncode=0))
+    assert sharing.copy_text_to_clipboard('x') is True
+    assert seen['argv'][0] == 'wl-copy'
+
+
+def test_copy_image_unsupported_returns_false(monkeypatch):
+    monkeypatch.setattr(sharing.sys, 'platform', 'win32')
+    assert sharing.copy_image_to_clipboard(sharing.Path('/tmp/x.png')) is False
+```
+
+**Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/rbx/box/test_sharing.py -v`
+Expected: FAIL — functions not defined.
+
+**Step 3: Implement**
+
+```python
+import os
+import sys
+
+
+def _linux_clipboard_tool() -> Optional[str]:
+    if os.environ.get('WAYLAND_DISPLAY') and shutil.which('wl-copy'):
+        return 'wl-copy'
+    if shutil.which('xclip'):
+        return 'xclip'
+    if shutil.which('wl-copy'):
+        return 'wl-copy'
+    return None
+
+
+def copy_text_to_clipboard(text: str) -> bool:
+    data = text.encode('utf-8')
+    if sys.platform == 'darwin' and shutil.which('pbcopy'):
+        argv: Optional[List[str]] = ['pbcopy']
+    elif sys.platform.startswith('linux'):
+        tool = _linux_clipboard_tool()
+        if tool == 'xclip':
+            argv = ['xclip', '-selection', 'clipboard']
+        elif tool == 'wl-copy':
+            argv = ['wl-copy']
+        else:
+            argv = None
+    else:
+        argv = None
+    if argv is None:
+        return False
+    result = subprocess.run(argv, input=data, capture_output=True)
+    return result.returncode == 0
+
+
+def copy_image_to_clipboard(png_path: Path) -> bool:
+    if sys.platform == 'darwin':
+        script = (
+            f'set the clipboard to '
+            f'(read (POSIX file "{png_path}") as «class PNGf»)'
+        )
+        result = subprocess.run(['osascript', '-e', script], capture_output=True)
+        return result.returncode == 0
+    if sys.platform.startswith('linux'):
+        tool = _linux_clipboard_tool()
+        data = png_path.read_bytes()
+        if tool == 'xclip':
+            argv = ['xclip', '-selection', 'clipboard', '-t', 'image/png']
+        elif tool == 'wl-copy':
+            argv = ['wl-copy', '--type', 'image/png']
+        else:
+            return False
+        result = subprocess.run(argv, input=data, capture_output=True)
+        return result.returncode == 0
+    return False
+```
+
+**Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/rbx/box/test_sharing.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/sharing.py tests/rbx/box/test_sharing.py
+git commit -m "feat(sharing): copy text and image to clipboard with fallback"
+```
+
+---
+
+### Task 3: Capture a report into a recording console + top-level `share_report`
+
+**Files:**
+- Modify: `rbx/box/sharing.py`
+- Test: `tests/rbx/box/test_sharing.py`
+
+This task adds (a) a recording-console factory, (b) export helpers, and (c) the orchestrator `share_report` that picks format → convert → clipboard → file fallback, returning a small result object so callers can print a confirmation.
+
+**Step 1: Write the failing tests**
+
+```python
+import rich.text
+
+from rbx.box import sharing
+
+
+def test_recording_console_is_not_a_terminal():
+    rec = sharing.recording_console(width=80)
+    assert rec.record is True
+    assert rec.is_terminal is False  # so rich.live.Live won't animate
+
+
+def test_export_text_captures_rendered_content():
+    rec = sharing.recording_console(width=80)
+    rec.print(rich.text.Text('Timing summary: 123 ms'))
+    text = sharing.export_text(rec)
+    assert 'Timing summary: 123 ms' in text
+
+
+def test_share_report_text_copies_to_clipboard(monkeypatch, tmp_path):
+    rec = sharing.recording_console(width=80)
+    rec.print('hello world')
+    monkeypatch.setattr(sharing, 'copy_text_to_clipboard', lambda t: True)
+    result = sharing.share_report(rec, fmt='text', title='t', out_dir=tmp_path)
+    assert result.copied is True
+    assert result.fmt == 'text'
+    assert result.file_path is None
+
+
+def test_share_report_text_falls_back_to_file(monkeypatch, tmp_path):
+    rec = sharing.recording_console(width=80)
+    rec.print('hello world')
+    monkeypatch.setattr(sharing, 'copy_text_to_clipboard', lambda t: False)
+    result = sharing.share_report(rec, fmt='text', title='t', out_dir=tmp_path)
+    assert result.copied is False
+    assert result.file_path is not None and result.file_path.exists()
+    assert 'hello world' in result.file_path.read_text()
+```
+
+**Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/rbx/box/test_sharing.py -v`
+Expected: FAIL.
+
+**Step 3: Implement**
+
+```python
+import rich.console
+
+from rbx import console as _console  # for the shared theme
+
+
+def recording_console(width: int = 120) -> rich.console.Console:
+    return rich.console.Console(
+        theme=_console.theme,
+        style='info',
+        highlight=False,
+        record=True,
+        width=width,
+        # No force_terminal: keeps is_terminal False so Live renders final frame.
+    )
+
+
+def export_text(rec: rich.console.Console) -> str:
+    return rec.export_text()
+
+
+def export_svg(rec: rich.console.Console, title: str) -> str:
+    return rec.export_svg(title=title)
+
+
+@dataclasses.dataclass
+class ShareResult:
+    fmt: str
+    copied: bool
+    file_path: Optional[Path] = None
+
+
+def share_report(
+    rec: rich.console.Console,
+    fmt: str,
+    title: str,
+    out_dir: Path,
+) -> ShareResult:
+    """Convert a recorded report to `fmt` ('png'|'text') and copy to clipboard.
+    Falls back to writing a file under out_dir if clipboard/convert is
+    unavailable."""
+    if fmt == 'text':
+        text = export_text(rec)
+        if copy_text_to_clipboard(text):
+            return ShareResult(fmt='text', copied=True)
+        path = out_dir / 'report.txt'
+        path.write_text(text)
+        return ShareResult(fmt='text', copied=False, file_path=path)
+
+    # fmt == 'png'
+    svg = export_svg(rec, title=title)
+    png_path = out_dir / 'report.png'
+    if svg_to_png(svg, png_path) is not None and copy_image_to_clipboard(png_path):
+        return ShareResult(fmt='png', copied=True, file_path=png_path)
+    # Could not convert and/or copy: persist whichever artifact we have.
+    if png_path.exists():
+        return ShareResult(fmt='png', copied=False, file_path=png_path)
+    svg_path = out_dir / 'report.svg'
+    svg_path.write_text(svg)
+    return ShareResult(fmt='png', copied=False, file_path=svg_path)
+```
+
+> `out_dir` should be a stable, discoverable location — use the package build dir. The CLI tasks pass `package.get_problem_build_path()` (or the closest existing build-dir helper; confirm the exact name in `rbx/box/package.py`).
+
+**Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/rbx/box/test_sharing.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/sharing.py tests/rbx/box/test_sharing.py
+git commit -m "feat(sharing): record reports and orchestrate share with fallback"
+```
+
+---
+
+### Task 4: Wire `--share` into `rbx run`
+
+**Files:**
+- Modify: `rbx/box/cli.py` (the `run` command, ~line 303; report print ~line 432)
+- Test: `tests/rbx/box/test_sharing.py` (capture-content unit test) + manual
+
+**Step 1: Add the flag.** In the `run` signature add:
+
+```python
+    share: Optional[str] = typer.Option(
+        None,
+        '--share',
+        help='Capture the run report and copy it to the clipboard. '
+        'Optionally specify a format: --share=png (default) or --share=text.',
+    ),
+```
+
+Typer note: to allow both `--share` (flag-like, default png) and `--share=text`, declare it as `Optional[str]` with no value meaning "not requested". Treat the empty/sentinel case: if the user passes bare `--share`, Typer needs a value. To support a bare flag, add a separate boolean is overkill; instead accept `--share png|text` and document `--share png`. If a true bare flag is desired, use a custom callback — keep it simple: require an explicit value, default examples in help.
+
+> Decision for this plan: `--share` takes an explicit value `png|text`. Validate it: if `share not in (None, 'png', 'text')`, print an error and `raise typer.Exit(1)`.
+
+**Step 2: After the existing report print**, add the capture path. Replace the existing `await print_run_report(...)` tail with:
+
+```python
+    await print_run_report(
+        solution_result,
+        console.console,
+        VerificationLevel(verification),
+        detailed=detailed,
+        skip_printing_limits=sanitized,
+    )
+
+    if share is not None:
+        from rbx.box import sharing
+
+        rec = sharing.recording_console()
+        await print_run_report(
+            solution_result,
+            rec,
+            VerificationLevel(verification),
+            detailed=detailed,
+            skip_printing_limits=sanitized,
+        )
+        result = sharing.share_report(
+            rec, fmt=share, title='rbx run report',
+            out_dir=package.get_problem_build_path(),
+        )
+        _print_share_result(result)  # small helper printing ✓/fallback line
+```
+
+Add `_print_share_result` near the command (or in `sharing.py` as `print_share_result(console, result)`):
+
+```python
+def print_share_result(console, result) -> None:
+    if result.copied:
+        console.print(f'[success]✓ Report copied to clipboard ({result.fmt.upper()}).[/success]')
+    elif result.file_path is not None:
+        console.print(
+            f'[warning]Could not copy to clipboard; wrote report to '
+            f'[item]{result.file_path}[/item].[/warning]'
+        )
+    else:
+        console.print('[error]Failed to share report.[/error]')
+```
+
+**Step 3: Test (capture content).** Add a test that re-rendering produces expected text. Reuse a package fixture:
+
+```python
+# tests/rbx/box/test_sharing.py
+import pytest
+
+@pytest.mark.test_pkg('...')  # pick an existing fixture pkg with solutions
+async def test_run_report_capture_contains_verdicts(pkg_from_testdata, ...):
+    # Build solution_result via the existing run path, render into recording
+    # console, assert export_text() contains a known solution name / 'Timing'.
+    ...
+```
+
+> If wiring a full run in a unit test is heavy, rely on Task 3's unit tests for `sharing` and verify `run --share` manually (Step 4). Do not over-invest here.
+
+**Step 4: Manual verification.**
+
+Run inside a test package:
+`uv run rbx run --share=text`
+Expected: normal report, then `✓ Report copied to clipboard (TEXT).`; paste shows the report.
+`uv run rbx run --share=png` (with `rsvg-convert`/ImageMagick installed): image on clipboard.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/cli.py rbx/box/sharing.py tests/rbx/box/test_sharing.py
+git commit -m "feat(run): add --share to copy run report to clipboard"
+```
+
+---
+
+### Task 5: Wire `--share` into `rbx time`
+
+**Files:**
+- Modify: `rbx/box/cli.py` (`time` command), `rbx/box/timing.py` (`compute_time_limits`)
+- Test: `tests/rbx/box/test_sharing.py`
+
+**Goal:** `time --share` captures the run report (for estimation) + the final per-language-group limits table. (Estimation fastest/slowest/formula lines are optional polish — include only if cheap.)
+
+**Step 1:** Add the same `--share` option to the `time` command signature and validation as Task 4.
+
+**Step 2:** Thread capture into `compute_time_limits`. It already holds `solution_result` and computes `estimated_tl` (a `LimitsProfile`). Add a `share: Optional[str] = None` parameter and, at the end (after `render_limits_table`), build a recording console and render the two pieces into it:
+
+```python
+    if share is not None:
+        from rbx.box import sharing
+
+        rec = sharing.recording_console()
+        await print_run_report(
+            solution_result, rec, VerificationLevel(verification),
+            detailed=detailed, skip_printing_limits=True,
+        )
+        rec.print()
+        rec.print(limits_info.build_limits_table(limits, title=f'Time limits ({profile})'))
+        result = sharing.share_report(
+            rec, fmt=share, title='rbx time report',
+            out_dir=package.get_problem_build_path(),
+        )
+        sharing.print_share_result(console.console, result)
+```
+
+Pass `share` from the `time` CLI command into `compute_time_limits(... , share=share)`.
+
+> `build_limits_table` returns a `rich.table.Table` (already used by `render_limits_table`). Reuse it — do not re-implement. Confirm `limits` here is the `LimitsProfile` that `render_limits_table` was called with.
+
+**Step 3: Test.** Unit-test the assembly by rendering a known `LimitsProfile` table into a recording console and asserting `export_text` contains a group/time figure. Reuse Task 3 helpers; mock the clipboard.
+
+**Step 4: Manual verification.**
+`uv run rbx time -s estimate --share=text`
+Expected: after estimation, `✓ Report copied to clipboard (TEXT).`; pasted text contains the run report **and** the language-group limits table.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/cli.py rbx/box/timing.py tests/rbx/box/test_sharing.py
+git commit -m "feat(time): add --share to copy estimation report to clipboard"
+```
+
+---
+
+### Task 6: Docs + lint + full test sweep
+
+**Files:**
+- Modify: relevant docs page for `rbx run` / `rbx time` (search `docs/` for the commands).
+- Modify: `rbx/box/CLAUDE.md` if it documents the reporting flow.
+
+**Steps:**
+1. Document the `--share` flag (formats, clipboard behavior, required converters for PNG: install `rsvg-convert` or ImageMagick; Linux needs `xclip`/`wl-copy`). Run `mise run docs` or the project's docs check per CLAUDE.md (use non-strict build; ~9 pre-existing strict warnings are unrelated).
+2. `uv run ruff check rbx/box/sharing.py rbx/box/cli.py rbx/box/timing.py && uv run ruff format rbx/box/sharing.py`
+3. `uv run pytest tests/rbx/box/test_sharing.py -v`
+4. `uv run pytest --ignore=tests/rbx/box/cli -n auto` (note pre-existing local C++/sandbox/docker failures per project memory — unrelated to this change).
+5. Commit docs:
+
+```bash
+git add docs/ rbx/box/CLAUDE.md
+git commit -m "docs(timing): document --share for run and time reports"
+```
+
+---
+
+## Open items / risks to validate during execution
+
+1. **Live final-frame capture.** Confirm `print_run_report` rendered into a non-terminal recording console produces the full final grid (not blank). If `LiveRunReporter` suppresses output entirely off-terminal, add a `static: bool` path to the reporter that prints the final table directly. Validate this **first** in Task 4 Step 4 before polishing.
+2. **Re-evaluation cost/side-effects.** Re-calling `print_run_report` for capture re-invokes the deferred `await eval()`s. These should be cached; confirm no real re-execution happens. If they do re-run, capture from the first render instead (pass the recording console as a tee is not possible — instead render once into the recorder and replay its text to the live console, or have the reporter expose its final renderable).
+3. **`qlmanage` output naming** differs; keep it last and treat its presence as best-effort.
+4. **`out_dir` helper name** — confirm the exact build-path accessor in `rbx/box/package.py`.

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -12,9 +12,10 @@ rbx [OPTIONS]
 | :--- | :--- | :--- | :--- |
 | `-c`, `--cache` | [CacheLevel][rbx.grading.grading_context.CacheLevel] | Which degree of caching to use. | `CACHE_ALL` |
 | `--sanitized`, `-s` | BOOLEAN | Whether to compile and run testlib components with sanitizers enabled. If you want to run the solutions with sanitizers enabled, use the "-s" flag in the corresponding run command. | `False` |
-| `--nocapture` | BOOLEAN | Whether to save extra logs and outputs from interactive solutions. | `True` |
+| `--capture`, `-cp` | BOOLEAN | Whether to save extra logs and outputs from interactive solutions. | `False` |
 | `-p`, `--profile` | TEXT | Which timing profile to use when running solutions. | - |
 | `--profiling` | BOOLEAN | Whether to profile (capture performance statistics) of the execution. | `False` |
+| `-C`, `--contest` | TEXT | Select a contest variant by id (when contest.rbx.yml has use_variants: true). Defaults to the RBX_CONTEST env var. | - |
 | `--version`, `-v` | BOOLEAN | - | `False` |
 
 
@@ -121,12 +122,13 @@ rbx run <SOLUTIONS> [OPTIONS]
 | :--- | :--- | :--- | :--- |
 | `--verification-level`, `--verification`, `-v` | INTEGER of [VerificationLevel][rbx.box.environment.VerificationLevel] | Verification level to use when building package. | `4` |
 | `--outcome`, `-o` | TEXT | Include only solutions whose expected outcomes intersect with this. | - |
-| `--tag`, `-t` | TEXT | Include only solutions whose tags intersect with this. | - |
+| `--tag` | TEXT | Include only solutions whose tags intersect with this. | - |
 | `--check` | BOOLEAN | Whether to not build outputs for tests and run checker. | `True` |
 | `--validate` | BOOLEAN | Whether to not validate outputs for tests. | `True` |
 | `--detailed`, `-d` | BOOLEAN | Whether to print a detailed view of the tests using tables. | `False` |
 | `--sanitized`, `-s` | BOOLEAN | Whether to compile the solutions with sanitizers enabled. | `False` |
 | `--choice`, `--choose`, `-c` | BOOLEAN | Whether to pick solutions interactively. | `False` |
+| `--share` | TEXT | Capture the run report and copy it to the clipboard. Pass a format: --share png or --share text. | - |
 
 
 ---
@@ -166,6 +168,7 @@ rbx time [OPTIONS]
 | `--runs`, `-r` | INTEGER | Number of runs to perform for each solution. Zero means the config default. | `0` |
 | `--profile`, `-p` | TEXT | Profile to use for time limit estimation. | `local` |
 | `--integrate`, `-i` | BOOLEAN | Integrate the given limits profile into the package. | `False` |
+| `--share` | TEXT | Capture the time report (run report + limits table) and copy it to the clipboard. Pass a format: --share png or --share text. | - |
 
 
 ---
@@ -189,7 +192,7 @@ rbx irun <SOLUTIONS> [OPTIONS]
 | :--- | :--- | :--- | :--- |
 | `--verification-level`, `--verification`, `-v` | INTEGER of [VerificationLevel][rbx.box.environment.VerificationLevel] | Verification level to use when building package. | `4` |
 | `--outcome`, `-o` | TEXT | Include only solutions whose expected outcomes intersect with this. | - |
-| `--tag`, `-t` | TEXT | Include only solutions whose tags intersect with this. | - |
+| `--tag` | TEXT | Include only solutions whose tags intersect with this. | - |
 | `--check` | BOOLEAN | Whether to not build outputs for tests and run checker. | `True` |
 | `--validate` | BOOLEAN | Whether to validate inputs. | `True` |
 | `--generator`, `-g` | TEXT | Generator call to use to generate a single test for execution. | - |
@@ -216,6 +219,7 @@ rbx create [OPTIONS]
 | :--- | :--- | :--- | :--- |
 | `--name` | TEXT | Name of the problem to create, which will be used as the name of the new folder. | - |
 | `--preset` | TEXT | Preset to use when creating the problem. | - |
+| `--local` | BOOLEAN | Whether to use a preset from the local version of rbx, instead of the global one (not recommended). | `False` |
 
 
 ---
@@ -257,6 +261,7 @@ rbx stress <NAME> [OPTIONS]
 | `--fuzz` | BOOLEAN | Whether to fuzz generator calls from all testgroups. | `False` |
 | `--fuzz-on` | TEXT | Testgroups to fuzz generator calls from. | - |
 | `--validate` | BOOLEAN | Whether to validate inputs. | `True` |
+| `--reference`, `-r` | TEXT | Reference solution to use for the stress test. | - |
 
 
 ---
@@ -510,7 +515,7 @@ rbx statements build <NAMES> [OPTIONS]
 | :--- | :--- | :--- | :--- |
 | `--verification-level`, `--verification`, `-v` | INTEGER of [VerificationLevel][rbx.box.environment.VerificationLevel] | Verification level to use when building package. | `4` |
 | `--languages` | TEXT | Languages to build statements for. If not specified, build statements for all available languages. | - |
-| `--output` | [StatementType][rbx.box.statements.schema.StatementType] | Output type to be generated. If not specified, will infer from the conversion steps specified in the package. | `PDF` |
+| `--output` | [StatementType][rbx.box.statements.schema.StatementType] | Output type to be generated. | `PDF` |
 | `--samples` | BOOLEAN | Whether to build the statement with samples or not. | `True` |
 | `--vars` | TEXT | Variables to be used in the statements. | - |
 | `--validate` | BOOLEAN | Whether to validate outputs for testcases or not. | `True` |
@@ -533,54 +538,48 @@ rbx download [OPTIONS]
 
 ### testlib
 
-Download the latest testlib.h. Always re-fetches from upstream.
+Download the latest testlib.h
 
 **Usage:**
 ```bash
 rbx download testlib [OPTIONS]
 ```
 
-**Options:**
-
-| Name | Description |
-| :--- | :--- |
-| `--into PATH` | Path (relative to the package root) where the file should be placed. Parent directories are created automatically. If omitted, the file is written to the current directory. |
+| Name | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `--into` | TEXT | Path (relative to the package root) where the file should be placed. Parent directories are created automatically. If omitted, the file is written to the current directory. | - |
 
 
 ---
 
 ### jngen
 
-Download the latest jngen.h. Always re-fetches from upstream.
+Download the latest jngen.h
 
 **Usage:**
 ```bash
 rbx download jngen [OPTIONS]
 ```
 
-**Options:**
-
-| Name | Description |
-| :--- | :--- |
-| `--into PATH` | Path (relative to the package root) where the file should be placed. Parent directories are created automatically. If omitted, the file is written to the current directory. |
+| Name | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `--into` | TEXT | Path (relative to the package root) where the file should be placed. Parent directories are created automatically. If omitted, the file is written to the current directory. | - |
 
 
 ---
 
 ### tgen
 
-Download the latest tgen.h. Always re-fetches from upstream.
+Download the latest tgen.h
 
 **Usage:**
 ```bash
 rbx download tgen [OPTIONS]
 ```
 
-**Options:**
-
-| Name | Description |
-| :--- | :--- |
-| `--into PATH` | Path (relative to the package root) where the file should be placed. Parent directories are created automatically. If omitted, the file is written to the current directory. |
+| Name | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `--into` | TEXT | Path (relative to the package root) where the file should be placed. Parent directories are created automatically. If omitted, the file is written to the current directory. | - |
 
 
 ---
@@ -651,6 +650,7 @@ rbx presets create [OPTIONS]
 | `--name` | TEXT | The name of the preset to create. This will also be the name of the folder. | - |
 | `--uri` | TEXT | The URI of the new preset. | - |
 | `--preset`, `-p` | TEXT | The URI of the preset to init the new preset from. | - |
+| `--local` | BOOLEAN | Whether to fetch the init preset from the local version of rbx, instead of the remote one (not recommended). | `False` |
 
 
 ---
@@ -726,6 +726,7 @@ rbx package polygon [OPTIONS]
 | `--upload-as-english` | BOOLEAN | If set, will force the main statement to be uploaded in English. | `False` |
 | `--upload-only` | TEXT | Only upload the following types of assets to Polygon. | - |
 | `--upload-skip` | TEXT | Skip uploading the following types of assets to Polygon. | - |
+| `--upload-tests-raw` | BOOLEAN | Upload built test inputs directly instead of relying on Polygon-side generators. Skips generator uploads and clears the test script. All test inputs must be < 1 MiB. Forces a full local build. Requires --upload. | `False` |
 | `--validate-statement` | BOOLEAN | If set, will validate the statement for Polygon. | `False` |
 
 
@@ -791,6 +792,10 @@ Manage contests (sub-command).
 rbx contest [OPTIONS]
 ```
 
+| Name | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `-C`, `--contest` | TEXT | Select a contest variant by id. | - |
+
 
 ---
 
@@ -808,6 +813,7 @@ rbx contest create [OPTIONS]
 | `--path` | TEXT | Path where to create the contest. | - |
 | `--preset`, `-p` | TEXT | Which preset to use to create this package. Can be a named of an already installed preset, or an URI, in which case the preset will be downloaded.
 If not provided, the default preset will be used, or the active preset if any. | - |
+| `--local` | BOOLEAN | Whether to use a preset from the local version of rbx, instead of the global one (not recommended). | `False` |
 
 
 ---
@@ -825,6 +831,28 @@ rbx contest init [OPTIONS]
 | :--- | :--- | :--- | :--- |
 | `--preset`, `-p` | TEXT | Which preset to use to create this package. Can be a named of an already installed preset, or an URI, in which case the preset will be downloaded.
 If not provided, the default preset will be used, or the active preset if any. | - |
+
+
+---
+
+### add_variant (av)
+
+Scaffold a new contest variant file.
+
+**Usage:**
+```bash
+rbx contest add_variant <VARIANT_ID> [OPTIONS]
+```
+
+**Arguments:**
+
+| Name | Description | Required |
+| :--- | :--- | :--- |
+| `VARIANT_ID` | Id of the new variant. Must match ^[A-Za-z][A-Za-z0-9_-]*$. | Yes |
+
+| Name | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `--preset`, `-p` | TEXT | Preset to scaffold the variant from. Defaults to the active preset in the current directory, then the default preset. | - |
 
 
 ---
@@ -919,6 +947,18 @@ rbx contest summary [OPTIONS]
 
 ---
 
+### list (ls)
+
+List all contests in the current directory.
+
+**Usage:**
+```bash
+rbx contest list [OPTIONS]
+```
+
+
+---
+
 ### statements (st)
 
 Manage contest-level statements.
@@ -951,7 +991,7 @@ rbx contest statements build <NAMES> [OPTIONS]
 | `--verification-level`, `--verification`, `-v` | INTEGER of [VerificationLevel][rbx.box.environment.VerificationLevel] | Verification level to use when building package. | `4` |
 | `--languages` | TEXT | Languages to build statements for. If not specified, build statements for all available languages. | - |
 | `--validate` | BOOLEAN | Whether to validate outputs for testcases or not. | `True` |
-| `--output` | [StatementType][rbx.box.statements.schema.StatementType] | Output type to be generated. If not specified, will infer from the conversion steps specified in the package. | `PDF` |
+| `--output` | [StatementType][rbx.box.statements.schema.StatementType] | Output type to be generated. | `PDF` |
 | `--samples` | BOOLEAN | Whether to build the statement with samples or not. | `True` |
 | `--vars` | TEXT | Variables to be used in the statements. | - |
 | `--install-tex` | BOOLEAN | Whether to install missing LaTeX packages. | `False` |
@@ -1143,6 +1183,18 @@ rbx tool boca view [OPTIONS]
 | Name | Type | Description | Default |
 | :--- | :--- | :--- | :--- |
 | `--contest-id`, `-c` | TEXT | Contest identifier to load (stored under app data). | - |
+
+
+---
+
+#### submit
+
+Submit solutions to BOCA.
+
+**Usage:**
+```bash
+rbx tool boca submit [OPTIONS]
+```
 
 
 ---

--- a/docs/setters/running/index.md
+++ b/docs/setters/running/index.md
@@ -53,6 +53,38 @@ animation below.
 
 {{ asciinema("6XYQ11Cv1HZ8TuTiCFXBXXM29") }}
 
+## Sharing a report
+
+Sometimes you want to send a run report (or a time-estimation report) to someone
+else. The `--share` flag captures the report exactly as it appears in your
+terminal and copies it to your **clipboard**, ready to paste into a chat, an
+issue, or an email.
+
+```bash
+# Copy the run report to the clipboard as an image (PNG)
+rbx run --share png
+
+# Copy it as plain text instead
+rbx run --share text
+
+# Works for the time-estimation report too — this captures the run report
+# *and* the per-language-group time limits table
+rbx time --share png
+```
+
+A few things to keep in mind:
+
+- `--share png` requires an **SVG-to-PNG converter** on your `PATH`. {{rbx}}
+  looks for `rsvg-convert`, then ImageMagick (`magick`/`convert`), then macOS
+  `qlmanage`. If none is found, the report is saved as an SVG file instead and
+  its path is printed.
+- Copying an **image** to the clipboard is supported on **macOS** and **Linux**
+  (the latter needs `xclip` or `wl-copy`). On other platforms — or when no
+  clipboard tool is available — the report is written to a file in your build
+  directory and its path is printed, so you never lose the artifact.
+- `--share text` works everywhere a clipboard tool is available, and falls back
+  to a file otherwise.
+
 ## Running tests with custom inputs
 
 You might want to run your solutions on a testcase that is not part of the testset, or even on a specific

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -544,7 +544,19 @@ async def time(
         '-i',
         help='Integrate the given limits profile into the package.',
     ),
+    share: Optional[str] = typer.Option(
+        None,
+        '--share',
+        help='Capture the time report (run report + limits table) and copy it '
+        'to the clipboard. Pass a format: --share png or --share text.',
+    ),
 ):
+    if share is not None and share not in ('png', 'text'):
+        console.console.print(
+            f'[error]Invalid --share format: {share!r} (use png or text).[/error]'
+        )
+        raise typer.Exit(1)
+
     current_profile = limits_info.get_display_limits_profile(profile)
     if current_profile is None:
         current_profile = limits_info.get_limits_profile(profile)
@@ -628,7 +640,7 @@ async def time(
         return None
 
     await timing.compute_time_limits(
-        check, detailed, runs, formula=formula, profile=profile, auto=auto
+        check, detailed, runs, formula=formula, profile=profile, auto=auto, share=share
     )
 
 

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -461,15 +461,7 @@ async def run(
             detailed=detailed,
             skip_printing_limits=sanitized,
         )
-        out_dir = package.get_build_path()
-        out_dir.mkdir(parents=True, exist_ok=True)
-        result = sharing.share_report(
-            rec,
-            fmt=share,
-            title='rbx run report',
-            out_dir=out_dir,
-        )
-        sharing.print_share_result(console.console, result)
+        sharing.capture_and_share(rec, fmt=share, title='rbx run report')
 
 
 @app.command(

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -364,6 +364,12 @@ async def run(
         'Pass a format: --share png or --share text.',
     ),
 ):
+    if share is not None and share not in ('png', 'text'):
+        console.console.print(
+            f'[error]Invalid --share format: {share!r} (use png or text).[/error]'
+        )
+        raise typer.Exit(1)
+
     main_solution = package.get_main_solution()
     if check and main_solution is None:
         console.console.print(
@@ -447,11 +453,6 @@ async def run(
     )
 
     if share is not None:
-        if share not in ('png', 'text'):
-            console.console.print(
-                f'[error]Invalid --share format: {share!r} (use png or text).[/error]'
-            )
-            raise typer.Exit(1)
         rec = sharing.recording_console()
         await print_run_report(
             solution_result,

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -28,6 +28,7 @@ from rbx.box import (
     package_utils,
     presets,
     setter_config,
+    sharing,
     state,
     summary,
     timing,
@@ -356,6 +357,12 @@ async def run(
         '-c',
         help='Whether to pick solutions interactively.',
     ),
+    share: Optional[str] = typer.Option(
+        None,
+        '--share',
+        help='Capture the run report and copy it to the clipboard. '
+        'Pass a format: --share png or --share text.',
+    ),
 ):
     main_solution = package.get_main_solution()
     if check and main_solution is None:
@@ -438,6 +445,30 @@ async def run(
         detailed=detailed,
         skip_printing_limits=sanitized,
     )
+
+    if share is not None:
+        if share not in ('png', 'text'):
+            console.console.print(
+                f'[error]Invalid --share format: {share!r} (use png or text).[/error]'
+            )
+            raise typer.Exit(1)
+        rec = sharing.recording_console()
+        await print_run_report(
+            solution_result,
+            rec,
+            VerificationLevel(verification),
+            detailed=detailed,
+            skip_printing_limits=sanitized,
+        )
+        out_dir = package.get_build_path()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        result = sharing.share_report(
+            rec,
+            fmt=share,
+            title='rbx run report',
+            out_dir=out_dir,
+        )
+        sharing.print_share_result(console.console, result)
 
 
 @app.command(

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -7,6 +7,10 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
+import rich.console
+
+from rbx import console as _console  # for the shared theme
+
 # Ordered preference of SVG->PNG converters. Each entry builds the argv given
 # (svg_path, png_path).
 _CONVERTERS = [
@@ -107,3 +111,75 @@ def copy_image_to_clipboard(png_path: Path) -> bool:
             return False
         return _run_clipboard(argv, input=data)
     return False
+
+
+def recording_console(width: int = 120) -> rich.console.Console:
+    return rich.console.Console(
+        theme=_console.theme,
+        style='info',
+        highlight=False,
+        record=True,
+        width=width,
+        # force_terminal=False keeps is_terminal False so rich.live.Live renders
+        # a single final frame instead of animating when we re-render reports.
+        force_terminal=False,
+    )
+
+
+def export_text(rec: rich.console.Console) -> str:
+    return rec.export_text()
+
+
+def export_svg(rec: rich.console.Console, title: str) -> str:
+    return rec.export_svg(title=title)
+
+
+@dataclasses.dataclass
+class ShareResult:
+    fmt: str
+    copied: bool
+    file_path: Optional[Path] = None
+
+
+def share_report(
+    rec: rich.console.Console,
+    fmt: str,
+    title: str,
+    out_dir: Path,
+) -> ShareResult:
+    """Convert a recorded report to `fmt` ('png'|'text') and copy to clipboard.
+    Falls back to writing a file under out_dir if clipboard/convert is
+    unavailable."""
+    if fmt == 'text':
+        text = export_text(rec)
+        if copy_text_to_clipboard(text):
+            return ShareResult(fmt='text', copied=True)
+        path = out_dir / 'report.txt'
+        path.write_text(text)
+        return ShareResult(fmt='text', copied=False, file_path=path)
+
+    # fmt == 'png'
+    svg = export_svg(rec, title=title)
+    png_path = out_dir / 'report.png'
+    if svg_to_png(svg, png_path) is not None and copy_image_to_clipboard(png_path):
+        return ShareResult(fmt='png', copied=True, file_path=png_path)
+    # Could not convert and/or copy: persist whichever artifact we have.
+    if png_path.exists():
+        return ShareResult(fmt='png', copied=False, file_path=png_path)
+    svg_path = out_dir / 'report.svg'
+    svg_path.write_text(svg)
+    return ShareResult(fmt='png', copied=False, file_path=svg_path)
+
+
+def print_share_result(console, result: ShareResult) -> None:
+    if result.copied:
+        console.print(
+            f'[success]✓ Report copied to clipboard ({result.fmt.upper()}).[/success]'
+        )
+    elif result.file_path is not None:
+        console.print(
+            f'[warning]Could not copy to clipboard; wrote report to '
+            f'[item]{result.file_path}[/item].[/warning]'
+        )
+    else:
+        console.print('[error]Failed to share report.[/error]')

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -13,12 +13,13 @@ import rich.console
 from rbx import console as _console  # for the shared theme
 
 # Ordered preference of SVG->PNG converters. Each entry builds the argv given
-# (svg_path, png_path).
+# (svg_path, png_path). Only converters that render an SVG faithfully to the
+# requested output path belong here (e.g. macOS `qlmanage` is excluded: it is a
+# thumbnailer that writes `<name>.png` into a directory, not a real renderer).
 _CONVERTERS = [
     ('rsvg-convert', lambda svg, png: ['rsvg-convert', str(svg), '-o', str(png)]),
     ('magick', lambda svg, png: ['magick', str(svg), str(png)]),
     ('convert', lambda svg, png: ['convert', str(svg), str(png)]),
-    ('qlmanage', lambda svg, png: ['qlmanage', '-t', '-o', str(png.parent), str(svg)]),
 ]
 
 
@@ -51,6 +52,14 @@ def svg_to_png(svg: str, png_path: Path) -> Optional[Path]:
         return None
     finally:
         svg_path.unlink(missing_ok=True)
+    # A zero exit code is not enough: a converter can succeed yet write nothing
+    # (or an empty file) to the requested path. Only report success if a usable
+    # PNG actually exists.
+    try:
+        if png_path.stat().st_size == 0:
+            return None
+    except OSError:
+        return None
     return png_path
 
 
@@ -199,11 +208,19 @@ def capture_and_share(
     rec: rich.console.Console, *, fmt: str, title: str
 ) -> ShareResult:
     """Share an already-recorded report: write fallbacks into the package build
-    dir, copy to the clipboard, and print the outcome."""
+    dir, copy to the clipboard, and print the outcome.
+
+    Sharing is a convenience side-effect that runs after the report has already
+    been shown, so any failure here (e.g. an unwritable build dir) degrades to a
+    warning instead of crashing the command."""
     from rbx.box import package
 
-    out_dir = package.get_build_path()
-    out_dir.mkdir(parents=True, exist_ok=True)
-    result = share_report(rec, fmt=fmt, title=title, out_dir=out_dir)
+    try:
+        out_dir = package.get_build_path()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        result = share_report(rec, fmt=fmt, title=title, out_dir=out_dir)
+    except OSError as e:
+        _console.console.print(f'[warning]Could not share report: {e}.[/warning]')
+        return ShareResult(fmt=fmt, copied=False)
     print_share_result(_console.console, result)
     return result

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -59,6 +59,16 @@ def _linux_clipboard_tool() -> Optional[str]:
     return None
 
 
+def _run_clipboard(argv: List[str], input: Optional[bytes] = None) -> bool:
+    """Run a clipboard subprocess. Returns True on a zero exit code, False if the
+    command fails to launch (OSError) or exits non-zero."""
+    try:
+        result = subprocess.run(argv, input=input, capture_output=True)
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
 def copy_text_to_clipboard(text: str) -> bool:
     data = text.encode('utf-8')
     if sys.platform == 'darwin' and shutil.which('pbcopy'):
@@ -75,26 +85,25 @@ def copy_text_to_clipboard(text: str) -> bool:
         argv = None
     if argv is None:
         return False
-    result = subprocess.run(argv, input=data, capture_output=True)
-    return result.returncode == 0
+    return _run_clipboard(argv, input=data)
 
 
 def copy_image_to_clipboard(png_path: Path) -> bool:
     if sys.platform == 'darwin':
-        script = (
-            f'set the clipboard to (read (POSIX file "{png_path}") as «class PNGf»)'
-        )
-        result = subprocess.run(['osascript', '-e', script], capture_output=True)
-        return result.returncode == 0
+        escaped = str(png_path).replace('\\', '\\\\').replace('"', '\\"')
+        script = f'set the clipboard to (read (POSIX file "{escaped}") as «class PNGf»)'
+        return _run_clipboard(['osascript', '-e', script])
     if sys.platform.startswith('linux'):
         tool = _linux_clipboard_tool()
-        data = png_path.read_bytes()
         if tool == 'xclip':
             argv = ['xclip', '-selection', 'clipboard', '-t', 'image/png']
         elif tool == 'wl-copy':
             argv = ['wl-copy', '--type', 'image/png']
         else:
             return False
-        result = subprocess.run(argv, input=data, capture_output=True)
-        return result.returncode == 0
+        try:
+            data = png_path.read_bytes()
+        except OSError:
+            return False
+        return _run_clipboard(argv, input=data)
     return False

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -29,8 +29,8 @@ def detect_png_converter() -> Optional[PngConverter]:
 
 
 def svg_to_png(svg: str, png_path: Path) -> Optional[Path]:
-    """Convert SVG text to a PNG file. Returns the path on success, None if no
-    converter is available."""
+    """Convert SVG text to a PNG file. Returns the path on success, or None if no
+    converter is available or the conversion failed."""
     converter = detect_png_converter()
     if converter is None:
         return None
@@ -40,6 +40,8 @@ def svg_to_png(svg: str, png_path: Path) -> Optional[Path]:
     try:
         argv = converter.build_argv(svg_path, png_path)
         subprocess.run(argv, check=True, capture_output=True)
+    except (subprocess.CalledProcessError, OSError):
+        return None
     finally:
         svg_path.unlink(missing_ok=True)
     return png_path

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -1,4 +1,5 @@
 import dataclasses
+import io
 import os
 import shutil
 import subprocess
@@ -123,6 +124,13 @@ def recording_console(width: int = 120) -> rich.console.Console:
         # force_terminal=False keeps is_terminal False so rich.live.Live renders
         # a single final frame instead of animating when we re-render reports.
         force_terminal=False,
+        # A non-terminal console would otherwise drop colors from the recording;
+        # force truecolor so the exported SVG keeps the report's styling.
+        color_system='truecolor',
+        # Discard the visible output: we only want the recorded buffer. Without
+        # this the re-rendered report would be printed to the real stdout a
+        # second time.
+        file=io.StringIO(),
     )
 
 

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -193,3 +193,17 @@ def print_share_result(console: rich.console.Console, result: ShareResult) -> No
         )
     else:
         console.print('[error]Failed to share report.[/error]')
+
+
+def capture_and_share(
+    rec: rich.console.Console, *, fmt: str, title: str
+) -> ShareResult:
+    """Share an already-recorded report: write fallbacks into the package build
+    dir, copy to the clipboard, and print the outcome."""
+    from rbx.box import package
+
+    out_dir = package.get_build_path()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result = share_report(rec, fmt=fmt, title=title, out_dir=out_dir)
+    print_share_result(_console.console, result)
+    return result

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -148,7 +148,13 @@ def export_text(rec: rich.console.Console) -> str:
 
 
 def export_svg(rec: rich.console.Console, title: str) -> str:
-    return rec.export_svg(title=title)
+    svg = rec.export_svg(title=title)
+    # Rich places the spaces that separate styled spans at the start/end of a
+    # <text> run. Some SVG rasterizers (e.g. rsvg-convert) trim that leading and
+    # trailing whitespace when laying out each run, which drops the separators
+    # (`AC solution` -> `ACsolution`). Mark every run as whitespace-preserving so
+    # those spaces survive conversion to PNG.
+    return svg.replace('<text ', '<text xml:space="preserve" ')
 
 
 @dataclasses.dataclass

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -1,0 +1,45 @@
+import dataclasses
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+# Ordered preference of SVG->PNG converters. Each entry builds the argv given
+# (svg_path, png_path).
+_CONVERTERS = [
+    ('rsvg-convert', lambda svg, png: ['rsvg-convert', str(svg), '-o', str(png)]),
+    ('magick', lambda svg, png: ['magick', str(svg), str(png)]),
+    ('convert', lambda svg, png: ['convert', str(svg), str(png)]),
+    ('qlmanage', lambda svg, png: ['qlmanage', '-t', '-o', str(png.parent), str(svg)]),
+]
+
+
+@dataclasses.dataclass
+class PngConverter:
+    tool: str
+    build_argv: object  # Callable[[Path, Path], List[str]]
+
+
+def detect_png_converter() -> Optional[PngConverter]:
+    for tool, build in _CONVERTERS:
+        if shutil.which(tool) is not None:
+            return PngConverter(tool=tool, build_argv=build)
+    return None
+
+
+def svg_to_png(svg: str, png_path: Path) -> Optional[Path]:
+    """Convert SVG text to a PNG file. Returns the path on success, None if no
+    converter is available."""
+    converter = detect_png_converter()
+    if converter is None:
+        return None
+    with tempfile.NamedTemporaryFile('w', suffix='.svg', delete=False) as f:
+        f.write(svg)
+        svg_path = Path(f.name)
+    try:
+        argv = converter.build_argv(svg_path, png_path)
+        subprocess.run(argv, check=True, capture_output=True)
+    finally:
+        svg_path.unlink(missing_ok=True)
+    return png_path

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -161,17 +161,19 @@ def share_report(
     # fmt == 'png'
     svg = export_svg(rec, title=title)
     png_path = out_dir / 'report.png'
-    if svg_to_png(svg, png_path) is not None and copy_image_to_clipboard(png_path):
-        return ShareResult(fmt='png', copied=True, file_path=png_path)
-    # Could not convert and/or copy: persist whichever artifact we have.
-    if png_path.exists():
+    converted = svg_to_png(svg, png_path)
+    if converted is not None:
+        # PNG was produced this run; try to copy it.
+        if copy_image_to_clipboard(png_path):
+            return ShareResult(fmt='png', copied=True, file_path=png_path)
         return ShareResult(fmt='png', copied=False, file_path=png_path)
+    # No converter available: persist the SVG so the user still has an artifact.
     svg_path = out_dir / 'report.svg'
     svg_path.write_text(svg)
     return ShareResult(fmt='png', copied=False, file_path=svg_path)
 
 
-def print_share_result(console, result: ShareResult) -> None:
+def print_share_result(console: rich.console.Console, result: ShareResult) -> None:
     if result.copied:
         console.print(
             f'[success]✓ Report copied to clipboard ({result.fmt.upper()}).[/success]'

--- a/rbx/box/sharing.py
+++ b/rbx/box/sharing.py
@@ -1,9 +1,11 @@
 import dataclasses
+import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 # Ordered preference of SVG->PNG converters. Each entry builds the argv given
 # (svg_path, png_path).
@@ -45,3 +47,54 @@ def svg_to_png(svg: str, png_path: Path) -> Optional[Path]:
     finally:
         svg_path.unlink(missing_ok=True)
     return png_path
+
+
+def _linux_clipboard_tool() -> Optional[str]:
+    if os.environ.get('WAYLAND_DISPLAY') and shutil.which('wl-copy'):
+        return 'wl-copy'
+    if shutil.which('xclip'):
+        return 'xclip'
+    if shutil.which('wl-copy'):
+        return 'wl-copy'
+    return None
+
+
+def copy_text_to_clipboard(text: str) -> bool:
+    data = text.encode('utf-8')
+    if sys.platform == 'darwin' and shutil.which('pbcopy'):
+        argv: Optional[List[str]] = ['pbcopy']
+    elif sys.platform.startswith('linux'):
+        tool = _linux_clipboard_tool()
+        if tool == 'xclip':
+            argv = ['xclip', '-selection', 'clipboard']
+        elif tool == 'wl-copy':
+            argv = ['wl-copy']
+        else:
+            argv = None
+    else:
+        argv = None
+    if argv is None:
+        return False
+    result = subprocess.run(argv, input=data, capture_output=True)
+    return result.returncode == 0
+
+
+def copy_image_to_clipboard(png_path: Path) -> bool:
+    if sys.platform == 'darwin':
+        script = (
+            f'set the clipboard to (read (POSIX file "{png_path}") as «class PNGf»)'
+        )
+        result = subprocess.run(['osascript', '-e', script], capture_output=True)
+        return result.returncode == 0
+    if sys.platform.startswith('linux'):
+        tool = _linux_clipboard_tool()
+        data = png_path.read_bytes()
+        if tool == 'xclip':
+            argv = ['xclip', '-selection', 'clipboard', '-t', 'image/png']
+        elif tool == 'wl-copy':
+            argv = ['wl-copy', '--type', 'image/png']
+        else:
+            return False
+        result = subprocess.run(argv, input=data, capture_output=True)
+        return result.returncode == 0
+    return False

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -2312,6 +2312,12 @@ class LiveRunReporter(FullRunReporter):
         self._update_live(finished=True)
         self.live.stop()
         self.live = None
+        # On a real terminal, Live.stop() advances to a new line, so each group
+        # lands on its own row. On a non-terminal console (e.g. when capturing
+        # the report to share it) Live finalizes without a trailing newline, so
+        # groups would otherwise run together; emit one explicitly.
+        if not self.console.is_terminal:
+            self.console.print()
 
     def render_pre_evaluation(self, entry: GenerationTestcaseEntry):
         self.pre_evaluated = entry.group_entry.index + 1

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -353,6 +353,7 @@ async def compute_time_limits(
     profile: str = 'local',
     formula: Optional[str] = None,
     auto: bool = False,
+    share: Optional[str] = None,
 ):
     if package.get_main_solution() is None:
         console.console.print(
@@ -409,6 +410,31 @@ async def compute_time_limits(
     limits_path.write_text(utils.model_to_yaml(limits))
 
     limits_info.render_limits_table(limits, title=f'Time limits ({profile})')
+
+    if share is not None:
+        from rbx.box import sharing
+
+        rec = sharing.recording_console()
+        await print_run_report(
+            solution_result,
+            rec,
+            VerificationLevel(verification),
+            detailed=detailed,
+            skip_printing_limits=True,
+        )
+        rec.print()
+        rec.print(
+            limits_info.build_limits_table(limits, title=f'Time limits ({profile})')
+        )
+        out_dir = package.get_build_path()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        result = sharing.share_report(
+            rec,
+            fmt=share,
+            title='rbx time report',
+            out_dir=out_dir,
+        )
+        sharing.print_share_result(console.console, result)
 
     return estimated_tl
 

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -15,6 +15,7 @@ from rbx.box import (
     package,
     safeeval,
     schema,
+    sharing,
     timing_group_picker,
     timing_groups,
 )
@@ -412,8 +413,6 @@ async def compute_time_limits(
     limits_info.render_limits_table(limits, title=f'Time limits ({profile})')
 
     if share is not None:
-        from rbx.box import sharing
-
         rec = sharing.recording_console()
         await print_run_report(
             solution_result,
@@ -426,15 +425,7 @@ async def compute_time_limits(
         rec.print(
             limits_info.build_limits_table(limits, title=f'Time limits ({profile})')
         )
-        out_dir = package.get_build_path()
-        out_dir.mkdir(parents=True, exist_ok=True)
-        result = sharing.share_report(
-            rec,
-            fmt=share,
-            title='rbx time report',
-            out_dir=out_dir,
-        )
-        sharing.print_share_result(console.console, result)
+        sharing.capture_and_share(rec, fmt=share, title='rbx time report')
 
     return estimated_tl
 

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -265,3 +265,15 @@ def test_capture_and_share_degrades_on_oserror(monkeypatch, tmp_path):
     rec = sharing.recording_console(width=80)
     result = sharing.capture_and_share(rec, fmt='text', title='t')
     assert result.copied is False
+
+
+def test_export_svg_marks_runs_whitespace_preserving():
+    # Rasterizers (rsvg-convert) trim leading/trailing whitespace per <text>
+    # run, which drops the spaces Rich puts between styled spans. Every run must
+    # be marked xml:space="preserve" so those separators survive PNG conversion.
+    rec = sharing.recording_console(width=80)
+    rec.print('Slowest [success]AC[/success] solution')
+    svg = sharing.export_svg(rec, title='t')
+    assert 'xml:space="preserve"' in svg
+    # No <text> run is left unmarked.
+    assert '<text ' not in svg.replace('<text xml:space="preserve" ', '')

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -27,15 +27,31 @@ def test_svg_to_png_invokes_converter(monkeypatch, tmp_path):
         'which',
         lambda name: f'/usr/bin/{name}' if name == 'magick' else None,
     )
+    png_path = tmp_path / 'r.png'
     calls = []
-    monkeypatch.setattr(
-        sharing.subprocess,
-        'run',
-        lambda *a, **k: calls.append((a, k)) or mock.Mock(returncode=0),
-    )
-    out = sharing.svg_to_png('<svg/>', tmp_path / 'r.png')
-    assert out == tmp_path / 'r.png'
+
+    def fake_run(*a, **k):
+        calls.append((a, k))
+        png_path.write_bytes(b'\x89PNG fake')  # converter produces the output
+        return mock.Mock(returncode=0)
+
+    monkeypatch.setattr(sharing.subprocess, 'run', fake_run)
+    out = sharing.svg_to_png('<svg/>', png_path)
+    assert out == png_path
     assert calls, 'converter should have been invoked'
+
+
+def test_svg_to_png_returns_none_on_empty_output(monkeypatch, tmp_path):
+    # Converter exits 0 but writes nothing usable to the requested path.
+    monkeypatch.setattr(
+        sharing.shutil,
+        'which',
+        lambda name: f'/usr/bin/{name}' if name == 'magick' else None,
+    )
+    monkeypatch.setattr(
+        sharing.subprocess, 'run', lambda *a, **k: mock.Mock(returncode=0)
+    )
+    assert sharing.svg_to_png('<svg/>', tmp_path / 'missing.png') is None
 
 
 def test_svg_to_png_returns_none_on_converter_failure(monkeypatch, tmp_path):
@@ -233,3 +249,19 @@ def test_share_report_captures_limits_table(tmp_path):
     text = sharing.export_text(rec)
     assert 'Time limits (local)' in text
     assert '1500 ms' in text
+
+
+def test_capture_and_share_degrades_on_oserror(monkeypatch, tmp_path):
+    # Sharing runs after the report is shown; a filesystem error must not crash
+    # the command.
+    from rbx.box import package
+
+    monkeypatch.setattr(package, 'get_build_path', lambda: tmp_path)
+
+    def boom(*a, **k):
+        raise OSError('disk full')
+
+    monkeypatch.setattr(sharing, 'share_report', boom)
+    rec = sharing.recording_console(width=80)
+    result = sharing.capture_and_share(rec, fmt='text', title='t')
+    assert result.copied is False

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -48,3 +48,42 @@ def test_svg_to_png_returns_none_on_converter_failure(monkeypatch, tmp_path):
 
     monkeypatch.setattr(sharing.subprocess, 'run', boom)
     assert sharing.svg_to_png('<svg/>', tmp_path / 'r.png') is None
+
+
+def test_copy_text_macos_uses_pbcopy(monkeypatch):
+    monkeypatch.setattr(sharing.sys, 'platform', 'darwin')
+    captured = {}
+
+    def fake_run(argv, input=None, **k):
+        captured['argv'] = argv
+        captured['input'] = input
+        return mock.Mock(returncode=0)
+
+    monkeypatch.setattr(sharing.subprocess, 'run', fake_run)
+    monkeypatch.setattr(sharing.shutil, 'which', lambda n: '/usr/bin/pbcopy')
+    assert sharing.copy_text_to_clipboard('hello') is True
+    assert captured['argv'] == ['pbcopy']
+    assert captured['input'] == b'hello'
+
+
+def test_copy_text_linux_wayland_uses_wl_copy(monkeypatch):
+    monkeypatch.setattr(sharing.sys, 'platform', 'linux')
+    monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-0')
+    monkeypatch.setattr(
+        sharing.shutil,
+        'which',
+        lambda n: '/usr/bin/wl-copy' if n == 'wl-copy' else None,
+    )
+    seen = {}
+    monkeypatch.setattr(
+        sharing.subprocess,
+        'run',
+        lambda argv, input=None, **k: seen.update(argv=argv) or mock.Mock(returncode=0),
+    )
+    assert sharing.copy_text_to_clipboard('x') is True
+    assert seen['argv'][0] == 'wl-copy'
+
+
+def test_copy_image_unsupported_returns_false(monkeypatch):
+    monkeypatch.setattr(sharing.sys, 'platform', 'win32')
+    assert sharing.copy_image_to_clipboard(sharing.Path('/tmp/x.png')) is False

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import rich.text
 
-from rbx.box import sharing
+from rbx.box import limits_info, schema, sharing
 
 
 def test_detect_png_converter_prefers_rsvg(monkeypatch):
@@ -221,3 +221,15 @@ def test_share_report_png_no_converter_falls_back_to_svg(monkeypatch, tmp_path):
     assert result.file_path == tmp_path / 'report.svg'
     assert result.file_path.exists()
     assert '<svg' in result.file_path.read_text()
+
+
+def test_share_report_captures_limits_table(tmp_path):
+    # The rbx time report stacks the run report and the per-language-group
+    # limits table into one recording console; this checks the limits table
+    # (the timing breakdown) is captured intact.
+    profile = schema.LimitsProfile(timeLimit=1500)
+    rec = sharing.recording_console(width=100)
+    rec.print(limits_info.build_limits_table(profile, title='Time limits (local)'))
+    text = sharing.export_text(rec)
+    assert 'Time limits (local)' in text
+    assert '1500 ms' in text

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -1,0 +1,36 @@
+from unittest import mock
+
+from rbx.box import sharing
+
+
+def test_detect_png_converter_prefers_rsvg(monkeypatch):
+    monkeypatch.setattr(
+        sharing.shutil,
+        'which',
+        lambda name: f'/usr/bin/{name}' if name == 'rsvg-convert' else None,
+    )
+    conv = sharing.detect_png_converter()
+    assert conv is not None
+    assert conv.tool == 'rsvg-convert'
+
+
+def test_detect_png_converter_none_available(monkeypatch):
+    monkeypatch.setattr(sharing.shutil, 'which', lambda name: None)
+    assert sharing.detect_png_converter() is None
+
+
+def test_svg_to_png_invokes_converter(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sharing.shutil,
+        'which',
+        lambda name: f'/usr/bin/{name}' if name == 'magick' else None,
+    )
+    calls = []
+    monkeypatch.setattr(
+        sharing.subprocess,
+        'run',
+        lambda *a, **k: calls.append((a, k)) or mock.Mock(returncode=0),
+    )
+    out = sharing.svg_to_png('<svg/>', tmp_path / 'r.png')
+    assert out == tmp_path / 'r.png'
+    assert calls, 'converter should have been invoked'

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import rich.text
+
 from rbx.box import sharing
 
 
@@ -123,3 +125,36 @@ def test_copy_text_oserror_returns_false(monkeypatch):
 
     monkeypatch.setattr(sharing.subprocess, 'run', boom)
     assert sharing.copy_text_to_clipboard('x') is False
+
+
+def test_recording_console_is_not_a_terminal():
+    rec = sharing.recording_console(width=80)
+    assert rec.record is True
+    assert rec.is_terminal is False  # so rich.live.Live won't animate
+
+
+def test_export_text_captures_rendered_content():
+    rec = sharing.recording_console(width=80)
+    rec.print(rich.text.Text('Timing summary: 123 ms'))
+    text = sharing.export_text(rec)
+    assert 'Timing summary: 123 ms' in text
+
+
+def test_share_report_text_copies_to_clipboard(monkeypatch, tmp_path):
+    rec = sharing.recording_console(width=80)
+    rec.print('hello world')
+    monkeypatch.setattr(sharing, 'copy_text_to_clipboard', lambda t: True)
+    result = sharing.share_report(rec, fmt='text', title='t', out_dir=tmp_path)
+    assert result.copied is True
+    assert result.fmt == 'text'
+    assert result.file_path is None
+
+
+def test_share_report_text_falls_back_to_file(monkeypatch, tmp_path):
+    rec = sharing.recording_console(width=80)
+    rec.print('hello world')
+    monkeypatch.setattr(sharing, 'copy_text_to_clipboard', lambda t: False)
+    result = sharing.share_report(rec, fmt='text', title='t', out_dir=tmp_path)
+    assert result.copied is False
+    assert result.file_path is not None and result.file_path.exists()
+    assert 'hello world' in result.file_path.read_text()

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -158,3 +158,46 @@ def test_share_report_text_falls_back_to_file(monkeypatch, tmp_path):
     assert result.copied is False
     assert result.file_path is not None and result.file_path.exists()
     assert 'hello world' in result.file_path.read_text()
+
+
+def test_share_report_png_copies_to_clipboard(monkeypatch, tmp_path):
+    rec = sharing.recording_console(width=80)
+    rec.print('hi')
+
+    def fake_convert(svg, png_path):
+        png_path.write_bytes(b'\x89PNG')
+        return png_path
+
+    monkeypatch.setattr(sharing, 'svg_to_png', fake_convert)
+    monkeypatch.setattr(sharing, 'copy_image_to_clipboard', lambda p: True)
+    result = sharing.share_report(rec, fmt='png', title='t', out_dir=tmp_path)
+    assert result.copied is True
+    assert result.fmt == 'png'
+    assert result.file_path == tmp_path / 'report.png'
+
+
+def test_share_report_png_copy_fails_keeps_png(monkeypatch, tmp_path):
+    rec = sharing.recording_console(width=80)
+    rec.print('hi')
+
+    def fake_convert(svg, png_path):
+        png_path.write_bytes(b'\x89PNG')
+        return png_path
+
+    monkeypatch.setattr(sharing, 'svg_to_png', fake_convert)
+    monkeypatch.setattr(sharing, 'copy_image_to_clipboard', lambda p: False)
+    result = sharing.share_report(rec, fmt='png', title='t', out_dir=tmp_path)
+    assert result.copied is False
+    assert result.file_path == tmp_path / 'report.png'
+    assert result.file_path.exists()
+
+
+def test_share_report_png_no_converter_falls_back_to_svg(monkeypatch, tmp_path):
+    rec = sharing.recording_console(width=80)
+    rec.print('hi')
+    monkeypatch.setattr(sharing, 'svg_to_png', lambda svg, png_path: None)
+    result = sharing.share_report(rec, fmt='png', title='t', out_dir=tmp_path)
+    assert result.copied is False
+    assert result.file_path == tmp_path / 'report.svg'
+    assert result.file_path.exists()
+    assert '<svg' in result.file_path.read_text()

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -34,3 +34,17 @@ def test_svg_to_png_invokes_converter(monkeypatch, tmp_path):
     out = sharing.svg_to_png('<svg/>', tmp_path / 'r.png')
     assert out == tmp_path / 'r.png'
     assert calls, 'converter should have been invoked'
+
+
+def test_svg_to_png_returns_none_on_converter_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sharing.shutil,
+        'which',
+        lambda name: f'/usr/bin/{name}' if name == 'magick' else None,
+    )
+
+    def boom(*a, **k):
+        raise sharing.subprocess.CalledProcessError(1, a[0] if a else 'magick')
+
+    monkeypatch.setattr(sharing.subprocess, 'run', boom)
+    assert sharing.svg_to_png('<svg/>', tmp_path / 'r.png') is None

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -133,6 +133,26 @@ def test_recording_console_is_not_a_terminal():
     assert rec.is_terminal is False  # so rich.live.Live won't animate
 
 
+def test_recording_console_does_not_write_to_real_stdout(capsys):
+    # The recording console must swallow its visible output (it writes to an
+    # in-memory buffer) so re-rendering a report for capture does not print it
+    # to the user's terminal a second time.
+    rec = sharing.recording_console(width=80)
+    rec.print('should not appear on stdout')
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert 'should not appear on stdout' in sharing.export_text(rec)
+
+
+def test_export_svg_preserves_report_colors():
+    # A non-terminal recording console would otherwise drop colors; the exported
+    # SVG must keep the report's styling (e.g. the bold-green 'success' style).
+    rec = sharing.recording_console(width=80)
+    rec.print(rich.text.Text('AC', style='success'))
+    svg = sharing.export_svg(rec, title='t')
+    assert 'fill: #98a84b' in svg  # theme 'success' resolves to bold green
+
+
 def test_export_text_captures_rendered_content():
     rec = sharing.recording_console(width=80)
     rec.print(rich.text.Text('Timing summary: 123 ms'))

--- a/tests/rbx/box/test_sharing.py
+++ b/tests/rbx/box/test_sharing.py
@@ -87,3 +87,39 @@ def test_copy_text_linux_wayland_uses_wl_copy(monkeypatch):
 def test_copy_image_unsupported_returns_false(monkeypatch):
     monkeypatch.setattr(sharing.sys, 'platform', 'win32')
     assert sharing.copy_image_to_clipboard(sharing.Path('/tmp/x.png')) is False
+
+
+def test_copy_image_macos_escapes_path_quotes(monkeypatch, tmp_path):
+    monkeypatch.setattr(sharing.sys, 'platform', 'darwin')
+    seen = {}
+
+    def fake_run(argv, **k):
+        seen['argv'] = argv
+        return mock.Mock(returncode=0)
+
+    monkeypatch.setattr(sharing.subprocess, 'run', fake_run)
+    weird = tmp_path / 'a"b.png'
+    weird.write_bytes(b'x')
+    assert sharing.copy_image_to_clipboard(weird) is True
+    script = seen['argv'][-1]
+    # the raw quote must be backslash-escaped inside the AppleScript string
+    assert '\\"' in script
+
+
+def test_copy_image_linux_missing_tool_does_not_read(monkeypatch, tmp_path):
+    monkeypatch.setattr(sharing.sys, 'platform', 'linux')
+    monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
+    monkeypatch.setattr(sharing.shutil, 'which', lambda n: None)
+    missing = tmp_path / 'does-not-exist.png'  # never created
+    assert sharing.copy_image_to_clipboard(missing) is False
+
+
+def test_copy_text_oserror_returns_false(monkeypatch):
+    monkeypatch.setattr(sharing.sys, 'platform', 'darwin')
+    monkeypatch.setattr(sharing.shutil, 'which', lambda n: '/usr/bin/pbcopy')
+
+    def boom(*a, **k):
+        raise OSError('exec failed')
+
+    monkeypatch.setattr(sharing.subprocess, 'run', boom)
+    assert sharing.copy_text_to_clipboard('x') is False


### PR DESCRIPTION
## Summary

Adds a `--share png|text` flag to `rbx run` and `rbx time` that captures the rendered report and copies it to the system **clipboard** — as a PNG image or plain text — so reports are easy to send to someone else. Closes #388.

- **`rbx run --share`** captures the full run report (limits header, verdicts, timing summary; detailed tables under `-d`).
- **`rbx time --share`** captures the run report *plus* the per-language-group time-limits table (the timing breakdown).
- Graceful degradation everywhere: no SVG→PNG converter → saves an SVG file; no clipboard tool / unsupported platform → writes the report to the build dir and prints the path. `--share` never crashes the command.

## How it works

New `rbx/box/sharing.py`:
- **Capture** — re-renders the report into a non-terminal `Console(record=True)`. Because it's non-terminal, `rich.live.Live` emits a single final frame instead of animating; `color_system='truecolor'` + an in-memory file preserve colors and avoid double-printing.
- **Convert** — `export_svg` → shells out to a runtime-detected converter (`rsvg-convert` → ImageMagick), validating a non-empty PNG was produced. No new Python dependency.
- **Clipboard** — `pbcopy`/`osascript` (macOS), `xclip`/`wl-copy` (Linux); text copy is cross-platform. Image clipboard on macOS + Linux.

## Test Plan

- [x] `uv run pytest tests/rbx/box/test_sharing.py` — 22/22 pass
- [x] Timing/limits suites — 102/102 pass
- [x] Manual: `rbx run --share text` and `--share png` copy to clipboard with no double-print; valid 1482×563 PNG generated; invalid/bare `--share` fails fast
- [x] `rbx time --share` limits-table capture verified (full `rbx time` run blocked only by a pre-existing local sandbox issue, unrelated to this change)
- [x] `ruff check` clean; docs build (non-strict) clean

> Note: the broader test sweep's failures are the pre-existing local `g++`/sandbox/docker tests, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)