### PR TITLE
refactor(cache): rename .box cache directory to .rbx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # rbx
+.rbx/
 .box/
 
 .DS_Store

--- a/rbx/box/global_package.py
+++ b/rbx/box/global_package.py
@@ -4,7 +4,7 @@ import pathlib
 import shutil
 from typing import Iterator, Type
 
-from rbx.config import get_app_path
+from rbx.config import CACHE_DIR_NAME, get_app_path
 from rbx.grading.caching import DependencyCache
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.judge.sandbox import SandboxBase
@@ -32,7 +32,7 @@ def is_cache_valid(cache_dir: pathlib.Path) -> bool:
 
 
 def get_global_cache_dir_path() -> pathlib.Path:
-    return get_app_path() / '.box'
+    return get_app_path() / CACHE_DIR_NAME
 
 
 @functools.cache

--- a/rbx/box/package.py
+++ b/rbx/box/package.py
@@ -40,7 +40,7 @@ from rbx.box.schema import (
 )
 from rbx.box.statements.schema import Statement
 from rbx.box.yaml_validation import load_yaml_model
-from rbx.config import get_builtin_checker
+from rbx.config import CACHE_DIR_NAME, get_builtin_checker
 from rbx.grading.caching import DependencyCache
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.judge.lock import make_async_file_lock
@@ -137,7 +137,7 @@ def get_ruyaml(root: pathlib.Path = pathlib.Path()) -> Tuple[ruyaml.YAML, ruyaml
 
 @functools.cache
 def get_problem_cache_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
-    return find_problem(root) / '.box'
+    return find_problem(root) / CACHE_DIR_NAME
 
 
 @functools.cache
@@ -608,7 +608,7 @@ def get_merged_capture_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path
 
 @functools.cache
 def is_cache_valid(root: pathlib.Path = pathlib.Path()):
-    cache_dir = find_problem(root) / '.box'
+    cache_dir = get_problem_cache_path(root)
     return global_package.is_cache_valid(cache_dir)
 
 

--- a/rbx/box/presets/__init__.py
+++ b/rbx/box/presets/__init__.py
@@ -39,7 +39,7 @@ from rbx.box.presets.schema import (
     VariableExpansion,
 )
 from rbx.box.yaml_validation import load_yaml_model
-from rbx.config import get_default_app_path
+from rbx.config import CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME, get_default_app_path
 from rbx.grading.judge.digester import digest_cooperatively
 
 if TYPE_CHECKING:
@@ -48,6 +48,12 @@ if TYPE_CHECKING:
 app = typer.Typer(no_args_is_help=True)
 
 _MAX_EXPAND_SIZE = 1024 * 1024  # 1024 KB
+
+# Cache/build artefacts ignored when globbing a package's source files. The
+# legacy cache dir is kept so stale caches don't leak into globbed output.
+_DEFAULT_GLOB_GITIGNORE = (
+    f'{CACHE_DIR_NAME}\n{LEGACY_CACHE_DIR_NAME}\nbuild\n.limits/local.yml\n'
+)
 
 
 def _expand_content(
@@ -230,7 +236,7 @@ def check_is_valid_package(root: pathlib.Path = pathlib.Path()):
 def _glob_while_ignoring(
     dir: pathlib.Path,
     glb: str,
-    extra_gitignore: Optional[str] = '.box\nbuild\n.limits/local.yml\n',
+    extra_gitignore: Optional[str] = _DEFAULT_GLOB_GITIGNORE,
     recursive: bool = False,
 ) -> Iterable[pathlib.Path]:
     from gitignore_parser import parse_gitignore, parse_gitignore_str
@@ -637,8 +643,11 @@ def get_preset_fetch_info_with_fallback(
 
 
 def clean_copied_package_dir(dest: pathlib.Path):
-    for box_dir in dest.rglob('.box'):
-        shutil.rmtree(str(box_dir), ignore_errors=True)
+    # Strip the current cache dir as well as the legacy one, so a stale cache
+    # left over from before #306 never leaks into a generated preset/package.
+    for cache_name in (CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME):
+        for cache_dir in dest.rglob(cache_name):
+            shutil.rmtree(str(cache_dir), ignore_errors=True)
     for lock in dest.rglob('.preset-lock.yml'):
         lock.unlink(missing_ok=True)
 

--- a/rbx/box/sanitizers/warning_stack.py
+++ b/rbx/box/sanitizers/warning_stack.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 from rbx import console, utils
 from rbx.box.formatting import href
 from rbx.box.schema import CodeItem
+from rbx.config import CACHE_DIR_NAME
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.steps import GradingFileOutput, PreprocessLog
 
@@ -65,7 +66,7 @@ def _get_warning_stack(root: pathlib.Path) -> WarningStack:
 
 @functools.cache
 def _get_cache_dir(root: pathlib.Path) -> pathlib.Path:
-    dir = root / '.box'
+    dir = root / CACHE_DIR_NAME
     dir.mkdir(parents=True, exist_ok=True)
     return dir
 

--- a/rbx/config.py
+++ b/rbx/config.py
@@ -19,6 +19,12 @@ app = typer.Typer(no_args_is_help=True)
 _RESOURCES_PKG = 'rbx.resources'
 _CONFIG_FILE_NAME = 'default_config.json'
 
+# Name of the per-problem and global rbx cache/build directory.
+CACHE_DIR_NAME = '.rbx'
+# Pre-#306 cache directory name. New code never writes here, but it is still
+# stripped when packaging/seeding so stale caches don't leak into outputs.
+LEGACY_CACHE_DIR_NAME = '.box'
+
 
 def format_vars(template: str, **kwargs) -> str:
     res = template

--- a/rbx/resources/presets/default/contest/.gitignore
+++ b/rbx/resources/presets/default/contest/.gitignore
@@ -1,4 +1,4 @@
-.box/
+.rbx/
 build/
 __pycache__/
 

--- a/rbx/resources/presets/default/problem/.gitignore
+++ b/rbx/resources/presets/default/problem/.gitignore
@@ -1,4 +1,4 @@
-.box/
+.rbx/
 build/
 .limits/local.yml
 __pycache__/

--- a/rbx/testdata/presets/simple-preset/problem/.gitignore
+++ b/rbx/testdata/presets/simple-preset/problem/.gitignore
@@ -1,4 +1,4 @@
 build/
 *.o
 *.exe
-.box/
+.rbx/

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -38,7 +38,7 @@ no marker filter, will pick up e2e tests like any other test.
    uv run rbx build
    ```
    Then remove the generated artefacts. `tests/e2e/testdata/.gitignore`
-   already covers `*/.box/`, `*/build/`, `*/rbx.h`, and friends, so a
+   already covers `*/.rbx/`, `*/build/`, `*/rbx.h`, and friends, so a
    `git status` after building should be clean.
 3. Author `tests/e2e/testdata/<name>/e2e.rbx.yml` with at least one
    scenario (see [Schema reference](#schema-reference) and
@@ -185,7 +185,7 @@ single (multiline) regex rather than repeating the key.
 
 #### `solutions`
 
-Per-solution verdict map. Reads `.box/runs/skeleton.yml` and the
+Per-solution verdict map. Reads `.rbx/runs/skeleton.yml` and the
 sibling `.eval` files, so the scenario must run `rbx run` (or
 equivalent) before the assertion fires.
 
@@ -337,7 +337,7 @@ uv run pytest tests/e2e/testdata/<pkg>/ -v --basetemp=/tmp/e2e-debug
 ```
 
 Each scenario then lives under
-`/tmp/e2e-debug/.../rbx-e2e-<...>/` and its `.box/`, `build/`, etc. can
+`/tmp/e2e-debug/.../rbx-e2e-<...>/` and its `.rbx/`, `build/`, etc. can
 be inspected directly.
 
 ## Marker passthrough

--- a/tests/e2e/assertions.py
+++ b/tests/e2e/assertions.py
@@ -170,12 +170,12 @@ def check_zip_file_contains(ctx: AssertionContext, matcher: ZipFileMatcher) -> N
 
 
 def _load_skeleton(package_root: pathlib.Path) -> SolutionReportSkeleton:
-    """Load ``<package_root>/.box/runs/skeleton.yml``.
+    """Load ``<package_root>/.rbx/runs/skeleton.yml``.
 
-    Note: ``.box/runs/.irun/`` is the interactive-debug scratch space and is
+    Note: ``.rbx/runs/.irun/`` is the interactive-debug scratch space and is
     never read here; we only ever read the top-level ``skeleton.yml``.
     """
-    skeleton_path = package_root / '.box' / 'runs' / 'skeleton.yml'
+    skeleton_path = package_root / '.rbx' / 'runs' / 'skeleton.yml'
     if not skeleton_path.is_file():
         raise AssertionError(
             f'no run results found at {skeleton_path}; did the scenario run '

--- a/tests/e2e/assertions.py
+++ b/tests/e2e/assertions.py
@@ -23,6 +23,7 @@ from rbx.box.solutions import (
     get_worst_outcome,
 )
 from rbx.box.testcase_schema import TestcaseEntry
+from rbx.config import CACHE_DIR_NAME
 from rbx.grading.steps import Evaluation
 from tests.e2e.spec import (
     SolutionMatcher,
@@ -175,7 +176,7 @@ def _load_skeleton(package_root: pathlib.Path) -> SolutionReportSkeleton:
     Note: ``.rbx/runs/.irun/`` is the interactive-debug scratch space and is
     never read here; we only ever read the top-level ``skeleton.yml``.
     """
-    skeleton_path = package_root / '.rbx' / 'runs' / 'skeleton.yml'
+    skeleton_path = package_root / CACHE_DIR_NAME / 'runs' / 'skeleton.yml'
     if not skeleton_path.is_file():
         raise AssertionError(
             f'no run results found at {skeleton_path}; did the scenario run '

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -12,7 +12,7 @@ session-scoped autouse fixtures that those conftests provide:
   real ``~/.local/share/rbx/`` is never touched.
 - ``precompilation_should_use_tmp_cache`` redirects the global precompilation
   cache to a tmpdir, so compiled artefacts do not accumulate in the user's
-  global ``.box`` cache.
+  global ``.rbx`` cache.
 - ``mock_setter_config`` writes a permissive setter config inside the
   redirected app path so checks (e.g. stack-size) do not query the host.
 - ``mock_pdflatex`` short-circuits the LaTeX build so statement scenarios
@@ -55,7 +55,7 @@ def precompilation_should_use_tmp_cache(monkeysession, tmp_path_factory):
     cache_dir = tmp_path_factory.mktemp('cache')
     monkeysession.setattr(
         'rbx.box.global_package.get_global_cache_dir_path',
-        lambda: cache_dir / '.box',
+        lambda: cache_dir / '.rbx',
     )
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -25,6 +25,7 @@ import pytest
 
 from rbx.box import setter_config
 from rbx.box.statements.latex import LatexResult
+from rbx.config import CACHE_DIR_NAME
 from tests.e2e.runner import E2EScenarioItem
 from tests.e2e.spec import load_spec
 
@@ -55,7 +56,7 @@ def precompilation_should_use_tmp_cache(monkeysession, tmp_path_factory):
     cache_dir = tmp_path_factory.mktemp('cache')
     monkeysession.setattr(
         'rbx.box.global_package.get_global_cache_dir_path',
-        lambda: cache_dir / '.rbx',
+        lambda: cache_dir / CACHE_DIR_NAME,
     )
 
 

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -31,7 +31,7 @@ from typer.testing import CliRunner
 from rbx import testing_utils
 from rbx.box.cli import app as rbx_app
 from rbx.box.contest import contest_state
-from rbx.config import get_default_app_path
+from rbx.config import CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME, get_default_app_path
 from tests.e2e.assertions import (
     AssertionContext,
     check_file_contains,
@@ -66,8 +66,8 @@ def _strip_ansi(text: str) -> str:
 # Note: ``.local.rbx`` is intentionally NOT excluded -- a fixture may commit a
 # minimal local preset there (e.g. so ``contest add_variant`` resolves offline).
 COPY_IGNORE_PATTERNS = (
-    '.rbx',
-    '.box',
+    CACHE_DIR_NAME,
+    LEGACY_CACHE_DIR_NAME,
     'build',
     '.limits',
     '__pycache__',

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -5,7 +5,7 @@ Each :class:`E2EScenarioItem` represents a single scenario from an
 directory (the directory containing ``e2e.rbx.yml``) is copied to a fresh
 temporary directory before the scenario runs, and all CLI invocations execute
 with that temporary directory as the cwd. This ensures the on-disk source
-tree is never mutated by ``rbx`` commands (which create ``.box/``, ``build/``
+tree is never mutated by ``rbx`` commands (which create ``.rbx/``, ``build/``
 and other artefacts).
 
 We intentionally do not use :class:`TestingPackage` here because its
@@ -66,6 +66,7 @@ def _strip_ansi(text: str) -> str:
 # Note: ``.local.rbx`` is intentionally NOT excluded -- a fixture may commit a
 # minimal local preset there (e.g. so ``contest add_variant`` resolves offline).
 COPY_IGNORE_PATTERNS = (
+    '.rbx',
     '.box',
     'build',
     '.limits',
@@ -84,7 +85,7 @@ def seed_package_from_preset(preset_name: str, dest: pathlib.Path) -> None:
     same location ``rbx`` itself resolves presets from) and copies it into
     ``dest``, dereferencing symlinks (so statement assets like
     ``documents/icpc.sty`` land as regular files) and skipping build cruft
-    (``.box``, ``build``, ...). ``dest`` is an existing package directory (the
+    (``.rbx``, ``build``, ...). ``dest`` is an existing package directory (the
     overlay target); any files already present (e.g. the fixture's own
     ``e2e.rbx.yml``) are preserved unless the preset overwrites them.
     """

--- a/tests/e2e/test_seed_from_preset.py
+++ b/tests/e2e/test_seed_from_preset.py
@@ -10,6 +10,7 @@ import pathlib
 
 import pytest
 
+from rbx.config import CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME
 from tests.e2e.runner import seed_package_from_preset
 from tests.e2e.spec import Scenario
 
@@ -42,8 +43,8 @@ def test_seed_package_from_preset_overlays_real_files(tmp_path: pathlib.Path):
     assert not icpc.is_symlink()
 
     # Build cruft was skipped.
-    assert not (dest / '.rbx').exists()
-    assert not (dest / '.box').exists()
+    assert not (dest / CACHE_DIR_NAME).exists()
+    assert not (dest / LEGACY_CACHE_DIR_NAME).exists()
     assert not (dest / 'build').exists()
 
     # The fixture file survived the overlay.

--- a/tests/e2e/test_seed_from_preset.py
+++ b/tests/e2e/test_seed_from_preset.py
@@ -42,6 +42,7 @@ def test_seed_package_from_preset_overlays_real_files(tmp_path: pathlib.Path):
     assert not icpc.is_symlink()
 
     # Build cruft was skipped.
+    assert not (dest / '.rbx').exists()
     assert not (dest / '.box').exists()
     assert not (dest / 'build').exists()
 

--- a/tests/e2e/test_solutions_matcher.py
+++ b/tests/e2e/test_solutions_matcher.py
@@ -1,6 +1,6 @@
 """Unit tests for ``check_solutions``.
 
-These tests build a fake on-disk ``.box/runs/`` tree (skeleton.yml +
+These tests build a fake on-disk ``.rbx/runs/`` tree (skeleton.yml +
 ``.eval`` files) using the real Pydantic models, so the matcher exercises
 the same load path as production code.
 """
@@ -53,12 +53,12 @@ def _make_fake_runs_dir(
     package_root: pathlib.Path,
     verdicts: Dict[str, Dict[str, List[Outcome]]],
 ) -> None:
-    """Build ``<package_root>/.box/runs/`` with a valid skeleton + .eval set.
+    """Build ``<package_root>/.rbx/runs/`` with a valid skeleton + .eval set.
 
     ``verdicts`` shape: ``{solution_path: {group_name: [outcome_per_idx, ...]}}``.
     All solutions must share the same group structure.
     """
-    runs_dir = package_root / '.box' / 'runs'
+    runs_dir = package_root / '.rbx' / 'runs'
     runs_dir.mkdir(parents=True, exist_ok=True)
 
     sol_paths = list(verdicts.keys())

--- a/tests/e2e/test_solutions_matcher.py
+++ b/tests/e2e/test_solutions_matcher.py
@@ -22,6 +22,7 @@ from rbx.box.solutions import (
     SolutionSkeleton,
 )
 from rbx.box.testcase_schema import TestcaseEntry
+from rbx.config import CACHE_DIR_NAME
 from rbx.grading.steps import (
     CheckerResult,
     Evaluation,
@@ -58,7 +59,7 @@ def _make_fake_runs_dir(
     ``verdicts`` shape: ``{solution_path: {group_name: [outcome_per_idx, ...]}}``.
     All solutions must share the same group structure.
     """
-    runs_dir = package_root / '.rbx' / 'runs'
+    runs_dir = package_root / CACHE_DIR_NAME / 'runs'
     runs_dir.mkdir(parents=True, exist_ok=True)
 
     sol_paths = list(verdicts.keys())

--- a/tests/e2e/testdata/.gitignore
+++ b/tests/e2e/testdata/.gitignore
@@ -1,3 +1,4 @@
+*/.rbx/
 */.box/
 */build/
 */rbx.h

--- a/tests/e2e/testdata/default-preset/.gitignore
+++ b/tests/e2e/testdata/default-preset/.gitignore
@@ -1,3 +1,4 @@
+.rbx/
 .box/
 build/
 .limits/local.yml

--- a/tests/rbx/box/conftest.py
+++ b/tests/rbx/box/conftest.py
@@ -49,7 +49,7 @@ def pkg_from_testdata(
         raise ValueError('test_pkg marker not found')
     testdata = testdata_path / marker.args[0]
     copytree_honoring_gitignore(
-        testdata, pkg_cleandir, extra_gitignore='.box\nbuild\n.limits/\n'
+        testdata, pkg_cleandir, extra_gitignore='.rbx\n.box\nbuild\n.limits/\n'
     )
     with pkg_cder(pkg_cleandir.absolute()):
         testing_utils.clear_all_functools_cache()
@@ -65,7 +65,7 @@ def pkg_from_resources(
         raise ValueError('resource_pkg marker not found')
     testdata = resources_path / marker.args[0]
     copytree_honoring_gitignore(
-        testdata, pkg_cleandir, extra_gitignore='.box/\nbuild/\n'
+        testdata, pkg_cleandir, extra_gitignore='.rbx/\n.box/\nbuild/\n'
     )
     with pkg_cder(pkg_cleandir.absolute()):
         testing_utils.clear_all_functools_cache()
@@ -103,7 +103,7 @@ def precompilation_should_use_tmp_cache(monkeysession, tmp_path_factory):
     cache_dir = tmp_path_factory.mktemp('cache')
     monkeysession.setattr(
         'rbx.box.global_package.get_global_cache_dir_path',
-        lambda: cache_dir / '.box',
+        lambda: cache_dir / '.rbx',
     )
 
 

--- a/tests/rbx/box/conftest.py
+++ b/tests/rbx/box/conftest.py
@@ -10,6 +10,7 @@ from rbx import testing_utils
 from rbx.box import package, setter_config
 from rbx.box.statements.latex import LatexResult
 from rbx.box.testing import testing_package
+from rbx.config import CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME
 from rbx.utils import copytree_honoring_gitignore
 
 
@@ -49,7 +50,9 @@ def pkg_from_testdata(
         raise ValueError('test_pkg marker not found')
     testdata = testdata_path / marker.args[0]
     copytree_honoring_gitignore(
-        testdata, pkg_cleandir, extra_gitignore='.rbx\n.box\nbuild\n.limits/\n'
+        testdata,
+        pkg_cleandir,
+        extra_gitignore=f'{CACHE_DIR_NAME}\n{LEGACY_CACHE_DIR_NAME}\nbuild\n.limits/\n',
     )
     with pkg_cder(pkg_cleandir.absolute()):
         testing_utils.clear_all_functools_cache()
@@ -65,7 +68,9 @@ def pkg_from_resources(
         raise ValueError('resource_pkg marker not found')
     testdata = resources_path / marker.args[0]
     copytree_honoring_gitignore(
-        testdata, pkg_cleandir, extra_gitignore='.rbx/\n.box/\nbuild/\n'
+        testdata,
+        pkg_cleandir,
+        extra_gitignore=f'{CACHE_DIR_NAME}/\n{LEGACY_CACHE_DIR_NAME}/\nbuild/\n',
     )
     with pkg_cder(pkg_cleandir.absolute()):
         testing_utils.clear_all_functools_cache()
@@ -103,7 +108,7 @@ def precompilation_should_use_tmp_cache(monkeysession, tmp_path_factory):
     cache_dir = tmp_path_factory.mktemp('cache')
     monkeysession.setattr(
         'rbx.box.global_package.get_global_cache_dir_path',
-        lambda: cache_dir / '.rbx',
+        lambda: cache_dir / CACHE_DIR_NAME,
     )
 
 

--- a/tests/rbx/box/presets/test_presets.py
+++ b/tests/rbx/box/presets/test_presets.py
@@ -571,14 +571,14 @@ class TestPresetInstallation:
         # Create directories that should be cleaned
         (dst / 'build').mkdir(parents=True)
         (dst / '.local.rbx').mkdir(parents=True)
-        (dst / 'problem' / '.box').mkdir(parents=True)
+        (dst / 'problem' / '.rbx').mkdir(parents=True)
 
         presets.install_preset_from_dir(simple_preset_testdata, dst, update=True)  # noqa: SLF001
 
         # Verify cleanup
         assert not (dst / 'build').exists()
         assert not (dst / '.local.rbx').exists()
-        assert not (dst / 'problem' / '.box').exists()
+        assert not (dst / 'problem' / '.rbx').exists()
 
     def test_install_problem_package(self, tmp_path, simple_preset_testdata):
         """Should install problem package files correctly."""
@@ -862,8 +862,12 @@ class TestCleanupFunctions:
     """Test directory cleanup functionality."""
 
     def test_clean_copied_package_dir(self, tmp_path):
-        """Should remove .box directories and lock files."""
+        """Should remove .rbx cache directories (and legacy .box) and lock files."""
         # Create files to be cleaned
+        (tmp_path / '.rbx').mkdir()
+        (tmp_path / 'nested' / '.rbx').mkdir(parents=True)
+        # Legacy cache dirs left over from before #306 must still be stripped so
+        # they never leak into a generated preset/package.
         (tmp_path / '.box').mkdir()
         (tmp_path / 'nested' / '.box').mkdir(parents=True)
         (tmp_path / '.preset-lock.yml').touch()
@@ -875,6 +879,8 @@ class TestCleanupFunctions:
         presets.clean_copied_package_dir(tmp_path)
 
         # Verify cleanup
+        assert not (tmp_path / '.rbx').exists()
+        assert not (tmp_path / 'nested' / '.rbx').exists()
         assert not (tmp_path / '.box').exists()
         assert not (tmp_path / 'nested' / '.box').exists()
         assert not (tmp_path / '.preset-lock.yml').exists()
@@ -886,7 +892,7 @@ class TestCleanupFunctions:
         # Create directories
         (tmp_path / 'build').mkdir()
         (tmp_path / '.local.rbx').mkdir()
-        (tmp_path / '.box').mkdir()
+        (tmp_path / '.rbx').mkdir()
         (tmp_path / 'contest.rbx.yml').touch()
 
         presets.clean_copied_contest_dir(tmp_path)
@@ -894,21 +900,21 @@ class TestCleanupFunctions:
         # Verify cleanup
         assert not (tmp_path / 'build').exists()
         assert not (tmp_path / '.local.rbx').exists()
-        assert not (tmp_path / '.box').exists()
+        assert not (tmp_path / '.rbx').exists()
         assert (tmp_path / 'contest.rbx.yml').exists()
 
     def test_clean_copied_problem_dir(self, tmp_path):
         """Should clean problem-specific directories."""
         # Create directories
         (tmp_path / 'build').mkdir()
-        (tmp_path / '.box').mkdir()
+        (tmp_path / '.rbx').mkdir()
         (tmp_path / 'main.cpp').touch()
 
         presets.clean_copied_problem_dir(tmp_path)
 
         # Verify cleanup
         assert not (tmp_path / 'build').exists()
-        assert not (tmp_path / '.box').exists()
+        assert not (tmp_path / '.rbx').exists()
         assert (tmp_path / 'main.cpp').exists()
 
 

--- a/tests/rbx/box/presets/test_presets.py
+++ b/tests/rbx/box/presets/test_presets.py
@@ -19,6 +19,7 @@ from rbx.box import presets
 from rbx.box.presets.lock_schema import LockedAsset, SymlinkInfo
 from rbx.box.presets.schema import TrackedAsset
 from rbx.box.testing.testing_preset import TestingPreset
+from rbx.config import CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME
 
 
 def test_preset_parses_libraries_block():
@@ -571,14 +572,14 @@ class TestPresetInstallation:
         # Create directories that should be cleaned
         (dst / 'build').mkdir(parents=True)
         (dst / '.local.rbx').mkdir(parents=True)
-        (dst / 'problem' / '.rbx').mkdir(parents=True)
+        (dst / 'problem' / CACHE_DIR_NAME).mkdir(parents=True)
 
         presets.install_preset_from_dir(simple_preset_testdata, dst, update=True)  # noqa: SLF001
 
         # Verify cleanup
         assert not (dst / 'build').exists()
         assert not (dst / '.local.rbx').exists()
-        assert not (dst / 'problem' / '.rbx').exists()
+        assert not (dst / 'problem' / CACHE_DIR_NAME).exists()
 
     def test_install_problem_package(self, tmp_path, simple_preset_testdata):
         """Should install problem package files correctly."""
@@ -864,12 +865,12 @@ class TestCleanupFunctions:
     def test_clean_copied_package_dir(self, tmp_path):
         """Should remove .rbx cache directories (and legacy .box) and lock files."""
         # Create files to be cleaned
-        (tmp_path / '.rbx').mkdir()
-        (tmp_path / 'nested' / '.rbx').mkdir(parents=True)
+        (tmp_path / CACHE_DIR_NAME).mkdir()
+        (tmp_path / 'nested' / CACHE_DIR_NAME).mkdir(parents=True)
         # Legacy cache dirs left over from before #306 must still be stripped so
         # they never leak into a generated preset/package.
-        (tmp_path / '.box').mkdir()
-        (tmp_path / 'nested' / '.box').mkdir(parents=True)
+        (tmp_path / LEGACY_CACHE_DIR_NAME).mkdir()
+        (tmp_path / 'nested' / LEGACY_CACHE_DIR_NAME).mkdir(parents=True)
         (tmp_path / '.preset-lock.yml').touch()
         (tmp_path / 'nested' / '.preset-lock.yml').touch()
 
@@ -879,10 +880,10 @@ class TestCleanupFunctions:
         presets.clean_copied_package_dir(tmp_path)
 
         # Verify cleanup
-        assert not (tmp_path / '.rbx').exists()
-        assert not (tmp_path / 'nested' / '.rbx').exists()
-        assert not (tmp_path / '.box').exists()
-        assert not (tmp_path / 'nested' / '.box').exists()
+        assert not (tmp_path / CACHE_DIR_NAME).exists()
+        assert not (tmp_path / 'nested' / CACHE_DIR_NAME).exists()
+        assert not (tmp_path / LEGACY_CACHE_DIR_NAME).exists()
+        assert not (tmp_path / 'nested' / LEGACY_CACHE_DIR_NAME).exists()
         assert not (tmp_path / '.preset-lock.yml').exists()
         assert not (tmp_path / 'nested' / '.preset-lock.yml').exists()
         assert (tmp_path / 'keep.txt').exists()
@@ -892,7 +893,7 @@ class TestCleanupFunctions:
         # Create directories
         (tmp_path / 'build').mkdir()
         (tmp_path / '.local.rbx').mkdir()
-        (tmp_path / '.rbx').mkdir()
+        (tmp_path / CACHE_DIR_NAME).mkdir()
         (tmp_path / 'contest.rbx.yml').touch()
 
         presets.clean_copied_contest_dir(tmp_path)
@@ -900,21 +901,21 @@ class TestCleanupFunctions:
         # Verify cleanup
         assert not (tmp_path / 'build').exists()
         assert not (tmp_path / '.local.rbx').exists()
-        assert not (tmp_path / '.rbx').exists()
+        assert not (tmp_path / CACHE_DIR_NAME).exists()
         assert (tmp_path / 'contest.rbx.yml').exists()
 
     def test_clean_copied_problem_dir(self, tmp_path):
         """Should clean problem-specific directories."""
         # Create directories
         (tmp_path / 'build').mkdir()
-        (tmp_path / '.rbx').mkdir()
+        (tmp_path / CACHE_DIR_NAME).mkdir()
         (tmp_path / 'main.cpp').touch()
 
         presets.clean_copied_problem_dir(tmp_path)
 
         # Verify cleanup
         assert not (tmp_path / 'build').exists()
-        assert not (tmp_path / '.rbx').exists()
+        assert not (tmp_path / CACHE_DIR_NAME).exists()
         assert (tmp_path / 'main.cpp').exists()
 
 

--- a/tests/rbx/box/test_cache_dirs.py
+++ b/tests/rbx/box/test_cache_dirs.py
@@ -6,6 +6,7 @@ import pathlib
 
 from rbx.box import package
 from rbx.box.package import find_problem_yaml
+from rbx.config import CACHE_DIR_NAME
 
 
 def test_problem_cache_path_uses_rbx_dir(cleandir: pathlib.Path):
@@ -17,5 +18,5 @@ def test_problem_cache_path_uses_rbx_dir(cleandir: pathlib.Path):
 
     cache_path = package.get_problem_cache_path(cleandir)
 
-    assert cache_path.name == '.rbx'
+    assert cache_path.name == CACHE_DIR_NAME
     assert cache_path.parent == cleandir

--- a/tests/rbx/box/test_cache_dirs.py
+++ b/tests/rbx/box/test_cache_dirs.py
@@ -1,0 +1,21 @@
+"""Tests for the rbx cache directory naming (issue #306: .box -> .rbx)."""
+
+from __future__ import annotations
+
+import pathlib
+
+from rbx.box import package
+from rbx.box.package import find_problem_yaml
+
+
+def test_problem_cache_path_uses_rbx_dir(cleandir: pathlib.Path):
+    (cleandir / 'problem.rbx.yml').write_text(
+        'name: cache-dir-problem\ntimeLimit: 1000\nmemoryLimit: 256\n'
+    )
+    find_problem_yaml.cache_clear()
+    package.get_problem_cache_path.cache_clear()
+
+    cache_path = package.get_problem_cache_path(cleandir)
+
+    assert cache_path.name == '.rbx'
+    assert cache_path.parent == cleandir

--- a/tests/rbx/conftest.py
+++ b/tests/rbx/conftest.py
@@ -51,7 +51,9 @@ def cleandir_with_testdata(
     if marker is None:
         raise ValueError('test_pkg marker not found')
     testdata = testdata_path / marker.args[0]
-    copytree_honoring_gitignore(testdata, cleandir, extra_gitignore='.box/\nbuild/\n')
+    copytree_honoring_gitignore(
+        testdata, cleandir, extra_gitignore='.rbx/\n.box/\nbuild/\n'
+    )
     yield cleandir
 
 

--- a/tests/rbx/conftest.py
+++ b/tests/rbx/conftest.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator
 import pytest
 from rich.console import Console
 
+from rbx.config import CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME
 from rbx.testing_utils import get_resources_path, get_testdata_path
 from rbx.utils import copytree_honoring_gitignore
 
@@ -52,7 +53,9 @@ def cleandir_with_testdata(
         raise ValueError('test_pkg marker not found')
     testdata = testdata_path / marker.args[0]
     copytree_honoring_gitignore(
-        testdata, cleandir, extra_gitignore='.rbx/\n.box/\nbuild/\n'
+        testdata,
+        cleandir,
+        extra_gitignore=f'{CACHE_DIR_NAME}/\n{LEGACY_CACHE_DIR_NAME}/\nbuild/\n',
     )
     yield cleandir
 

--- a/tests/rbx/grading/conftest.py
+++ b/tests/rbx/grading/conftest.py
@@ -3,6 +3,7 @@ from collections.abc import Iterator
 
 import pytest
 
+from rbx.config import CACHE_DIR_NAME
 from rbx.grading.caching import DependencyCache
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.judge.sandbox import SandboxBase
@@ -12,7 +13,7 @@ from rbx.grading.judge.storage import FilesystemStorage, Storage
 
 @pytest.fixture
 def storage(request, cleandir: pathlib.Path) -> Iterator[Storage]:
-    storage_path = cleandir / '.rbx' / '.storage'
+    storage_path = cleandir / CACHE_DIR_NAME / '.storage'
     yield FilesystemStorage(storage_path)
 
 
@@ -30,4 +31,4 @@ def sandbox(request, file_cacher: FileCacher) -> Iterator[SandboxBase]:
 def dependency_cache(
     request, cleandir: pathlib.Path, file_cacher: FileCacher
 ) -> Iterator[DependencyCache]:
-    yield DependencyCache(cleandir / '.rbx', file_cacher)
+    yield DependencyCache(cleandir / CACHE_DIR_NAME, file_cacher)

--- a/tests/rbx/grading/conftest.py
+++ b/tests/rbx/grading/conftest.py
@@ -12,7 +12,7 @@ from rbx.grading.judge.storage import FilesystemStorage, Storage
 
 @pytest.fixture
 def storage(request, cleandir: pathlib.Path) -> Iterator[Storage]:
-    storage_path = cleandir / '.box' / '.storage'
+    storage_path = cleandir / '.rbx' / '.storage'
     yield FilesystemStorage(storage_path)
 
 
@@ -30,4 +30,4 @@ def sandbox(request, file_cacher: FileCacher) -> Iterator[SandboxBase]:
 def dependency_cache(
     request, cleandir: pathlib.Path, file_cacher: FileCacher
 ) -> Iterator[DependencyCache]:
-    yield DependencyCache(cleandir / '.box', file_cacher)
+    yield DependencyCache(cleandir / '.rbx', file_cacher)


### PR DESCRIPTION
Closes #306.

The `.box` cache/build directory name no longer reflects the tool (`rbx`). This renames it to `.rbx`.

## Changes
- Add `CACHE_DIR_NAME = '.rbx'` and `LEGACY_CACHE_DIR_NAME = '.box'` constants in `rbx/config.py`; the name was previously hardcoded as `'.box'` across several modules.
- Point the per-problem cache (`package.py`), global precompilation cache (`global_package.py`), and warning-stack cache (`sanitizers/warning_stack.py`) at `CACHE_DIR_NAME`.
- `presets`: `clean_copied_package_dir` and the package-glob ignore default now strip/ignore **both** `.rbx` and the legacy `.box`, so a stale cache left over after an upgrade never leaks into a generated preset/package.
- gitignore templates for new packages now emit `.rbx/`; dev/testdata gitignores keep both names.
- Updated test fixtures, e2e assertions/runner/matcher, and the e2e README.

## Design decisions
- **No migration / no fallback read:** old `.box` caches are gitignored and regenerated, so they simply orphan and rebuild as `.rbx` on the next run.
- **Constant, not scattered literals:** prevents the "name duplicated everywhere" problem from recurring.

## Testing
- TDD: added `tests/rbx/box/test_cache_dirs.py` and a legacy-`.box`-strip assertion (red → green).
- Diffed full-suite failing node-IDs **with vs. without** these changes: **zero** new failures introduced. The remaining failures on my machine are pre-existing C++ compilation / sandbox / docker issues unrelated to this change.
- `ruff check` + `ruff format` clean; commitizen check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)