### PR TITLE
fix(polygon): escape upload error comments and warn on truncation

### DIFF
--- a/rbx/box/packaging/polygon/polygon_api.py
+++ b/rbx/box/packaging/polygon/polygon_api.py
@@ -17,6 +17,12 @@ import typer
 
 from rbx import console
 
+# Polygon truncates the ``comment`` field of FAILED responses (e.g. server-side
+# compilation errors) to this many characters. The limit is on the message
+# portion, after Polygon's own ``<field>: `` label, and is enforced server-side,
+# so rbx cannot recover the rest -- it can only warn and point at the UI (#389).
+COMMENT_LENGTH_LIMIT = 255
+
 
 class Polygon:
     """ """

--- a/rbx/box/packaging/polygon/upload.py
+++ b/rbx/box/packaging/polygon/upload.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Literal, Optional, Set
 
 import rich
+import rich.markup
 import rich.progress
 import typer
 
@@ -49,6 +50,26 @@ ParamChoices = Literal['statements', 'solutions', 'tests', 'files']
 ALL_PARAMS_CHOICES = list(ParamChoices.__args__)
 MAX_WORKERS = 4
 _RAW_TEST_SIZE_LIMIT = 1024 * 1024
+
+
+def _format_request_failed_comment(comment: str) -> str:
+    """Prepare a Polygon FAILED ``comment`` for safe Rich rendering.
+
+    Compiler output routinely contains ``[...]`` (e.g. ``[with _Tp = int]``), so it
+    must be escaped or Rich would interpret it as markup and silently drop those
+    segments. When the comment reaches Polygon's server-side length cap it was
+    almost certainly truncated, so we append a hint pointing at the Polygon UI,
+    which holds the full compilation log (#389).
+    """
+    rendered = rich.markup.escape(comment)
+    if len(comment) >= api.COMMENT_LENGTH_LIMIT:
+        rendered += (
+            f'\n[warning]Note: Polygon truncates error messages to '
+            f'{api.COMMENT_LENGTH_LIMIT} characters, so this one is likely cut off. '
+            f'Open the problem in the Polygon UI to see the full compilation log.'
+            f'[/warning]'
+        )
+    return rendered
 
 
 def _get_polygon_api() -> api.Polygon:
@@ -369,7 +390,7 @@ def _upload_generator(
         )
     except api.PolygonRequestFailedException as e:
         console.console.print(
-            f'[error]Failed to upload generator {generator.href()}:[/error]\n{e.comment}'
+            f'[error]Failed to upload generator {generator.href()}:[/error]\n{_format_request_failed_comment(e.comment)}'
         )
         raise typer.Exit(1) from None
 
@@ -440,7 +461,9 @@ def _upload_testcases(problem: api.Problem, ns: flattening.FlatNamespace):
                 )
             except api.PolygonRequestFailedException as e:
                 if 'already used in non-script' in e.comment.lower():
-                    console.console.print(f'[error]{e.comment}[/error]')
+                    console.console.print(
+                        f'[error]{_format_request_failed_comment(e.comment)}[/error]'
+                    )
                     console.console.print(
                         '[error]Please remove the conflicting manual tests on the Polygon UI and try again.[/error]'
                     )
@@ -511,7 +534,7 @@ def _upload_solutions(problem: api.Problem, ns: flattening.FlatNamespace):
                 future.result()
             except api.PolygonRequestFailedException as e:
                 console.console.print(
-                    f'[error]Failed to upload solution {solution.href()}:[/error]\n{e.comment}'
+                    f'[error]Failed to upload solution {solution.href()}:[/error]\n{_format_request_failed_comment(e.comment)}'
                 )
 
     def delete_solution(solution: api.Solution):
@@ -537,7 +560,7 @@ def _upload_solutions(problem: api.Problem, ns: flattening.FlatNamespace):
                 future.result()
             except api.PolygonRequestFailedException as e:
                 console.console.print(
-                    f'[error]Failed to delete solution [item]{solution.name}[/item]:[/error]\n{e.comment}'  # pyright: ignore[reportAttributeAccessIssue]
+                    f'[error]Failed to delete solution [item]{solution.name}[/item]:[/error]\n{_format_request_failed_comment(e.comment)}'  # pyright: ignore[reportAttributeAccessIssue]
                 )
 
 

