### PR TITLE
feat(boca)!: remove legacy BOCA env fields for v1 + migration guide (#471)

### DIFF
--- a/docs/migrating-to-v1.md
+++ b/docs/migrating-to-v1.md
@@ -1,0 +1,107 @@
+# Migrating to rbx v1
+
+rbx v1 removes a few {{boca}} configuration knobs in `env.rbx.yml` that were kept
+only for backward compatibility. They are marked **deprecated** in the current
+schema and will stop working in v1.
+
+If you rely on the bundled `default` preset, there's nothing to do — it has already
+been migrated. You only need to act if you maintain a **custom `env.rbx.yml`** (run
+`rbx config edit` to open it). Each section below shows the old form and its
+replacement.
+
+## `bocaLanguage` → `languages`
+
+The singular per-language `bocaLanguage` is replaced by the plural `languages` list.
+The first entry is the canonical (rbx → BOCA) mapping; every entry is emitted as a
+separate per-language script in the package.
+
+```yaml title="Before"
+languages:
+  - name: "cpp"
+    # ...
+    extensions:
+      boca:
+        bocaLanguage: "cc"
+```
+
+```yaml title="After"
+languages:
+  - name: "cpp"
+    # ...
+    extensions:
+      boca:
+        languages: ["cc"]   # or ["cc", "cpp"] to emit both
+```
+
+## Env-level `languages` allowlist → per-language `languages`
+
+The top-level `extensions.boca.languages` list (an allowlist of BOCA languages to
+emit) is removed. In v1 the emitted set is the **union** of every rbx language's own
+`languages`. Move each entry onto the corresponding rbx language and delete the
+env-level list.
+
+```yaml title="Before"
+extensions:
+  boca:
+    languages: ["cc", "cpp", "c", "py3"]   # env-level allowlist
+```
+
+```yaml title="After"
+languages:
+  - name: "cpp"
+    extensions:
+      boca: { languages: ["cc", "cpp"], template: "cc" }
+  - name: "c"
+    extensions:
+      boca: { languages: ["c"], template: "c" }
+  - name: "py"
+    extensions:
+      boca: { languages: ["py3"], template: "py3" }
+# (env-level `extensions.boca.languages` removed)
+```
+
+!!! warning
+    Both fields are named `languages` but live at different levels: the **per-language**
+    one (under each language's `extensions.boca`) is the replacement; the **env-level**
+    one (at the top of `env.rbx.yml`) is the one being removed.
+
+## `template` is now required
+
+When an rbx language declares `languages`, the `template` field becomes **required** —
+the old fallback to the first `languages` entry is gone. Set it explicitly to one of
+the on-disk template dirs: `c`, `cc`, `cpp`, `java`, `kt`, `py2`, `py3`.
+
+```yaml title="Before"
+extensions:
+  boca:
+    languages: ["cc", "cpp"]   # template inferred from "cc"
+```
+
+```yaml title="After"
+extensions:
+  boca:
+    languages: ["cc", "cpp"]
+    template: "cc"             # required, names the template dir to source scripts from
+```
+
+After v1, loading an `env.rbx.yml` that uses any removed field (or omits a now-required
+`template`) fails with a clear validation error.
+
+## Also removed: `maximumTimeError`
+
+The env-level `extensions.boca.maximumTimeError` has been ignored since rbx started
+emitting exact fractional time limits, and is removed in v1. If you used it to widen
+the per-solution time budget, use `minRunningTime` instead (see
+[Packaging: BOCA](setters/packaging/boca.md#minimum-running-time)).
+
+```yaml title="Before"
+extensions:
+  boca:
+    maximumTimeError: 1.5
+```
+
+```yaml title="After"
+extensions:
+  boca:
+    minRunningTime: 1000   # milliseconds
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - "cpp-on-macos.md"
       - "stack-limit.md"
       - "intro/windows-git.md"
+      - "Migrating to rbx v1": "migrating-to-v1.md"
 theme:
   name: material
   custom_dir: docs/templates

--- a/rbx/box/packaging/CLAUDE.md
+++ b/rbx/box/packaging/CLAUDE.md
@@ -71,7 +71,7 @@ Polygon (offline + upload) and BOCA/MOJ are **flat** judges: they compile each s
 
 Supports interactive problems with special `run` scripts.
 
-**`extension.py`** -- env-level `BocaExtension` (`flags`, `minRunningTime`, `preferContestLetter`, `usePypy`) and per-language `BocaLanguageExtension` (`languages` list + required `template`). Both `model_config = extra='forbid'`. rbx v1 (#471) removed the legacy singular `bocaLanguage`, the env-level `languages` allowlist, the implicit `template` fallback, and `maximumTimeError` (#494); a `model_validator` rejects each removed field at env load with a migration hint, and `template` is required whenever `languages` is set. `resolved_languages`/`primary_language`/`resolved_template` now read only the plural fields.
+**`extension.py`** -- env-level `BocaExtension` (`flags`, `minRunningTime`, `preferContestLetter`, `usePypy`) and per-language `BocaLanguageExtension` (`languages` list + required `template`). Both `model_config = extra='forbid'`. rbx v1 (#471) removed the legacy singular `bocaLanguage`, the env-level `languages` allowlist, the implicit `template` fallback, and `maximumTimeError` (#494). Removed fields are kept as fields flagged `Annotated[..., Removed()]` + `Field(deprecated='<migration hint>')`: the shared `RejectsRemovedFields` base (in `rbx/utils.py`) reads the flag and raises that hint at env load, so the explanation lives on the field. `template` is required whenever `languages` is set (`model_validator`), and `resolved_languages`/`primary_language`/`resolved_template` read only the plural fields.
 
 ### MOJ (`moj/`)
 

--- a/rbx/box/packaging/CLAUDE.md
+++ b/rbx/box/packaging/CLAUDE.md
@@ -71,7 +71,7 @@ Polygon (offline + upload) and BOCA/MOJ are **flat** judges: they compile each s
 
 Supports interactive problems with special `run` scripts.
 
-**`extension.py`** -- `BocaExtension` model with language mapping, flags, `minRunningTime`, `preferContestLetter`, `usePypy`. (`maximumTimeError` is deprecated/ignored -- see issue #494.)
+**`extension.py`** -- env-level `BocaExtension` (`flags`, `minRunningTime`, `preferContestLetter`, `usePypy`) and per-language `BocaLanguageExtension` (`languages` list + required `template`). Both `model_config = extra='forbid'`. rbx v1 (#471) removed the legacy singular `bocaLanguage`, the env-level `languages` allowlist, the implicit `template` fallback, and `maximumTimeError` (#494); a `model_validator` rejects each removed field at env load with a migration hint, and `template` is required whenever `languages` is set. `resolved_languages`/`primary_language`/`resolved_template` now read only the plural fields.
 
 ### MOJ (`moj/`)
 

--- a/rbx/box/packaging/boca/boca_language_utils.py
+++ b/rbx/box/packaging/boca/boca_language_utils.py
@@ -32,13 +32,6 @@ def get_boca_language_from_rbx_language(rbx_language: str) -> BocaLanguage:
     primary = language_extension.primary_language
     if primary:
         return typing.cast(BocaLanguage, primary)
-    env = get_environment()
-    if (
-        env.extensions is not None
-        and env.extensions.boca is not None
-        and rbx_language.lower() in env.extensions.boca.languages
-    ):
-        return typing.cast(BocaLanguage, rbx_language.lower())
     if rbx_language.lower() in typing.get_args(BocaLanguage):
         return typing.cast(BocaLanguage, rbx_language.lower())
     raise ValueError(f'No Boca language found for Rbx language {rbx_language}')
@@ -47,7 +40,7 @@ def get_boca_language_from_rbx_language(rbx_language: str) -> BocaLanguage:
 def get_boca_template_name(boca_language: BocaLanguage) -> str:
     """Return the on-disk BOCA template dir name (under rbx/resources/packagers/boca/)
     to source per-language scripts from when emitting `boca_language`. Falls back to
-    `boca_language` itself when no rbx language declares it (zero-config / env-level
+    `boca_language` itself when no rbx language declares it (zero-config name-fallback
     path)."""
     rbx_language_name = get_rbx_language_from_boca_language(boca_language)
     rbx_language = next(
@@ -68,15 +61,11 @@ def get_boca_template_name(boca_language: BocaLanguage) -> str:
 
 def get_emitted_boca_languages() -> typing.List[BocaLanguage]:
     """Return the ordered, deduplicated set of BOCA languages to emit per-language
-    script dirs for. Computed as a union across two passes:
+    script dirs for. For each rbx language in env.languages:
 
-    1. Per-rbx-language pass — for each language in env.languages:
-       - If the boca extension's resolved_languages is non-empty, contribute
-         every entry.
-       - Otherwise (zero-config name fallback): if the rbx language name is itself
-         a BocaLanguage literal, contribute it.
-    2. Env-level pass — append every entry from extensions.boca.languages
-       (back-compat for envs that still set the legacy allowlist).
+    - If the boca extension's resolved_languages is non-empty, contribute every entry.
+    - Otherwise (zero-config name fallback): if the rbx language name is itself a
+      BocaLanguage literal, contribute it.
 
     Order is preserved: entries appear in the order first seen.
     """
@@ -95,9 +84,5 @@ def get_emitted_boca_languages() -> typing.List[BocaLanguage]:
         elif language.name in boca_literals:
             # Name-fallback safety net for zero-config users.
             seen.setdefault(language.name, None)
-
-    if env.extensions is not None and env.extensions.boca is not None:
-        for boca_lang in env.extensions.boca.languages:
-            seen.setdefault(boca_lang, None)
 
     return typing.cast(typing.List[BocaLanguage], list(seen.keys()))

--- a/rbx/box/packaging/boca/extension.py
+++ b/rbx/box/packaging/boca/extension.py
@@ -1,39 +1,13 @@
 import typing
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
+
+from rbx.utils import RejectsRemovedFields, Removed
 
 BocaLanguage = typing.Literal['c', 'cpp', 'cc', 'kt', 'java', 'py2', 'py3']
 
-# Fields removed in rbx v1, mapped to an actionable migration hint. Surfaced as a
-# clear error at env load (see the "Migrating to rbx v1" troubleshooting guide).
-_REMOVED_ENV_FIELDS = {
-    'languages': (
-        'Env-level `extensions.boca.languages` was removed in rbx v1. Declare '
-        '`languages` per rbx language under its `extensions.boca` instead; the '
-        "emitted set is the union of every language's `languages`."
-    ),
-    'maximumTimeError': (
-        '`maximumTimeError` was removed in rbx v1. It has been ignored since #494 '
-        '(rbx emits exact fractional time limits). Use `minRunningTime` instead.'
-    ),
-}
-_REMOVED_LANGUAGE_FIELDS = {
-    'bocaLanguage': (
-        '`bocaLanguage` was removed in rbx v1. Use `languages` (a list) instead, '
-        'with an explicit `template`.'
-    ),
-}
 
-
-def _reject_removed(data: typing.Any, removed: typing.Mapping[str, str]) -> typing.Any:
-    if isinstance(data, dict):
-        for field, hint in removed.items():
-            if field in data:
-                raise ValueError(hint)
-    return data
-
-
-class BocaExtension(BaseModel):
+class BocaExtension(RejectsRemovedFields):
     model_config = ConfigDict(extra='forbid')
 
     flags: typing.Dict[BocaLanguage, str] = {}
@@ -44,10 +18,22 @@ class BocaExtension(BaseModel):
     preferContestLetter: bool = False
     usePypy: bool = False
 
-    @model_validator(mode='before')
-    @classmethod
-    def _reject_removed_fields(cls, data: typing.Any) -> typing.Any:
-        return _reject_removed(data, _REMOVED_ENV_FIELDS)
+    # Removed in rbx v1 (see the "Migrating to rbx v1" troubleshooting guide).
+    languages: typing.Annotated[typing.Optional[typing.List[str]], Removed()] = Field(
+        default=None,
+        deprecated=(
+            'Env-level `extensions.boca.languages` was removed in rbx v1. Declare '
+            '`languages` per rbx language under its `extensions.boca` instead; the '
+            "emitted set is the union of every language's `languages`."
+        ),
+    )
+    maximumTimeError: typing.Annotated[typing.Optional[float], Removed()] = Field(
+        default=None,
+        deprecated=(
+            '`maximumTimeError` was removed in rbx v1. It has been ignored since #494 '
+            '(rbx emits exact fractional time limits). Use `minRunningTime` instead.'
+        ),
+    )
 
     def flags_with_defaults(self) -> typing.Dict[BocaLanguage, str]:
         res: typing.Dict[BocaLanguage, str] = {
@@ -59,7 +45,7 @@ class BocaExtension(BaseModel):
         return res
 
 
-class BocaLanguageExtension(BaseModel):
+class BocaLanguageExtension(RejectsRemovedFields):
     model_config = ConfigDict(extra='forbid')
 
     # BOCA languages this rbx language maps to. The first entry is the canonical/primary
@@ -71,10 +57,14 @@ class BocaLanguageExtension(BaseModel):
     # is set.
     template: typing.Optional[str] = None
 
-    @model_validator(mode='before')
-    @classmethod
-    def _reject_removed_fields(cls, data: typing.Any) -> typing.Any:
-        return _reject_removed(data, _REMOVED_LANGUAGE_FIELDS)
+    # Removed in rbx v1 (see the "Migrating to rbx v1" troubleshooting guide).
+    bocaLanguage: typing.Annotated[typing.Optional[str], Removed()] = Field(
+        default=None,
+        deprecated=(
+            '`bocaLanguage` was removed in rbx v1. Use `languages` (a list) instead, '
+            'with an explicit `template`.'
+        ),
+    )
 
     @model_validator(mode='after')
     def _require_template_with_languages(self) -> 'BocaLanguageExtension':

--- a/rbx/box/packaging/boca/extension.py
+++ b/rbx/box/packaging/boca/extension.py
@@ -1,25 +1,53 @@
 import typing
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 BocaLanguage = typing.Literal['c', 'cpp', 'cc', 'kt', 'java', 'py2', 'py3']
 
+# Fields removed in rbx v1, mapped to an actionable migration hint. Surfaced as a
+# clear error at env load (see the "Migrating to rbx v1" troubleshooting guide).
+_REMOVED_ENV_FIELDS = {
+    'languages': (
+        'Env-level `extensions.boca.languages` was removed in rbx v1. Declare '
+        '`languages` per rbx language under its `extensions.boca` instead; the '
+        "emitted set is the union of every language's `languages`."
+    ),
+    'maximumTimeError': (
+        '`maximumTimeError` was removed in rbx v1. It has been ignored since #494 '
+        '(rbx emits exact fractional time limits). Use `minRunningTime` instead.'
+    ),
+}
+_REMOVED_LANGUAGE_FIELDS = {
+    'bocaLanguage': (
+        '`bocaLanguage` was removed in rbx v1. Use `languages` (a list) instead, '
+        'with an explicit `template`.'
+    ),
+}
+
+
+def _reject_removed(data: typing.Any, removed: typing.Mapping[str, str]) -> typing.Any:
+    if isinstance(data, dict):
+        for field, hint in removed.items():
+            if field in data:
+                raise ValueError(hint)
+    return data
+
 
 class BocaExtension(BaseModel):
-    languages: typing.List[BocaLanguage] = []
+    model_config = ConfigDict(extra='forbid')
+
     flags: typing.Dict[BocaLanguage, str] = {}
     # Optional floor (in milliseconds) on the TOTAL BOCA time budget. When set, the
     # solution is run ceil(minRunningTime / timeLimit) times so the accumulated budget
     # reaches this floor, while the effective per-run TL stays exactly equal to the real TL.
     minRunningTime: typing.Optional[int] = Field(default=None, gt=0)
-    # Deprecated (issue #494): BOCA/safeexec supports fractional time budgets, so rbx no
-    # longer rounds TLs. This field is ignored; use `minRunningTime` instead.
-    maximumTimeError: typing.Optional[float] = Field(
-        default=None,
-        deprecated='Ignored since #494; rbx emits exact fractional TLs. Use minRunningTime.',
-    )
     preferContestLetter: bool = False
     usePypy: bool = False
+
+    @model_validator(mode='before')
+    @classmethod
+    def _reject_removed_fields(cls, data: typing.Any) -> typing.Any:
+        return _reject_removed(data, _REMOVED_ENV_FIELDS)
 
     def flags_with_defaults(self) -> typing.Dict[BocaLanguage, str]:
         res: typing.Dict[BocaLanguage, str] = {
@@ -32,27 +60,35 @@ class BocaExtension(BaseModel):
 
 
 class BocaLanguageExtension(BaseModel):
-    # Deprecated: use `languages` instead. Kept for back-compat (see issue #471).
-    bocaLanguage: typing.Optional[str] = Field(
-        default=None,
-        deprecated='Use `languages` instead.',
-    )
-    # BOCA languages this rbx language maps to. First entry is the canonical/primary,
-    # used as the forward (rbx -> BOCA) mapping. All entries are emitted as separate
-    # per-language script dirs in the BOCA package (e.g. ['cc', 'cpp'] emits both).
+    model_config = ConfigDict(extra='forbid')
+
+    # BOCA languages this rbx language maps to. The first entry is the canonical/primary
+    # one, used as the forward (rbx -> BOCA) mapping. Every entry is emitted as a separate
+    # per-language script dir in the BOCA package (e.g. ['cc', 'cpp'] emits both).
     languages: typing.Optional[typing.List[str]] = None
     # On-disk BOCA template dir (under rbx/resources/packagers/boca/{compile,run,
-    # interactive}/) to source per-language scripts from. Falls back to
-    # primary_language for back-compat (see issue #471).
+    # interactive}/) to source per-language scripts from. Required whenever `languages`
+    # is set.
     template: typing.Optional[str] = None
+
+    @model_validator(mode='before')
+    @classmethod
+    def _reject_removed_fields(cls, data: typing.Any) -> typing.Any:
+        return _reject_removed(data, _REMOVED_LANGUAGE_FIELDS)
+
+    @model_validator(mode='after')
+    def _require_template_with_languages(self) -> 'BocaLanguageExtension':
+        if self.languages and not self.template:
+            raise ValueError(
+                'A `template` is required when `languages` is set on a BOCA language '
+                'extension. Set `template` to one of the on-disk template dirs '
+                '(c, cc, cpp, java, kt, py2, py3).'
+            )
+        return self
 
     @property
     def resolved_languages(self) -> typing.List[str]:
-        if self.languages:
-            return self.languages
-        if self.bocaLanguage:
-            return [self.bocaLanguage]
-        return []
+        return self.languages or []
 
     @property
     def primary_language(self) -> typing.Optional[str]:
@@ -61,4 +97,4 @@ class BocaLanguageExtension(BaseModel):
 
     @property
     def resolved_template(self) -> typing.Optional[str]:
-        return self.template or self.primary_language
+        return self.template

--- a/rbx/box/tooling/boca/scraper.py
+++ b/rbx/box/tooling/boca/scraper.py
@@ -17,10 +17,10 @@ from throttlex import Throttler
 from rbx import console, utils
 from rbx.box import naming
 from rbx.box.environment import (
-    get_environment,
     get_language_or_nil,
 )
 from rbx.box.packaging.boca.boca_language_utils import (
+    get_emitted_boca_languages,
     get_rbx_language_from_boca_language,
 )
 from rbx.box.tooling.boca.debug_utils import pretty_print_request_data
@@ -116,9 +116,8 @@ class BocaDetailedRun(BocaRun):
 
 
 def get_boca_languages() -> List[BocaLanguage]:
-    env = get_environment()
     res = []
-    for bocaLanguage in env.extensions.boca.languages:
+    for bocaLanguage in get_emitted_boca_languages():
         rbxLanguage = get_rbx_language_from_boca_language(bocaLanguage)
         rbxLanguage = get_language_or_nil(rbxLanguage)
         if rbxLanguage is None:

--- a/rbx/utils.py
+++ b/rbx/utils.py
@@ -1,5 +1,6 @@
 import atexit
 import contextlib
+import dataclasses
 import enum
 import functools
 import json
@@ -34,7 +35,7 @@ import typer
 import yaml
 from packaging.version import InvalidVersion
 from packaging.version import Version as PyPIVersion
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from rich import text
 from rich.highlighter import JSONHighlighter
 
@@ -43,6 +44,53 @@ from rbx.console import console
 
 T = TypeVar('T', bound=BaseModel)
 _R = TypeVar('_R')
+
+
+@dataclasses.dataclass(frozen=True)
+class Removed:
+    """Annotation flag marking a model field that has been removed.
+
+    Pair it with Pydantic's native ``Field(deprecated=...)`` on a model that inherits
+    :class:`RejectsRemovedFields`::
+
+        legacy: Annotated[Optional[str], Removed()] = Field(
+            default=None, deprecated='Use `new_field` instead (removed in v1).'
+        )
+
+    The ``deprecated`` text is the single source of truth: it renders the field as
+    deprecated in the schema/docs AND becomes the error message if a config still sets
+    the field. Unlike a bare ``deprecated`` field -- which only warns on attribute
+    access and stays usable -- a ``Removed`` field is a hard load-time error.
+    """
+
+
+class RejectsRemovedFields(BaseModel):
+    """Base model that rejects any field flagged with :class:`Removed`.
+
+    A config that still sets a removed field fails to load with that field's
+    ``deprecated`` message. Pair with ``model_config = ConfigDict(extra='forbid')`` so
+    unknown fields are rejected too.
+    """
+
+    @model_validator(mode='before')
+    @classmethod
+    def _reject_removed_fields(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        for name, field in cls.model_fields.items():
+            if not any(isinstance(m, Removed) for m in field.metadata):
+                continue
+            keys = {name}
+            if field.alias is not None:
+                keys.add(field.alias)
+            if keys & data.keys():
+                message = (
+                    field.deprecated
+                    if isinstance(field.deprecated, str)
+                    else f'`{name}` was removed.'
+                )
+                raise ValueError(message)
+        return data
 
 
 def loop_agnostic_async_cache(

--- a/tests/e2e/testdata/multi-contest/.local.rbx/env.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/.local.rbx/env.rbx.yml
@@ -23,7 +23,8 @@ languages:
       command: "./{executable}"
     extensions:
       boca:
-        bocaLanguage: "cc"
+        languages: ["cc"]
+        template: "cc"
       polygon:
         polygonLanguage: "cpp.gcc13-64-winlibs-g++20"
   - name: "c"
@@ -42,7 +43,8 @@ languages:
       executable: "{compilable}"
     extensions:
       boca:
-        bocaLanguage: "py3"
+        languages: ["py3"]
+        template: "py3"
   - name: "java"
     readableName: "Java"
     extension: "java"
@@ -71,10 +73,10 @@ languages:
       executable: "Main.jar"
     extensions:
       boca:
-        bocaLanguage: "kt"
+        languages: ["kt"]
+        template: "kt"
 extensions:
   boca:
-    languages: ["c", "cc", "java", "py3", "kt"]
     flags:
       c: "-O2 -static"
       cc: "-std=c++20 -O2 -lm -static"

--- a/tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/env.rbx.yml
+++ b/tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/env.rbx.yml
@@ -25,10 +25,10 @@ languages:
       command: "./{executable}"
     extensions:
       boca:
-        bocaLanguage: "cc"
+        languages: ["cc"]
+        template: "cc"
 extensions:
   boca:
-    languages: ["cc"]
     flags:
       cc: "-std=c++20 -O2 -lm -static"
     minRunningTime: 1000

--- a/tests/rbx/box/packaging/boca/test_extension.py
+++ b/tests/rbx/box/packaging/boca/test_extension.py
@@ -1,15 +1,12 @@
+import pytest
+from pydantic import ValidationError
+
 from rbx.box.packaging.boca.extension import BocaExtension, BocaLanguageExtension
 
 
-def test_resolved_languages_uses_plural_when_set():
-    ext = BocaLanguageExtension(languages=['cc', 'cpp'])
+def test_resolved_languages_uses_plural():
+    ext = BocaLanguageExtension(languages=['cc', 'cpp'], template='cc')
     assert ext.resolved_languages == ['cc', 'cpp']
-    assert ext.primary_language == 'cc'
-
-
-def test_resolved_languages_falls_back_to_singular():
-    ext = BocaLanguageExtension(bocaLanguage='cc')
-    assert ext.resolved_languages == ['cc']
     assert ext.primary_language == 'cc'
 
 
@@ -19,19 +16,9 @@ def test_resolved_languages_empty_when_unset():
     assert ext.primary_language is None
 
 
-def test_resolved_template_uses_explicit_when_set():
+def test_resolved_template_uses_explicit():
     ext = BocaLanguageExtension(languages=['cc', 'cpp'], template='cc')
     assert ext.resolved_template == 'cc'
-
-
-def test_resolved_template_falls_back_to_primary():
-    ext = BocaLanguageExtension(languages=['cc', 'cpp'])
-    assert ext.resolved_template == 'cc'
-
-
-def test_resolved_template_falls_back_through_singular():
-    ext = BocaLanguageExtension(bocaLanguage='py3')
-    assert ext.resolved_template == 'py3'
 
 
 def test_resolved_template_none_when_unset():
@@ -39,8 +26,34 @@ def test_resolved_template_none_when_unset():
     assert ext.resolved_template is None
 
 
-def test_boca_extension_languages_defaults_to_empty():
-    assert BocaExtension().languages == []
+def test_template_required_when_languages_set():
+    # The implicit template fallback was removed in rbx v1: declaring `languages`
+    # without an explicit `template` is now a validation error.
+    with pytest.raises(ValidationError):
+        BocaLanguageExtension(languages=['cc', 'cpp'])
+
+
+def test_bocalanguage_field_removed():
+    # The deprecated singular `bocaLanguage` was removed in rbx v1.
+    with pytest.raises(ValidationError):
+        BocaLanguageExtension(bocaLanguage='cc')
+
+
+def test_unknown_language_field_rejected():
+    with pytest.raises(ValidationError):
+        BocaLanguageExtension(unknownField='x')
+
+
+def test_env_level_languages_field_removed():
+    # The env-level allowlist `extensions.boca.languages` was removed in rbx v1.
+    with pytest.raises(ValidationError):
+        BocaExtension(languages=['cc'])
+
+
+def test_maximum_time_error_field_removed():
+    # `maximumTimeError` (ignored since #494) was removed in rbx v1.
+    with pytest.raises(ValidationError):
+        BocaExtension(maximumTimeError=1.5)
 
 
 def test_min_running_time_defaults_to_none():
@@ -48,9 +61,6 @@ def test_min_running_time_defaults_to_none():
 
 
 def test_min_running_time_rejects_non_positive():
-    import pytest
-    from pydantic import ValidationError
-
     with pytest.raises(ValidationError):
         BocaExtension(minRunningTime=0)
     with pytest.raises(ValidationError):

--- a/tests/rbx/box/packaging/boca/test_language_utils.py
+++ b/tests/rbx/box/packaging/boca/test_language_utils.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from rbx.box.packaging.boca import boca_language_utils
-from rbx.box.packaging.boca.extension import BocaExtension, BocaLanguageExtension
+from rbx.box.packaging.boca.extension import BocaLanguageExtension
 
 
 def _mk_language(name: str, ext: BocaLanguageExtension | None = None):
@@ -12,17 +12,26 @@ def _mk_language(name: str, ext: BocaLanguageExtension | None = None):
 
 
 def test_forward_map_uses_primary_from_languages(monkeypatch):
-    cpp_lang = _mk_language('cpp', BocaLanguageExtension(languages=['cc', 'cpp']))
+    cpp_lang = _mk_language(
+        'cpp', BocaLanguageExtension(languages=['cc', 'cpp'], template='cc')
+    )
     monkeypatch.setattr(boca_language_utils, 'get_language', lambda n: cpp_lang)
-    env = mock.MagicMock()
-    env.extensions = None
-    monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
 
     assert boca_language_utils.get_boca_language_from_rbx_language('cpp') == 'cc'
 
 
+def test_forward_map_name_fallback_for_literal(monkeypatch):
+    # rbx language named 'c' with NO boca extension falls back to its own name.
+    c_lang = _mk_language('c', BocaLanguageExtension())
+    monkeypatch.setattr(boca_language_utils, 'get_language', lambda n: c_lang)
+
+    assert boca_language_utils.get_boca_language_from_rbx_language('c') == 'c'
+
+
 def test_reverse_map_resolves_alias_via_membership(monkeypatch):
-    cpp_lang = _mk_language('cpp', BocaLanguageExtension(languages=['cc', 'cpp']))
+    cpp_lang = _mk_language(
+        'cpp', BocaLanguageExtension(languages=['cc', 'cpp'], template='cc')
+    )
     env = mock.MagicMock()
     env.languages = [cpp_lang]
     monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
@@ -34,49 +43,26 @@ def test_reverse_map_resolves_alias_via_membership(monkeypatch):
     assert boca_language_utils.get_rbx_language_from_boca_language('cpp') == 'cpp'
 
 
-def test_reverse_map_back_compat_with_singular(monkeypatch):
-    py_lang = _mk_language('py', BocaLanguageExtension(bocaLanguage='py3'))
-    env = mock.MagicMock()
-    env.languages = [py_lang]
-    monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
-    monkeypatch.setattr(
-        boca_language_utils, 'get_language_by_extension_or_nil', lambda _: None
-    )
-
-    assert boca_language_utils.get_rbx_language_from_boca_language('py3') == 'py'
-
-
-def _mk_env(languages, boca_ext_languages=None):
+def _mk_env(languages):
     env = mock.MagicMock()
     env.languages = languages
-    if boca_ext_languages is None:
-        env.extensions = None
-    else:
-        env.extensions = mock.MagicMock()
-        env.extensions.boca = BocaExtension(languages=boca_ext_languages)
     return env
 
 
 def test_emitted_set_union_from_languages(monkeypatch):
     env = _mk_env(
         [
-            _mk_language('cpp', BocaLanguageExtension(languages=['cc', 'cpp'])),
-            _mk_language('py', BocaLanguageExtension(bocaLanguage='py3')),
+            _mk_language(
+                'cpp', BocaLanguageExtension(languages=['cc', 'cpp'], template='cc')
+            ),
+            _mk_language(
+                'py', BocaLanguageExtension(languages=['py3'], template='py3')
+            ),
         ]
     )
     monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
 
     assert boca_language_utils.get_emitted_boca_languages() == ['cc', 'cpp', 'py3']
-
-
-def test_emitted_set_includes_env_level_languages(monkeypatch):
-    env = _mk_env(
-        [_mk_language('cpp', BocaLanguageExtension(languages=['cc']))],
-        boca_ext_languages=['java'],
-    )
-    monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
-
-    assert boca_language_utils.get_emitted_boca_languages() == ['cc', 'java']
 
 
 def test_emitted_set_name_fallback_for_zero_config(monkeypatch):
@@ -91,8 +77,10 @@ def test_emitted_set_name_fallback_for_zero_config(monkeypatch):
 def test_emitted_set_deduplicates_and_preserves_order(monkeypatch):
     env = _mk_env(
         [
-            _mk_language('cpp', BocaLanguageExtension(languages=['cc', 'cpp'])),
-            _mk_language('cc', BocaLanguageExtension(languages=['cc'])),
+            _mk_language(
+                'cpp', BocaLanguageExtension(languages=['cc', 'cpp'], template='cc')
+            ),
+            _mk_language('cc', BocaLanguageExtension(languages=['cc'], template='cc')),
         ]
     )
     monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
@@ -104,7 +92,9 @@ def test_emitted_set_name_fallback_skipped_when_resolved_non_empty(monkeypatch):
     # When an rbx language declares languages, name-fallback must NOT also
     # contribute the language's name. cpp -> ['cc'] should emit only ['cc'],
     # never ['cc', 'cpp'].
-    env = _mk_env([_mk_language('cpp', BocaLanguageExtension(languages=['cc']))])
+    env = _mk_env(
+        [_mk_language('cpp', BocaLanguageExtension(languages=['cc'], template='cc'))]
+    )
     monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
 
     assert boca_language_utils.get_emitted_boca_languages() == ['cc']
@@ -119,18 +109,6 @@ def test_emitted_set_non_literal_name_with_no_boca_config_contributes_nothing(
     monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
 
     assert boca_language_utils.get_emitted_boca_languages() == []
-
-
-def test_emitted_set_dedupes_resolved_with_env_level_overlap(monkeypatch):
-    # cpp resolves to ['cc']; env-level lists ['cc', 'java'].
-    # Expect ['cc', 'java'] — 'cc' appears once, in resolved-first order.
-    env = _mk_env(
-        [_mk_language('cpp', BocaLanguageExtension(languages=['cc']))],
-        boca_ext_languages=['cc', 'java'],
-    )
-    monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)
-
-    assert boca_language_utils.get_emitted_boca_languages() == ['cc', 'java']
 
 
 def test_get_boca_template_name_uses_resolved_template(monkeypatch):
@@ -154,7 +132,7 @@ def test_get_boca_template_name_uses_resolved_template(monkeypatch):
 def test_get_boca_template_name_falls_back_to_boca_language(monkeypatch):
     # No rbx language declared -> reverse map returns the BOCA name itself,
     # and the helper must fall back to using the BOCA name as the template dir
-    # rather than raising. Preserves zero-config / env-level emission.
+    # rather than raising. Preserves zero-config emission.
     env = mock.MagicMock()
     env.languages = []
     monkeypatch.setattr(boca_language_utils, 'get_environment', lambda: env)

--- a/tests/rbx/box/packaging/boca/test_packager_limits.py
+++ b/tests/rbx/box/packaging/boca/test_packager_limits.py
@@ -18,7 +18,7 @@ def _env_aliasing_cpp_to_cc_and_cpp():
     cpp_lang = mock.MagicMock()
     cpp_lang.name = 'cpp'
     cpp_lang.get_extension_or_default.return_value = BocaLanguageExtension(
-        languages=['cc', 'cpp']
+        languages=['cc', 'cpp'], template='cc'
     )
     env = mock.MagicMock()
     env.languages = [cpp_lang]


### PR DESCRIPTION
Fully resolves #471: removes the three backward-compat BOCA `env.rbx.yml` behaviors (after their deprecation window), plus the already-ignored `maximumTimeError` (#494), and ships the user-facing migration guide.

## Breaking changes (rbx v1)

- **`bocaLanguage`** (singular, per-language) → use `languages` (a list).
- **env-level `extensions.boca.languages`** allowlist → declare `languages` per rbx language; the emitted set is their union.
- **implicit `template` fallback** → `template` is now **required** whenever a language declares `languages`.
- **`maximumTimeError`** (ignored since #494) → use `minRunningTime`.

Both `BocaExtension` and `BocaLanguageExtension` now use `model_config = extra='forbid'` plus a `model_validator` that rejects each removed field **at env load** with an actionable migration hint (satisfying the issue's "clear error" acceptance criterion).

## Changes

- `boca/extension.py` — drop `bocaLanguage`, env-level `languages`, `maximumTimeError`; `template` required with `languages`; `resolved_*` read only the plural fields.
- `boca/boca_language_utils.py` — drop the env-level branch in the reverse map and the env-level union pass in `get_emitted_boca_languages`.
- `tooling/boca/scraper.py` — `get_boca_languages` now sources from `get_emitted_boca_languages()` (per-language resolved set) instead of the removed env-level list.
- Migrated both bundled e2e fixtures (`multi-contest`, `pkg-boca-min-running-time`) to the new shape — emitted language set + templates preserved byte-for-byte.
- Updated unit tests, `packaging/CLAUDE.md`.
- **Docs**: new "Troubleshooting → Migrating to rbx v1" guide with before/after migration snippets.

## Verification

- `tests/rbx/box/packaging` — 191 passed; `boca/` — 40 passed; presets/environment/schema — 128 passed.
- Direct check: default preset env still loads through the full `Environment` model; each removed field (and `languages` without `template`) raises a clear migration error.
- `mkdocs build` — migration page + auto-generated schema reference render with no new warnings.

The default preset was already migrated in #453, so no bundled preset references the removed fields (acceptance criteria met).

> **Note on versioning**: the commit carries a `BREAKING CHANGE:` footer so commitizen tags it as breaking; the actual version bump (the v1 cut) is left to the maintainer's release step.

Closes #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
