### PR TITLE
docs(contest): clarify create-path is relative to the contest root (#414)

### DIFF
--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -798,7 +798,7 @@ def create(
             help='Name of the problem to create, which will be used as the name of the new folder. '
             'A path relative to the current directory may be given (e.g. "problems/my-problem"), '
             'in which case the problem name is the basename ("my-problem").',
-            prompt='What should the name of the problem be?',
+            prompt='What should the problem be named? You may also give a path relative to the current directory (e.g. "problems/my-problem" creates a problem named "my-problem" in that directory)',
         ),
     ],
     preset: Annotated[

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -796,8 +796,8 @@ def create(
         str,
         typer.Option(
             help='Name of the problem to create, which will be used as the name of the new folder. '
-            'A relative path may be given (e.g. "problems/my-problem"), in which case the problem '
-            'name is the basename ("my-problem").',
+            'A path relative to the current directory may be given (e.g. "problems/my-problem"), '
+            'in which case the problem name is the basename ("my-problem").',
             prompt='What should the name of the problem be?',
         ),
     ],

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -69,7 +69,8 @@ def create(
     path: Annotated[
         str,
         typer.Option(
-            help='Path where to create the contest.',
+            help='Path (relative to the current directory) where to create the contest '
+            '(e.g. "contests/ioi2024").',
             prompt='Where should the contest be created, relative to the current directory? (e.g. "contests/ioi2024")',
         ),
     ],
@@ -242,7 +243,9 @@ def add(
     path: Annotated[
         str,
         typer.Option(
-            help='Path where to create the problem. Name part of the path will be used as the problem name.',
+            help='Path (relative to the contest root) where to create the problem. '
+            'The name part of the path will be used as the problem name '
+            '(e.g. "problems/choco" creates a problem named "choco" in that directory).',
             prompt='Where should the problem be created, relative to the contest root? (e.g. problems/choco will create a problem named "choco" in this directory)',
         ),
     ],


### PR DESCRIPTION
Fixes #414.

`rbx contest add` resolves `--path` relative to the contest root (the `@within_contest` decorator cds into it), but the `--help` text never said so — only the interactive `prompt` did. Anyone running `rbx contest add --help` or passing `--path`/`--short-name` non-interactively had no way to know.

This makes the help text explicit, and sweeps the rest of the "create something at a path" command family for the same gap:

- **`rbx contest add`** (the issue) — `--path` help now reads *"Path (relative to the contest root) where to create the problem…"* with the `problems/choco → choco` example.
- **`rbx contest create`** — `--path` help now says *"relative to the current directory"* (it previously just said "Path where to create the contest"; only its prompt mentioned it).
- **`rbx create`** — clarified the relative path is *"relative to the current directory"*.

Out of scope: `rbx compile` / `rbx validate` take a path to an *existing* asset via the `PackagePath` annotation (locate, not create), and `rbx download lib --into` already documents "relative to the package root" — used as the wording template here.

No behavior change — help strings only.

## Verification
- Rendered `--help` for all three commands; each now states what the path is relative to.
- `ruff format` + `ruff check` pass on both touched files.
- Pre-commit hooks (ruff, commitizen) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)