### PR TITLE
refactor(grading): replace is_*_command aliases with command_kinds

### DIFF
--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -38,6 +38,7 @@ from rbx.box.sanitizers import warning_stack
 from rbx.box.schema import CodeItem, Solution
 from rbx.grading import grading_context, profiling, steps, steps_with_caching
 from rbx.grading.judge.sandbox import SandboxParams
+from rbx.grading.language_kind import LanguageKind, command_kinds
 from rbx.grading.steps import (
     DigestHolder,
     DigestOrDest,
@@ -48,8 +49,6 @@ from rbx.grading.steps import (
     RunLog,
     RunLogMetadata,
     get_exe_from_command,
-    is_cpp_command,
-    is_cxx_command,
     maybe_get_bits_stdcpp_for_commands,
 )
 from rbx.utils import is_arm
@@ -113,7 +112,7 @@ async def is_executable_sanitized(executable: DigestOrSource) -> bool:
 
 
 def add_sanitizer_flags_to_command(command: str) -> str:
-    if is_cxx_command(command):
+    if LanguageKind.CXX in command_kinds(command):
         return command + ' -fsanitize=address,undefined -fno-omit-frame-pointer -g'
     return command
 
@@ -128,20 +127,20 @@ CXX_WARNING_FLAGS = (
 
 
 def add_color_flags_to_command(command: str) -> str:
-    if is_cxx_command(command):
+    if LanguageKind.CXX in command_kinds(command):
         return command + ' -fdiagnostics-color=always'
     return command
 
 
 def add_warning_flags_to_command(command: str) -> str:
-    if is_cxx_command(command):
+    if LanguageKind.CXX in command_kinds(command):
         return command + ' ' + CXX_WARNING_FLAGS
     return command
 
 
 def add_arm_flags_to_command(command: str) -> str:
     # Disable FMA in ARM.
-    if is_cxx_command(command) and is_arm():
+    if LanguageKind.CXX in command_kinds(command) and is_arm():
         return command + ' -ffp-contract=off'
     return command
 
@@ -467,7 +466,7 @@ async def _prepare_run(
 
 
 def _should_precompile(commands: List[str]) -> bool:
-    return any(is_cpp_command(command) for command in commands)
+    return any(LanguageKind.CPP in command_kinds(command) for command in commands)
 
 
 async def _precompile_header(
@@ -705,7 +704,7 @@ async def compile_item(
             commands = [
                 command + f' -I{steps.INTERNAL_DIR}'
                 for command in commands
-                if is_cxx_command(get_exe_from_command(command))
+                if LanguageKind.CXX in command_kinds(get_exe_from_command(command))
             ]
 
         # Precompile C++ interesting header files.

--- a/rbx/box/sanitizers/compilation_warnings.py
+++ b/rbx/box/sanitizers/compilation_warnings.py
@@ -4,11 +4,11 @@ from collections import Counter
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 from rbx import utils
+from rbx.grading.language_kind import LanguageKind, command_kinds
 from rbx.grading.steps import (
     PreprocessLog,
     _is_first_party_warning_file,
     get_exe_from_command,
-    is_cxx_command,
 )
 
 if TYPE_CHECKING:
@@ -151,4 +151,7 @@ def apply_warning_status(task: 'CompilationTask') -> None:
     task.warning_summary = summarizer.summarize(warning_logs)
 
 
-register(is_cxx_command, CppCompilationWarningSummarizer())
+register(
+    lambda exe: LanguageKind.CXX in command_kinds(exe),
+    CppCompilationWarningSummarizer(),
+)

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -457,40 +457,18 @@ def get_exe_from_command(command: str) -> str:
     return cmds[0]
 
 
-# These ``is_*_command`` predicates are thin aliases over ``command_kinds`` and are
-# kept for readability at call sites. New code should prefer ``command_kinds``
-# directly; tracked for deprecation in https://github.com/rsalesc/rbx/issues/529.
-def _is_c_command(exe_command: str) -> bool:
-    return LanguageKind.C in command_kinds(exe_command)
-
-
-def is_cpp_command(exe_command: str) -> bool:
-    return LanguageKind.CPP in command_kinds(exe_command)
-
-
-def is_cxx_command(exe_command: str) -> bool:
-    return LanguageKind.CXX in command_kinds(exe_command)
-
-
 def is_cxx_sanitizer_command(command: str) -> bool:
+    """Whether ``command`` compiles C/C++ *and* enables a sanitizer.
+
+    Compound predicate (cxx + ``fsanitize``) kept as a named helper because the
+    combination is checked at several call sites.
+    """
     exe = get_exe_from_command(command)
     if not exe:
         return False
-    if not is_cxx_command(exe):
+    if LanguageKind.CXX not in command_kinds(exe):
         return False
     return 'fsanitize' in command
-
-
-def is_java_command(exe_command: str) -> bool:
-    return LanguageKind.JAVA in command_kinds(exe_command)
-
-
-def is_kotlin_command(exe_command: str) -> bool:
-    return LanguageKind.KOTLIN in command_kinds(exe_command)
-
-
-def is_java_like_command(exe_command: str) -> bool:
-    return LanguageKind.JVM in command_kinds(exe_command)
 
 
 @functools.cache
@@ -511,7 +489,7 @@ def _get_cxx_version_output(command: str, extra_flags: str = '') -> Optional[str
     if not cmds:
         return None
     exe = cmds[0]
-    if not is_cxx_command(exe):
+    if LanguageKind.CXX not in command_kinds(exe):
         return None
 
     extra = shlex.split(extra_flags)
@@ -539,7 +517,7 @@ def is_internal_path(path: pathlib.Path) -> bool:
 
 
 def _maybe_get_bits_stdcpp_for_clang(command: str) -> Optional[GradingFileInput]:
-    if not is_cpp_command(get_exe_from_command(command)):
+    if LanguageKind.CPP not in command_kinds(get_exe_from_command(command)):
         return None
     version_output = _get_cxx_version_output(command)
     if version_output is None:
@@ -573,7 +551,7 @@ def _find_system_paths_in_version_output(version_output: str) -> List[pathlib.Pa
 
 
 def _get_system_bits_stdcpp(command: str) -> Optional[GradingFileInput]:
-    if not is_cpp_command(get_exe_from_command(command)):
+    if LanguageKind.CPP not in command_kinds(get_exe_from_command(command)):
         return None
     version_output = _get_cxx_version_output(command, '-xc++ -E -')
     if version_output is None:
@@ -780,7 +758,7 @@ async def compile(
         params.set_stdall(stdout=stdout_file, stderr=stderr_file)
 
         # Remove memory constraints for Java.
-        if is_java_like_command(get_exe_from_command(command)):
+        if LanguageKind.JVM in command_kinds(get_exe_from_command(command)):
             params.address_space = None
 
         try:
@@ -795,7 +773,10 @@ async def compile(
                         utils.highlight_json_obj(cmd),
                     )
                     err.print('[warning]Is it installed and on your PATH?[/warning]')
-                    if is_cxx_command(e.executable) and sys.platform == 'darwin':
+                    if (
+                        LanguageKind.CXX in command_kinds(e.executable)
+                        and sys.platform == 'darwin'
+                    ):
                         err.print(
                             '[warning]On macOS the GNU compiler is not bundled — '
                             "install it with '[item]brew install gcc[/item]', then "
@@ -870,7 +851,7 @@ async def run(
     params = params.model_copy(deep=True)  # Copy to allow further modification.
 
     # Remove memory constraints for Java.
-    if is_java_like_command(get_exe_from_command(command)):
+    if LanguageKind.JVM in command_kinds(get_exe_from_command(command)):
         params.address_space = None
 
     try:
@@ -915,7 +896,7 @@ async def run_coordinated(
     interactor_params = interactor.params.model_copy(deep=True)
     solution_params = solution.params.model_copy(deep=True)
 
-    if is_java_like_command(get_exe_from_command(solution.command)):
+    if LanguageKind.JVM in command_kinds(get_exe_from_command(solution.command)):
         solution_params.address_space = None
 
     try:


### PR DESCRIPTION
Closes #529. Follow-up to #528 / #524.

Phase 2 (#524) introduced `LanguageKind` / `command_kinds(...)` in `rbx/grading/language_kind.py` and kept the `is_*_command` predicates as thin aliases to limit churn in #528. This PR removes those aliases and inlines `LanguageKind.X in command_kinds(...)` at every call site.

## Changes

- **`rbx/grading/steps.py`** — Removed all six aliases. Three were already dead (`_is_c_command`, `is_java_command`, `is_kotlin_command` — zero call sites). Inlined `is_cpp_command` / `is_cxx_command` / `is_java_like_command` at their call sites. Kept `is_cxx_sanitizer_command` (compound `cxx` + `fsanitize` predicate, as the issue requested) but rewrote it to call `command_kinds` internally and added a docstring.
- **`rbx/box/code.py`** — Dropped the two `steps` imports, added `from rbx.grading.language_kind import LanguageKind, command_kinds`, replaced 6 call sites.
- **`rbx/box/sanitizers/compilation_warnings.py`** — Replaced the `register(is_cxx_command, ...)` predicate with `register(lambda exe: LanguageKind.CXX in command_kinds(exe), ...)`.

Historical `docs/plans/*.md` still mention the old names; left untouched since they record state as of their dates. No live code references the removed predicates.

## Verification

- `ruff check` + `ruff format --check` pass
- Modules import cleanly; 427 grading + sanitizer tests collect without error
- 41 targeted tests pass (sanitizer registry, warning summarizer/parser, `is_cxx_sanitizer_command` detection)
- Behavior-preserving by direct substitution: each `is_X_command(c)` was literally defined as `LanguageKind.X in command_kinds(c)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)