### PR TITLE
fix: derive package/preset name from path basename in create commands

### DIFF
--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -795,7 +795,9 @@ def create(
     name: Annotated[
         str,
         typer.Option(
-            help='Name of the problem to create, which will be used as the name of the new folder.',
+            help='Name of the problem to create, which will be used as the name of the new folder. '
+            'A relative path may be given (e.g. "problems/my-problem"), in which case the problem '
+            'name is the basename ("my-problem").',
             prompt='What should the name of the problem be?',
         ),
     ],

--- a/rbx/box/creation.py
+++ b/rbx/box/creation.py
@@ -1,17 +1,20 @@
 import pathlib
 from typing import Annotated, Optional
 
+import pydantic
 import typer
 
 from rbx import console, utils
 from rbx.box import package, presets
+from rbx.box.schema import Package
 
 
 def create(
     name: Annotated[
         str,
         typer.Argument(
-            help='The name of the problem package to create. This will also be the name of the folder.'
+            help='The name of the problem package to create. This will also be the name of the folder. '
+            'A relative path may be given, in which case the problem name is its basename.'
         ),
     ],
     preset: Annotated[
@@ -31,10 +34,27 @@ def create(
         ),
     ] = False,
 ):
-    console.console.print(f'Creating new problem [item]{name}[/item]...')
+    dest_path = path or pathlib.Path(name)
+
+    # The problem name is the basename of the destination folder, even when a
+    # relative path is given (e.g. `problems/my-problem` -> `my-problem`).
+    problem_name = dest_path.stem
+    try:
+        utils.validate_field(Package, 'name', problem_name)
+    except pydantic.ValidationError:
+        console.console.print(
+            f'[error]Invalid problem name [item]{problem_name}[/item], '
+            f'derived from [item]{name}[/item].[/error]'
+        )
+        console.console.print(
+            '[error]A problem name must be 3-32 characters long and contain only '
+            'letters, digits, dashes and underscores.[/error]'
+        )
+        raise typer.Exit(1) from None
+
+    console.console.print(f'Creating new problem [item]{problem_name}[/item]...')
 
     fetch_info = presets.get_preset_fetch_info_with_fallback(preset, local=local)
-    dest_path = path or pathlib.Path(name)
 
     if dest_path.exists():
         console.console.print(
@@ -46,7 +66,7 @@ def create(
 
     # Change problem name.
     ru, problem = package.get_ruyaml(dest_path)
-    problem['name'] = name
+    problem['name'] = problem_name
     utils.save_ruyaml(dest_path / 'problem.rbx.yml', ru, problem)
 
     # fix_package(dest_path)

--- a/rbx/box/presets/__init__.py
+++ b/rbx/box/presets/__init__.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 from typing import Annotated, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
+import pydantic
 import questionary
 import ruyaml
 import typer
@@ -1148,7 +1149,8 @@ def create(
     name: Annotated[
         str,
         typer.Option(
-            help='The name of the preset to create. This will also be the name of the folder.',
+            help='The name of the preset to create. This will also be the name of the folder. '
+            'A relative path may be given, in which case the preset name is its basename.',
             prompt='What is the name of your new preset?',
         ),
     ],
@@ -1173,10 +1175,27 @@ def create(
         ),
     ] = False,
 ):
-    console.console.print(f'Creating new preset [item]{name}[/item]...')
+    dest_path = pathlib.Path(name)
+
+    # The preset name is the basename of the destination folder, even when a
+    # relative path is given (e.g. `presets/my-preset` -> `my-preset`).
+    preset_name = dest_path.stem
+    try:
+        utils.validate_field(Preset, 'name', preset_name)
+    except pydantic.ValidationError:
+        console.console.print(
+            f'[error]Invalid preset name [item]{preset_name}[/item], '
+            f'derived from [item]{name}[/item].[/error]'
+        )
+        console.console.print(
+            '[error]A preset name must be 3-32 characters long and contain only '
+            'letters, digits, dashes and underscores.[/error]'
+        )
+        raise typer.Exit(1) from None
+
+    console.console.print(f'Creating new preset [item]{preset_name}[/item]...')
 
     fetch_info = get_preset_fetch_info_with_fallback(from_preset, local=local)
-    dest_path = pathlib.Path(name)
     if dest_path.exists():
         console.console.print(
             f'[error]Directory [item]{dest_path}[/item] already exists.[/error]'
@@ -1186,7 +1205,7 @@ def create(
     install_preset(dest_path, fetch_info)
 
     ru, preset = get_ruyaml(dest_path)
-    preset['name'] = name
+    preset['name'] = preset_name
     preset['uri'] = uri
     utils.save_ruyaml(dest_path / 'preset.rbx.yml', ru, preset)
 

--- a/tests/rbx/box/presets/test_presets_create.py
+++ b/tests/rbx/box/presets/test_presets_create.py
@@ -1,0 +1,71 @@
+"""Tests for `rbx presets create` (rbx.box.presets.create)."""
+
+import pathlib
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import ruyaml
+import typer
+
+from rbx import utils
+from rbx.box import presets
+from rbx.box.presets.schema import Preset
+
+
+def _install_preset_stub(dest_pkg: pathlib.Path, fetch_info=None, **kwargs):
+    """Mimic presets.install_preset: create the folder and a minimal preset."""
+    dest_pkg.mkdir(parents=True, exist_ok=True)
+    (dest_pkg / 'preset.rbx.yml').write_text(
+        'name: "placeholder"\nuri: "placeholder/uri"\n'
+    )
+
+
+def _read_field(dest: pathlib.Path, field: str):
+    yaml = ruyaml.YAML()
+    data = yaml.load((dest / 'preset.rbx.yml').read_text())
+    return data[field]
+
+
+@pytest.fixture
+def mock_presets():
+    with (
+        mock.patch.object(
+            presets,
+            'get_preset_fetch_info_with_fallback',
+            return_value=SimpleNamespace(),
+        ),
+        mock.patch.object(presets, 'install_preset', side_effect=_install_preset_stub),
+    ):
+        yield
+
+
+def test_create_with_plain_name(cleandir, mock_presets):
+    presets.create('my-preset', uri='rsalesc/rbx-preset')
+
+    dest = pathlib.Path('my-preset')
+    assert dest.is_dir()
+    assert _read_field(dest, 'name') == 'my-preset'
+    assert _read_field(dest, 'uri') == 'rsalesc/rbx-preset'
+
+
+def test_create_with_relative_path_uses_basename_as_name(cleandir, mock_presets):
+    presets.create('presets/my-preset', uri='rsalesc/rbx-preset')
+
+    # Folder is created at the full relative path...
+    dest = pathlib.Path('presets/my-preset')
+    assert dest.is_dir()
+
+    # ...but the preset name is only the basename, and it is a valid name.
+    name = _read_field(dest, 'name')
+    assert name == 'my-preset'
+    utils.validate_field(Preset, 'name', name)
+
+
+def test_create_with_invalid_derived_name_fails_fast(cleandir, mock_presets):
+    # Basename `ab` is too short (min 3 chars): fail before creating anything.
+    with pytest.raises(typer.Exit):
+        presets.create('presets/ab', uri='rsalesc/rbx-preset')
+
+    assert not pathlib.Path('presets/ab').exists()
+    assert not pathlib.Path('presets').exists()

--- a/tests/rbx/box/test_creation.py
+++ b/tests/rbx/box/test_creation.py
@@ -1,0 +1,73 @@
+"""Tests for rbx.box.creation (the `rbx create` command)."""
+
+import pathlib
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import ruyaml
+import typer
+
+from rbx import utils
+from rbx.box import creation
+from rbx.box.schema import Package
+
+
+def _install_problem_stub(dest_pkg: pathlib.Path, fetch_info=None, materialize=True):
+    """Mimic presets.install_problem: create the folder and a minimal package."""
+    dest_pkg.mkdir(parents=True, exist_ok=True)
+    (dest_pkg / 'problem.rbx.yml').write_text(
+        'name: "placeholder"\ntimeLimit: 1000\nmemoryLimit: 256\n'
+    )
+
+
+def _read_name(dest: pathlib.Path) -> str:
+    yaml = ruyaml.YAML()
+    data = yaml.load((dest / 'problem.rbx.yml').read_text())
+    return data['name']
+
+
+@pytest.fixture
+def mock_presets():
+    with (
+        mock.patch.object(
+            creation.presets,
+            'get_preset_fetch_info_with_fallback',
+            return_value=SimpleNamespace(),
+        ),
+        mock.patch.object(
+            creation.presets, 'install_problem', side_effect=_install_problem_stub
+        ),
+        mock.patch.object(creation.presets, 'generate_lock'),
+    ):
+        yield
+
+
+def test_create_with_plain_name(cleandir, mock_presets):
+    creation.create('my-problem')
+
+    dest = pathlib.Path('my-problem')
+    assert dest.is_dir()
+    assert _read_name(dest) == 'my-problem'
+
+
+def test_create_with_relative_path_uses_basename_as_name(cleandir, mock_presets):
+    creation.create('problems/my-problem')
+
+    # Folder is created at the full relative path...
+    dest = pathlib.Path('problems/my-problem')
+    assert dest.is_dir()
+
+    # ...but the problem name is only the basename, and it is a valid name.
+    name = _read_name(dest)
+    assert name == 'my-problem'
+    utils.validate_field(Package, 'name', name)
+
+
+def test_create_with_invalid_derived_name_fails_fast(cleandir, mock_presets):
+    # Basename `ab` is too short (min 3 chars): fail before creating anything.
+    with pytest.raises(typer.Exit):
+        creation.create('problems/ab')
+
+    assert not pathlib.Path('problems/ab').exists()
+    assert not pathlib.Path('problems').exists()


### PR DESCRIPTION
## What

`rbx create` (and, as found in follow-up, `rbx presets create`) wrote a relative path **name** verbatim into the package's `name` field. Since `/` is not allowed by the name pattern (`^[a-zA-Z0-9][a-zA-Z0-9\-_]*$`), a subsequent `rbx build` / preset load failed. The folder was created correctly, but the name in the YAML was wrong/invalid.

Closes #410.

## Changes

Both `rbx create` and `rbx presets create` now:
- Derive the name from the destination folder's **basename** (`dest_path.stem`), mirroring the existing `rbx contest add` behavior. So `problems/my-problem` → folder at `problems/my-problem`, name `my-problem`.
- Validate the derived name **up front** (against the schema's `name` field) so an invalid name fails fast with a clear message instead of leaving a half-created, unbuildable package.
- Document relative-path support in the CLI/argument help text.

### Related commands checked (not affected)

- `rbx contest add` — already correct (uses `problem_path.stem` + validates).
- `rbx contest create` / `rbx contest init` — do **not** write a path into the contest name (the name comes from the preset template), so they don't hit this bug.
- `rbx contest add_variant` — sets the name from a validated variant id.

## Testing

- New `tests/rbx/box/test_creation.py` and `tests/rbx/box/presets/test_presets_create.py` (3 tests each): plain name, relative-path basename, and invalid-name fail-fast. The relative-path tests reproduce the bug (failed before, pass now).
- 224 contest + presets + creation tests pass; ruff lint + format clean.
- Ran the issue's exact repro end-to-end: `rbx create --name problems/my-problem`, then `rbx build` in the created folder → **"Problem built."** with `name: my-problem`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
