### PR TITLE
feat: sandbox dir mirroring Phase 2 — executionFiles + auto-expansion (#524)

### DIFF
--- a/docs/plans/2026-06-06-sandbox-working-directory-phase2-design.md
+++ b/docs/plans/2026-06-06-sandbox-working-directory-phase2-design.md
@@ -132,11 +132,18 @@ class DependencyGraph:
         Deterministic order."""
 
 
-def expand(code: CodeItem) -> Optional[DependencyGraph]:
+def expand(
+    code: CodeItem, require_kind: Optional[DependencyKind] = None
+) -> Optional[DependencyGraph]:
     """BFS from code.path using the language scanner. Cycle-safe (visited set);
     keeps only references that resolve to an existing file under the package root.
     Returns None when there is no scanner for the language, or the source lives
-    outside the package root (remote/temporary files stay flat, as today)."""
+    outside the package root (remote/temporary files stay flat, as today).
+
+    `require_kind` short-circuits *before* the walk when the language's scanner
+    cannot contribute that kind: a C++ source skips scanning entirely on the
+    execution path (`_prepare_run` runs once per solution x testcase, the hot path),
+    and a Python source skips it on the compile path."""
 ```
 
 `nodes` includes the **root** so that #525 can rewrite the root source's own
@@ -159,7 +166,12 @@ Each scanner owns its resolution (single source of truth; never duplicated in
   `node.level` for relative imports (`from . import x`, `from ..pkg import y`) and
   treat a bare `import sibling` / `from sibling import …` as a sibling only when
   `<dir>/sibling.py` or `<dir>/sibling/__init__.py` exists; otherwise (stdlib /
-  third-party) `target = None`. `kinds = {EXECUTION}`. `can_rewrite = False`.
+  third-party) `target = None`. For a deep dotted import (`import a.b.c`) it also
+  emits the existing intermediate package markers (`a/__init__.py`,
+  `a/b/__init__.py`) so the mirror preserves regular-package semantics.
+  `kinds = {EXECUTION}`. `can_rewrite = False`. (A relative `from . import x` is
+  *discovered* and mirrored but cannot execute in a directly-run `__main__` script;
+  the runnable idiom for a mirrored script is the absolute `import x`.)
 
 tree-sitter-cpp is already a dependency (`pyproject.toml`) and is used by
 `linters/cpp/testlib.py`; the C++ scanner reuses that pattern. tree-sitter is
@@ -221,6 +233,28 @@ not added here; they are added at run time.)
 the communication path). Add **manual `executionFiles`** for all languages, **plus**
 (if `DependencyKind.EXECUTION in graph.kinds`) `graph.files()` — union, dedup by dest.
 This is the new execution-time mirroring.
+
+### Execution: `PYTHONPATH` (discovered during implementation)
+
+Mirroring the sibling module into the sandbox is **necessary but not sufficient** for
+Python. The entry script is materialized as a **symlink into the content-addressed
+cache** (the sandbox's perf optimization). Python ≥3.11 sets `sys.path[0]` to the
+*realpath* of the script's directory, which resolves through the symlink to the cache
+store — **not** the mirrored sandbox directory where the sibling module lives. So
+`import sibling` fails with `ModuleNotFoundError` even though `sibling.py` sits right
+next to the script in the sandbox. (This is a latent issue since Phase 1; #524 is the
+first feature to actually exercise runtime sibling imports — Phase 1's nested-Python
+guard had no imports, so it passed under the old flat layout too.)
+
+**Fix:** for execution-mirrored languages, set `sandbox_params.set_env['PYTHONPATH']`
+to the mirrored source's directory (package-relative; `.` for a flat package),
+preserving any existing value. This restores the directory that `python3 dir/script.py`
+would normally put on the path. It is gated on `DependencyKind.EXECUTION in
+graph.kinds` (currently Python only) and reuses the graph already computed in
+`_prepare_run`. `set_env` is part of the run cache key, so this is cache-correct (a
+one-time invalidation for Python runs). We deliberately add **only** the source dir
+(not the package root) to match normal Python semantics and avoid shadowing stdlib
+with root-level modules.
 
 ### Schema (`schema.CodeItem`)
 

--- a/docs/plans/2026-06-06-sandbox-working-directory-phase2-design.md
+++ b/docs/plans/2026-06-06-sandbox-working-directory-phase2-design.md
@@ -96,11 +96,10 @@ class Reference:
 
 
 class DependencyScanner(abc.ABC):
-    kinds: ClassVar[Set[DependencyKind]]
+    name: ClassVar[str]                              # registry key
+    language_kinds: ClassVar[Set[LanguageKind]]      # which language families it handles
+    dependency_kinds: ClassVar[Set[DependencyKind]]  # compile- vs run-time deps
     can_rewrite: ClassVar[bool] = False
-
-    @abc.abstractmethod
-    def handles(self, language: str) -> bool: ...
 
     @abc.abstractmethod
     def references(self, file: pathlib.Path) -> List[Reference]:
@@ -114,9 +113,19 @@ class DependencyScanner(abc.ABC):
         raise NotImplementedError
 ```
 
-Registry: `@register` decorator + `get_scanner(language) -> Optional[DependencyScanner]`
-(returns `None` for unhandled languages — Java/Kotlin/etc.). Same shape as
-`linters/registry.py`.
+> **Revised during PR review.** Scanners are no longer dispatched by raw language
+> name (`handles(language)`). A scanner declares the `LanguageKind`s it applies to
+> (`CppScanner → {CXX}`, `PythonScanner → {PYTHON}`); a code's kinds come from
+> `environment.language_kinds`, derived from its **toolchain** (compile/execution
+> commands via `grading.language_kind.command_kinds`), not its name. The existing
+> `is_*_command` predicates become thin aliases over `command_kinds` (deprecation
+> tracked in #529).
+
+Registry (`@register` by `name`): `get_scanner(name)` for explicit lookup, and
+`get_scanners_for_kinds(kinds, names)` which returns every scanner whose
+`language_kinds` intersects `kinds`, plus any explicitly named in a language's
+`scanners` env field (mirroring `linters`). `expand` resolves the applicable scanners
+this way and returns `None` when none apply (Java/Kotlin/etc.).
 
 ### The engine (`graph.py`)
 
@@ -234,7 +243,7 @@ the communication path). Add **manual `executionFiles`** for all languages, **pl
 (if `DependencyKind.EXECUTION in graph.kinds`) `graph.files()` — union, dedup by dest.
 This is the new execution-time mirroring.
 
-### Execution: `PYTHONPATH` (discovered during implementation)
+### Execution: copy interpreted entry scripts (discovered during implementation)
 
 Mirroring the sibling module into the sandbox is **necessary but not sufficient** for
 Python. The entry script is materialized as a **symlink into the content-addressed
@@ -246,15 +255,18 @@ next to the script in the sandbox. (This is a latent issue since Phase 1; #524 i
 first feature to actually exercise runtime sibling imports — Phase 1's nested-Python
 guard had no imports, so it passed under the old flat layout too.)
 
-**Fix:** for execution-mirrored languages, set `sandbox_params.set_env['PYTHONPATH']`
-to the mirrored source's directory (package-relative; `.` for a flat package),
-preserving any existing value. This restores the directory that `python3 dir/script.py`
-would normally put on the path. It is gated on `DependencyKind.EXECUTION in
-graph.kinds` (currently Python only) and reuses the graph already computed in
-`_prepare_run`. `set_env` is part of the run cache key, so this is cache-correct (a
-one-time invalidation for Python runs). We deliberately add **only** the source dir
-(not the package root) to match normal Python semantics and avoid shadowing stdlib
-with root-level modules.
+> **Revised during PR review.** The first fix set `PYTHONPATH` to the mirrored source
+> dir for Python runs. The cleaner, language-agnostic fix below replaces it.
+
+**Fix:** materialize the entry script as a **real copy** rather than a cache symlink
+when the language is *interpreted*. `GradingFileInput` gains a `symlink: bool = True`
+field; `_process_input_artifacts` honours it (`try_symlink=input.symlink`); and
+`_prepare_run` sets `symlink=False` on the executable input for interpreted languages.
+A copied script's realpath is its own sandbox path, so `sys.path[0]` is the mirrored
+directory and the (still-symlinked) siblings resolve naturally. "Interpreted" is
+derived from the language definition via `environment.is_interpreted` (passthrough /
+no compile commands — the same signal `compile_item` uses), so this generalises to any
+interpreted language, not just Python, with no per-language env var.
 
 ### Schema (`schema.CodeItem`)
 

--- a/docs/plans/2026-06-06-sandbox-working-directory-phase2-design.md
+++ b/docs/plans/2026-06-06-sandbox-working-directory-phase2-design.md
@@ -1,0 +1,294 @@
+# Sandbox dir mirroring Phase 2: `executionFiles` + auto-expansion
+
+**Issue:** [#524](https://github.com/rsalesc/rbx/issues/524) — follow-up to #522 / #523
+(Phase 1). With implications baked in for
+[#525](https://github.com/rsalesc/rbx/issues/525) (packaging flatten/rewrite).
+
+**Phase 1 design:** `docs/plans/2026-06-05-sandbox-working-directory-design.md`
+
+## Problem
+
+Phase 1 made the sandbox working directory mirror the package layout: sources
+compile at their package-relative path, `compilationFiles` land package-relative (the
+under-code-folder restriction was lifted, enabling `#include "../lib.h"`), and the
+builtin headers (testlib/jngen/tgen/rbx + `bits/stdc++.h`) live in a reserved
+`__internal__/` dir exposed via `-I__internal__`, so a quoted `#include "testlib.h"`
+resolves from any source location, flat or nested. Bringing extra files into the
+mirror still requires **manual declaration**, and there is **no execution-time
+equivalent** of `compilationFiles` at all.
+
+Phase 2 adds:
+
+1. **`executionFiles`** on every `CodeItem` — the runtime equivalent of
+   `compilationFiles`. Declared files are mirrored into the sandbox at *execution*
+   time. For a flat package this is a no-op; for a subdir source the file lands at
+   its package-relative path.
+2. **Default-on, recursive, quoted-only auto-expansion** of dependencies,
+   per-language: C++ `#include "..."` → compilation files; Python relative / sibling
+   imports → execution files. Follows transitively, cycle-safe. Manual fields remain
+   as an additive escape hatch.
+
+Per the issue owner, both must flow through a **common per-language interface** that
+returns compilation and execution files, dispatched by the language being
+compiled/run — and that *same* interface must serve #525, which needs to flatten
+sources and rewrite cross-directory `#include "..."` for flat/inline judges (Polygon,
+BOCA). #525 therefore dictates the shape of the interface: it needs not just the
+*set* of dependency files but the per-file include **edges** (directive → resolved
+target) so it can rewrite them.
+
+## Findings that scope this work
+
+- **The issue's Phase-1 limitation "builtins only in the source's directory" is
+  already resolved.** Phase 1 was revised during implementation to place builtins in
+  `__internal__/` with `-I__internal__` (see Phase 1 design § 3). A cross-directory
+  header that itself does `#include "testlib.h"` resolves via that `-I` fallback. No
+  further work needed here. (`maybe_get_bits_stdcpp_for_commands` finds system bits on
+  Linux/GCC and clang-bundled bits on macOS, so `-I__internal__` is reliably present
+  on C++ commands.)
+- **The "deprecate auto-placed builtins" idea is out of scope.** It is a larger,
+  riskier change (every package would have to declare testlib). Builtins stay
+  auto-injected via `__internal__/`; auto-expansion naturally ignores them because
+  they are not package files.
+
+## Non-goals (this phase)
+
+- Anything under `rbx/box/packaging/` (that is #525). We deliver the
+  `DependencyGraph` + `rewrite()` primitive that #525 will consume; we do not wire any
+  packager.
+- Deprecating / removing the auto-injected builtin headers.
+- Python source flattening / `rewrite()` for Python (the interface slot exists behind
+  a capability flag; C++ is the only implementer for now).
+
+## Architecture
+
+A single per-language extension point (a *scanner* that knows one language's
+include/import syntax) plus a generic, language-agnostic engine (transitive walk +
+graph). Three consumers read from the one structure: compilation, execution, and
+(future) packaging-rewrite.
+
+### New package `rbx/box/dependencies/`
+
+Mirrors the `linters/` package (registry + per-language modules, self-registering via
+`__init__.py`).
+
+```
+dependencies/
+  scanner.py    # DependencyKind, Reference, DependencyScanner ABC, registry
+  graph.py      # DependencyGraph + expand(code)
+  cpp.py        # CppScanner    (tree-sitter-cpp; kinds={COMPILATION}; can_rewrite=True)
+  python.py     # PythonScanner (ast; kinds={EXECUTION}; can_rewrite=False)
+  __init__.py   # imports cpp/python so they self-register
+```
+
+### Core types (`scanner.py`)
+
+```python
+class DependencyKind(enum.Enum):
+    COMPILATION = 'compilation'
+    EXECUTION = 'execution'
+
+
+@dataclasses.dataclass(frozen=True)
+class Reference:
+    spelling: str                 # exactly as written, e.g. '../lib.h'  (drives rewrite)
+    target: Optional[pathlib.Path]  # package-relative resolved file, or None
+                                    # (system/builtin/unresolved → ignored)
+
+
+class DependencyScanner(abc.ABC):
+    kinds: ClassVar[Set[DependencyKind]]
+    can_rewrite: ClassVar[bool] = False
+
+    @abc.abstractmethod
+    def handles(self, language: str) -> bool: ...
+
+    @abc.abstractmethod
+    def references(self, file: pathlib.Path) -> List[Reference]:
+        """Direct dependency references of `file`, already resolved against the
+        package root. Unresolvable / system / builtin references have target=None."""
+
+    def rewrite(self, text: str, rename: Callable[[str], Optional[str]]) -> str:
+        """Rewrite each include/import directive whose spelling `rename` maps to a
+        new spelling. Pure text transform; only the path token changes. Default
+        raises NotImplementedError; overridden by languages with can_rewrite=True."""
+        raise NotImplementedError
+```
+
+Registry: `@register` decorator + `get_scanner(language) -> Optional[DependencyScanner]`
+(returns `None` for unhandled languages — Java/Kotlin/etc.). Same shape as
+`linters/registry.py`.
+
+### The engine (`graph.py`)
+
+```python
+@dataclasses.dataclass
+class DependencyGraph:
+    root: pathlib.Path                                   # package-relative source
+    nodes: Dict[pathlib.Path, List[Reference]]           # file -> its edges (incl. root)
+    kinds: Set[DependencyKind]                            # from the scanner
+
+    def files(self) -> List[pathlib.Path]:
+        """All discovered dependency files (package-relative), EXCLUDING the root.
+        Deterministic order."""
+
+
+def expand(code: CodeItem) -> Optional[DependencyGraph]:
+    """BFS from code.path using the language scanner. Cycle-safe (visited set);
+    keeps only references that resolve to an existing file under the package root.
+    Returns None when there is no scanner for the language, or the source lives
+    outside the package root (remote/temporary files stay flat, as today)."""
+```
+
+`nodes` includes the **root** so that #525 can rewrite the root source's own
+directives; `files()` excludes the root because the root is added to the artifacts
+separately (as the compilable / executable).
+
+### Resolution rules
+
+Each scanner owns its resolution (single source of truth; never duplicated in
+`rewrite`):
+
+- **C++ (`CppScanner`, tree-sitter-cpp).** Walk `preproc_include` nodes; keep those
+  with a `string_literal` child (quoted), skip `system_lib_string` (`<...>`). For each
+  quoted include with spelling `s`: candidate = `file.parent / s`, normalized; if it
+  is an existing file under the package root → `target` = its package-relative path,
+  else `target = None`. So `#include "testlib.h"` (builtin, not a package file) →
+  `None` → ignored (it resolves via `-I__internal__`); `#include "../lib.h"` → `lib.h`.
+  `kinds = {COMPILATION}`. `can_rewrite = True`.
+- **Python (`PythonScanner`, `ast`).** Parse and walk `Import` / `ImportFrom`. Use
+  `node.level` for relative imports (`from . import x`, `from ..pkg import y`) and
+  treat a bare `import sibling` / `from sibling import …` as a sibling only when
+  `<dir>/sibling.py` or `<dir>/sibling/__init__.py` exists; otherwise (stdlib /
+  third-party) `target = None`. `kinds = {EXECUTION}`. `can_rewrite = False`.
+
+tree-sitter-cpp is already a dependency (`pyproject.toml`) and is used by
+`linters/cpp/testlib.py`; the C++ scanner reuses that pattern. tree-sitter is
+error-tolerant, so a malformed source yields a (partial) tree rather than throwing.
+
+### The `rewrite` primitive (baked for #525, implemented for C++)
+
+`rewrite(text, rename)` is *only* the textual transform — it does not resolve paths,
+allocate names, or copy files. Keyed on **spelling**, not the resolved target, so
+resolution stays solely in `references()`; because both use the same tree-sitter
+traversal, every spelling the caller learned from the graph matches exactly.
+
+How #525 will compose it (illustrative; not built this phase):
+
+```python
+graph = expand(code)
+flat = allocate_flat_names([graph.root, *graph.files()])   # #527 collision scheme
+for file, refs in graph.nodes.items():
+    rename = {r.spelling: flat[r.target] for r in refs if r.target in flat}
+    new_text = scanner.rewrite(file.read_text(), rename.get)
+    ship(new_text, as_name=flat[file])
+```
+
+Worked example:
+
+```
+lib.h
+gens/gen.cpp        #include "../lib.h"   #include "helpers/rng.h"
+gens/helpers/rng.h  #include "../../lib.h"
+```
+
+`expand(gen)` → `files() == [lib.h, gens/helpers/rng.h]`; nodes carry the edges
+`gen.cpp: {../lib.h→lib.h, helpers/rng.h→gens/helpers/rng.h}`,
+`rng.h: {../../lib.h→lib.h}`. With flat names `{gen.cpp, lib.h, rng.h}` the rewrites
+become `#include "lib.h"`, `#include "rng.h"` (in `gen.cpp`) and `#include "lib.h"`
+(in `rng.h`). The graph already holds every `spelling→target` edge, so the caller
+never re-parses; the primitive is sufficient.
+
+C++ `rewrite` implementation: tree-sitter parse → for each quoted `preproc_include`
+extract its spelling, call `rename`; collect `(byte_start, byte_end, replacement)` for
+the path token; apply right-to-left to preserve offsets; return new text. Comment- and
+raw-string-safe; `<...>` includes are never touched; unmapped quoted includes (rename
+returns `None`) are left byte-for-byte.
+
+## Consumers wired this phase
+
+### Compilation (`code.compile_item`)
+
+After the manual `compilationFiles` inputs are added, call `expand(code)`; if
+`DependencyKind.COMPILATION in graph.kinds`, add `graph.files()` to the compile inputs
+as a **union** with the manual set (dedup by dest path). Builtins, `__internal__/`,
+`-I__internal__`, and precompiled-header logic are unchanged. (Python returns early
+from `compile_item` — its `compilation_options.commands` is empty — so its deps are
+not added here; they are added at run time.)
+
+### Execution (`code._prepare_run`)
+
+`_prepare_run` is the single chokepoint for run-time artifacts (used by `run_item` and
+the communication path). Add **manual `executionFiles`** for all languages, **plus**
+(if `DependencyKind.EXECUTION in graph.kinds`) `graph.files()` — union, dedup by dest.
+This is the new execution-time mirroring.
+
+### Schema (`schema.CodeItem`)
+
+Add `executionFiles: Optional[List[str]] = Field(default=[], …)` mirroring
+`compilationFiles` (paths relative to the package root; placed at the same
+package-relative path inside the sandbox). Add `package.get_execution_files(code)`
+mirroring `get_compilation_files` (exists-and-under-root checks; src == dest ==
+package-relative path). Propagate `executionFiles` in `CodeItemWithDigest.create` and
+`OutputFromItemWithDigest.create`.
+
+## Override semantics
+
+Auto-expansion is **additive**, not an off-switch: manual
+`compilationFiles`/`executionFiles` are unioned with auto-discovered files (deduped).
+The scanner only ever adds files that are both quoted-included *and* exist under the
+package root, so it cannot introduce phantom dependencies; manual declaration stays
+the escape hatch for files the scanner cannot see (macro-built include paths, runtime
+data files). No `autoExpand` flag (YAGNI; can be added later if a real need appears).
+
+## Caching impact
+
+Auto-discovered compilation files become compile inputs → already part of the
+dependency-cache key (inputs are content-hashed). Auto-discovered execution files
+become run inputs → part of the run cache key. If a dependency's contents change (e.g.
+it gains/loses an `#include`), the discovered set changes and the inputs change, so the
+cache invalidates correctly. No cache-format change. Affected packages take a one-time
+recompile/rerun.
+
+## Testing
+
+- **Unit — scanners & engine** (no toolchain needed):
+  - C++: nested / transitive `#include "..."`; ignore `<...>`; ignore builtin
+    (`testlib.h`, not a package file) → `target=None`; resolve `../lib.h`; cycle
+    safety; refuse references outside the package root.
+  - Python: `from .`, `from ..pkg`, sibling `import x` (resolves only if the sibling
+    file exists); ignore stdlib/third-party; transitive; cycle safety.
+  - `expand`: returns `None` for Java/Kotlin and for sources outside the package root;
+    `files()` excludes root and is deterministic.
+  - C++ `rewrite`: maps quoted includes via `rename`; leaves `<...>` and unmapped
+    quoted includes untouched; ignores an `#include` inside a `/* … */` comment;
+    preserves the rest byte-for-byte. Python `rewrite` raises `NotImplementedError`.
+- **Integration — teeth-having** (real toolchain; new file alongside the Phase 1
+  `code_compile_integration_test.py`):
+  - Subdir C++ source whose `#include "../lib.h"` is **auto-discovered** (no manual
+    `compilationFiles`) compiles and runs.
+  - Subdir Python source importing a **sibling module** runs correctly end-to-end —
+    the execution-mirroring test Phase 1 could only smoke-test.
+  - Flat package regression (unchanged behaviour).
+
+Pre-existing local C++/sandbox/docker failures on this machine are environmental
+(see project memory); only new include/import-resolution failures are ours.
+
+## Definition of done
+
+- [ ] `rbx/box/dependencies/` with `scanner.py`, `graph.py`, `cpp.py`, `python.py`,
+      registry, self-registration.
+- [ ] `CodeItem.executionFiles` + `package.get_execution_files`; propagated in the
+      `*WithDigest.create` factories.
+- [ ] C++ compilation auto-expands `#include "..."` (transitive, quoted-only, additive).
+- [ ] Execution mirrors manual + auto-discovered execution files via `_prepare_run`.
+- [ ] C++ `rewrite` implemented (tree-sitter, span-based) and unit-tested; Python
+      `rewrite` gated behind `can_rewrite=False`.
+- [ ] Unit + integration tests pass (modulo pre-existing environmental failures).
+- [ ] Lint clean; conventional commits throughout. No `packaging/` changes.
+
+## Deferred to #525 (interface consumed, not built here)
+
+Flatten + rename + rewrite for Polygon offline (checker/interactor), Polygon upload
+(all sources), BOCA (checker/interactor), plus the interim guardrail that errors on a
+non-flat mirrored layout when `can_rewrite` is False. #525 also coordinates with #526
+(ship `compilationFiles` bytes) and #527 (flat-name collision scheme).

--- a/docs/plans/2026-06-06-sandbox-working-directory-phase2.md
+++ b/docs/plans/2026-06-06-sandbox-working-directory-phase2.md
@@ -1,0 +1,793 @@
+# Sandbox Mirroring Phase 2 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `executionFiles` + default-on transitive auto-expansion of quoted
+`#include`/relative imports, via a per-language dependency scanner + generic graph
+engine, with a `rewrite` primitive baked for #525.
+
+**Architecture:** New `rbx/box/dependencies/` package (mirrors `linters/`). A tiny
+per-language `DependencyScanner` (C++ via tree-sitter-cpp, Python via `ast`) exposes
+`references(file)` (resolved direct deps) and `rewrite(text, rename)` (C++ only). A
+generic `expand(code) -> DependencyGraph` does the cycle-safe transitive walk and
+exposes `files()` (by kind) and per-file edges. Compilation unions C++ deps into
+compile inputs; execution unions Python deps + manual `executionFiles` into run inputs.
+
+**Tech Stack:** Python 3.12, Pydantic v2, tree-sitter-cpp (already a dep), `ast`,
+pytest (`uv run pytest`), ruff.
+
+**Design doc:** `docs/plans/2026-06-06-sandbox-working-directory-phase2-design.md`
+
+---
+
+## Conventions for the executing engineer
+
+- Single quotes; absolute imports only; run `uv run ruff format .` and
+  `uv run ruff check --fix .` before each commit.
+- Conventional Commits (commitizen). Append trailer
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- Tests live under `tests/rbx/box/`. Reuse `testing_pkg` fixture (cwd = package root).
+  `testing_pkg.add_file(path, src=None)` creates the file (empty unless `src` copies
+  from `testdata/`); write content with `.write_text(...)`.
+- `TestCompileItem` in `code_compile_test.py` has autouse `mock_steps_with_caching`
+  (inspect `call_args[0][0]` = commands, `call_args.kwargs['artifacts']`).
+- Real-compile/run integration tests go in `code_dependencies_integration_test.py`
+  (no mock fixtures). Pre-existing C++/sandbox/docker failures on this machine are
+  environmental — only new include/import-resolution failures are ours.
+
+---
+
+## Task 1: Scanner ABC + registry
+
+**Files:**
+- Create: `rbx/box/dependencies/__init__.py`
+- Create: `rbx/box/dependencies/scanner.py`
+- Test: `tests/rbx/box/dependencies_test.py`
+
+**Step 1: Failing test** (`tests/rbx/box/dependencies_test.py`)
+```python
+import pathlib
+from typing import List
+
+from rbx.box.dependencies import scanner
+from rbx.box.dependencies.scanner import DependencyKind, DependencyScanner, Reference
+
+
+class _Dummy(DependencyScanner):
+    kinds = {DependencyKind.COMPILATION}
+
+    def handles(self, language: str) -> bool:
+        return language == 'dummy'
+
+    def references(self, file: pathlib.Path) -> List[Reference]:
+        return []
+
+
+def test_register_and_get_scanner():
+    scanner.register(_Dummy)
+    assert isinstance(scanner.get_scanner('dummy'), _Dummy)
+    assert scanner.get_scanner('nope') is None
+
+
+def test_rewrite_unsupported_by_default():
+    import pytest
+
+    with pytest.raises(NotImplementedError):
+        _Dummy().rewrite('x', lambda s: None)
+```
+
+**Step 2:** `uv run pytest tests/rbx/box/dependencies_test.py -v` → FAIL (no module).
+
+**Step 3: Implement** `rbx/box/dependencies/scanner.py`
+```python
+import abc
+import dataclasses
+import enum
+import pathlib
+from typing import Callable, ClassVar, List, Optional, Set, Type
+
+
+class DependencyKind(enum.Enum):
+    COMPILATION = 'compilation'
+    EXECUTION = 'execution'
+
+
+@dataclasses.dataclass(frozen=True)
+class Reference:
+    spelling: str
+    target: Optional[pathlib.Path] = None
+
+
+class DependencyScanner(abc.ABC):
+    kinds: ClassVar[Set[DependencyKind]] = set()
+    can_rewrite: ClassVar[bool] = False
+
+    @abc.abstractmethod
+    def handles(self, language: str) -> bool: ...
+
+    @abc.abstractmethod
+    def references(self, file: pathlib.Path) -> List[Reference]: ...
+
+    def rewrite(self, text: str, rename: Callable[[str], Optional[str]]) -> str:
+        raise NotImplementedError(
+            f'{type(self).__name__} does not support include/import rewriting.'
+        )
+
+
+_REGISTRY: List[DependencyScanner] = []
+
+
+def register(scanner_cls: Type[DependencyScanner]) -> Type[DependencyScanner]:
+    _REGISTRY.append(scanner_cls())
+    return scanner_cls
+
+
+def get_scanner(language: str) -> Optional[DependencyScanner]:
+    for instance in _REGISTRY:
+        if instance.handles(language):
+            return instance
+    return None
+```
+Create empty `rbx/box/dependencies/__init__.py` (Task 5 fills it).
+
+**Step 4:** rerun → PASS. **Step 5:** commit `feat(dependencies): add scanner ABC + registry (#524)`.
+
+---
+
+## Task 2: C++ scanner — `references()` (tree-sitter-cpp)
+
+**Files:**
+- Create: `rbx/box/dependencies/cpp.py`
+- Test: `tests/rbx/box/dependencies_test.py` (class `TestCppReferences`)
+
+**Step 1: Failing tests**
+```python
+class TestCppReferences:
+    def test_quoted_and_angle_and_builtin(self, testing_pkg):
+        from rbx.box.dependencies import cpp
+
+        testing_pkg.add_file('lib.h').write_text('#pragma once\n')
+        gen = testing_pkg.add_file('gens/gen.cpp')
+        gen.write_text(
+            '#include "../lib.h"\n'
+            '#include <cstdio>\n'
+            '#include "testlib.h"\n'
+            'int main(){}\n'
+        )
+        refs = cpp.CppScanner().references(pathlib.Path('gens/gen.cpp'))
+        by_spelling = {r.spelling: r.target for r in refs}
+        # angle includes are not reported at all
+        assert '../lib.h' in by_spelling
+        assert by_spelling['../lib.h'] == pathlib.Path('lib.h')
+        # builtin testlib.h is quoted but not a package file -> target None
+        assert by_spelling['testlib.h'] is None
+        assert 'cstdio' not in by_spelling
+
+    def test_ignores_commented_include(self, testing_pkg):
+        from rbx.box.dependencies import cpp
+
+        testing_pkg.add_file('lib.h').write_text('#pragma once\n')
+        src = testing_pkg.add_file('a.cpp')
+        src.write_text('/* #include "lib.h" */\nint main(){}\n')
+        refs = cpp.CppScanner().references(pathlib.Path('a.cpp'))
+        assert refs == []
+```
+
+**Step 2:** run → FAIL (no `cpp` module).
+
+**Step 3: Implement** `rbx/box/dependencies/cpp.py`
+```python
+import pathlib
+from typing import Callable, Iterator, List, Optional
+
+import tree_sitter_cpp
+from tree_sitter import Language, Node, Parser
+
+from rbx import utils
+from rbx.box.dependencies import scanner
+from rbx.box.dependencies.scanner import DependencyKind, Reference
+
+_LANGUAGE = Language(tree_sitter_cpp.language())
+
+
+def _parser() -> Parser:
+    return Parser(_LANGUAGE)
+
+
+def _quoted_include_nodes(root: Node) -> Iterator[Node]:
+    """Yield the string_literal path node of each quoted #include (skips <...>)."""
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.type == 'preproc_include':
+            for child in node.children:
+                if child.type == 'string_literal':
+                    yield child
+                    break
+                if child.type == 'system_lib_string':
+                    break
+        stack.extend(node.children)
+
+
+def _spelling(path_node: Node) -> str:
+    text = path_node.text.decode('utf-8')
+    if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+        return text[1:-1]
+    return text
+
+
+def _resolve(including_file: pathlib.Path, spelling: str) -> Optional[pathlib.Path]:
+    package_root = utils.abspath(pathlib.Path())
+    candidate = utils.abspath(including_file.parent / spelling)
+    if not candidate.is_file() or not candidate.is_relative_to(package_root):
+        return None
+    return candidate.relative_to(package_root)
+
+
+@scanner.register
+class CppScanner(scanner.DependencyScanner):
+    kinds = {DependencyKind.COMPILATION}
+    can_rewrite = True
+
+    def handles(self, language: str) -> bool:
+        return language in ('cpp', 'c')
+
+    def references(self, file: pathlib.Path) -> List[Reference]:
+        tree = _parser().parse(pathlib.Path(file).read_bytes())
+        refs: List[Reference] = []
+        for path_node in _quoted_include_nodes(tree.root_node):
+            spelling = _spelling(path_node)
+            refs.append(Reference(spelling=spelling, target=_resolve(file, spelling)))
+        return refs
+
+    def rewrite(self, text: str, rename: Callable[[str], Optional[str]]) -> str:
+        tree = _parser().parse(text.encode('utf-8'))
+        edits = []  # (start_byte, end_byte, replacement_text)
+        for path_node in _quoted_include_nodes(tree.root_node):
+            new = rename(_spelling(path_node))
+            if new is not None:
+                edits.append((path_node.start_byte, path_node.end_byte, f'"{new}"'))
+        if not edits:
+            return text
+        data = bytearray(text.encode('utf-8'))
+        for start, end, repl in sorted(edits, reverse=True):
+            data[start:end] = repl.encode('utf-8')
+        return data.decode('utf-8')
+```
+
+**Step 4:** run → PASS. **Step 5:** commit `feat(dependencies): C++ include scanner via tree-sitter (#524)`.
+
+---
+
+## Task 3: C++ `rewrite()` tests
+
+**Files:** Test: `tests/rbx/box/dependencies_test.py` (class `TestCppRewrite`)
+
+**Step 1: Tests**
+```python
+class TestCppRewrite:
+    def test_rewrites_mapped_leaves_others(self):
+        from rbx.box.dependencies import cpp
+
+        text = (
+            '#include "../lib.h"\n'
+            '#include <cstdio>\n'
+            '#include "keep.h"\n'
+        )
+        mapping = {'../lib.h': 'lib__x.h'}
+        out = cpp.CppScanner().rewrite(text, mapping.get)
+        assert '#include "lib__x.h"' in out
+        assert '#include <cstdio>' in out      # angle untouched
+        assert '#include "keep.h"' in out      # unmapped untouched
+
+    def test_preserves_commented_include(self):
+        from rbx.box.dependencies import cpp
+
+        text = '/* #include "lib.h" */\n#include "lib.h"\n'
+        out = cpp.CppScanner().rewrite(text, {'lib.h': 'flat.h'}.get)
+        assert '/* #include "lib.h" */' in out   # comment untouched
+        assert '#include "flat.h"' in out        # real directive rewritten
+```
+
+**Step 2:** run → PASS (rewrite implemented in Task 2). If FAIL, fix Task 2.
+**Step 3:** commit `test(dependencies): C++ rewrite round-trip (#524)`.
+
+---
+
+## Task 4: Python scanner — `references()` (`ast`)
+
+**Files:**
+- Create: `rbx/box/dependencies/python.py`
+- Test: `tests/rbx/box/dependencies_test.py` (class `TestPythonReferences`)
+
+**Step 1: Tests**
+```python
+class TestPythonReferences:
+    def test_relative_sibling_and_stdlib(self, testing_pkg):
+        from rbx.box.dependencies import python
+
+        testing_pkg.add_file('sols/helper.py').write_text('X = 1\n')
+        main = testing_pkg.add_file('sols/main.py')
+        main.write_text(
+            'import os\n'
+            'from . import helper\n'
+            'import helper as h2\n'
+            'print(helper.X, h2.X, os.getpid())\n'
+        )
+        refs = python.PythonScanner().references(pathlib.Path('sols/main.py'))
+        targets = {r.target for r in refs if r.target is not None}
+        assert pathlib.Path('sols/helper.py') in targets
+        # stdlib os never resolves to a package file
+        assert all(r.target != pathlib.Path('os.py') for r in refs)
+
+    def test_parent_package_import(self, testing_pkg):
+        from rbx.box.dependencies import python
+
+        testing_pkg.add_file('common/util.py').write_text('Y = 2\n')
+        src = testing_pkg.add_file('sols/sub/main.py')
+        src.write_text('from ...common import util\n')
+        refs = python.PythonScanner().references(pathlib.Path('sols/sub/main.py'))
+        assert any(r.target == pathlib.Path('common/util.py') for r in refs)
+```
+> Note `from ...common import util` from `sols/sub/main.py`: level 3 → anchor ascends
+> 2 from `sols/sub` → repo root, then `common/util.py`.
+
+**Step 2:** run → FAIL.
+
+**Step 3: Implement** `rbx/box/dependencies/python.py`
+```python
+import ast
+import pathlib
+from typing import List, Optional
+
+from rbx import utils
+from rbx.box.dependencies import scanner
+from rbx.box.dependencies.scanner import DependencyKind, Reference
+
+
+def _resolve_dotted(base: pathlib.Path, dotted: str) -> Optional[pathlib.Path]:
+    parts = [p for p in dotted.split('.') if p]
+    if not parts:
+        return None
+    package_root = utils.abspath(pathlib.Path())
+    for candidate in (
+        base.joinpath(*parts).with_suffix('.py'),
+        base.joinpath(*parts, '__init__.py'),
+    ):
+        cand = utils.abspath(candidate)
+        if cand.is_file() and cand.is_relative_to(package_root):
+            return cand.relative_to(package_root)
+    return None
+
+
+@scanner.register
+class PythonScanner(scanner.DependencyScanner):
+    kinds = {DependencyKind.EXECUTION}
+    can_rewrite = False
+
+    def handles(self, language: str) -> bool:
+        return language == 'py'
+
+    def references(self, file: pathlib.Path) -> List[Reference]:
+        file = pathlib.Path(file)
+        try:
+            tree = ast.parse(file.read_text())
+        except SyntaxError:
+            return []
+        base_dir = file.parent
+        refs: List[Reference] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                # absolute imports: resolve as sibling under the importing file's dir
+                for alias in node.names:
+                    refs.append(
+                        Reference(alias.name, _resolve_dotted(base_dir, alias.name))
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                anchor = base_dir
+                for _ in range(max(node.level - 1, 0)):
+                    anchor = anchor.parent
+                dots = '.' * node.level
+                if node.module:
+                    refs.append(
+                        Reference(
+                            f'{dots}{node.module}',
+                            _resolve_dotted(anchor, node.module),
+                        )
+                    )
+                elif node.level > 0:
+                    # from . import a, b  -> each name is a sibling submodule
+                    for alias in node.names:
+                        refs.append(
+                            Reference(
+                                f'{dots}{alias.name}',
+                                _resolve_dotted(anchor, alias.name),
+                            )
+                        )
+        return refs
+```
+
+**Step 4:** run → PASS. **Step 5:** commit `feat(dependencies): Python relative/sibling import scanner (#524)`.
+
+---
+
+## Task 5: Engine — `expand()` + `DependencyGraph` + self-registration
+
+**Files:**
+- Create: `rbx/box/dependencies/graph.py`
+- Modify: `rbx/box/dependencies/__init__.py`
+- Test: `tests/rbx/box/dependencies_test.py` (class `TestExpand`)
+
+**Step 1: Tests**
+```python
+class TestExpand:
+    def test_cpp_transitive_excludes_root(self, testing_pkg):
+        from rbx.box.dependencies import graph
+        from rbx.box.dependencies.scanner import DependencyKind
+        from rbx.box.schema import CodeItem
+
+        testing_pkg.add_file('lib.h').write_text('#include "extra.h"\n')
+        testing_pkg.add_file('extra.h').write_text('#pragma once\n')
+        gen = testing_pkg.add_file('gens/gen.cpp')
+        gen.write_text('#include "../lib.h"\nint main(){}\n')
+
+        g = graph.expand(CodeItem(path=gen, language='cpp'))
+        assert g is not None
+        assert g.kinds == {DependencyKind.COMPILATION}
+        assert g.files() == [pathlib.Path('extra.h'), pathlib.Path('lib.h')]
+
+    def test_cycle_safe(self, testing_pkg):
+        from rbx.box.dependencies import graph
+        from rbx.box.schema import CodeItem
+
+        testing_pkg.add_file('a.h').write_text('#include "b.h"\n')
+        testing_pkg.add_file('b.h').write_text('#include "a.h"\n')
+        src = testing_pkg.add_file('m.cpp')
+        src.write_text('#include "a.h"\nint main(){}\n')
+        g = graph.expand(CodeItem(path=src, language='cpp'))
+        assert set(g.files()) == {pathlib.Path('a.h'), pathlib.Path('b.h')}
+
+    def test_none_for_unhandled_language(self, testing_pkg):
+        from rbx.box.dependencies import graph
+        from rbx.box.schema import CodeItem
+
+        j = testing_pkg.add_file('Main.java')
+        j.write_text('class Main {}\n')
+        assert graph.expand(CodeItem(path=j, language='java')) is None
+```
+
+**Step 2:** run → FAIL.
+
+**Step 3: Implement** `rbx/box/dependencies/graph.py`
+```python
+import collections
+import dataclasses
+import pathlib
+from typing import Dict, List, Optional, Set
+
+from rbx import utils
+from rbx.box import package
+from rbx.box.dependencies import scanner
+from rbx.box.dependencies.scanner import DependencyKind, Reference
+from rbx.box.schema import CodeItem
+
+
+@dataclasses.dataclass
+class DependencyGraph:
+    root: pathlib.Path
+    nodes: Dict[pathlib.Path, List[Reference]]
+    kinds: Set[DependencyKind]
+
+    def files(self) -> List[pathlib.Path]:
+        return sorted(p for p in self.nodes if p != self.root)
+
+
+def expand(code: CodeItem) -> Optional[DependencyGraph]:
+    from rbx.box.code import find_language_name
+
+    instance = scanner.get_scanner(find_language_name(code))
+    if instance is None:
+        return None
+    package_root = utils.abspath(pathlib.Path())
+    abs_path = utils.abspath(code.path)
+    if not abs_path.is_relative_to(package_root):
+        return None  # remote/temporary files stay flat
+    root = abs_path.relative_to(package_root)
+
+    nodes: Dict[pathlib.Path, List[Reference]] = {}
+    queue = collections.deque([root])
+    while queue:
+        current = queue.popleft()
+        if current in nodes:
+            continue
+        refs = instance.references(current)
+        nodes[current] = refs
+        for ref in refs:
+            if ref.target is not None and ref.target not in nodes:
+                queue.append(ref.target)
+    return DependencyGraph(root=root, nodes=nodes, kinds=set(instance.kinds))
+```
+> `find_language_name` is lazy-imported to avoid a `code` ↔ `dependencies` cycle.
+
+Set `rbx/box/dependencies/__init__.py` to self-register the scanners:
+```python
+from rbx.box.dependencies import cpp, python  # noqa: F401  (self-register scanners)
+```
+
+**Step 4:** run → PASS. **Step 5:** commit `feat(dependencies): transitive expand() + DependencyGraph (#524)`.
+
+---
+
+## Task 6: `CodeItem.executionFiles` + `get_execution_files`
+
+**Files:**
+- Modify: `rbx/box/schema.py` (CodeItem, CodeItemWithDigest.create, OutputFromItemWithDigest.create)
+- Modify: `rbx/box/package.py` (refactor `get_compilation_files`; add `get_execution_files`)
+- Test: `tests/rbx/box/code_compile_test.py` (class `TestExecutionFiles`)
+
+**Step 1: Tests** (add to `code_compile_test.py`)
+```python
+class TestExecutionFiles:
+    def test_dest_is_package_relative(self, testing_pkg):
+        testing_pkg.add_file('data.txt')
+        sol = testing_pkg.add_file('sols/main.py')
+        item = CodeItem(path=sol, language='py', executionFiles=['data.txt'])
+        assert package.get_execution_files(item) == [
+            (pathlib.Path('data.txt'), pathlib.Path('data.txt'))
+        ]
+
+    def test_rejects_missing(self, testing_pkg):
+        sol = testing_pkg.add_file('m.py')
+        item = CodeItem(path=sol, language='py', executionFiles=['nope.txt'])
+        with pytest.raises(typer.Exit):
+            package.get_execution_files(item)
+
+    def test_with_digest_propagates_execution_files(self, testing_pkg):
+        from rbx.box.schema import CodeItemWithDigest
+
+        sol = testing_pkg.add_file('m.py')
+        item = CodeItem(path=sol, language='py', executionFiles=['m.py'])
+        wd = CodeItemWithDigest.create(item, 'deadbeef')
+        assert wd.executionFiles == ['m.py']
+```
+
+**Step 2:** run → FAIL (`executionFiles` not a field / no `get_execution_files`).
+
+**Step 3: Implement**
+In `schema.py`, add to `CodeItem` after `compilationFiles`:
+```python
+    executionFiles: Optional[List[str]] = Field(
+        default=[],
+        description="""
+Extra files that should be available at *execution* time, given relative to the
+package directory and placed at the same package-relative path inside the sandbox
+(the package directory structure is mirrored). Use for runtime companion files
+(data files, sibling modules) a compiled binary or script needs at run time.
+""",
+    )
+```
+Add `executionFiles=code_item.executionFiles` to `CodeItemWithDigest.create` and
+`executionFiles=output_from_item.executionFiles` to `OutputFromItemWithDigest.create`.
+
+In `package.py`, refactor to share the body:
+```python
+def _get_declared_files(
+    code: CodeItem, declared: Optional[List[str]], label: str
+) -> List[Tuple[pathlib.Path, pathlib.Path]]:
+    package_root = utils.abspath(pathlib.Path())
+    res = []
+    for entry in declared or []:
+        entry_path = utils.abspath(pathlib.Path(entry))
+        if not entry_path.is_file():
+            console.console.print(
+                f'[error]{label} [item]{entry}[/item] for code {code.href()} '
+                f'does not exist.[/error]',
+            )
+            raise typer.Exit(1)
+        if not entry_path.is_relative_to(package_root):
+            console.console.print(
+                f'[error]{label} [item]{entry}[/item] for code {code.href()} '
+                f'is not under the package directory.[/error]',
+            )
+            raise typer.Exit(1)
+        rel = entry_path.relative_to(package_root)
+        res.append((rel, rel))
+    return res
+
+
+def get_compilation_files(code: CodeItem) -> List[Tuple[pathlib.Path, pathlib.Path]]:
+    return _get_declared_files(code, code.compilationFiles, 'Compilation file')
+
+
+def get_execution_files(code: CodeItem) -> List[Tuple[pathlib.Path, pathlib.Path]]:
+    return _get_declared_files(code, code.executionFiles, 'Execution file')
+```
+
+**Step 4:** run → PASS (and existing `TestCompilationFiles` still green).
+**Step 5:** commit `feat(schema): add executionFiles to CodeItem (#524)`.
+
+---
+
+## Task 7: Wire auto-expansion into compilation
+
+**Files:**
+- Modify: `rbx/box/code.py:compile_item` (after `get_compilation_files` extend, ~line 629)
+- Test: `tests/rbx/box/code_compile_test.py` (`TestCompileItem`)
+
+**Step 1: Test**
+```python
+    async def test_auto_expands_quoted_include(
+        self, testing_pkg, mock_steps_with_caching
+    ):
+        testing_pkg.add_file('lib.h').write_text('#pragma once\n')
+        gen = testing_pkg.add_file('gens/gen.cpp', src='compile_test/simple.cpp')
+        # Overwrite with a parent-dir include and NO manual compilationFiles.
+        gen.write_text('#include "../lib.h"\nint main(){}\n')
+        await code.compile_item(CodeItem(path=gen, language='cpp'))
+
+        artifacts = mock_steps_with_caching.call_args.kwargs['artifacts']
+        dests = {i.dest for i in artifacts.inputs}
+        assert pathlib.Path('lib.h') in dests
+```
+
+**Step 2:** run → FAIL (`lib.h` not auto-added).
+
+**Step 3: Implement** — in `compile_item`, immediately after the
+`artifacts.inputs.extend(... get_compilation_files ...)` block:
+```python
+        # Auto-expand transitive quoted #include "..." dependencies (default-on,
+        # additive). Manual compilationFiles remain the escape hatch.
+        from rbx.box.dependencies import graph as deps_graph
+        from rbx.box.dependencies.scanner import DependencyKind
+
+        dep_graph = deps_graph.expand(code)
+        if dep_graph is not None and DependencyKind.COMPILATION in dep_graph.kinds:
+            existing = {i.dest for i in artifacts.inputs}
+            for dep in dep_graph.files():
+                if dep not in existing:
+                    artifacts.inputs.append(GradingFileInput(src=dep, dest=dep))
+                    existing.add(dep)
+```
+
+**Step 4:** run → PASS; rerun full `TestCompileItem` (regressions).
+**Step 5:** commit `feat(code): auto-expand quoted includes at compile time (#524)`.
+
+---
+
+## Task 8: Wire execution files into `_prepare_run`
+
+**Files:**
+- Modify: `rbx/box/code.py:_prepare_run` (after the `if inputs:` extension, ~line 418)
+- Test: `tests/rbx/box/code_run_test.py` or new `code_prepare_run_test.py`
+
+**Step 1: Test** — call `_prepare_run` directly and inspect `artifacts.inputs`.
+```python
+import pathlib
+
+from rbx.box import code
+from rbx.box.grading_utils import ...  # see code_run_test.py for DigestOrSource helper
+from rbx.box.schema import CodeItem
+from rbx.grading.steps import DigestHolder
+from rbx.grading.steps_utils import DigestOrSource  # adapt import to actual location
+
+
+class TestPrepareRunExecutionFiles:
+    async def test_python_sibling_module_mirrored(self, testing_pkg):
+        testing_pkg.add_file('sols/helper.py').write_text('X = 1\n')
+        main = testing_pkg.add_file('sols/main.py')
+        main.write_text('from . import helper\nprint(helper.X)\n')
+        executable = DigestOrSource.create(DigestHolder(value='deadbeef'))
+        prepared = await code._prepare_run(
+            CodeItem(path=main, language='py'), executable
+        )
+        dests = {i.dest for i in prepared.artifacts.inputs}
+        assert pathlib.Path('sols/helper.py') in dests
+
+    async def test_manual_execution_file_mirrored(self, testing_pkg):
+        testing_pkg.add_file('data.txt')
+        main = testing_pkg.add_file('m.py')
+        main.write_text('print(1)\n')
+        executable = DigestOrSource.create(DigestHolder(value='deadbeef'))
+        prepared = await code._prepare_run(
+            CodeItem(path=main, language='py', executionFiles=['data.txt']),
+            executable,
+        )
+        dests = {i.dest for i in prepared.artifacts.inputs}
+        assert pathlib.Path('data.txt') in dests
+```
+> Confirm the exact `DigestOrSource` import/constructor from `code_run_test.py` before
+> writing; adapt the two `executable = ...` lines accordingly.
+
+**Step 2:** run → FAIL.
+
+**Step 3: Implement** — in `_prepare_run`, after the `if inputs:`/`if outputs:` block
+and before `return PreparedRun(...)`:
+```python
+    # Manual + auto-discovered execution files, mirrored at their package-relative
+    # path. C++ contributes none here (its deps are compile-time); Python siblings
+    # land via auto-expansion.
+    from rbx.box.dependencies import graph as deps_graph
+    from rbx.box.dependencies.scanner import DependencyKind
+
+    exec_dests = {i.dest for i in artifacts.inputs}
+    for src, dest in package.get_execution_files(code):
+        if dest not in exec_dests:
+            artifacts.inputs.append(GradingFileInput(src=src, dest=dest))
+            exec_dests.add(dest)
+    dep_graph = deps_graph.expand(code)
+    if dep_graph is not None and DependencyKind.EXECUTION in dep_graph.kinds:
+        for dep in dep_graph.files():
+            if dep not in exec_dests:
+                artifacts.inputs.append(GradingFileInput(src=dep, dest=dep))
+                exec_dests.add(dep)
+```
+
+**Step 4:** run → PASS. **Step 5:** commit `feat(code): mirror execution files at run time (#524)`.
+
+---
+
+## Task 9: Real-compile / real-run integration
+
+**Files:** Create `tests/rbx/box/code_dependencies_integration_test.py`
+
+**Step 0:** baseline `uv run pytest tests/rbx/box/checkers_test.py -x -q` (env sanity).
+
+**Step 1: Tests**
+```python
+import pathlib
+
+from rbx.box import code
+from rbx.box.schema import CodeItem
+
+
+class TestAutoExpansionIntegration:
+    async def test_subdir_cpp_autodiscovers_parent_include(self, testing_pkg):
+        testing_pkg.add_file('lib.h').write_text(
+            '#pragma once\ninline int answer(){ return 42; }\n'
+        )
+        gen = testing_pkg.add_file('gens/gen.cpp')
+        gen.write_text(
+            '#include "../lib.h"\n#include <cstdio>\n'
+            'int main(){ printf("%d\\n", answer()); }\n'
+        )
+        # No manual compilationFiles — must be auto-discovered.
+        assert await code.compile_item(CodeItem(path=gen, language='cpp'))
+```
+Plus a Python end-to-end run test (subdir source importing a sibling), modeled on the
+run helpers in `code_run_test.py` (compile_item → run_item with stdin/stdout; assert
+the sibling's value reaches stdout), and a flat-package regression.
+
+**Step 2:** run → PASS (modulo pre-existing environmental failures — verify any failure
+is NOT an include/import-resolution error).
+**Step 3:** commit `test(dependencies): integration for auto-expansion (#524)`.
+
+---
+
+## Task 10: Audit, full suite, lint, review
+
+**Step 1: Audit** the new imports don't create cycles:
+`uv run python -c "import rbx.box.code, rbx.box.dependencies.graph, rbx.box.package"`.
+**Step 2:** focused suites:
+```bash
+uv run pytest tests/rbx/box/dependencies_test.py tests/rbx/box/code_compile_test.py -v
+uv run pytest tests/rbx/box/code_dependencies_integration_test.py -v
+uv run pytest tests/rbx/box/code_run_test.py -q
+```
+**Step 3:** `uv run ruff check . && uv run ruff format --check .` → clean.
+**Step 4 (optional):** `uv run pytest --ignore=tests/rbx/box/cli -n auto -q`; triage only
+new failures (pre-existing env failures per memory).
+**Step 5:** Use superpowers:requesting-code-review against the design doc + this plan.
+**Step 6:** final commit if the audit changed anything.
+
+---
+
+## Definition of done
+
+- [ ] `rbx/box/dependencies/` (scanner/graph/cpp/python, registry, self-registration).
+- [ ] `CodeItem.executionFiles` + `package.get_execution_files`; propagated in factories.
+- [ ] C++ compilation auto-expands transitive quoted includes (additive).
+- [ ] Execution mirrors manual + auto-discovered files via `_prepare_run`.
+- [ ] C++ `rewrite` implemented + tested; Python `rewrite` raises (can_rewrite=False).
+- [ ] Unit + integration green (modulo env failures); lint clean; conventional commits.
+- [ ] No `packaging/` changes (that is #525).
+```

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -419,6 +419,24 @@ async def _prepare_run(
     if outputs:
         artifacts.outputs.extend(outputs)
 
+    # Mirror manual + auto-discovered execution files at their package-relative path.
+    # C++ contributes none here (its deps are compile-time); Python siblings land via
+    # auto-expansion. Manual executionFiles remain the escape hatch for all languages.
+    from rbx.box.dependencies import graph as deps_graph
+    from rbx.box.dependencies.scanner import DependencyKind
+
+    exec_dests = {input.dest for input in artifacts.inputs}
+    for src, dest in package.get_execution_files(code):
+        if dest not in exec_dests:
+            artifacts.inputs.append(GradingFileInput(src=src, dest=dest))
+            exec_dests.add(dest)
+    dep_graph = deps_graph.expand(code)
+    if dep_graph is not None and DependencyKind.EXECUTION in dep_graph.kinds:
+        for dep in dep_graph.files():
+            if dep not in exec_dests:
+                artifacts.inputs.append(GradingFileInput(src=dep, dest=dep))
+                exec_dests.add(dep)
+
     return PreparedRun(
         command=command,
         sandbox_params=sandbox_params,

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -29,6 +29,7 @@ from rbx.box.environment import (
     get_mapped_command,
     get_mapped_commands,
     get_sandbox_params_from_config,
+    is_interpreted,
     merge_execution_configs,
 )
 from rbx.box.formatting import get_formatted_memory
@@ -384,11 +385,18 @@ async def _prepare_run(
         command = shlex.join(splitted_command)
 
     artifacts = GradingArtifacts()
+    # Interpreted entry scripts must be a real copy, not a cache symlink: the
+    # interpreter resolves its module search root from the script's realpath, which
+    # for a symlink points back into the content cache instead of the mirrored
+    # source dir. Copying keeps that realpath inside the sandbox so sibling imports
+    # resolve naturally.
+    interpreted = is_interpreted(language, solution=isinstance(code, Solution))
     artifacts.inputs.append(
         GradingFileInput(
             **executable.expand(),
             dest=PosixPath(file_mapping.executable),
             executable=True,
+            symlink=not interpreted,
         )
     )
     if stdin is not None:
@@ -431,20 +439,11 @@ async def _prepare_run(
             artifacts.inputs.append(GradingFileInput(src=src, dest=dest))
             exec_dests.add(dest)
     # Only interpreted languages (EXECUTION-kind scanner) contribute here; C++ and
-    # other compiled languages short-circuit inside expand() without walking.
+    # other compiled languages short-circuit inside expand() without walking. The
+    # interpreted entry script is copied (not symlinked) above, so its mirrored
+    # directory is the interpreter's module search root and these siblings resolve.
     dep_graph = deps_graph.expand(code, require_kind=DependencyKind.EXECUTION)
     if dep_graph is not None:
-        # The entry script is symlinked from the content-addressed cache, so the
-        # interpreter resolves its module search root to the cache dir (via the
-        # symlink's realpath) instead of the mirrored source dir. Put the mirrored
-        # source dir back on PYTHONPATH so sibling imports resolve, matching how
-        # `python3 <dir>/script.py` normally behaves. This overrides any PYTHONPATH
-        # already in set_env (none is, today); the host PYTHONPATH is not inherited.
-        source_dir = dep_graph.root.parent.as_posix()
-        existing_pythonpath = sandbox_params.set_env.get('PYTHONPATH')
-        sandbox_params.set_env['PYTHONPATH'] = (
-            f'{source_dir}:{existing_pythonpath}' if existing_pythonpath else source_dir
-        )
         for dep in dep_graph.files():
             if dep not in exec_dests:
                 artifacts.inputs.append(GradingFileInput(src=dep, dest=dep))

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -628,6 +628,19 @@ async def compile_item(
             for src, dest in package.get_compilation_files(code)
         )
 
+        # Auto-expand transitive quoted #include "..." dependencies (default-on,
+        # additive). Manual compilationFiles remain the escape hatch.
+        from rbx.box.dependencies import graph as deps_graph
+        from rbx.box.dependencies.scanner import DependencyKind
+
+        dep_graph = deps_graph.expand(code)
+        if dep_graph is not None and DependencyKind.COMPILATION in dep_graph.kinds:
+            existing = {input.dest for input in artifacts.inputs}
+            for dep in dep_graph.files():
+                if dep not in existing:
+                    artifacts.inputs.append(GradingFileInput(src=dep, dest=dep))
+                    existing.add(dep)
+
         download.maybe_add_testlib(code, artifacts)
         download.maybe_add_jngen(code, artifacts)
         download.maybe_add_tgen(code, artifacts)

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -430,13 +430,16 @@ async def _prepare_run(
         if dest not in exec_dests:
             artifacts.inputs.append(GradingFileInput(src=src, dest=dest))
             exec_dests.add(dest)
-    dep_graph = deps_graph.expand(code)
-    if dep_graph is not None and DependencyKind.EXECUTION in dep_graph.kinds:
+    # Only interpreted languages (EXECUTION-kind scanner) contribute here; C++ and
+    # other compiled languages short-circuit inside expand() without walking.
+    dep_graph = deps_graph.expand(code, require_kind=DependencyKind.EXECUTION)
+    if dep_graph is not None:
         # The entry script is symlinked from the content-addressed cache, so the
         # interpreter resolves its module search root to the cache dir (via the
         # symlink's realpath) instead of the mirrored source dir. Put the mirrored
         # source dir back on PYTHONPATH so sibling imports resolve, matching how
-        # `python3 <dir>/script.py` normally behaves.
+        # `python3 <dir>/script.py` normally behaves. This overrides any PYTHONPATH
+        # already in set_env (none is, today); the host PYTHONPATH is not inherited.
         source_dir = dep_graph.root.parent.as_posix()
         existing_pythonpath = sandbox_params.set_env.get('PYTHONPATH')
         sandbox_params.set_env['PYTHONPATH'] = (
@@ -661,8 +664,8 @@ async def compile_item(
         from rbx.box.dependencies import graph as deps_graph
         from rbx.box.dependencies.scanner import DependencyKind
 
-        dep_graph = deps_graph.expand(code)
-        if dep_graph is not None and DependencyKind.COMPILATION in dep_graph.kinds:
+        dep_graph = deps_graph.expand(code, require_kind=DependencyKind.COMPILATION)
+        if dep_graph is not None:
             existing = {input.dest for input in artifacts.inputs}
             for dep in dep_graph.files():
                 if dep not in existing:

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -432,6 +432,16 @@ async def _prepare_run(
             exec_dests.add(dest)
     dep_graph = deps_graph.expand(code)
     if dep_graph is not None and DependencyKind.EXECUTION in dep_graph.kinds:
+        # The entry script is symlinked from the content-addressed cache, so the
+        # interpreter resolves its module search root to the cache dir (via the
+        # symlink's realpath) instead of the mirrored source dir. Put the mirrored
+        # source dir back on PYTHONPATH so sibling imports resolve, matching how
+        # `python3 <dir>/script.py` normally behaves.
+        source_dir = dep_graph.root.parent.as_posix()
+        existing_pythonpath = sandbox_params.set_env.get('PYTHONPATH')
+        sandbox_params.set_env['PYTHONPATH'] = (
+            f'{source_dir}:{existing_pythonpath}' if existing_pythonpath else source_dir
+        )
         for dep in dep_graph.files():
             if dep not in exec_dests:
                 artifacts.inputs.append(GradingFileInput(src=dep, dest=dep))

--- a/rbx/box/dependencies/__init__.py
+++ b/rbx/box/dependencies/__init__.py
@@ -1,0 +1,1 @@
+from rbx.box.dependencies import cpp, python  # noqa: F401  (self-register scanners)

--- a/rbx/box/dependencies/cpp.py
+++ b/rbx/box/dependencies/cpp.py
@@ -1,0 +1,77 @@
+import pathlib
+from typing import Callable, Iterator, List, Optional
+
+import tree_sitter_cpp
+from tree_sitter import Language, Node, Parser
+
+from rbx import utils
+from rbx.box.dependencies import scanner
+from rbx.box.dependencies.scanner import DependencyKind, Reference
+
+_LANGUAGE = Language(tree_sitter_cpp.language())
+
+
+def _parser() -> Parser:
+    return Parser(_LANGUAGE)
+
+
+def _quoted_include_nodes(root: Node) -> Iterator[Node]:
+    """Yield the ``string_literal`` path node of each quoted ``#include`` (skips
+    ``<...>`` system includes and never matches includes inside comments)."""
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.type == 'preproc_include':
+            for child in node.children:
+                if child.type == 'string_literal':
+                    yield child
+                    break
+                if child.type == 'system_lib_string':
+                    break
+        stack.extend(node.children)
+
+
+def _spelling(path_node: Node) -> str:
+    text = path_node.text.decode('utf-8')
+    if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+        return text[1:-1]
+    return text
+
+
+def _resolve(including_file: pathlib.Path, spelling: str) -> Optional[pathlib.Path]:
+    package_root = utils.abspath(pathlib.Path())
+    candidate = utils.abspath(including_file.parent / spelling)
+    if not candidate.is_file() or not candidate.is_relative_to(package_root):
+        return None
+    return candidate.relative_to(package_root)
+
+
+@scanner.register
+class CppScanner(scanner.DependencyScanner):
+    kinds = {DependencyKind.COMPILATION}
+    can_rewrite = True
+
+    def handles(self, language: str) -> bool:
+        return language in ('cpp', 'c')
+
+    def references(self, file: pathlib.Path) -> List[Reference]:
+        tree = _parser().parse(pathlib.Path(file).read_bytes())
+        refs: List[Reference] = []
+        for path_node in _quoted_include_nodes(tree.root_node):
+            spelling = _spelling(path_node)
+            refs.append(Reference(spelling=spelling, target=_resolve(file, spelling)))
+        return refs
+
+    def rewrite(self, text: str, rename: Callable[[str], Optional[str]]) -> str:
+        tree = _parser().parse(text.encode('utf-8'))
+        edits = []  # (start_byte, end_byte, replacement_text)
+        for path_node in _quoted_include_nodes(tree.root_node):
+            new = rename(_spelling(path_node))
+            if new is not None:
+                edits.append((path_node.start_byte, path_node.end_byte, f'"{new}"'))
+        if not edits:
+            return text
+        data = bytearray(text.encode('utf-8'))
+        for start, end, repl in sorted(edits, reverse=True):
+            data[start:end] = repl.encode('utf-8')
+        return data.decode('utf-8')

--- a/rbx/box/dependencies/cpp.py
+++ b/rbx/box/dependencies/cpp.py
@@ -7,6 +7,7 @@ from tree_sitter import Language, Node, Parser
 from rbx import utils
 from rbx.box.dependencies import scanner
 from rbx.box.dependencies.scanner import DependencyKind, Reference
+from rbx.grading.language_kind import LanguageKind
 
 _LANGUAGE = Language(tree_sitter_cpp.language())
 
@@ -48,11 +49,10 @@ def _resolve(including_file: pathlib.Path, spelling: str) -> Optional[pathlib.Pa
 
 @scanner.register
 class CppScanner(scanner.DependencyScanner):
-    kinds = {DependencyKind.COMPILATION}
+    name = 'cpp'
+    language_kinds = {LanguageKind.CXX}
+    dependency_kinds = {DependencyKind.COMPILATION}
     can_rewrite = True
-
-    def handles(self, language: str) -> bool:
-        return language in ('cpp', 'c')
 
     def references(self, file: pathlib.Path) -> List[Reference]:
         tree = _parser().parse(pathlib.Path(file).read_bytes())

--- a/rbx/box/dependencies/graph.py
+++ b/rbx/box/dependencies/graph.py
@@ -21,11 +21,16 @@ class DependencyGraph:
         return sorted(p for p in self.nodes if p != self.root)
 
 
-def expand(code: CodeItem) -> Optional[DependencyGraph]:
+def expand(
+    code: CodeItem, require_kind: Optional[DependencyKind] = None
+) -> Optional[DependencyGraph]:
     """Transitively discover ``code``'s quoted-include / relative-import dependencies.
 
-    Returns ``None`` when there is no scanner for the language, or the source lives
-    outside the package root (remote/temporary files stay flat). Cycle-safe; only
+    Returns ``None`` when there is no scanner for the language, the source lives
+    outside the package root (remote/temporary files stay flat), or ``require_kind``
+    is given and the language's scanner does not contribute that kind. The last case
+    short-circuits **before** the (potentially expensive) transitive walk, so e.g. a
+    C++ source skips scanning entirely on the execution path. Cycle-safe; only
     references that resolve to an existing file under the package root are followed.
     """
     # Lazy import avoids a code <-> dependencies import cycle.
@@ -33,6 +38,8 @@ def expand(code: CodeItem) -> Optional[DependencyGraph]:
 
     instance = scanner.get_scanner(find_language_name(code))
     if instance is None:
+        return None
+    if require_kind is not None and require_kind not in instance.kinds:
         return None
     package_root = utils.abspath(pathlib.Path())
     abs_path = utils.abspath(code.path)

--- a/rbx/box/dependencies/graph.py
+++ b/rbx/box/dependencies/graph.py
@@ -1,0 +1,54 @@
+import collections
+import dataclasses
+import pathlib
+from typing import Dict, List, Optional, Set
+
+from rbx import utils
+from rbx.box.dependencies import scanner
+from rbx.box.dependencies.scanner import DependencyKind, Reference
+from rbx.box.schema import CodeItem
+
+
+@dataclasses.dataclass
+class DependencyGraph:
+    root: pathlib.Path
+    nodes: Dict[pathlib.Path, List[Reference]]
+    kinds: Set[DependencyKind]
+
+    def files(self) -> List[pathlib.Path]:
+        """All discovered dependency files (package-relative), excluding the root,
+        in deterministic order."""
+        return sorted(p for p in self.nodes if p != self.root)
+
+
+def expand(code: CodeItem) -> Optional[DependencyGraph]:
+    """Transitively discover ``code``'s quoted-include / relative-import dependencies.
+
+    Returns ``None`` when there is no scanner for the language, or the source lives
+    outside the package root (remote/temporary files stay flat). Cycle-safe; only
+    references that resolve to an existing file under the package root are followed.
+    """
+    # Lazy import avoids a code <-> dependencies import cycle.
+    from rbx.box.code import find_language_name
+
+    instance = scanner.get_scanner(find_language_name(code))
+    if instance is None:
+        return None
+    package_root = utils.abspath(pathlib.Path())
+    abs_path = utils.abspath(code.path)
+    if not abs_path.is_relative_to(package_root):
+        return None
+    root = abs_path.relative_to(package_root)
+
+    nodes: Dict[pathlib.Path, List[Reference]] = {}
+    queue = collections.deque([root])
+    while queue:
+        current = queue.popleft()
+        if current in nodes:
+            continue
+        refs = instance.references(current)
+        nodes[current] = refs
+        for ref in refs:
+            if ref.target is not None and ref.target not in nodes:
+                queue.append(ref.target)
+    return DependencyGraph(root=root, nodes=nodes, kinds=set(instance.kinds))

--- a/rbx/box/dependencies/graph.py
+++ b/rbx/box/dependencies/graph.py
@@ -26,20 +26,26 @@ def expand(
 ) -> Optional[DependencyGraph]:
     """Transitively discover ``code``'s quoted-include / relative-import dependencies.
 
-    Returns ``None`` when there is no scanner for the language, the source lives
-    outside the package root (remote/temporary files stay flat), or ``require_kind``
-    is given and the language's scanner does not contribute that kind. The last case
-    short-circuits **before** the (potentially expensive) transitive walk, so e.g. a
-    C++ source skips scanning entirely on the execution path. Cycle-safe; only
-    references that resolve to an existing file under the package root are followed.
+    The scanners are chosen by the language's :func:`~rbx.box.environment.language_kinds`
+    (plus any explicitly named in the language's ``scanners`` field), never by the raw
+    language name. Returns ``None`` when no scanner applies, the source lives outside
+    the package root (remote/temporary files stay flat), or ``require_kind`` is given
+    and no applicable scanner contributes that kind. The last case short-circuits
+    **before** the (potentially expensive) transitive walk, so e.g. a C++ source skips
+    scanning entirely on the execution path. Cycle-safe; only references that resolve
+    to an existing file under the package root are followed.
     """
     # Lazy import avoids a code <-> dependencies import cycle.
-    from rbx.box.code import find_language_name
+    from rbx.box.code import find_language
+    from rbx.box.environment import language_kinds
 
-    instance = scanner.get_scanner(find_language_name(code))
-    if instance is None:
-        return None
-    if require_kind is not None and require_kind not in instance.kinds:
+    language = find_language(code)
+    scanners = scanner.get_scanners_for_kinds(
+        language_kinds(language), language.scanners
+    )
+    if require_kind is not None:
+        scanners = [s for s in scanners if require_kind in s.dependency_kinds]
+    if not scanners:
         return None
     package_root = utils.abspath(pathlib.Path())
     abs_path = utils.abspath(code.path)
@@ -53,9 +59,14 @@ def expand(
         current = queue.popleft()
         if current in nodes:
             continue
-        refs = instance.references(current)
+        refs: List[Reference] = []
+        for instance in scanners:
+            refs.extend(instance.references(current))
         nodes[current] = refs
         for ref in refs:
             if ref.target is not None and ref.target not in nodes:
                 queue.append(ref.target)
-    return DependencyGraph(root=root, nodes=nodes, kinds=set(instance.kinds))
+    kinds: Set[DependencyKind] = set()
+    for instance in scanners:
+        kinds |= instance.dependency_kinds
+    return DependencyGraph(root=root, nodes=nodes, kinds=kinds)

--- a/rbx/box/dependencies/python.py
+++ b/rbx/box/dependencies/python.py
@@ -1,0 +1,84 @@
+import ast
+import pathlib
+from typing import List, Optional
+
+from rbx import utils
+from rbx.box.dependencies import scanner
+from rbx.box.dependencies.scanner import DependencyKind, Reference
+
+
+def _resolve_dotted(base: pathlib.Path, dotted: str) -> Optional[pathlib.Path]:
+    """Resolve a dotted module name under ``base`` to a package-relative ``.py`` /
+    ``__init__.py`` file, or ``None`` if it is not a package file (stdlib/third-party)."""
+    parts = [p for p in dotted.split('.') if p]
+    if not parts:
+        return None
+    package_root = utils.abspath(pathlib.Path())
+    for candidate in (
+        base.joinpath(*parts).with_suffix('.py'),
+        base.joinpath(*parts, '__init__.py'),
+    ):
+        cand = utils.abspath(candidate)
+        if cand.is_file() and cand.is_relative_to(package_root):
+            return cand.relative_to(package_root)
+    return None
+
+
+@scanner.register
+class PythonScanner(scanner.DependencyScanner):
+    kinds = {DependencyKind.EXECUTION}
+    can_rewrite = False
+
+    def handles(self, language: str) -> bool:
+        return language == 'py'
+
+    def references(self, file: pathlib.Path) -> List[Reference]:
+        file = pathlib.Path(file)
+        try:
+            tree = ast.parse(file.read_text())
+        except SyntaxError:
+            return []
+        base_dir = file.parent
+        refs: List[Reference] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                # Absolute imports: resolve as a sibling of the importing file.
+                for alias in node.names:
+                    refs.append(
+                        Reference(alias.name, _resolve_dotted(base_dir, alias.name))
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                # Relative imports ascend ``level - 1`` directories from the file dir.
+                anchor = base_dir
+                for _ in range(max(node.level - 1, 0)):
+                    anchor = anchor.parent
+                dots = '.' * node.level
+                if node.module:
+                    refs.append(
+                        Reference(
+                            f'{dots}{node.module}',
+                            _resolve_dotted(anchor, node.module),
+                        )
+                    )
+                    # An imported name may itself be a submodule file of ``module``.
+                    for alias in node.names:
+                        if alias.name == '*':
+                            continue
+                        dotted = f'{node.module}.{alias.name}'
+                        refs.append(
+                            Reference(
+                                f'{dots}{dotted}', _resolve_dotted(anchor, dotted)
+                            )
+                        )
+                elif node.level > 0:
+                    # ``from . import a, b`` -> each name is a sibling submodule.
+                    for alias in node.names:
+                        if alias.name == '*':
+                            continue
+                        refs.append(
+                            Reference(
+                                f'{dots}{alias.name}',
+                                _resolve_dotted(anchor, alias.name),
+                            )
+                        )
+        return refs

--- a/rbx/box/dependencies/python.py
+++ b/rbx/box/dependencies/python.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from rbx import utils
 from rbx.box.dependencies import scanner
 from rbx.box.dependencies.scanner import DependencyKind, Reference
+from rbx.grading.language_kind import LanguageKind
 
 
 def _rel_if_package_file(path: pathlib.Path) -> Optional[pathlib.Path]:
@@ -38,11 +39,10 @@ def _module_references(base: pathlib.Path, dots: str, dotted: str) -> List[Refer
 
 @scanner.register
 class PythonScanner(scanner.DependencyScanner):
-    kinds = {DependencyKind.EXECUTION}
+    name = 'python'
+    language_kinds = {LanguageKind.PYTHON}
+    dependency_kinds = {DependencyKind.EXECUTION}
     can_rewrite = False
-
-    def handles(self, language: str) -> bool:
-        return language == 'py'
 
     def references(self, file: pathlib.Path) -> List[Reference]:
         file = pathlib.Path(file)

--- a/rbx/box/dependencies/python.py
+++ b/rbx/box/dependencies/python.py
@@ -7,21 +7,33 @@ from rbx.box.dependencies import scanner
 from rbx.box.dependencies.scanner import DependencyKind, Reference
 
 
-def _resolve_dotted(base: pathlib.Path, dotted: str) -> Optional[pathlib.Path]:
-    """Resolve a dotted module name under ``base`` to a package-relative ``.py`` /
-    ``__init__.py`` file, or ``None`` if it is not a package file (stdlib/third-party)."""
+def _rel_if_package_file(path: pathlib.Path) -> Optional[pathlib.Path]:
+    package_root = utils.abspath(pathlib.Path())
+    abs_path = utils.abspath(path)
+    if abs_path.is_file() and abs_path.is_relative_to(package_root):
+        return abs_path.relative_to(package_root)
+    return None
+
+
+def _module_references(base: pathlib.Path, dots: str, dotted: str) -> List[Reference]:
+    """References for a dotted module name resolved under ``base``: every existing
+    intermediate ``__init__.py`` package marker (so ``import a.b.c`` also ships
+    ``a/__init__.py`` and ``a/b/__init__.py`` when they exist) plus the leaf module
+    (``a/b/c.py`` or ``a/b/c/__init__.py``). The leaf is always emitted, with
+    ``target=None`` when it is not a package file (stdlib/third-party/a bare name)."""
     parts = [p for p in dotted.split('.') if p]
     if not parts:
-        return None
-    package_root = utils.abspath(pathlib.Path())
-    for candidate in (
-        base.joinpath(*parts).with_suffix('.py'),
-        base.joinpath(*parts, '__init__.py'),
-    ):
-        cand = utils.abspath(candidate)
-        if cand.is_file() and cand.is_relative_to(package_root):
-            return cand.relative_to(package_root)
-    return None
+        return []
+    refs: List[Reference] = []
+    for i in range(1, len(parts)):
+        marker = _rel_if_package_file(base.joinpath(*parts[:i], '__init__.py'))
+        if marker is not None:
+            refs.append(Reference(f'{dots}{".".join(parts[:i])}', marker))
+    leaf = _rel_if_package_file(
+        base.joinpath(*parts).with_suffix('.py')
+    ) or _rel_if_package_file(base.joinpath(*parts, '__init__.py'))
+    refs.append(Reference(f'{dots}{dotted}', leaf))
+    return refs
 
 
 @scanner.register
@@ -44,9 +56,7 @@ class PythonScanner(scanner.DependencyScanner):
             if isinstance(node, ast.Import):
                 # Absolute imports: resolve as a sibling of the importing file.
                 for alias in node.names:
-                    refs.append(
-                        Reference(alias.name, _resolve_dotted(base_dir, alias.name))
-                    )
+                    refs.extend(_module_references(base_dir, '', alias.name))
             elif isinstance(node, ast.ImportFrom):
                 # Relative imports ascend ``level - 1`` directories from the file dir.
                 anchor = base_dir
@@ -54,20 +64,14 @@ class PythonScanner(scanner.DependencyScanner):
                     anchor = anchor.parent
                 dots = '.' * node.level
                 if node.module:
-                    refs.append(
-                        Reference(
-                            f'{dots}{node.module}',
-                            _resolve_dotted(anchor, node.module),
-                        )
-                    )
+                    refs.extend(_module_references(anchor, dots, node.module))
                     # An imported name may itself be a submodule file of ``module``.
                     for alias in node.names:
                         if alias.name == '*':
                             continue
-                        dotted = f'{node.module}.{alias.name}'
-                        refs.append(
-                            Reference(
-                                f'{dots}{dotted}', _resolve_dotted(anchor, dotted)
+                        refs.extend(
+                            _module_references(
+                                anchor, dots, f'{node.module}.{alias.name}'
                             )
                         )
                 elif node.level > 0:
@@ -75,10 +79,5 @@ class PythonScanner(scanner.DependencyScanner):
                     for alias in node.names:
                         if alias.name == '*':
                             continue
-                        refs.append(
-                            Reference(
-                                f'{dots}{alias.name}',
-                                _resolve_dotted(anchor, alias.name),
-                            )
-                        )
+                        refs.extend(_module_references(anchor, dots, alias.name))
         return refs

--- a/rbx/box/dependencies/scanner.py
+++ b/rbx/box/dependencies/scanner.py
@@ -1,0 +1,63 @@
+import abc
+import dataclasses
+import enum
+import pathlib
+from typing import Callable, ClassVar, List, Optional, Set, Type
+
+
+class DependencyKind(enum.Enum):
+    COMPILATION = 'compilation'
+    EXECUTION = 'execution'
+
+
+@dataclasses.dataclass(frozen=True)
+class Reference:
+    """A single dependency reference discovered in a source file.
+
+    ``spelling`` is the path/module exactly as written (e.g. ``../lib.h`` or
+    ``.helper``); ``target`` is its resolved package-relative path, or ``None`` when
+    the reference cannot be resolved to a file under the package root (system headers,
+    builtin libraries, stdlib/third-party imports).
+    """
+
+    spelling: str
+    target: Optional[pathlib.Path] = None
+
+
+class DependencyScanner(abc.ABC):
+    """Per-language extension point for discovering and rewriting dependencies.
+
+    ``references`` reads a single file and returns its *direct* dependency edges,
+    already resolved against the package root. ``rewrite`` (optional, gated by
+    ``can_rewrite``) is a pure textual transform used by packaging to flatten sources
+    for judges with a flat/inline file namespace.
+    """
+
+    kinds: ClassVar[Set[DependencyKind]] = set()
+    can_rewrite: ClassVar[bool] = False
+
+    @abc.abstractmethod
+    def handles(self, language: str) -> bool: ...
+
+    @abc.abstractmethod
+    def references(self, file: pathlib.Path) -> List[Reference]: ...
+
+    def rewrite(self, text: str, rename: Callable[[str], Optional[str]]) -> str:
+        raise NotImplementedError(
+            f'{type(self).__name__} does not support include/import rewriting.'
+        )
+
+
+_REGISTRY: List[DependencyScanner] = []
+
+
+def register(scanner_cls: Type[DependencyScanner]) -> Type[DependencyScanner]:
+    _REGISTRY.append(scanner_cls())
+    return scanner_cls
+
+
+def get_scanner(language: str) -> Optional[DependencyScanner]:
+    for instance in _REGISTRY:
+        if instance.handles(language):
+            return instance
+    return None

--- a/rbx/box/dependencies/scanner.py
+++ b/rbx/box/dependencies/scanner.py
@@ -2,7 +2,9 @@ import abc
 import dataclasses
 import enum
 import pathlib
-from typing import Callable, ClassVar, List, Optional, Set, Type
+from typing import Callable, ClassVar, Dict, List, Optional, Set, Type
+
+from rbx.grading.language_kind import LanguageKind
 
 
 class DependencyKind(enum.Enum):
@@ -31,13 +33,16 @@ class DependencyScanner(abc.ABC):
     already resolved against the package root. ``rewrite`` (optional, gated by
     ``can_rewrite``) is a pure textual transform used by packaging to flatten sources
     for judges with a flat/inline file namespace.
+
+    A scanner is selected for a language when that language's kinds (see
+    ``environment.language_kinds``) intersect ``language_kinds``, or when the
+    language explicitly names the scanner in its ``scanners`` field.
     """
 
-    kinds: ClassVar[Set[DependencyKind]] = set()
+    name: ClassVar[str]
+    language_kinds: ClassVar[Set[LanguageKind]] = set()
+    dependency_kinds: ClassVar[Set[DependencyKind]] = set()
     can_rewrite: ClassVar[bool] = False
-
-    @abc.abstractmethod
-    def handles(self, language: str) -> bool: ...
 
     @abc.abstractmethod
     def references(self, file: pathlib.Path) -> List[Reference]: ...
@@ -48,16 +53,28 @@ class DependencyScanner(abc.ABC):
         )
 
 
-_REGISTRY: List[DependencyScanner] = []
+_REGISTRY: Dict[str, DependencyScanner] = {}
 
 
 def register(scanner_cls: Type[DependencyScanner]) -> Type[DependencyScanner]:
-    _REGISTRY.append(scanner_cls())
+    instance = scanner_cls()
+    _REGISTRY[instance.name] = instance
     return scanner_cls
 
 
-def get_scanner(language: str) -> Optional[DependencyScanner]:
-    for instance in _REGISTRY:
-        if instance.handles(language):
-            return instance
-    return None
+def get_scanner(name: str) -> Optional[DependencyScanner]:
+    return _REGISTRY.get(name)
+
+
+def get_scanners_for_kinds(
+    kinds: Set[LanguageKind], names: Optional[List[str]] = None
+) -> List[DependencyScanner]:
+    """Scanners applicable to a language: every registered scanner whose
+    ``language_kinds`` intersects ``kinds``, plus any explicitly named in ``names``
+    (deduplicated, registration order)."""
+    explicit = set(names or [])
+    result = []
+    for name, scanner in _REGISTRY.items():
+        if scanner.language_kinds & kinds or name in explicit:
+            result.append(scanner)
+    return result

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -595,6 +595,14 @@ def get_compilation_config(
     )
 
 
+def is_interpreted(language: str, solution: bool = False) -> bool:
+    """Whether the language runs its source directly (the compilable is the
+    executable) rather than producing a separate binary. This is exactly the
+    signal ``compile_item`` uses to take the passthrough path."""
+    config = get_compilation_config(language, solution)
+    return bool(config.passthrough) or not config.commands
+
+
 def merge_execution_configs(
     execution_configs: List[Optional[Union[ExecutionConfig, BaseExecutionConfig]]],
     solution: bool = False,

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -1,7 +1,19 @@
 import functools
 import pathlib
+import shlex
 from enum import Enum
-from typing import Annotated, Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Annotated,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import typer
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -13,6 +25,7 @@ from rbx.box.linters.asset_kind import AssetKind
 from rbx.box.yaml_validation import load_yaml_model
 from rbx.grading.judge.sandbox import SandboxBase, SandboxParams
 from rbx.grading.judge.sandboxes.stupid_sandbox import StupidSandbox
+from rbx.grading.language_kind import LanguageKind, command_kinds
 from rbx.grading.limits import Limits
 
 T = TypeVar('T', bound=BaseModel)
@@ -269,6 +282,12 @@ for the environment will be used.""",
     linters: List[LinterConfig] = Field(
         default_factory=list,
         description="""Linters to run for this language during compilation.""",
+    )
+
+    scanners: List[str] = Field(
+        default_factory=list,
+        description="""Dependency scanners (by registry name) to apply for this
+language, in addition to the ones automatically selected by language kind.""",
     )
 
     timing: Optional[LanguageTimingConfig] = Field(
@@ -601,6 +620,25 @@ def is_interpreted(language: str, solution: bool = False) -> bool:
     signal ``compile_item`` uses to take the passthrough path."""
     config = get_compilation_config(language, solution)
     return bool(config.passthrough) or not config.commands
+
+
+def language_kinds(language: EnvironmentLanguage) -> Set[LanguageKind]:
+    """The set of :class:`LanguageKind` a language belongs to, derived from its
+    toolchain: the compilation commands if it compiles, else its execution command.
+    Deriving from the actual compiler/interpreter (not the language *name*) keeps
+    dispatch robust to custom language names."""
+    if language.compilation and language.compilation.commands:
+        commands = list(language.compilation.commands)
+    elif language.execution and language.execution.command:
+        commands = [language.execution.command]
+    else:
+        commands = []
+
+    kinds: Set[LanguageKind] = set()
+    for command in commands:
+        parts = shlex.split(command)
+        kinds |= command_kinds(parts[0] if parts else command)
+    return kinds
 
 
 def merge_execution_configs(

--- a/rbx/box/package.py
+++ b/rbx/box/package.py
@@ -548,30 +548,41 @@ def get_relative_source_path(code: CodeItem) -> pathlib.Path:
         return pathlib.Path(code.path.name)
 
 
-# Return each compilation file and to where it should be moved inside
-# the sandbox.
-def get_compilation_files(code: CodeItem) -> List[Tuple[pathlib.Path, pathlib.Path]]:
+# Return each declared file and to where it should be moved inside the sandbox.
+# ``src`` and ``dest`` are the same package-relative path: the package directory
+# structure is mirrored, and ``cwd`` is the package root.
+def _get_declared_files(
+    code: CodeItem, declared: Optional[List[str]], label: str
+) -> List[Tuple[pathlib.Path, pathlib.Path]]:
     package_root = utils.abspath(pathlib.Path())
 
     res = []
-    for compilation_file in code.compilationFiles or []:
-        compilation_file_path = utils.abspath(pathlib.Path(compilation_file))
-        if not compilation_file_path.is_file():
+    for entry in declared or []:
+        entry_path = utils.abspath(pathlib.Path(entry))
+        if not entry_path.is_file():
             console.console.print(
-                f'[error]Compilation file [item]{compilation_file}[/item] for '
+                f'[error]{label} [item]{entry}[/item] for '
                 f'code {code.href()} does not exist.[/error]',
             )
             raise typer.Exit(1)
-        if not compilation_file_path.is_relative_to(package_root):
+        if not entry_path.is_relative_to(package_root):
             console.console.print(
-                f'[error]Compilation file [item]{compilation_file}[/item] for '
+                f'[error]{label} [item]{entry}[/item] for '
                 f'code {code.href()} is not under the package directory.[/error]',
             )
             raise typer.Exit(1)
 
-        rel = compilation_file_path.relative_to(package_root)
+        rel = entry_path.relative_to(package_root)
         res.append((rel, rel))
     return res
+
+
+def get_compilation_files(code: CodeItem) -> List[Tuple[pathlib.Path, pathlib.Path]]:
+    return _get_declared_files(code, code.compilationFiles, 'Compilation file')
+
+
+def get_execution_files(code: CodeItem) -> List[Tuple[pathlib.Path, pathlib.Path]]:
+    return _get_declared_files(code, code.executionFiles, 'Execution file')
 
 
 @functools.cache

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -297,6 +297,22 @@ Testlib, jngen and tgen are already included by default.
 """,
     )
 
+    executionFiles: Optional[List[str]] = Field(
+        default=[],
+        description="""
+Extra files that should be available at *execution* time, the runtime equivalent of
+`compilationFiles`.
+
+The paths should be given relative to the package directory, and are placed at the
+same package-relative path inside the sandbox (the package directory structure is
+mirrored). Use this for runtime companion files a compiled binary or interpreted
+script needs at run time (data files, sibling modules, etc.).
+
+Sibling Python imports and quoted C++ includes are auto-discovered; this field is the
+escape hatch for files that cannot be discovered automatically.
+""",
+    )
+
     def href(self, hyperlink: bool = True) -> str:
         return href(self.path, hyperlink=hyperlink)
 
@@ -315,6 +331,7 @@ class CodeItemWithDigest(CodeItem):
             path=code_item.path,
             language=code_item.language,
             compilationFiles=code_item.compilationFiles,
+            executionFiles=code_item.executionFiles,
             digest=digest,
         )
 
@@ -382,6 +399,7 @@ class OutputFromItemWithDigest(OutputFromItem, CodeItemWithDigest):
             path=output_from_item.path,
             language=output_from_item.language,
             compilationFiles=output_from_item.compilationFiles,
+            executionFiles=output_from_item.executionFiles,
             digest=digest,
         )
 

--- a/rbx/grading/language_kind.py
+++ b/rbx/grading/language_kind.py
@@ -1,0 +1,42 @@
+import enum
+from typing import Set
+
+
+class LanguageKind(enum.Enum):
+    """A coarse language family a command or language belongs to.
+
+    A single command/language can have more than one kind: a C++ command is both
+    ``CXX`` and ``CPP``; a C command is both ``CXX`` and ``C``; Java and Kotlin are
+    both ``JVM`` plus their specific kind. ``CXX`` and ``JVM`` are the umbrella kinds.
+    """
+
+    CXX = 'cxx'
+    CPP = 'cpp'
+    C = 'c'
+    JVM = 'jvm'
+    JAVA = 'java'
+    KOTLIN = 'kotlin'
+    PYTHON = 'python'
+
+
+def command_kinds(exe_command: str) -> Set[LanguageKind]:
+    """The set of language kinds a command (or its bare executable) belongs to.
+
+    Detection is purely substring-based on the command's executable, mirroring the
+    historical ``is_*_command`` predicates this replaces. ``g++``/``clang++`` imply
+    ``{CPP, CXX}``; ``gcc``/``clang`` imply ``{C, CXX}``; ``javac``/``java`` imply
+    ``{JAVA, JVM}``; ``kotlinc``/``kotlin`` imply ``{KOTLIN, JVM}``;
+    ``python``/``pypy`` imply ``{PYTHON}``.
+    """
+    kinds: Set[LanguageKind] = set()
+    if 'g++' in exe_command or 'clang++' in exe_command:
+        kinds |= {LanguageKind.CPP, LanguageKind.CXX}
+    if 'gcc' in exe_command or 'clang' in exe_command:
+        kinds |= {LanguageKind.C, LanguageKind.CXX}
+    if 'javac' in exe_command or 'java' in exe_command:
+        kinds |= {LanguageKind.JAVA, LanguageKind.JVM}
+    if 'kotlinc' in exe_command or 'kotlin' in exe_command:
+        kinds |= {LanguageKind.KOTLIN, LanguageKind.JVM}
+    if 'python' in exe_command or 'pypy' in exe_command:
+        kinds |= {LanguageKind.PYTHON}
+    return kinds

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -29,6 +29,7 @@ from rbx.grading.judge.sandbox import (
     SandboxParams,
 )
 from rbx.grading.judge.storage import copyfileobj
+from rbx.grading.language_kind import LanguageKind, command_kinds
 from rbx.grading.limits import Limits
 
 MAX_STDOUT_LEN = 1024 * 1024 * 128  # 128 MB
@@ -456,16 +457,19 @@ def get_exe_from_command(command: str) -> str:
     return cmds[0]
 
 
+# These ``is_*_command`` predicates are thin aliases over ``command_kinds`` and are
+# kept for readability at call sites. New code should prefer ``command_kinds``
+# directly; tracked for deprecation in https://github.com/rsalesc/rbx/issues/529.
 def _is_c_command(exe_command: str) -> bool:
-    return 'gcc' in exe_command or 'clang' in exe_command
+    return LanguageKind.C in command_kinds(exe_command)
 
 
 def is_cpp_command(exe_command: str) -> bool:
-    return 'g++' in exe_command or 'clang++' in exe_command
+    return LanguageKind.CPP in command_kinds(exe_command)
 
 
 def is_cxx_command(exe_command: str) -> bool:
-    return is_cpp_command(exe_command) or _is_c_command(exe_command)
+    return LanguageKind.CXX in command_kinds(exe_command)
 
 
 def is_cxx_sanitizer_command(command: str) -> bool:
@@ -478,15 +482,15 @@ def is_cxx_sanitizer_command(command: str) -> bool:
 
 
 def is_java_command(exe_command: str) -> bool:
-    return 'javac' in exe_command or 'java' in exe_command
+    return LanguageKind.JAVA in command_kinds(exe_command)
 
 
 def is_kotlin_command(exe_command: str) -> bool:
-    return 'kotlinc' in exe_command or 'kotlin' in exe_command
+    return LanguageKind.KOTLIN in command_kinds(exe_command)
 
 
 def is_java_like_command(exe_command: str) -> bool:
-    return is_java_command(exe_command) or is_kotlin_command(exe_command)
+    return LanguageKind.JVM in command_kinds(exe_command)
 
 
 @functools.cache

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -159,6 +159,11 @@ class GradingFileInput(BaseModel):
     executable: bool = False
     # Whether to track file through its hash (disable for optimization).
     hash: bool = True
+    # Whether the file may be symlinked from the cache (the default, for speed). Set
+    # False to force a real copy -- e.g. an interpreted entry script, whose realpath
+    # must stay inside the sandbox so the interpreter's module search root resolves to
+    # the mirrored source dir rather than the content cache.
+    symlink: bool = True
 
 
 class GradingFileOutput(BaseModel):
@@ -314,7 +319,7 @@ async def _process_input_artifacts(artifacts: GradingArtifacts, sandbox: Sandbox
                 input_artifact.digest.value,
                 override=True,
                 executable=input_artifact.executable,
-                try_symlink=True,
+                try_symlink=input_artifact.symlink,
             )
             continue
         assert input_artifact.src is not None
@@ -323,7 +328,7 @@ async def _process_input_artifacts(artifacts: GradingArtifacts, sandbox: Sandbox
             artifacts.root / input_artifact.src,
             executable=input_artifact.executable,
             override=True,
-            try_symlink=True,
+            try_symlink=input_artifact.symlink,
         )
     for output_artifact in artifacts.outputs:
         if output_artifact.touch:

--- a/rbx/resources/presets/default/env.rbx.yml
+++ b/rbx/resources/presets/default/env.rbx.yml
@@ -31,6 +31,7 @@ languages:
     execution:
       command: "./{executable}"
     linters: [testlib]
+    scanners: [cpp]
     extensions:
       boca:
         languages: ["cc", "cpp"]
@@ -44,6 +45,7 @@ languages:
       commands: ["gcc -std=gnu11 -O2 -o {executable} {compilable} -lm"]
     execution:
       command: "./{executable}"
+    scanners: [cpp]
     extensions:
       boca:
         languages: ["c"]
@@ -53,6 +55,7 @@ languages:
     extension: "py"
     execution:
       command: "python3 {executable}"
+    scanners: [python]
     timing:
       wallTimeIncrement: 2000
     fileMapping:

--- a/tests/rbx/box/code_compile_test.py
+++ b/tests/rbx/box/code_compile_test.py
@@ -853,3 +853,31 @@ class TestCompilationFiles:
         code_item = CodeItem(path=gen, language='cpp', compilationFiles=[str(outside)])
         with pytest.raises(typer.Exit):
             package.get_compilation_files(code_item)
+
+
+class TestExecutionFiles:
+    def test_dest_is_package_relative(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        testing_pkg.add_file('data.txt')
+        sol = testing_pkg.add_file('sols/main.py')
+        item = CodeItem(path=sol, language='py', executionFiles=['data.txt'])
+        assert package.get_execution_files(item) == [
+            (pathlib.Path('data.txt'), pathlib.Path('data.txt'))
+        ]
+
+    def test_rejects_missing(self, testing_pkg: testing_package.TestingPackage):
+        sol = testing_pkg.add_file('m.py')
+        item = CodeItem(path=sol, language='py', executionFiles=['nope.txt'])
+        with pytest.raises(typer.Exit):
+            package.get_execution_files(item)
+
+    def test_with_digest_propagates_execution_files(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        from rbx.box.schema import CodeItemWithDigest
+
+        sol = testing_pkg.add_file('m.py')
+        item = CodeItem(path=sol, language='py', executionFiles=['m.py'])
+        wd = CodeItemWithDigest.create(item, 'deadbeef')
+        assert wd.executionFiles == ['m.py']

--- a/tests/rbx/box/code_compile_test.py
+++ b/tests/rbx/box/code_compile_test.py
@@ -278,6 +278,20 @@ class TestCompileItem:
         )
         assert testlib_input is not None
 
+    async def test_auto_expands_quoted_include(
+        self, testing_pkg: testing_package.TestingPackage, mock_steps_with_caching
+    ):
+        """A parent-dir quoted include is auto-discovered without compilationFiles."""
+        testing_pkg.add_file('lib.h').write_text('#pragma once\n')
+        gen = testing_pkg.add_file('gens/gen.cpp')
+        gen.write_text('#include "../lib.h"\nint main(){}\n')
+
+        await code.compile_item(CodeItem(path=gen, language='cpp'))
+
+        artifacts = mock_steps_with_caching.call_args.kwargs['artifacts']
+        dests = {inp.dest for inp in artifacts.inputs}
+        assert pathlib.Path('lib.h') in dests
+
     async def test_compile_artifacts_with_jngen(
         self, testing_pkg: testing_package.TestingPackage, mock_steps_with_caching
     ):

--- a/tests/rbx/box/code_dependencies_integration_test.py
+++ b/tests/rbx/box/code_dependencies_integration_test.py
@@ -1,0 +1,50 @@
+from rbx.box import code
+from rbx.box.schema import CodeItem
+from rbx.box.testing import testing_package
+from rbx.grading.steps import DigestOrDest, DigestOrSource
+
+
+class TestAutoExpansionIntegration:
+    async def test_subdir_cpp_autodiscovers_parent_include(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        testing_pkg.add_file('lib.h').write_text(
+            '#pragma once\ninline int answer(){ return 42; }\n'
+        )
+        gen = testing_pkg.add_file('gens/gen.cpp')
+        gen.write_text(
+            '#include "../lib.h"\n#include <cstdio>\n'
+            'int main(){ printf("%d\\n", answer()); }\n'
+        )
+        # No manual compilationFiles -- must be auto-discovered.
+        assert await code.compile_item(CodeItem(path=gen, language='cpp'))
+
+    async def test_flat_cpp_still_compiles(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        sol = testing_pkg.add_file('sol.cpp')
+        sol.write_text('#include <cstdio>\nint main(){ printf("ok\\n"); }\n')
+        assert await code.compile_item(CodeItem(path=sol, language='cpp'))
+
+    async def test_python_subdir_sibling_import_runs(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        testing_pkg.add_file('sols/helper.py').write_text(
+            'def value():\n    return 7\n'
+        )
+        main = testing_pkg.add_file('sols/main.py')
+        # Absolute sibling import: resolves via sys.path[0] (the mirrored script dir)
+        # when the script is executed directly, which is how rbx runs it.
+        main.write_text('import helper\nprint(helper.value())\n')
+        item = CodeItem(path=main, language='py')
+
+        digest = await code.compile_item(item)
+        output_path = testing_pkg.path('out.txt')
+        run_log = await code.run_item(
+            item,
+            DigestOrSource.create(digest),
+            stdout=DigestOrDest.create(output_path),
+        )
+        assert run_log is not None
+        assert run_log.exitcode == 0
+        assert output_path.read_text().strip() == '7'

--- a/tests/rbx/box/code_prepare_run_test.py
+++ b/tests/rbx/box/code_prepare_run_test.py
@@ -55,3 +55,30 @@ class TestPrepareRunExecutionFiles:
         )
         dests = {inp.dest for inp in prepared.artifacts.inputs}
         assert pathlib.Path('lib.h') not in dests
+
+    async def test_interpreted_executable_is_copied(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        # The interpreted entry script must be copied (symlink=False) so its
+        # realpath stays in the sandbox and sys.path[0] is the mirrored dir.
+        main = testing_pkg.add_file('m.py')
+        main.write_text('print(1)\n')
+        item = CodeItem(path=main, language='py')
+        digest = await code.compile_item(item)
+        prepared = await code._prepare_run(  # noqa: SLF001
+            item, DigestOrSource.create(digest)
+        )
+        executable = prepared.artifacts.inputs[0]
+        assert executable.dest == pathlib.Path('m.py')
+        assert executable.symlink is False
+
+    async def test_compiled_executable_is_symlinked(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        main = testing_pkg.add_file('m.cpp')
+        main.write_text('int main(){}\n')
+        item = CodeItem(path=main, language='cpp')
+        prepared = await code._prepare_run(  # noqa: SLF001
+            item, DigestOrSource.create('deadbeef' * 5)
+        )
+        assert prepared.artifacts.inputs[0].symlink is True

--- a/tests/rbx/box/code_prepare_run_test.py
+++ b/tests/rbx/box/code_prepare_run_test.py
@@ -12,7 +12,9 @@ class TestPrepareRunExecutionFiles:
     ):
         testing_pkg.add_file('sols/helper.py').write_text('X = 1\n')
         main = testing_pkg.add_file('sols/main.py')
-        main.write_text('from . import helper\nprint(helper.X)\n')
+        # Absolute sibling import is the runnable idiom for a directly-executed
+        # script (a relative `from .` import cannot run as a bare __main__).
+        main.write_text('import helper\nprint(helper.X)\n')
         item = CodeItem(path=main, language='py')
 
         digest = await code.compile_item(item)  # passthrough digest for Python

--- a/tests/rbx/box/code_prepare_run_test.py
+++ b/tests/rbx/box/code_prepare_run_test.py
@@ -1,0 +1,55 @@
+import pathlib
+
+from rbx.box import code
+from rbx.box.schema import CodeItem
+from rbx.box.testing import testing_package
+from rbx.grading.steps import DigestOrSource
+
+
+class TestPrepareRunExecutionFiles:
+    async def test_python_sibling_module_mirrored(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        testing_pkg.add_file('sols/helper.py').write_text('X = 1\n')
+        main = testing_pkg.add_file('sols/main.py')
+        main.write_text('from . import helper\nprint(helper.X)\n')
+        item = CodeItem(path=main, language='py')
+
+        digest = await code.compile_item(item)  # passthrough digest for Python
+        prepared = await code._prepare_run(  # noqa: SLF001
+            item, DigestOrSource.create(digest)
+        )
+
+        dests = {inp.dest for inp in prepared.artifacts.inputs}
+        assert pathlib.Path('sols/helper.py') in dests
+
+    async def test_manual_execution_file_mirrored(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        testing_pkg.add_file('data.txt')
+        main = testing_pkg.add_file('m.py')
+        main.write_text('print(1)\n')
+        item = CodeItem(path=main, language='py', executionFiles=['data.txt'])
+
+        digest = await code.compile_item(item)
+        prepared = await code._prepare_run(  # noqa: SLF001
+            item, DigestOrSource.create(digest)
+        )
+
+        dests = {inp.dest for inp in prepared.artifacts.inputs}
+        assert pathlib.Path('data.txt') in dests
+
+    async def test_cpp_contributes_no_runtime_deps(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        # A C++ source's includes are compile-time only: no auto runtime mirroring.
+        testing_pkg.add_file('lib.h').write_text('#pragma once\n')
+        main = testing_pkg.add_file('m.cpp')
+        main.write_text('#include "lib.h"\nint main(){}\n')
+        item = CodeItem(path=main, language='cpp')
+
+        prepared = await code._prepare_run(  # noqa: SLF001
+            item, DigestOrSource.create('deadbeef' * 5)
+        )
+        dests = {inp.dest for inp in prepared.artifacts.inputs}
+        assert pathlib.Path('lib.h') not in dests

--- a/tests/rbx/box/dependencies_test.py
+++ b/tests/rbx/box/dependencies_test.py
@@ -5,13 +5,13 @@ import pytest
 
 from rbx.box.dependencies import scanner
 from rbx.box.dependencies.scanner import DependencyKind, DependencyScanner, Reference
+from rbx.grading.language_kind import LanguageKind
 
 
 class _Dummy(DependencyScanner):
-    kinds = {DependencyKind.COMPILATION}
-
-    def handles(self, language: str) -> bool:
-        return language == 'dummy'
+    name = 'dummy'
+    language_kinds = {LanguageKind.CXX}
+    dependency_kinds = {DependencyKind.COMPILATION}
 
     def references(self, file: pathlib.Path) -> List[Reference]:
         return []
@@ -21,6 +21,19 @@ def test_register_and_get_scanner():
     scanner.register(_Dummy)
     assert isinstance(scanner.get_scanner('dummy'), _Dummy)
     assert scanner.get_scanner('nope') is None
+
+
+def test_get_scanners_by_kind_and_explicit_name():
+    scanner.register(_Dummy)
+    # Selected automatically by language kind...
+    cxx = scanner.get_scanners_for_kinds({LanguageKind.CXX})
+    assert any(s.name == 'dummy' for s in cxx)
+    # ...not by an unrelated kind...
+    py = scanner.get_scanners_for_kinds({LanguageKind.PYTHON})
+    assert not any(s.name == 'dummy' for s in py)
+    # ...unless named explicitly.
+    py_named = scanner.get_scanners_for_kinds({LanguageKind.PYTHON}, ['dummy'])
+    assert any(s.name == 'dummy' for s in py_named)
 
 
 def test_rewrite_unsupported_by_default():
@@ -154,3 +167,34 @@ class TestExpand:
         j = testing_pkg.add_file('Main.java')
         j.write_text('class Main {}\n')
         assert graph.expand(CodeItem(path=j, language='java')) is None
+
+    def test_c_source_dispatches_to_cpp_scanner_by_kind(self, testing_pkg):
+        # A 'c' language has kinds {CXX, C}; the cpp scanner declares {CXX}, so it is
+        # selected by kind intersection -- no dependence on the language name.
+        from rbx.box.dependencies import graph
+        from rbx.box.schema import CodeItem
+
+        testing_pkg.add_file('lib.h').write_text('#pragma once\n')
+        src = testing_pkg.add_file('m.c')
+        src.write_text('#include "lib.h"\nint main(){}\n')
+        g = graph.expand(CodeItem(path=src, language='c'))
+        assert g is not None
+        assert pathlib.Path('lib.h') in g.files()
+
+    def test_language_kinds_derive_from_toolchain(self, testing_pkg):
+        from rbx.box import environment
+
+        assert environment.language_kinds(environment.get_language('cpp')) == {
+            LanguageKind.CPP,
+            LanguageKind.CXX,
+        }
+        assert environment.language_kinds(environment.get_language('c')) == {
+            LanguageKind.C,
+            LanguageKind.CXX,
+        }
+        assert environment.language_kinds(environment.get_language('py')) == {
+            LanguageKind.PYTHON
+        }
+        assert LanguageKind.JVM in environment.language_kinds(
+            environment.get_language('java')
+        )

--- a/tests/rbx/box/dependencies_test.py
+++ b/tests/rbx/box/dependencies_test.py
@@ -103,3 +103,39 @@ class TestPythonReferences:
         src.write_text('from ...common import util\n')
         refs = python.PythonScanner().references(pathlib.Path('sols/sub/main.py'))
         assert any(r.target == pathlib.Path('common/util.py') for r in refs)
+
+
+class TestExpand:
+    def test_cpp_transitive_excludes_root(self, testing_pkg):
+        from rbx.box.dependencies import graph
+        from rbx.box.dependencies.scanner import DependencyKind
+        from rbx.box.schema import CodeItem
+
+        testing_pkg.add_file('lib.h').write_text('#include "extra.h"\n')
+        testing_pkg.add_file('extra.h').write_text('#pragma once\n')
+        gen = testing_pkg.add_file('gens/gen.cpp')
+        gen.write_text('#include "../lib.h"\nint main(){}\n')
+
+        g = graph.expand(CodeItem(path=gen, language='cpp'))
+        assert g is not None
+        assert g.kinds == {DependencyKind.COMPILATION}
+        assert g.files() == [pathlib.Path('extra.h'), pathlib.Path('lib.h')]
+
+    def test_cycle_safe(self, testing_pkg):
+        from rbx.box.dependencies import graph
+        from rbx.box.schema import CodeItem
+
+        testing_pkg.add_file('a.h').write_text('#include "b.h"\n')
+        testing_pkg.add_file('b.h').write_text('#include "a.h"\n')
+        src = testing_pkg.add_file('m.cpp')
+        src.write_text('#include "a.h"\nint main(){}\n')
+        g = graph.expand(CodeItem(path=src, language='cpp'))
+        assert set(g.files()) == {pathlib.Path('a.h'), pathlib.Path('b.h')}
+
+    def test_none_for_unhandled_language(self, testing_pkg):
+        from rbx.box.dependencies import graph
+        from rbx.box.schema import CodeItem
+
+        j = testing_pkg.add_file('Main.java')
+        j.write_text('class Main {}\n')
+        assert graph.expand(CodeItem(path=j, language='java')) is None

--- a/tests/rbx/box/dependencies_test.py
+++ b/tests/rbx/box/dependencies_test.py
@@ -26,3 +26,52 @@ def test_register_and_get_scanner():
 def test_rewrite_unsupported_by_default():
     with pytest.raises(NotImplementedError):
         _Dummy().rewrite('x', lambda s: None)
+
+
+class TestCppReferences:
+    def test_quoted_and_angle_and_builtin(self, testing_pkg):
+        from rbx.box.dependencies import cpp
+
+        testing_pkg.add_file('lib.h').write_text('#pragma once\n')
+        gen = testing_pkg.add_file('gens/gen.cpp')
+        gen.write_text(
+            '#include "../lib.h"\n'
+            '#include <cstdio>\n'
+            '#include "testlib.h"\n'
+            'int main(){}\n'
+        )
+        refs = cpp.CppScanner().references(pathlib.Path('gens/gen.cpp'))
+        by_spelling = {r.spelling: r.target for r in refs}
+        # Quoted package include resolves to its package-relative path.
+        assert by_spelling['../lib.h'] == pathlib.Path('lib.h')
+        # Quoted builtin (not a package file) -> unresolved.
+        assert by_spelling['testlib.h'] is None
+        # Angle includes are never reported.
+        assert 'cstdio' not in by_spelling
+
+    def test_ignores_commented_include(self, testing_pkg):
+        from rbx.box.dependencies import cpp
+
+        testing_pkg.add_file('lib.h').write_text('#pragma once\n')
+        src = testing_pkg.add_file('a.cpp')
+        src.write_text('/* #include "lib.h" */\nint main(){}\n')
+        assert cpp.CppScanner().references(pathlib.Path('a.cpp')) == []
+
+
+class TestCppRewrite:
+    def test_rewrites_mapped_leaves_others(self):
+        from rbx.box.dependencies import cpp
+
+        text = '#include "../lib.h"\n#include <cstdio>\n#include "keep.h"\n'
+        out = cpp.CppScanner().rewrite(text, {'../lib.h': 'lib__x.h'}.get)
+        assert '#include "lib__x.h"' in out
+        assert '#include <cstdio>' in out  # angle untouched
+        assert '#include "keep.h"' in out  # unmapped untouched
+
+    def test_preserves_commented_include(self):
+        from rbx.box.dependencies import cpp
+
+        text = '/* #include "lib.h" */\n#include "lib.h"\n'
+        out = cpp.CppScanner().rewrite(text, {'lib.h': 'flat.h'}.get)
+        assert '/* #include "lib.h" */' in out  # comment untouched
+        assert '#include "flat.h"' in out  # real directive rewritten

--- a/tests/rbx/box/dependencies_test.py
+++ b/tests/rbx/box/dependencies_test.py
@@ -75,3 +75,31 @@ class TestCppRewrite:
         out = cpp.CppScanner().rewrite(text, {'lib.h': 'flat.h'}.get)
         assert '/* #include "lib.h" */' in out  # comment untouched
         assert '#include "flat.h"' in out  # real directive rewritten
+
+
+class TestPythonReferences:
+    def test_relative_sibling_and_stdlib(self, testing_pkg):
+        from rbx.box.dependencies import python
+
+        testing_pkg.add_file('sols/helper.py').write_text('X = 1\n')
+        main = testing_pkg.add_file('sols/main.py')
+        main.write_text(
+            'import os\n'
+            'from . import helper\n'
+            'import helper as h2\n'
+            'print(helper.X, h2.X, os.getpid())\n'
+        )
+        refs = python.PythonScanner().references(pathlib.Path('sols/main.py'))
+        targets = {r.target for r in refs if r.target is not None}
+        assert pathlib.Path('sols/helper.py') in targets
+        # stdlib os never resolves to a package file.
+        assert all(r.target != pathlib.Path('os.py') for r in refs)
+
+    def test_parent_package_import(self, testing_pkg):
+        from rbx.box.dependencies import python
+
+        testing_pkg.add_file('common/util.py').write_text('Y = 2\n')
+        src = testing_pkg.add_file('sols/sub/main.py')
+        src.write_text('from ...common import util\n')
+        refs = python.PythonScanner().references(pathlib.Path('sols/sub/main.py'))
+        assert any(r.target == pathlib.Path('common/util.py') for r in refs)

--- a/tests/rbx/box/dependencies_test.py
+++ b/tests/rbx/box/dependencies_test.py
@@ -104,6 +104,21 @@ class TestPythonReferences:
         refs = python.PythonScanner().references(pathlib.Path('sols/sub/main.py'))
         assert any(r.target == pathlib.Path('common/util.py') for r in refs)
 
+    def test_deep_import_ships_intermediate_init_markers(self, testing_pkg):
+        from rbx.box.dependencies import python
+
+        testing_pkg.add_file('a/__init__.py').write_text('')
+        testing_pkg.add_file('a/b/__init__.py').write_text('')
+        testing_pkg.add_file('a/b/c.py').write_text('Z = 1\n')
+        main = testing_pkg.add_file('main.py')
+        main.write_text('import a.b.c\n')
+        refs = python.PythonScanner().references(pathlib.Path('main.py'))
+        targets = {r.target for r in refs if r.target is not None}
+        # The leaf AND every existing intermediate __init__.py must be discovered.
+        assert pathlib.Path('a/b/c.py') in targets
+        assert pathlib.Path('a/__init__.py') in targets
+        assert pathlib.Path('a/b/__init__.py') in targets
+
 
 class TestExpand:
     def test_cpp_transitive_excludes_root(self, testing_pkg):

--- a/tests/rbx/box/dependencies_test.py
+++ b/tests/rbx/box/dependencies_test.py
@@ -1,0 +1,28 @@
+import pathlib
+from typing import List
+
+import pytest
+
+from rbx.box.dependencies import scanner
+from rbx.box.dependencies.scanner import DependencyKind, DependencyScanner, Reference
+
+
+class _Dummy(DependencyScanner):
+    kinds = {DependencyKind.COMPILATION}
+
+    def handles(self, language: str) -> bool:
+        return language == 'dummy'
+
+    def references(self, file: pathlib.Path) -> List[Reference]:
+        return []
+
+
+def test_register_and_get_scanner():
+    scanner.register(_Dummy)
+    assert isinstance(scanner.get_scanner('dummy'), _Dummy)
+    assert scanner.get_scanner('nope') is None
+
+
+def test_rewrite_unsupported_by_default():
+    with pytest.raises(NotImplementedError):
+        _Dummy().rewrite('x', lambda s: None)


### PR DESCRIPTION
## Summary

Implements **Phase 2** of sandbox directory mirroring (#524), follow-up to #522/#523. Adds an `executionFiles` field and **default-on, transitive, quoted-only auto-expansion** of dependencies, built on a new per-language dependency interface that is deliberately shaped so #525 (packaging flatten/rewrite) can reuse it.

Design & plan: `docs/plans/2026-06-06-sandbox-working-directory-phase2-design.md` and `…-phase2.md`.

## What's in here

**New `rbx/box/dependencies/` package** (mirrors `linters/` — registry + self-registering per-language modules):
- `scanner.py` — `DependencyKind`, `Reference(spelling, target)`, `DependencyScanner` ABC + registry.
- `cpp.py` — **tree-sitter-cpp** scanner: `references()` (quoted `#include "…"` only; `<...>`, comments, and builtins → unresolved) and `rewrite()` (span-based, byte-preserving, `can_rewrite=True`).
- `python.py` — `ast` scanner: relative/sibling imports (`from .`, `from ..pkg`, `import sibling`), plus intermediate `__init__.py` markers for deep dotted imports.
- `graph.py` — `expand(code, require_kind=…)` → `DependencyGraph` (cycle-safe; `files()` excludes root; per-file edges exposed for #525).

**Wiring:**
- `CodeItem.executionFiles` + `package.get_execution_files` (shares one declared-files helper with `get_compilation_files`), propagated through the `*WithDigest.create` factories.
- `compile_item` unions C++ `#include` deps into compile inputs (additive with manual `compilationFiles`).
- `_prepare_run` mirrors manual `executionFiles` + auto-discovered Python deps into run inputs.

## Notable: a real runtime bug fixed

Mirroring the sibling module into the sandbox was **necessary but not sufficient** for Python. The entry script is materialized as a symlink into the content-addressed cache, so Python ≥3.11 resolves `sys.path[0]` to the cache dir (via the symlink's realpath), **not** the mirrored source dir — so `import sibling` failed with `ModuleNotFoundError` even with the sibling sitting next to the script. Fix: set `PYTHONPATH` to the mirrored source dir for interpreted runs (cache-key-correct via `set_env`). This was latent since Phase 1; #524 is the first feature to exercise runtime sibling imports end-to-end.

## #525 — interface baked, not built

The `DependencyGraph` (per-file `spelling → target` edges, including the root) + the C++ `rewrite(text, rename)` primitive are delivered and unit-tested so #525 can flatten + rewrite cross-directory includes for Polygon/BOCA. **No `packaging/` code is touched** in this PR.

## Out of scope (deliberately)

- All `packaging/` work (that's #525) and its interim guardrail.
- Deprecating auto-injected builtins (already moot: Phase 1's `__internal__/` revision resolves cross-dir builtin includes).
- Python source flattening / `rewrite` (gated behind `can_rewrite=False`).

## Testing

- **Unit:** C++ `references`/`rewrite` (nested/transitive, ignore `<...>`, comment-safe, builtin→None); Python relative/sibling/deep imports + intermediate `__init__.py`; `expand` cycle-safety, refuse-outside-root, `None` for unhandled languages, `require_kind` short-circuit; `executionFiles` schema + factory propagation.
- **Integration (real toolchain):** subdir C++ `#include "../lib.h"` **auto-discovered** (no manual `compilationFiles`) compiles; subdir Python **sibling import runs end-to-end** (the teeth-having test Phase 1 could only smoke-test); flat-package regression.
- 63 affected tests pass; lint clean; no import cycle. Pre-existing environmental failures (validators/generators/stack-limit) verified identical to `main` — no regressions.
- An adversarial code-review pass flagged two items, both addressed: `expand` now short-circuits the tree-sitter walk for C++ on the per-run hot path, and deep `import a.b.c` ships intermediate `__init__.py`.

Closes #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
