### PR TITLE
feat(ui): show visualizer errors in a dismissible modal

### DIFF
--- a/rbx/box/ui/CLAUDE.md
+++ b/rbx/box/ui/CLAUDE.md
@@ -42,7 +42,8 @@ rbxApp (main menu: OptionList)
 | `ReviewScreen` | `review.py` | Code review confirm/reject (y/n keybindings) |
 | `SelectorScreen` | `selector.py` | Generic modal list selector, returns index |
 | `RichLogModal` | `rich_log_modal.py` | Modal popup for rich markup text |
-| `ErrorScreen` | `error.py` | Simple error display |
+| `ErrorScreen` | `error.py` | Simple full-screen text display (used for empty-states like "No runs found") |
+| `ErrorModal` | `error_modal.py` | Dismissible, scrollable modal showing a formatted `RbxException` (compile/runtime output); opened via `rbxBaseApp.show_error`. `q`/`esc` close |
 
 ## Key Widgets (`widgets/`)
 
@@ -80,6 +81,7 @@ Helper functions that load run results from disk:
 - **`@work(exclusive=True)`** -- `FileLog` and `InteractionBox` use this for cancellable async file loading.
 - **`self.watch(widget, 'index', callback)`** -- Test explorer screens watch `ListView.index` to react to selection changes.
 - **CSS** in `css/app.tcss` uses Textual's TCSS syntax with `$`-prefixed theme variables.
+- **Surfacing exceptions** -- `rbxBaseApp.show_error(exc)` (`main.py`) pushes an `ErrorModal` rendering `exc.from_ansi()` (formatting preserved, scrollable, not truncated). Use it instead of `notify(e.plain(), severity='error')` for `RbxException`s that may carry long output; the visualizer actions in `test_explorer.py`/`run_test_explorer.py` do (#380). Short one-line validation messages ("No test selected") stay toasts. Screens call it as `self.app.show_error(e)  # type: ignore[attr-defined]`.
 
 ## Keybindings
 

--- a/rbx/box/ui/css/app.tcss
+++ b/rbx/box/ui/css/app.tcss
@@ -129,6 +129,20 @@ TestExplorerScreen, RunTestExplorerScreen {
         }
 }
 
+#error-dialog {
+        max-width: 100;
+        width: 90%;
+        height: auto;
+
+        RichLog {
+                border: solid $error;
+                border-title-color: $error;
+                padding: 0 1;
+                height: auto;
+                max-height: 80%;
+        }
+}
+
 #selector-dialog {
         max-width: 80;
         height: auto;

--- a/rbx/box/ui/main.py
+++ b/rbx/box/ui/main.py
@@ -1,6 +1,7 @@
 import pathlib
 from typing import Type
 
+import rich.text
 import typer
 from rich.segment import Segments
 from textual.app import App, ComposeResult
@@ -10,8 +11,10 @@ from textual.widgets import Footer, Header, OptionList
 
 from rbx import console
 from rbx.box import remote
+from rbx.box.exception import RbxException
 from rbx.box.ui.help_panel import HelpPanelMixin
 from rbx.box.ui.screens.differ import DifferScreen
+from rbx.box.ui.screens.error_modal import ErrorModal
 from rbx.box.ui.screens.limits_editor import LimitsEditorScreen
 from rbx.box.ui.screens.run_explorer import RunExplorerScreen
 from rbx.box.ui.screens.test_explorer import TestExplorerScreen
@@ -40,6 +43,17 @@ class rbxBaseApp(VimNavMixin, HelpPanelMixin, App):
 
         # Default behavior (Rich traceback + return code 1)
         return super()._handle_exception(error)
+
+    def show_error(self, exc: RbxException) -> None:
+        """Surface an RbxException in a dismissible, scrollable modal.
+
+        Preferred over a toast notification for errors that carry long,
+        formatted output (e.g. a visualizer's compile/runtime failure).
+        """
+        content = exc.from_ansi()
+        if not content.plain.strip():
+            content = rich.text.Text('An unexpected error occurred.')
+        self.push_screen(ErrorModal(content, title='Error'))
 
 
 class rbxApp(rbxBaseApp):