--- a/tests/rbx/box/packaging/test_polygon_upload_error_format.py
+++ b/tests/rbx/box/packaging/test_polygon_upload_error_format.py
@@ -1,0 +1,54 @@
+"""Tests for formatting Polygon FAILED-response comments before display (#389).
+
+Two concerns:
+- Compiler output frequently contains ``[...]`` (e.g. ``[with _Tp = int]``) which
+  Rich would otherwise consume as markup and silently drop.
+- Polygon truncates the ``comment`` field server-side, so long compilation errors
+  are cut off; users should be told to look at the full log on the Polygon UI.
+"""
+
+from rich.text import Text
+
+from rbx.box.packaging.polygon import polygon_api as api
+from rbx.box.packaging.polygon import upload
+
+
+def _render_plain(markup: str) -> str:
+    return Text.from_markup(markup).plain
+
+
+def test_bracketed_compiler_text_survives_rendering():
+    comment = (
+        'file: sol.cpp:5:9: error: no matching function [with _Tp = int; _Up = long]'
+    )
+
+    rendered = _render_plain(upload._format_request_failed_comment(comment))  # noqa: SLF001
+
+    # The bracketed segment must NOT be eaten by Rich markup parsing.
+    assert '[with _Tp = int; _Up = long]' in rendered
+
+
+def test_long_comment_gets_truncation_hint():
+    # A comment at/over Polygon's cap is almost certainly truncated.
+    comment = 'file: ' + 'x' * api.COMMENT_LENGTH_LIMIT
+
+    rendered = _render_plain(upload._format_request_failed_comment(comment))  # noqa: SLF001
+
+    assert str(api.COMMENT_LENGTH_LIMIT) in rendered
+    assert 'Polygon' in rendered
+    assert 'truncat' in rendered.lower()
+
+
+def test_short_comment_has_no_truncation_hint():
+    comment = 'file: sol.cpp: ok'
+
+    rendered = _render_plain(upload._format_request_failed_comment(comment))  # noqa: SLF001
+
+    assert 'truncat' not in rendered.lower()
+    # The original message is preserved verbatim.
+    assert comment in rendered
+
+
+def test_polygon_comment_length_limit_is_255():
+    # Documents the observed Polygon API cap on the message portion (#389).
+    assert api.COMMENT_LENGTH_LIMIT == 255


### PR DESCRIPTION
## Summary

Fixes #389 — Polygon compilation errors were being "cropped" when long.

Investigation (against the live Polygon API) found **two stacked problems**:

1. **Polygon API caps the FAILED `comment` field at 255 chars** (`"file: "` + 255 = 261 total). This is server-side and enforced regardless of error size — verified by sweeping 50→800 error lines (comment length constant at 261) and by `raw response == parsed comment`. rbx cannot recover the rest.
2. **rbx silently dropped bracketed text.** All upload error sites printed the comment through Rich markup, so `[...]` segments ubiquitous in C++ template/STL errors (e.g. `[with T = int]`) were swallowed before the user ever saw them.

## Changes

- `polygon_api.py`: add documented `COMMENT_LENGTH_LIMIT = 255` constant.
- `upload.py`: add `_format_request_failed_comment()` that (a) escapes the comment so bracketed text survives Rich rendering, and (b) appends a hint pointing to the Polygon UI for the full log when the comment hits the cap. Wired into all 4 error-print sites (generator, script conflict, solution upload, solution delete).
- New tests in `test_polygon_upload_error_format.py`.

## Verification

- TDD: tests failed first (missing feature), then passed.
- `ruff check` + `ruff format` clean; commitizen hook passed.
- `tests/rbx/box/packaging/` → 197 passed, 1 xfailed (only pre-existing BOCA docker e2e errors, unrelated).
- Real-API before/after on a `[with T = int]` template error:
  - before: `void f(T) ':` (bracket eaten)
  - after: `void f(T) [with T = int]':` (preserved)

## Scope note

The 255-char truncation itself is Polygon-side and unfixable by rbx; this PR mitigates the rbx-side markup bug and surfaces a clear warning. A deeper option (local pre-compile to show the full error) was intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
