### PR TITLE
feat(irun): --merge-stderr/-e flag for true line-order stderr interleave (#517)

### DIFF
--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -200,6 +200,7 @@ rbx irun <SOLUTIONS> [OPTIONS]
 | `--output`, `-O` | BOOLEAN | Whether to ask user for custom output. | `False` |
 | `--visualize` | BOOLEAN | Whether to generate visualizations for inputs and outputs. | `False` |
 | `--print`, `-p` | BOOLEAN | Whether to print outputs to terminal. | `False` |
+| `--merge-stderr`, `-e` | BOOLEAN | Interleave stderr with the solution output in true line order (colored distinctly). Requires -p. Default: stderr is shown in a separate section. | `False` |
 | `--sanitized`, `-s` | BOOLEAN | Whether to compile the solutions with sanitizers enabled. | `False` |
 | `--choice`, `--choose`, `-c` | BOOLEAN | Whether to pick solutions interactively. | `False` |
 

--- a/docs/setters/running/index.md
+++ b/docs/setters/running/index.md
@@ -112,6 +112,20 @@ also use the `-p` flag to instruct it to print the results into the console inst
 
 {{ asciinema("OW9JfUpTzwQlvwcXmR3xSnS3q") }}
 
+When printing with `-p`, the solution's `stderr` is shown in its own colored section right after the output.
+If you'd rather see it woven into the output in true line order — handy for debugging where each log line was
+emitted relative to the program's output — add the `--merge-stderr` / `-e` flag. The interleaved `stderr` lines
+are colored distinctly, and the clean output is left untouched so the checker still sees exactly what the
+solution printed.
+
+```bash
+# Interleave stderr with the output in true line order (requires -p)
+rbx irun <solution-name> -t sample/0 -p -e
+```
+
+For [interactive (communication) problems](/setters/grading/interactors/), `-e` folds the solution's `stderr`
+into the interaction view as a third stream, alongside the interactor and solution messages.
+
 !!! tip
     By default, the test you've written will be validated, so make sure you've typed it perfectly.
 

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -701,6 +701,14 @@ async def irun(
     print: bool = typer.Option(
         False, '--print', '-p', help='Whether to print outputs to terminal.'
     ),
+    merge_stderr: bool = typer.Option(
+        False,
+        '--merge-stderr',
+        '-e',
+        help='Interleave stderr with the solution output in true line order '
+        '(colored distinctly). Requires -p. Default: stderr is shown in a '
+        'separate section.',
+    ),
     sanitized: bool = typer.Option(
         False,
         '--sanitized',
@@ -771,6 +779,7 @@ async def irun(
             testcase_entry=get_parsed_entry(testcase) if testcase else None,
             custom_output=output,
             print=print,
+            merge_stderr=merge_stderr,
             sanitized=sanitized,
             validate=validate,
             visualize=visualize,

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -758,6 +758,8 @@ async def run_item(
     extra_args: Optional[str] = None,
     extra_config: Optional[ExecutionConfig] = None,
     retry_index: Optional[int] = None,
+    merged_capture: Optional[DigestOrDest] = None,
+    line_capture: bool = False,
 ) -> Optional[RunLog]:
     with package.get_new_sandbox() as sandbox:
         _check_stack_limit()
@@ -776,6 +778,20 @@ async def run_item(
             extra_config,
             retry_index,
         )
+
+        if merged_capture is not None:
+            # Tee stdout ('>') and stderr ('!') into a single merged file in true
+            # write order, keeping the clean stdout/stderr files intact. Used by
+            # ``rbx irun --merge-stderr`` for batch tasks.
+            merged_capture_path = pathlib.Path(MERGED_CAPTURE_FILENAME)
+            prepared.sandbox_params.merged_capture = merged_capture_path
+            prepared.sandbox_params.tee_mode = 'line' if line_capture else 'char'
+            prepared.artifacts.outputs.append(
+                GradingFileOutput(
+                    src=merged_capture_path,
+                    **merged_capture.expand(),
+                )
+            )
 
         with profiling.PushContext('code.run_item'):
             # Do not cache remote solutions.
@@ -836,6 +852,7 @@ async def run_communication(
     solution: CommunicationItem,
     merged_capture: Optional[DigestOrDest] = None,
     line_capture: bool = False,
+    tee_stderr: bool = False,
     retry_index: Optional[int] = None,
 ) -> Tuple[Optional[RunLog], Optional[RunLog]]:
     with package.get_new_sandbox() as sandbox:
@@ -886,4 +903,5 @@ async def run_communication(
                 dependency_cache=package.get_dependency_cache(),
                 merged_capture=merged_capture_path,
                 line_capture=line_capture,
+                tee_stderr=tee_stderr,
             )

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -127,6 +127,11 @@ class SolutionReportSkeleton(BaseModel):
     compiled_solutions: Dict[str, str]
     verification: VerificationLevel
     capture_pipes: bool = False
+    # When set (irun -e), the solution's stderr is interleaved with its output in
+    # true line order. Riding on the skeleton keeps a toggled flag from ever
+    # serving a stale merged capture (irun only caches with an explicit
+    # --testcase).
+    merge_stderr: bool = False
 
     def get_solution_limits(self, solution: Solution) -> Limits:
         lang = code.find_language_name(solution)
@@ -804,6 +809,7 @@ async def _run_interactive_solutions(
                 interactor_digest=interactor_digest,
                 verification=verification,
                 capture_pipes=skeleton.capture_pipes,
+                merge_stderr=skeleton.merge_stderr,
             )
 
         yield EvaluationItem(
@@ -831,6 +837,7 @@ async def _get_interactive_skeleton(
     sanitized: bool = False,
     verification: VerificationLevel = VerificationLevel.NONE,
     check: bool = True,
+    merge_stderr: bool = False,
 ) -> SolutionReportSkeleton:
     solutions, compiled_solutions = await _get_compiled_solutions_for_skeleton(
         tracked_solutions,
@@ -862,6 +869,7 @@ async def _get_interactive_skeleton(
         verification=verification,
         compiled_solutions=compiled_solutions,
         capture_pipes=should_capture_pipes(package.get_interactor_or_nil()),
+        merge_stderr=merge_stderr,
     )
 
     skeleton_file = irun_dir / 'skeleton.yml'
@@ -879,11 +887,21 @@ async def run_and_print_interactive_solutions(
     check: bool = True,
     custom_output: bool = False,
     print: bool = False,
+    merge_stderr: bool = False,
     sanitized: bool = False,
     validate: bool = True,
     visualize: bool = False,
 ):
     pkg = package.find_problem_package_or_die()
+
+    # Interleaving stderr only changes what is rendered, which only happens with
+    # -p. Warn (don't fail) if -e is given without -p.
+    if merge_stderr and not print:
+        console.console.print(
+            '[warning]--merge-stderr/-e has no effect without --print/-p; '
+            'stderr will be written to its file as usual.[/warning]'
+        )
+        merge_stderr = False
 
     # Refresh irun dir.
     irun_dir = package.get_problem_iruns_dir()
@@ -912,6 +930,7 @@ async def run_and_print_interactive_solutions(
             sanitized=sanitized,
             progress=progress,
             check=check,
+            merge_stderr=merge_stderr,
         )
         items = _run_interactive_solutions(
             entry,
@@ -938,7 +957,27 @@ async def run_and_print_interactive_solutions(
             )
 
         stdout_path = eval.log.stdout_absolute_path
-        if print and stdout_path is not None:
+        merged_path = (
+            stdout_path.with_suffix('.pio') if stdout_path is not None else None
+        )
+        if (
+            print
+            and skeleton.merge_stderr
+            and merged_path is not None
+            and merged_path.is_file()
+        ):
+            # Interleaved view: the merged capture already weaves stderr (red)
+            # into the output/interaction in true line order, so render it in
+            # place of the plain Output + separate Stderr sections.
+            rule = 'Interaction' if pkg.type == TaskType.COMMUNICATION else 'Output'
+            console.console.rule(rule, style='status')
+            print_best_output(
+                [merged_path],
+                pkg.type,
+                empty_warning=True,
+                capture_pipes=skeleton.capture_pipes,
+            )
+        elif print and stdout_path is not None:
             if pkg.type == TaskType.COMMUNICATION:
                 console.console.rule('Interaction', style='status')
                 output_files = get_all_interaction_files(stdout_path) + [

--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -91,6 +91,7 @@ async def run_solution_on_testcase(
     use_timelimit: bool = True,
     capture_pipes: Optional[bool] = None,
     line_capture: bool = False,
+    merge_stderr: bool = False,
     nruns: int = 0,
     filestem: Optional[str] = None,
     is_stress: bool = False,
@@ -114,6 +115,7 @@ async def run_solution_on_testcase(
             filestem=filestem,
             is_stress=is_stress,
             line_capture=line_capture,
+            merge_stderr=merge_stderr,
         )
 
     async def run_fn(retry_index: int) -> Evaluation:
@@ -139,6 +141,10 @@ async def run_solution_on_testcase(
         eval_path = output_path.with_suffix('.eval')
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
+        # When interleaving is requested, tee stdout/stderr into a merged '.pio'
+        # file in true write order; the clean stdout/stderr files are unaffected.
+        merged_capture_path = output_path.with_suffix('.pio') if merge_stderr else None
+
         with profiling.PushContext('tasks.run_solution_on_testcase'):
             run_log = await run_item(
                 solution,
@@ -148,6 +154,10 @@ async def run_solution_on_testcase(
                 stderr=DigestOrDest.create(error_path),
                 extra_config=extra_config,
                 retry_index=retry_index,
+                merged_capture=DigestOrDest.create(merged_capture_path)
+                if merged_capture_path is not None
+                else None,
+                line_capture=True,
             )
 
         if checker_digest is not None:
@@ -237,6 +247,7 @@ async def _run_communication_solution_on_testcase(
     use_timelimit: bool = True,
     capture_pipes: Optional[bool] = None,
     line_capture: bool = False,
+    merge_stderr: bool = False,
     nruns: int = 0,
     filestem: Optional[str] = None,
     is_stress: bool = False,
@@ -326,7 +337,11 @@ async def _run_communication_solution_on_testcase(
             file_prefix='solution',
         )
 
-        merged_capture_path = output_path.with_suffix('.pio') if capture_pipes else None
+        # ``merge_stderr`` needs the merged capture to interleave the solution's
+        # stderr into, even when pipe capture is otherwise off.
+        merged_capture_path = (
+            output_path.with_suffix('.pio') if (capture_pipes or merge_stderr) else None
+        )
         interactor_run_log, run_log = await run_communication(
             interactor=interactor_item,
             solution=solution_item,
@@ -334,7 +349,10 @@ async def _run_communication_solution_on_testcase(
             merged_capture=DigestOrDest.create(merged_capture_path)
             if merged_capture_path
             else None,
-            line_capture=line_capture,
+            # Force line-level teeing when folding stderr in, so each marked line
+            # stays atomic in the merged file.
+            line_capture=line_capture or merge_stderr,
+            tee_stderr=merge_stderr,
         )
 
         checker_result = await checkers.check_communication(

--- a/rbx/grading/judge/sandbox.py
+++ b/rbx/grading/judge/sandbox.py
@@ -145,6 +145,15 @@ class SandboxParams(pydantic.BaseModel):
     reverse_io: bool = False
     pgid: Optional[int] = None
 
+    # When set, stdout and stderr are tee'd (in true write order, marked '>' and
+    # '!' respectively) into this file while the clean stdout/stderr files are
+    # still produced. Used by ``rbx irun --merge-stderr`` for batch tasks. Left
+    # unset for every other run, so it never affects normal execution or caching.
+    merged_capture: Optional[pathlib.Path] = None
+    # Tee granularity for ``merged_capture`` ('line' or 'char'). Defaults to
+    # line-level teeing, which keeps each marked line atomic in the merged file.
+    tee_mode: Optional[Literal['char', 'line']] = None
+
     def get_cacheable_params(self) -> Dict[str, Any]:
         return self.model_dump(mode='json', exclude_unset=True, exclude_none=True)
 
@@ -208,6 +217,10 @@ class CommunicationParams(pydantic.BaseModel):
 
     merged_capture: Optional[pathlib.Path] = None
     tee_mode: Optional[Literal['char', 'line']] = 'char'
+    # When True, the solution's stderr is also tee'd into ``merged_capture``
+    # (marked '!'), interleaved with the interactor/solution dialogue in true
+    # write order, while still being written to the solution's stderr file.
+    tee_stderr: bool = False
 
 
 class SandboxLog(pydantic.BaseModel):

--- a/rbx/grading/judge/sandboxes/line_tee.py
+++ b/rbx/grading/judge/sandboxes/line_tee.py
@@ -15,9 +15,11 @@ extra = sys.argv[2]
 
 with open(extra, 'w') as f:
     for line in sys.stdin:
-        # Write merged capture first.
-        sys.stderr.write(c)
-        sys.stderr.write(line)
+        # Write merged capture first. The marker and the line are written in a
+        # single call so that, when several tees append to the same merged file
+        # concurrently (e.g. a solution's stdout and stderr in batch mode), the
+        # marker can never be split away from its line by an interleaving write.
+        sys.stderr.write(c + line)
         sys.stderr.flush()
 
         # Write to program.

--- a/rbx/grading/judge/sandboxes/stupid_sandbox.py
+++ b/rbx/grading/judge/sandboxes/stupid_sandbox.py
@@ -245,10 +245,80 @@ class StupidSandbox(SandboxBase):
         ) as commands:
             commands.write('%s\n' % command)
 
+        if params.merged_capture is not None:
+            return self._run_with_merged_capture(command, params)
+
         program = Program(command, self._get_program_params(params))
         result = program.wait()
 
         return self._get_sandbox_log(result, params)
+
+    def _run_with_merged_capture(
+        self, command: List[str], params: SandboxParams
+    ) -> SandboxLog:
+        """Run a single program, teeing its stdout ('>') and stderr ('!') into a
+        merged capture file in true write order while still producing the clean
+        stdout/stderr files. Used by ``rbx irun --merge-stderr`` for batch tasks.
+        """
+        assert params.merged_capture is not None
+        communication_params = CommunicationParams(
+            merged_capture=params.merged_capture,
+            tee_mode=params.tee_mode or 'line',
+        )
+        # Seed the merged file with the prefix header expected by the '.pio'
+        # parser; the tees then append their marked lines.
+        self.create_file_from_string(params.merged_capture, '<\n>\n', override=True)
+
+        program_params = self._get_program_params(params)
+        base_io = self._get_io(params)
+        # The program's stdout/stderr are piped into the tees; its stdin still
+        # comes straight from the input file (if any).
+        program_params.io = ProgramIO(
+            input=base_io.input,
+            output=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        program = Program(command, program_params)
+        assert program.pipes.output is not None
+        assert program.pipes.stderr is not None
+
+        group_id = os.getpgid(program.pid)
+        stdout_tee = self._get_tee_program(
+            '>',
+            stdin=program.pipes.output,
+            stdout=subprocess.DEVNULL,
+            capture=params.stdout_file,
+            pgid=group_id,
+            communication_params=communication_params,
+        )
+        stderr_tee = self._get_tee_program(
+            '!',
+            stdin=program.pipes.stderr,
+            stdout=subprocess.DEVNULL,
+            capture=params.stderr_file,
+            pgid=group_id,
+            communication_params=communication_params,
+        )
+
+        result: Optional[SandboxLog] = None
+        for _ in range(3):
+            pid, status, ru = os.wait4(-group_id, 0)
+            if pid == program.pid:
+                program_result = program.process_exit(status, ru)
+                result = self._get_sandbox_log(program_result, params)
+                # Closing the read ends signals EOF to the tees so they finish.
+                program.pipes.output.close()
+                program.pipes.stderr.close()
+            elif pid in (stdout_tee.pid, stderr_tee.pid):
+                pass
+            else:
+                raise RuntimeError(f'Unknown pid: {pid}')
+
+        for p in (program, stdout_tee, stderr_tee):
+            p.close()
+
+        assert result is not None
+        return result
 
     def run_communication(
         self,
@@ -284,6 +354,13 @@ class StupidSandbox(SandboxBase):
         should_tee = self._needs_teeing(
             params, interactor_params, communication_params.merged_capture
         )
+        # Tee the solution's stderr into the merged capture (marked '!') only
+        # when we already have a merged file to append to.
+        should_tee_stderr = (
+            should_tee
+            and communication_params.tee_stderr
+            and communication_params.merged_capture is not None
+        )
 
         if should_tee:
             if communication_params.merged_capture:
@@ -312,16 +389,34 @@ class StupidSandbox(SandboxBase):
             solution_input_pipe = interactor_tee.pipes.output
             solution_output_pipe = solution_tee.pipes.input
 
+        stderr_tee: Optional[Program] = None
+        if should_tee_stderr:
+            # The tee writes the clean stderr copy to its own extra file (the
+            # solution's stderr file) and the '!'-marked copy to the merged
+            # capture; its stdout is irrelevant so it is discarded.
+            stderr_tee = self._get_tee_program(
+                '!',
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                capture=params.stderr_file,
+                pgid=group_id,
+                communication_params=communication_params,
+            )
+            assert stderr_tee.pipes.input is not None
+
         program_params = self._get_program_params(params)
         program_params.io = self._get_io(params, pipe_io=True)
         program_params.io.input = solution_input_pipe
         program_params.io.output = solution_output_pipe
+        if stderr_tee is not None:
+            program_params.io.stderr = stderr_tee.pipes.input
         program_params.pgid = group_id
         program = Program(command, program_params)
 
         results: List[Optional[SandboxLog]] = [None, None]
 
-        for idx in range(4 if should_tee else 2):
+        num_processes = 2 + (2 if should_tee else 0) + (1 if should_tee_stderr else 0)
+        for idx in range(num_processes):
             pid, status, ru = os.wait4(-group_id, 0)
 
             if pid == interactor.pid:
@@ -348,7 +443,12 @@ class StupidSandbox(SandboxBase):
                 if should_tee:
                     assert solution_tee.pipes.input is not None
                     solution_tee.pipes.input.close()
+                if stderr_tee is not None:
+                    assert stderr_tee.pipes.input is not None
+                    stderr_tee.pipes.input.close()
             elif should_tee and (pid in (solution_tee.pid, interactor_tee.pid)):
+                pass
+            elif stderr_tee is not None and pid == stderr_tee.pid:
                 pass
             else:
                 raise RuntimeError(f'Unknown pid: {pid}')
@@ -358,6 +458,8 @@ class StupidSandbox(SandboxBase):
         if should_tee:
             for p in (solution_tee, interactor_tee):
                 p.close()
+        if stderr_tee is not None:
+            stderr_tee.close()
 
         return typing.cast(Tuple[SandboxLog, SandboxLog], tuple(results))
 

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -877,6 +877,7 @@ async def run_coordinated(
     sandbox: SandboxBase,
     merged_capture: Optional[pathlib.Path] = None,
     line_capture: bool = False,
+    tee_stderr: bool = False,
 ) -> Tuple[Optional[RunLog], Optional[RunLog]]:
     sandbox.reset()
 
@@ -902,6 +903,7 @@ async def run_coordinated(
             CommunicationParams(
                 merged_capture=merged_capture,
                 tee_mode='line' if line_capture else 'char',
+                tee_stderr=tee_stderr,
             ),
         )
 

--- a/rbx/grading/steps_with_caching.py
+++ b/rbx/grading/steps_with_caching.py
@@ -108,6 +108,7 @@ async def run_coordinated(
     dependency_cache: DependencyCache,
     merged_capture: Optional[pathlib.Path] = None,
     line_capture: bool = False,
+    tee_stderr: bool = False,
 ) -> Tuple[Optional[RunLog], Optional[RunLog]]:
     artifacts.logs = GradingLogsHolder()
 
@@ -130,6 +131,7 @@ async def run_coordinated(
         ),
     }
     cacheable_params['line_capture'] = line_capture
+    cacheable_params['tee_stderr'] = tee_stderr
 
     if interactor.metadata is not None and interactor.metadata.retryIndex is not None:
         cacheable_params['interactor.__retry_index__'] = interactor.metadata.retryIndex
@@ -158,6 +160,7 @@ async def run_coordinated(
                         sandbox,
                         merged_capture=merged_capture,
                         line_capture=line_capture,
+                        tee_stderr=tee_stderr,
                     )
             else:
                 cached_profile.stop()

--- a/rbx/testdata/steps_run_test/interleaved_io.py
+++ b/rbx/testdata/steps_run_test/interleaved_io.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+import sys
+
+# Interleave writes to stdout and stderr so the merged capture can be checked
+# for true line-order teeing.
+print('out line 1', flush=True)
+print('err line 1', file=sys.stderr, flush=True)
+print('out line 2', flush=True)
+print('err line 2', file=sys.stderr, flush=True)

--- a/tests/e2e/assertions.py
+++ b/tests/e2e/assertions.py
@@ -71,6 +71,14 @@ def check_stdout_contains(
             raise AssertionError(f'stdout missing {needle!r}')
 
 
+def check_stdout_not_contains(
+    ctx: AssertionContext, expected: Union[str, List[str]]
+) -> None:
+    for needle in _as_list(expected):
+        if needle in ctx.stdout:
+            raise AssertionError(f'stdout unexpectedly contains {needle!r}')
+
+
 def check_stderr_contains(
     ctx: AssertionContext, expected: Union[str, List[str]]
 ) -> None:

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -41,6 +41,7 @@ from tests.e2e.assertions import (
     check_stderr_contains,
     check_stdout_contains,
     check_stdout_matches,
+    check_stdout_not_contains,
     check_tests,
     check_zip_contains,
     check_zip_file_contains,
@@ -106,6 +107,7 @@ def seed_package_from_preset(preset_name: str, dest: pathlib.Path) -> None:
 # Field names on ``Expect`` paired with the assertion check they dispatch to.
 _GENERIC_CHECKS = (
     ('stdout_contains', check_stdout_contains),
+    ('stdout_not_contains', check_stdout_not_contains),
     ('stderr_contains', check_stderr_contains),
     ('stdout_matches', check_stdout_matches),
     ('files_exist', check_files_exist),

--- a/tests/e2e/spec.py
+++ b/tests/e2e/spec.py
@@ -111,6 +111,7 @@ class ZipFileMatcher(_Forbid):
 
 class Expect(_Forbid):
     stdout_contains: Union[str, List[str], None] = None
+    stdout_not_contains: Union[str, List[str], None] = None
     stderr_contains: Union[str, List[str], None] = None
     stdout_matches: Optional[str] = None
     files_exist: List[str] = Field(default_factory=list)

--- a/tests/e2e/testdata/irun-stderr/e2e.rbx.yml
+++ b/tests/e2e/testdata/irun-stderr/e2e.rbx.yml
@@ -7,3 +7,16 @@ scenarios:
           stdout_contains:
             - "Stderr"
             - "DBG_STDERR_MARKER"
+  - name: merge-stderr
+    steps:
+      - cmd: build
+      # With -e, stderr is interleaved with the output in true line order
+      # instead of being shown under a separate "Stderr" section.
+      - cmd: irun sols/main.cpp -t main/0 -p -e -v4
+        expect:
+          stdout_contains:
+            - "DBG_STDERR_MARKER"
+          stdout_not_contains:
+            - "Stderr"
+          files_exist:
+            - "**/*.pio"

--- a/tests/rbx/grading/steps_run_coordinated_test.py
+++ b/tests/rbx/grading/steps_run_coordinated_test.py
@@ -444,6 +444,77 @@ class TestStepsRunCoordinated:
 
         assert merged_content == expected_content
 
+    async def test_run_coordinated_with_merged_capture_and_stderr(
+        self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path
+    ):
+        """Solution stderr is tee'd into the merged capture (marked '!')."""
+        interactor_file = testdata_path / 'steps_run_test' / 'simple_interactor.py'
+        solution_file = testdata_path / 'steps_run_test' / 'simple_solution.py'
+
+        artifacts = GradingArtifacts(root=cleandir)
+        artifacts.inputs.extend(
+            [
+                GradingFileInput(
+                    src=interactor_file, dest=pathlib.Path('interactor.py')
+                ),
+                GradingFileInput(src=solution_file, dest=pathlib.Path('solution.py')),
+            ]
+        )
+        artifacts.outputs.extend(
+            [
+                GradingFileOutput(
+                    src=pathlib.Path('merged.log'), dest=pathlib.Path('merged.log')
+                ),
+                GradingFileOutput(
+                    src=pathlib.Path('solution.stderr'),
+                    dest=pathlib.Path('solution.stderr'),
+                ),
+            ]
+        )
+        artifacts.logs = GradingLogsHolder()
+
+        interactor_params = CoordinatedRunParams(
+            command=f'{sys.executable} interactor.py',
+            params=SandboxParams(timeout=5000),
+        )
+        solution_params = CoordinatedRunParams(
+            command=f'{sys.executable} solution.py',
+            params=SandboxParams(
+                stderr_file=pathlib.Path('solution.stderr'),
+                timeout=5000,
+            ),
+        )
+
+        solution_log, interactor_log = await steps.run_coordinated(
+            interactor_params,
+            solution_params,
+            artifacts,
+            sandbox,
+            merged_capture=pathlib.Path('merged.log'),
+            line_capture=True,
+            tee_stderr=True,
+        )
+
+        assert solution_log is not None
+        assert interactor_log is not None
+
+        merged_content = (cleandir / 'merged.log').read_text()
+        merged_lines = merged_content.splitlines()
+
+        # stderr lines appear in the merged capture, marked with '!'.
+        assert '!Received: world' in merged_lines
+        assert '!Solution finished' in merged_lines
+        # stdout (solution) lines are marked '>', interactor lines '<'.
+        assert '>3' in merged_lines
+        assert '<world' in merged_lines
+
+        # The standalone stderr file stays clean (no markers, no stdout).
+        solution_stderr = (cleandir / 'solution.stderr').read_text()
+        assert 'Received: world' in solution_stderr
+        assert 'Solution finished' in solution_stderr
+        assert '!' not in solution_stderr
+        assert '>3' not in solution_stderr
+
     async def test_run_coordinated_output_artifacts_failure(
         self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path
     ):

--- a/tests/rbx/grading/steps_run_test.py
+++ b/tests/rbx/grading/steps_run_test.py
@@ -959,6 +959,56 @@ class TestStepsRun:
         assert 'test1.py' in glob_output_content
         assert 'test2.py' in glob_output_content
 
+    async def test_run_with_merged_capture(
+        self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path
+    ):
+        """Batch run tees stdout ('>') and stderr ('!') into a merged file while
+        keeping the clean stdout/stderr files intact."""
+        script_file = testdata_path / 'steps_run_test' / 'interleaved_io.py'
+        artifacts = GradingArtifacts(root=cleandir)
+        artifacts.inputs.append(
+            GradingFileInput(src=script_file, dest=pathlib.Path('script.py'))
+        )
+        artifacts.outputs.extend(
+            [
+                GradingFileOutput(
+                    src=pathlib.Path('output.txt'), dest=pathlib.Path('output.txt')
+                ),
+                GradingFileOutput(
+                    src=pathlib.Path('output.err'), dest=pathlib.Path('output.err')
+                ),
+                GradingFileOutput(
+                    src=pathlib.Path('merged.pio'), dest=pathlib.Path('merged.pio')
+                ),
+            ]
+        )
+        artifacts.logs = GradingLogsHolder()
+
+        params = SandboxParams(
+            stdout_file=pathlib.Path('output.txt'),
+            stderr_file=pathlib.Path('output.err'),
+            merged_capture=pathlib.Path('merged.pio'),
+        )
+        command = f'{sys.executable} script.py'
+
+        result = await steps.run(command, params, sandbox, artifacts)
+
+        assert result is not None
+        assert result.exitcode == 0
+
+        # Clean stdout/stderr files stay unpolluted (no markers, no cross-stream
+        # contents), so the checker can still read clean output.
+        assert (cleandir / 'output.txt').read_text() == 'out line 1\nout line 2\n'
+        assert (cleandir / 'output.err').read_text() == 'err line 1\nerr line 2\n'
+
+        # The merged file interleaves both streams with their markers.
+        merged_lines = (cleandir / 'merged.pio').read_text().splitlines()
+        assert merged_lines[:2] == ['<', '>']
+        assert '>out line 1' in merged_lines
+        assert '>out line 2' in merged_lines
+        assert '!err line 1' in merged_lines
+        assert '!err line 2' in merged_lines
+
 
 def test_run_log_summary_includes_sandbox_message_on_sandbox_error():
     log = steps.RunLog(


### PR DESCRIPTION
Implements **Phase 3 of #266** (tracked in #517): an opt-in `--merge-stderr` / `-e` flag for `rbx irun` that interleaves a solution's `stderr` with its output in **true line order**, with stderr lines colored distinctly. Default (no flag) keeps the separate "Stderr" section delivered in PR #516 (Phases 1–2).

Closes #517.

## What it does

- `rbx irun <sol> -t <tc> -p -e` weaves stderr (red, marker `!`) into the Output (batch) or Interaction (communication) view in the order lines were actually written.
- Clean stdout/stderr files are left untouched, so the checker is unaffected.
- For **COMMUNICATION** problems, stderr folds into the existing interaction capture as a third stream alongside the interactor and solution.
- Used without `-p`, it warns and is a no-op (doesn't error).

## How

Reuses the existing tee / `merged_capture` machinery (stderr = marker `!`, color `error`, parsed as pipe `2` — already wired in PR #516's `parse_interaction`/`print_interaction`).

- **Grading core** (`stupid_sandbox.py`): batch `run()` gains an optional `merged_capture` that tees stdout (`>`) and stderr (`!`) into one file in true write order; `run_communication()` gains a `tee_stderr` stream. `line_tee.py` now writes each marker+line in a single atomic write so concurrent tees can't corrupt the merged file.
- **Threading**: `tee_stderr` / `merged_capture` flow through `steps` → `steps_with_caching` → `code.run_item` / `run_communication` → `tasks`. `merge_stderr` rides on `SolutionReportSkeleton` so toggling the flag never serves a stale merged capture (irun only caches with an explicit `--testcase`).
- **CLI + render**: `-e` added to `irun`; renders the merged `.pio` via `print_interaction` instead of the plain Output + separate Stderr section.

## Notes / limitations

- In merged-capture mode the program's stdout/stderr are piped through tees, so file-size-based OLE detection is bypassed (RLIMIT_FSIZE still applies at the process level). This only affects the interactive debug-only `irun -e` path, never judging/packaging.

## Tests

- Grading tests for both the batch (`steps_run_test.py::test_run_with_merged_capture`) and communication (`steps_run_coordinated_test.py::test_run_coordinated_with_merged_capture_and_stderr`) tee paths.
- e2e `merge-stderr` scenario driving a real C++ batch run: asserts the stderr marker is interleaved, no separate "Stderr" section is shown, and a merged `.pio` is produced. Adds a `stdout_not_contains` assertion to the e2e DSL.
- Docs: `running/index.md` + regenerated `cli.md`.

## Verification

- Full grading suite: 386 passed, 1 skipped.
- Both `irun-stderr` e2e scenarios pass.
- `ruff check` + `ruff format --check` clean; non-strict `mkdocs build` succeeds.
- Pre-existing unrelated failures (checker/validator/sandbox unit tests, stack-limit) reproduce identically on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)