--- a/rbx/box/ui/screens/error_modal.py
+++ b/rbx/box/ui/screens/error_modal.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+import rich.text
+from textual.app import ComposeResult
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import RichLog
+
+
+class ErrorModal(ModalScreen[None]):
+    """Dismissible, scrollable modal that shows a formatted error message.
+
+    Used by ``rbxBaseApp.show_error`` to surface ``RbxException`` output (e.g.
+    a visualizer's compile/runtime failure) in full. Unlike a toast
+    notification it preserves the captured ANSI styling and never truncates --
+    the inner ``RichLog`` wraps long lines and scrolls when focused.
+    """
+
+    BINDINGS = [
+        ('q', 'app.pop_screen', 'Close'),
+        ('escape', 'app.pop_screen', 'Close'),
+    ]
+
+    def __init__(self, content: rich.text.Text, title: Optional[str] = 'Error'):
+        super().__init__()
+        self.content_text = content
+        self._title = title
+
+    def compose(self) -> ComposeResult:
+        with Container(id='error-dialog'):
+            log = RichLog(markup=False, wrap=True)
+            if self._title:
+                log.border_title = self._title
+            yield log
+
+    def on_mount(self) -> None:
+        log = self.query_one(RichLog)
+        log.write(self.content_text)
+        log.focus()

--- a/rbx/box/ui/screens/run_test_explorer.py
+++ b/rbx/box/ui/screens/run_test_explorer.py
@@ -222,7 +222,7 @@ class RunTestExplorerScreen(Screen):
                 Testcase(inputPath=input_path)
             )
         except RbxException as e:
-            self.app.notify(e.plain(), severity='error', markup=False)
+            self.app.show_error(e)  # type: ignore[attr-defined]
 
     async def action_open_output_visualizer(self):
         input_path = self.query_one('#test-input', FileLog).path
@@ -245,4 +245,4 @@ class RunTestExplorerScreen(Screen):
                 answer_path=answer_path,
             )
         except RbxException as e:
-            self.app.notify(e.plain(), severity='error', markup=False)
+            self.app.show_error(e)  # type: ignore[attr-defined]

--- a/rbx/box/ui/screens/test_explorer.py
+++ b/rbx/box/ui/screens/test_explorer.py
@@ -157,4 +157,4 @@ class TestExplorerScreen(Screen):
                 )
             )
         except RbxException as e:
-            self.app.notify(e.plain(), severity='error', markup=False)
+            self.app.show_error(e)  # type: ignore[attr-defined]

--- a/tests/rbx/box/ui/test_error_modal.py
+++ b/tests/rbx/box/ui/test_error_modal.py
@@ -1,0 +1,131 @@
+"""Tests for the ErrorModal and rbxBaseApp.show_error helper (issue #380).
+
+Visualizer actions used to surface RbxExceptions as transient, plain-text toast
+notifications (``notify(e.plain(), severity='error')``), which truncated and
+auto-dismissed long compiler/runtime output. They now open a dismissible,
+scrollable ErrorModal that preserves the formatted message.
+"""
+
+from unittest import mock
+
+from textual.widgets import RichLog
+
+from rbx.box.exception import RbxException
+from rbx.box.ui.main import rbxApp
+from rbx.box.ui.screens.error_modal import ErrorModal
+
+
+def _exc(text: str) -> RbxException:
+    """Build an RbxException carrying ``text`` as captured console output."""
+    exc = RbxException()
+    exc.print(text)
+    return exc
+
+
+def _rich_log_text(modal: ErrorModal) -> str:
+    rich_log = modal.query_one(RichLog)
+    return '\n'.join(strip.text for strip in rich_log.lines)
+
+
+async def test_show_error_opens_error_modal_with_message():
+    async with rbxApp().run_test() as pilot:
+        app = pilot.app
+        assert not isinstance(app.screen, ErrorModal)
+
+        app.show_error(_exc('visualizer failed to compile'))
+        await pilot.pause()
+
+        assert isinstance(app.screen, ErrorModal)
+        assert 'visualizer failed to compile' in _rich_log_text(app.screen)
+
+
+async def test_error_modal_dismissed_with_q():
+    async with rbxApp().run_test() as pilot:
+        app = pilot.app
+        app.show_error(_exc('boom'))
+        await pilot.pause()
+        assert isinstance(app.screen, ErrorModal)
+
+        await pilot.press('q')
+        await pilot.pause()
+        assert not isinstance(app.screen, ErrorModal)
+
+
+async def test_error_modal_dismissed_with_escape():
+    async with rbxApp().run_test() as pilot:
+        app = pilot.app
+        app.show_error(_exc('boom'))
+        await pilot.pause()
+        assert isinstance(app.screen, ErrorModal)
+
+        await pilot.press('escape')
+        await pilot.pause()
+        assert not isinstance(app.screen, ErrorModal)
+
+
+async def test_show_error_falls_back_when_message_empty():
+    async with rbxApp().run_test() as pilot:
+        app = pilot.app
+
+        app.show_error(RbxException())  # no captured output
+        await pilot.pause()
+
+        assert isinstance(app.screen, ErrorModal)
+        assert _rich_log_text(app.screen).strip()  # not blank
+
+
+async def test_visualizer_error_routes_to_error_modal():
+    """The real visualizer action surfaces an RbxException via the modal.
+
+    Mounts the TestExplorerScreen (mocking package discovery and testcase
+    extraction, mirroring the help-panel tests), points the input FileLog at a
+    dummy path, and makes the visualizer raise. The except-block must open an
+    ErrorModal rather than a toast notification.
+    """
+    import pathlib
+
+    from rbx.box.schema import TaskType
+    from rbx.box.ui.screens import test_explorer
+    from rbx.box.ui.widgets.file_log import FileLog
+
+    pkg = mock.Mock()
+    pkg.type = TaskType.BATCH
+
+    async def _no_testcases():
+        return []
+
+    async def _raise(*args, **kwargs):
+        exc = RbxException()
+        exc.print('visualizer crashed at runtime')
+        raise exc
+
+    with (
+        mock.patch.object(
+            test_explorer.package,
+            'find_problem_package_or_die',
+            return_value=pkg,
+        ),
+        mock.patch.object(
+            test_explorer,
+            'extract_generation_testcases_from_groups',
+            side_effect=_no_testcases,
+        ),
+        mock.patch.object(
+            test_explorer.visualizers,
+            'run_ui_input_visualizer_for_testcase',
+            side_effect=_raise,
+        ),
+    ):
+        async with rbxApp().run_test() as pilot:
+            screen = test_explorer.TestExplorerScreen()
+            await pilot.app.push_screen(screen)
+            await pilot.pause()
+
+            screen.query_one('#test-input', FileLog).path = (
+                pathlib.Path.cwd() / 'dummy.in'
+            )
+            await screen.action_open_visualizer()
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ErrorModal)
+            assert 'visualizer crashed at runtime' in _rich_log_text(pilot.app.screen)


### PR DESCRIPTION
Closes #380.

## Problem

`rbx ui` surfaced visualizer `RbxException`s as transient toast notifications:

```python
except RbxException as e:
    self.app.notify(e.plain(), severity='error', markup=False)
```

`RbxException` carries long, ANSI-formatted compiler/runtime output, but the toast `.plain()`-stripped its formatting and truncated/auto-dismissed it — so a failing visualizer's compile error couldn't actually be read. Per the issue's discussion, these were the only error sites that warranted this (all in visualizers).

## Change

- **`ErrorModal`** (`screens/error_modal.py`, new) — a dismissible `ModalScreen` with a focusable, wrapping, scrollable `RichLog`; `q`/`esc` close.
- **`rbxBaseApp.show_error(exc)`** (`main.py`) — pushes the modal rendering `exc.from_ansi()` (formatting preserved, untruncated), with a generic fallback when the exception is empty. Inherited by all TUI apps.
- **`#error-dialog`** CSS (`css/app.tcss`) — wider/taller than the one-line `#rich-dialog`, with an `$error`-colored border.
- The three visualizer `except RbxException` blocks (`test_explorer.py`, `run_test_explorer.py` ×2) now call `self.app.show_error(e)`. Short one-line validation toasts ("No test selected") are intentionally left as notifications; the existing full-screen `ErrorScreen` ("No runs found") empty-state is untouched.

## Tests

`tests/rbx/box/ui/test_error_modal.py` (Textual pilot):
- `show_error` opens an `ErrorModal` showing the message
- dismiss with both `q` and `esc`
- empty-message fallback renders a non-blank modal
- end-to-end: the **real** `TestExplorerScreen.action_open_visualizer` routes a raised `RbxException` to the modal

Verification: 5/5 new tests pass, full `tests/rbx/box/ui` suite (48) passes, `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)