### PR TITLE
refactor(contest): consolidate build folders with problems (#353)

### DIFF
--- a/docs/plans/2026-06-08-consolidate-build-folders-design.md
+++ b/docs/plans/2026-06-08-consolidate-build-folders-design.md
@@ -1,0 +1,99 @@
+# Consolidate rbx build folders between contests and problems
+
+Tracking issue: [#353](https://github.com/rsalesc/rbx/issues/353)
+
+## Problem
+
+Problems and contests resolve their build directories inconsistently:
+
+- **Problems** resolve the build root via the configurable `buildDir` setting
+  (`environment.get_build_dir()`, default `build`) in `package.get_build_path`,
+  and place intermediate statement artifacts under `build/statements/<name>`
+  (`package.get_statements_build_path`).
+- **Contests** *hardcode* `pathlib.Path('build')` in
+  `build_contest_statements.py` (two sites) and place intermediate statement
+  artifacts under `build/statement_build/<name>`
+  (`get_statement_build_dir`).
+
+This means a contest ignores a custom `buildDir` (e.g. `buildDir: out` redirects
+problem artifacts but not contest artifacts), and the intermediate statement
+folder is named differently (`statements/` vs `statement_build/`). Final outputs
+(`build/<name>.<suffix>`) already match.
+
+The issue text describes an older state (`build.rbx/` for problems). Since then
+the problem build dir became the configurable `buildDir` (default `build`), so
+both nominally use `build/` today; the two inconsistencies above are what remain.
+
+## Goal
+
+Make the contest build layout match the problem layout:
+
+1. Honor the configurable `buildDir` instead of hardcoding `build`.
+2. Rename the contest's intermediate statement folder `statement_build/` →
+   `statements/`.
+
+## Design
+
+### Change 1 — `rbx/box/contest/contest_package.py`
+
+Add two cached path helpers mirroring the problem-side helpers in `package.py`:
+
+```python
+@functools.cache
+def get_contest_build_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
+    return find_contest(root) / environment.get_build_dir()
+
+
+@functools.cache
+def get_contest_statements_build_path(
+    root: pathlib.Path = pathlib.Path(),
+) -> pathlib.Path:
+    return get_contest_build_path(root) / 'statements'
+```
+
+- New import: `from rbx.box import environment` (no import cycle — `environment`
+  does not import contest code).
+- Returns absolute paths via `find_contest()`, more robust than today's relative
+  `Path('build')`.
+- Auto-covered by `testing_utils.clear_all_functools_cache` (it already iterates
+  `contest_package` for any function exposing `cache_clear`), satisfying the
+  test-isolation rule for new `@functools.cache` helpers.
+
+### Change 2 — `rbx/box/contest/build_contest_statements.py`
+
+Rewire the two hardcoded sites to the new helpers:
+
+- `get_statement_build_dir` (intermediate dir):
+  `Path('build') / 'statement_build' / name`
+  → `contest_package.get_contest_statements_build_path() / statement.name`
+- Final output path:
+  `Path('build') / name`
+  → `contest_package.get_contest_build_path() / statement.name`
+
+Net effect: contests write intermediates to `<buildDir>/statements/<name>` and
+final output to `<buildDir>/<name>.<suffix>` — identical convention to problems,
+and `buildDir` is now respected.
+
+Both call sites run under the `@within_contest` decorator (cwd = contest root),
+so `find_contest()` resolves.
+
+### No migration
+
+`build/` is gitignored and fully regenerable, so no on-disk migration is needed —
+only the convention changes going forward.
+
+## Testing
+
+- New unit test (contest package tests): `get_contest_statements_build_path()`
+  resolves to `<contest_root>/build/statements`, and overriding `buildDir`
+  (e.g. `out`, via mocking `environment.get_build_dir`) redirects it.
+- Existing contest statement build tests stay green — the default-case final
+  output path `build/<name>.<suffix>` is unchanged.
+- `uv run pytest tests/rbx/box/contest tests/rbx/box/statements`.
+- `uv run ruff check` / `ruff format` on changed files.
+
+## Risk
+
+Low. Two call sites, both inside `@within_contest`; the build folder is
+disposable. The `@functools.cache` keyed by `root` is safe because all contest
+variants share the same contest directory (sibling `contest.<id>.rbx.yml` files).

--- a/docs/plans/2026-06-08-consolidate-build-folders-design.md
+++ b/docs/plans/2026-06-08-consolidate-build-folders-design.md
@@ -77,6 +77,31 @@ and `buildDir` is now respected.
 Both call sites run under the `@within_contest` decorator (cwd = contest root),
 so `find_contest()` resolves.
 
+### Change 3 — other contest sites that hardcoded `build`
+
+A thorough sweep found three more contest sites that hardcoded `build` and so
+ignored a custom `buildDir`. All are routed through the configurable build dir:
+
+- `rbx/box/packaging/contest_main.py` — the contest package **output dir** (where
+  the final contest `.zip` is written) was `pathlib.Path('build')`; now
+  `contest_package.get_contest_build_path()`.
+- `rbx/box/stats.py` — `_get_build_path` returned `root / 'build'` for contests
+  (the `rbx stats` build-size report); now `root / environment.get_build_dir()`.
+  Resolved against the package root directly (not via `find_contest`) to avoid
+  contest-variant lookups in a read-only reporting path.
+- `rbx/box/cli.py` — `rbx clear` cleaned a hardcoded `build`; the contest branch
+  now also cleans `get_contest_build_path()` so a custom `buildDir` is removed.
+
+**Deliberately left as-is** (default-name only, special context):
+
+- `rbx/box/presets/__init__.py` — preset-tree cleanup deletes `dest / 'build'`. It
+  runs on a freshly *copied* tree before any environment is active, so resolving a
+  custom `buildDir` there is awkward, and preset source trees should not carry
+  build artifacts. A custom-`buildDir` preset that ships stale artifacts is a deep
+  edge case left for a follow-up if it ever matters.
+- `rbx/box/testing/testing_package.py` — a test-only helper that builds expected
+  paths under the default `build`; tests run with the default environment.
+
 ### No migration
 
 `build/` is gitignored and fully regenerable, so no on-disk migration is needed —

--- a/docs/plans/2026-06-08-consolidate-build-folders-design.md
+++ b/docs/plans/2026-06-08-consolidate-build-folders-design.md
@@ -92,13 +92,25 @@ ignored a custom `buildDir`. All are routed through the configurable build dir:
 - `rbx/box/cli.py` — `rbx clear` cleaned a hardcoded `build`; the contest branch
   now also cleans `get_contest_build_path()` so a custom `buildDir` is removed.
 
-**Deliberately left as-is** (default-name only, special context):
+### Change 4 — preset-tree cleanup honors the preset's own buildDir
 
-- `rbx/box/presets/__init__.py` — preset-tree cleanup deletes `dest / 'build'`. It
-  runs on a freshly *copied* tree before any environment is active, so resolving a
-  custom `buildDir` there is awkward, and preset source trees should not carry
-  build artifacts. A custom-`buildDir` preset that ships stale artifacts is a deep
-  edge case left for a follow-up if it ever matters.
+When a preset (or a problem/contest created from one) is copied, build artifacts
+are stripped so they don't leak into the generated tree. This used the hardcoded
+`build`. It must instead use the **preset's own** `env.rbx.yml` `buildDir` (not the
+user's active environment), so a preset with a custom `buildDir` is cleaned
+correctly. `rbx/box/presets/__init__.py`:
+
+- New `get_preset_build_dir(env_path)` reads just the `buildDir` field from the
+  preset's `env.rbx.yml` via raw YAML (robust to stub/partial envs — the preset
+  env is not always a fully-valid `Environment`), falling back to `build`.
+- `clean_copied_contest_dir` / `clean_copied_problem_dir` gain a `build_dir`
+  parameter (default `build`, so existing callers/tests are unaffected).
+- `install_preset_from_dir` resolves the build dir from `dest / preset.env`;
+  `install_contest` / `install_problem` resolve it from
+  `get_preset_environment_path(dest_pkg)`.
+
+**Deliberately left as-is**:
+
 - `rbx/box/testing/testing_package.py` — a test-only helper that builds expected
   paths under the default `build`; tests run with the default environment.
 

--- a/docs/plans/2026-06-08-consolidate-build-folders.md
+++ b/docs/plans/2026-06-08-consolidate-build-folders.md
@@ -1,0 +1,200 @@
+# Consolidate Build Folders Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make contest statement builds honor the configurable `buildDir` and use the same `build/statements/` intermediate folder name as problems.
+
+**Architecture:** Add two cached path helpers to `contest_package.py` mirroring the problem-side helpers in `package.py` (`get_contest_build_path` → `find_contest(root) / environment.get_build_dir()`, and `get_contest_statements_build_path` → that `/ 'statements'`). Then rewire the two hardcoded `pathlib.Path('build')` sites in `build_contest_statements.py` to use them.
+
+**Tech Stack:** Python 3, Pydantic v2, pytest, Typer.
+
+Design doc: `docs/plans/2026-06-08-consolidate-build-folders-design.md`
+
+---
+
+### Task 1: Add contest build-path helpers
+
+**Files:**
+- Modify: `rbx/box/contest/contest_package.py` (add `environment` import + two helpers after `find_contest`, ~line 209)
+- Test: `tests/rbx/box/contest/test_contest_package.py`
+
+**Step 1: Write the failing tests**
+
+Add a new test class at the end of `tests/rbx/box/contest/test_contest_package.py`:
+
+```python
+class TestContestBuildPaths:
+    @pytest.fixture(autouse=True)
+    def _clear_caches(self):
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.get_contest_build_path.cache_clear()
+        cp_module.get_contest_statements_build_path.cache_clear()
+        yield
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.get_contest_build_path.cache_clear()
+        cp_module.get_contest_statements_build_path.cache_clear()
+
+    def test_build_path_uses_default_build_dir(self, tmp_path: pathlib.Path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+
+        assert cp_module.get_contest_build_path(tmp_path) == tmp_path / 'build'
+
+    def test_statements_build_path_under_build(self, tmp_path: pathlib.Path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+
+        assert (
+            cp_module.get_contest_statements_build_path(tmp_path)
+            == tmp_path / 'build' / 'statements'
+        )
+
+    def test_build_path_honors_custom_build_dir(self, tmp_path: pathlib.Path):
+        from unittest import mock
+
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+
+        with mock.patch.object(
+            cp_module.environment, 'get_build_dir', return_value=pathlib.Path('out')
+        ):
+            cp_module.get_contest_build_path.cache_clear()
+            cp_module.get_contest_statements_build_path.cache_clear()
+            assert cp_module.get_contest_build_path(tmp_path) == tmp_path / 'out'
+            assert (
+                cp_module.get_contest_statements_build_path(tmp_path)
+                == tmp_path / 'out' / 'statements'
+            )
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_package.py::TestContestBuildPaths -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'get_contest_build_path'`
+
+**Step 3: Write minimal implementation**
+
+In `rbx/box/contest/contest_package.py`, add `environment` to the box import:
+
+```python
+from rbx.box import cd, environment
+```
+
+Then add, right after `find_contest` (after line 209):
+
+```python
+@functools.cache
+def get_contest_build_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
+    return find_contest(root) / environment.get_build_dir()
+
+
+@functools.cache
+def get_contest_statements_build_path(
+    root: pathlib.Path = pathlib.Path(),
+) -> pathlib.Path:
+    return get_contest_build_path(root) / 'statements'
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_package.py::TestContestBuildPaths -v`
+Expected: PASS (3 tests)
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/contest_package.py tests/rbx/box/contest/test_contest_package.py
+git commit -m "feat(contest): add buildDir-aware contest build-path helpers (#353)"
+```
+
+---
+
+### Task 2: Rewire contest statement builder to the helpers
+
+**Files:**
+- Modify: `rbx/box/contest/build_contest_statements.py:383-384` (`get_statement_build_dir`) and `:410`
+- Test: `tests/rbx/box/contest/test_contest_package.py` (the helpers test above already covers path resolution; add a focused assertion on `get_statement_build_dir`)
+
+**Step 1: Write the failing test**
+
+Add to the `TestContestBuildPaths` class:
+
+```python
+    def test_statement_build_dir_uses_statements_folder(
+        self, tmp_path: pathlib.Path
+    ):
+        from rbx.box.contest import build_contest_statements
+        from rbx.box.contest.schema import ContestStatement
+        from rbx.box.statements.schema import StatementType
+
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+        statement = ContestStatement(
+            name='st', path=pathlib.Path('st.rbx.tex'), type=StatementType.rbxTeX
+        )
+
+        with cd.new_package_cd(tmp_path):
+            result = build_contest_statements.get_statement_build_dir(statement)
+
+        assert result == tmp_path / 'build' / 'statements' / 'st'
+```
+
+> Verify the `ContestStatement` constructor args and `StatementType` member during
+> implementation — read `rbx/box/contest/schema.py` and `rbx/box/statements/schema.py`
+> and adjust the minimal valid construction if needed. `cd` is already imported in
+> the module under test; import it in the test if not present.
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest "tests/rbx/box/contest/test_contest_package.py::TestContestBuildPaths::test_statement_build_dir_uses_statements_folder" -v`
+Expected: FAIL — result is `build/statement_build/st`, not `<tmp>/build/statements/st`.
+
+**Step 3: Write the implementation**
+
+In `rbx/box/contest/build_contest_statements.py`, ensure the contest_package import exists (add if missing):
+
+```python
+from rbx.box.contest import contest_package
+```
+
+Replace `get_statement_build_dir` (lines 383-384):
+
+```python
+def get_statement_build_dir(statement: ContestStatement) -> pathlib.Path:
+    return contest_package.get_contest_statements_build_path() / statement.name
+```
+
+Replace the final output path (line 410):
+
+```python
+    statement_path = (
+        contest_package.get_contest_build_path() / statement.name
+    ).with_suffix(last_output.get_file_suffix())
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/rbx/box/contest tests/rbx/box/statements -q`
+Expected: PASS (no regressions; new assertion passes).
+
+**Step 5: Lint and format**
+
+Run: `uv run ruff check rbx/box/contest/build_contest_statements.py rbx/box/contest/contest_package.py tests/rbx/box/contest/test_contest_package.py && uv run ruff format rbx/box/contest/build_contest_statements.py rbx/box/contest/contest_package.py tests/rbx/box/contest/test_contest_package.py`
+Expected: clean.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/contest/build_contest_statements.py tests/rbx/box/contest/test_contest_package.py
+git commit -m "refactor(contest): build statements under buildDir/statements (#353)"
+```
+
+---
+
+### Task 3: Final verification
+
+**Step 1:** Re-read the issue and design doc; confirm both inconsistencies are resolved (buildDir honored + folder renamed).
+
+**Step 2:** Run the broader contest + statements + naming suites once more:
+`uv run pytest tests/rbx/box/contest tests/rbx/box/statements tests/rbx/box/test_naming.py -q`
+Expected: PASS.
+
+**Step 3:** Grep for any remaining hardcoded contest build literals:
+`grep -rn "statement_build\|pathlib.Path('build')" rbx/box/contest/`
+Expected: no matches.

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -36,7 +36,7 @@ from rbx.box import (
 )
 from rbx.box.contest import contest_state
 from rbx.box.contest import main as contest
-from rbx.box.contest.contest_package import find_contest_yaml
+from rbx.box.contest.contest_package import find_contest_yaml, get_contest_build_path
 from rbx.box.environment import VerificationLevel, get_app_environment_path
 from rbx.box.generation_schema import get_parsed_entry
 from rbx.box.header import generate_header
@@ -1373,6 +1373,7 @@ def _clear_package_cache():
         _clean(package.get_problem_cache_path())
 
     if cd.is_contest_package():
+        _clean(get_contest_build_path())
         console.console.print(
             '[warning]If you want to clear the problem caches of all problems in the contest, '
             'run [item]rbx contest each clean[/item].[/warning]'

--- a/rbx/box/contest/build_contest_statements.py
+++ b/rbx/box/contest/build_contest_statements.py
@@ -10,7 +10,11 @@ import typer
 from rbx import console
 from rbx.box import cd, limits_info, naming, package_utils
 from rbx.box.contest import statement_overriding
-from rbx.box.contest.contest_package import get_problems
+from rbx.box.contest.contest_package import (
+    get_contest_build_path,
+    get_contest_statements_build_path,
+    get_problems,
+)
 from rbx.box.contest.schema import Contest, ContestProblem, ContestStatement
 from rbx.box.fields import Primitive
 from rbx.box.formatting import href
@@ -381,7 +385,7 @@ async def build_statement_rooted(
 
 
 def get_statement_build_dir(statement: ContestStatement) -> pathlib.Path:
-    return pathlib.Path('build') / 'statement_build' / statement.name
+    return get_contest_statements_build_path() / statement.name
 
 
 async def build_statement(
@@ -407,7 +411,7 @@ async def build_statement(
         install_tex=install_tex,
     )
 
-    statement_path = (pathlib.Path('build') / statement.name).with_suffix(
+    statement_path = (get_contest_build_path() / statement.name).with_suffix(
         last_output.get_file_suffix()
     )
     active_profile = limits_info.get_active_profile()

--- a/rbx/box/contest/contest_package.py
+++ b/rbx/box/contest/contest_package.py
@@ -6,7 +6,7 @@ import ruyaml
 import typer
 
 from rbx import console, utils
-from rbx.box import cd
+from rbx.box import cd, environment
 from rbx.box.contest.contest_state import is_valid_variant_id
 from rbx.box.contest.schema import Contest
 from rbx.box.package import find_problem_package_or_die
@@ -207,6 +207,18 @@ def find_contest(
     if found is None:
         _die_no_contest(root)
     return found.parent
+
+
+@functools.cache
+def get_contest_build_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
+    return find_contest(root) / environment.get_build_dir()
+
+
+@functools.cache
+def get_contest_statements_build_path(
+    root: pathlib.Path = pathlib.Path(),
+) -> pathlib.Path:
+    return get_contest_build_path(root) / 'statements'
 
 
 def within_contest(func):

--- a/rbx/box/packaging/contest_main.py
+++ b/rbx/box/packaging/contest_main.py
@@ -79,7 +79,10 @@ async def run_contest_packager(
         limits_info.use_profile(contest_packager_cls.name()),
     ):
         result_path = packager.package(
-            built_packages, pathlib.Path('build'), pathlib.Path(td), built_statements
+            built_packages,
+            contest_package.get_contest_build_path(),
+            pathlib.Path(td),
+            built_statements,
         )
 
     console.console.print(

--- a/rbx/box/presets/__init__.py
+++ b/rbx/box/presets/__init__.py
@@ -656,12 +656,14 @@ def get_preset_build_dir(env_path: Optional[pathlib.Path]) -> pathlib.Path:
     """Resolve the buildDir configured by a preset's env.rbx.yml.
 
     Used when stripping build artifacts from a copied preset/package so a
-    custom buildDir (not just the default 'build') is removed and never leaks
-    into the generated tree. Only the buildDir field is read, so a stub or
-    partially-specified env still resolves; a missing/unset value falls back to
-    the default 'build'.
+    custom buildDir is removed and never leaks into the generated tree. Only the
+    buildDir field is read, so a stub or partially-specified env still resolves;
+    a missing/unset value falls back to the env schema's default buildDir.
     """
-    default = pathlib.Path('build')
+    # Lazy import: rbx.box.environment imports this module.
+    from rbx.box.environment import Environment
+
+    default = Environment.model_fields['buildDir'].default
     if env_path is None or not env_path.is_file():
         return default
     data = yaml.safe_load(env_path.read_text())

--- a/rbx/box/presets/__init__.py
+++ b/rbx/box/presets/__init__.py
@@ -652,15 +652,38 @@ def clean_copied_package_dir(dest: pathlib.Path):
         lock.unlink(missing_ok=True)
 
 
-def clean_copied_contest_dir(dest: pathlib.Path, delete_local_rbx: bool = True):
-    shutil.rmtree(str(dest / 'build'), ignore_errors=True)
+def get_preset_build_dir(env_path: Optional[pathlib.Path]) -> pathlib.Path:
+    """Resolve the buildDir configured by a preset's env.rbx.yml.
+
+    Used when stripping build artifacts from a copied preset/package so a
+    custom buildDir (not just the default 'build') is removed and never leaks
+    into the generated tree. Only the buildDir field is read, so a stub or
+    partially-specified env still resolves; a missing/unset value falls back to
+    the default 'build'.
+    """
+    default = pathlib.Path('build')
+    if env_path is None or not env_path.is_file():
+        return default
+    data = yaml.safe_load(env_path.read_text())
+    build_dir = data.get('buildDir') if isinstance(data, dict) else None
+    return pathlib.Path(build_dir) if build_dir else default
+
+
+def clean_copied_contest_dir(
+    dest: pathlib.Path,
+    delete_local_rbx: bool = True,
+    build_dir: pathlib.Path = pathlib.Path('build'),
+):
+    shutil.rmtree(str(dest / build_dir), ignore_errors=True)
     if delete_local_rbx:
         shutil.rmtree(str(dest / '.local.rbx'), ignore_errors=True)
     clean_copied_package_dir(dest)
 
 
-def clean_copied_problem_dir(dest: pathlib.Path):
-    shutil.rmtree(str(dest / 'build'), ignore_errors=True)
+def clean_copied_problem_dir(
+    dest: pathlib.Path, build_dir: pathlib.Path = pathlib.Path('build')
+):
+    shutil.rmtree(str(dest / build_dir), ignore_errors=True)
     clean_copied_package_dir(dest)
 
 
@@ -702,14 +725,18 @@ def install_preset_from_dir(
         (dest / 'preset.rbx.yml').write_text(utils.model_to_yaml(preset))
 
     # Clean up all cache and left over directories before copying
-    # to avoid conflicts.
-    shutil.rmtree(str(dest / 'build'), ignore_errors=True)
+    # to avoid conflicts. Resolve the build dir from the preset's own env so a
+    # custom buildDir is stripped instead of the default 'build'.
+    build_dir = get_preset_build_dir(
+        dest / preset.env if preset.env is not None else None
+    )
+    shutil.rmtree(str(dest / build_dir), ignore_errors=True)
     shutil.rmtree(str(dest / '.local.rbx'), ignore_errors=True)
 
     if preset.contest is not None:
-        clean_copied_contest_dir(dest / preset.contest)
+        clean_copied_contest_dir(dest / preset.contest, build_dir=build_dir)
     if preset.problem is not None:
-        clean_copied_problem_dir(dest / preset.problem)
+        clean_copied_problem_dir(dest / preset.problem, build_dir=build_dir)
 
     clean_copied_package_dir(dest)
 
@@ -1002,7 +1029,11 @@ def install_contest(
         preset.tracking.contest,
         expansions=expansions,
     )
-    clean_copied_contest_dir(dest_pkg, delete_local_rbx=False)
+    clean_copied_contest_dir(
+        dest_pkg,
+        delete_local_rbx=False,
+        build_dir=get_preset_build_dir(get_preset_environment_path(dest_pkg)),
+    )
     if materialize:
         materialize_libraries(preset, dest_pkg, is_contest=True)
 
@@ -1038,7 +1069,10 @@ def install_problem(
         preset.tracking.problem,
         expansions=expansions,
     )
-    clean_copied_problem_dir(dest_pkg)
+    clean_copied_problem_dir(
+        dest_pkg,
+        build_dir=get_preset_build_dir(get_preset_environment_path(dest_pkg)),
+    )
     if materialize:
         materialize_libraries(preset, dest_pkg, is_contest=False)
 

--- a/rbx/box/stats.py
+++ b/rbx/box/stats.py
@@ -2,6 +2,7 @@ import pathlib
 from typing import Iterable, List, Tuple
 
 from rbx import console
+from rbx.box import environment
 from rbx.box.cd import (
     find_all_ancestor_packages,
     is_contest_package,
@@ -59,9 +60,11 @@ def get_cache_size(root: pathlib.Path = pathlib.Path()) -> int:
 
 
 def _get_build_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
-    if not is_problem_package(root):
-        return root / 'build'
-    return get_build_path(root)
+    if is_problem_package(root):
+        return get_build_path(root)
+    # Contests (and other packages) honor the same configurable buildDir; resolve
+    # it against the package root directly to avoid contest-variant lookups here.
+    return root / environment.get_build_dir()
 
 
 def get_build_size(root: pathlib.Path = pathlib.Path()) -> int:

--- a/tests/rbx/box/contest/test_contest_package.py
+++ b/tests/rbx/box/contest/test_contest_package.py
@@ -340,6 +340,18 @@ class TestContestBuildPaths:
                 == tmp_path / 'out' / 'statements'
             )
 
+    def test_statement_build_dir_uses_statements_folder(self, tmp_path: pathlib.Path):
+        from rbx.box.contest import build_contest_statements
+        from rbx.box.contest.schema import ContestStatement
+
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+        statement = ContestStatement(name='main')
+
+        with cp_module.cd.new_package_cd(tmp_path):
+            result = build_contest_statements.get_statement_build_dir(statement)
+
+        assert result == tmp_path / 'build' / 'statements' / 'main'
+
 
 class TestFindContestPackageOrDieDispatcher:
     def test_die_lists_available_variants(self, tmp_path, capsys):

--- a/tests/rbx/box/contest/test_contest_package.py
+++ b/tests/rbx/box/contest/test_contest_package.py
@@ -300,6 +300,47 @@ class TestFindContestYamlVariantAware:
             cp_module.find_contest_yaml.cache_clear()
 
 
+class TestContestBuildPaths:
+    @pytest.fixture(autouse=True)
+    def _clear_caches(self):
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.get_contest_build_path.cache_clear()
+        cp_module.get_contest_statements_build_path.cache_clear()
+        yield
+        cp_module.find_contest_yaml.cache_clear()
+        cp_module.get_contest_build_path.cache_clear()
+        cp_module.get_contest_statements_build_path.cache_clear()
+
+    def test_build_path_uses_default_build_dir(self, tmp_path: pathlib.Path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+
+        assert cp_module.get_contest_build_path(tmp_path) == tmp_path / 'build'
+
+    def test_statements_build_path_under_build(self, tmp_path: pathlib.Path):
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+
+        assert (
+            cp_module.get_contest_statements_build_path(tmp_path)
+            == tmp_path / 'build' / 'statements'
+        )
+
+    def test_build_path_honors_custom_build_dir(self, tmp_path: pathlib.Path):
+        from unittest import mock
+
+        (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+
+        with mock.patch.object(
+            cp_module.environment, 'get_build_dir', return_value=pathlib.Path('out')
+        ):
+            cp_module.get_contest_build_path.cache_clear()
+            cp_module.get_contest_statements_build_path.cache_clear()
+            assert cp_module.get_contest_build_path(tmp_path) == tmp_path / 'out'
+            assert (
+                cp_module.get_contest_statements_build_path(tmp_path)
+                == tmp_path / 'out' / 'statements'
+            )
+
+
 class TestFindContestPackageOrDieDispatcher:
     def test_die_lists_available_variants(self, tmp_path, capsys):
         (tmp_path / 'contest.rbx.yml').write_text('use_variants: true\n')

--- a/tests/rbx/box/presets/test_presets.py
+++ b/tests/rbx/box/presets/test_presets.py
@@ -8,6 +8,7 @@ This module tests preset management functionality including:
 - Lock file generation and syncing
 """
 
+import shutil
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Iterator, Optional
@@ -581,6 +582,29 @@ class TestPresetInstallation:
         assert not (dst / '.local.rbx').exists()
         assert not (dst / 'problem' / CACHE_DIR_NAME).exists()
 
+    def test_install_preset_cleans_custom_build_dir(
+        self, tmp_path, simple_preset_testdata
+    ):
+        """A preset whose env sets a custom buildDir must have THAT dir stripped."""
+        # Copy the preset and point its env at a custom buildDir.
+        src = tmp_path / 'src'
+        shutil.copytree(simple_preset_testdata, src)
+        env_path = src / 'env.rbx.yml'
+        env_path.write_text(env_path.read_text() + '\nbuildDir: out\n')
+
+        dst = tmp_path / 'installed'
+        dst.mkdir()
+        # Stale custom-buildDir artifacts at the root and each package.
+        (dst / 'out').mkdir()
+        (dst / 'problem' / 'out').mkdir(parents=True)
+        (dst / 'contest' / 'out').mkdir(parents=True)
+
+        presets.install_preset_from_dir(src, dst, update=True)
+
+        assert not (dst / 'out').exists()
+        assert not (dst / 'problem' / 'out').exists()
+        assert not (dst / 'contest' / 'out').exists()
+
     def test_install_problem_package(self, tmp_path, simple_preset_testdata):
         """Should install problem package files correctly."""
         package_dir = tmp_path / 'package'
@@ -917,6 +941,44 @@ class TestCleanupFunctions:
         assert not (tmp_path / 'build').exists()
         assert not (tmp_path / CACHE_DIR_NAME).exists()
         assert (tmp_path / 'main.cpp').exists()
+
+    def test_clean_copied_problem_dir_custom_build_dir(self, tmp_path):
+        """Should clean the configured build dir, not the hardcoded 'build'."""
+        (tmp_path / 'out' / 'tests').mkdir(parents=True)
+        (tmp_path / 'main.cpp').touch()
+
+        presets.clean_copied_problem_dir(tmp_path, build_dir=Path('out'))
+
+        assert not (tmp_path / 'out').exists()
+        assert (tmp_path / 'main.cpp').exists()
+
+    def test_clean_copied_contest_dir_custom_build_dir(self, tmp_path):
+        """Should clean the configured build dir, not the hardcoded 'build'."""
+        (tmp_path / 'out' / 'statements').mkdir(parents=True)
+        (tmp_path / 'contest.rbx.yml').touch()
+
+        presets.clean_copied_contest_dir(tmp_path, build_dir=Path('out'))
+
+        assert not (tmp_path / 'out').exists()
+        assert (tmp_path / 'contest.rbx.yml').exists()
+
+
+class TestPresetBuildDir:
+    """Resolution of a preset's configured buildDir from its env.rbx.yml."""
+
+    def test_reads_custom_build_dir_from_env(self, tmp_path):
+        (tmp_path / 'env.rbx.yml').write_text('buildDir: out\n')
+
+        assert presets.get_preset_build_dir(tmp_path / 'env.rbx.yml') == Path('out')
+
+    def test_defaults_to_build_when_unset(self, tmp_path):
+        (tmp_path / 'env.rbx.yml').write_text('languages: []\n')
+
+        assert presets.get_preset_build_dir(tmp_path / 'env.rbx.yml') == Path('build')
+
+    def test_defaults_to_build_when_no_env(self, tmp_path):
+        assert presets.get_preset_build_dir(None) == Path('build')
+        assert presets.get_preset_build_dir(tmp_path / 'missing.yml') == Path('build')
 
 
 # ==========================

--- a/tests/rbx/box/test_stats.py
+++ b/tests/rbx/box/test_stats.py
@@ -1,0 +1,40 @@
+"""Tests for build path resolution in the stats command."""
+
+import pathlib
+from unittest import mock
+
+from rbx.box import stats
+
+
+def _write_artifact(directory: pathlib.Path, size: int) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / 'artifact.bin').write_bytes(b'x' * size)
+
+
+def test_build_size_problem_honors_custom_build_dir(tmp_path: pathlib.Path):
+    (tmp_path / 'problem.rbx.yml').write_text('name: prob\n')
+    _write_artifact(tmp_path / 'out', 50)
+
+    with mock.patch(
+        'rbx.box.environment.get_build_dir', return_value=pathlib.Path('out')
+    ):
+        assert stats.get_build_size(tmp_path) == 50
+
+
+def test_build_size_contest_honors_custom_build_dir(tmp_path: pathlib.Path):
+    (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+    _write_artifact(tmp_path / 'out', 100)
+
+    # Without honoring buildDir, this would look in tmp_path/'build' (empty) -> 0.
+    with mock.patch(
+        'rbx.box.environment.get_build_dir', return_value=pathlib.Path('out')
+    ):
+        assert stats.get_build_size(tmp_path) == 100
+
+
+def test_build_size_contest_default_ignores_custom_dir(tmp_path: pathlib.Path):
+    (tmp_path / 'contest.rbx.yml').write_text('name: my-contest\n')
+    # Default buildDir is 'build'; artifacts under 'out' must not be counted.
+    _write_artifact(tmp_path / 'out', 100)
+
+    assert stats.get_build_size(tmp_path) == 0


### PR DESCRIPTION
## Summary

Closes #353.

Consolidates the contest build-folder layout to match problems, and makes **all** build-dir references honor the configurable `buildDir`.

**Statements (the originally-scoped inconsistency):**
- Contests hardcoded `pathlib.Path('build')` for statement intermediates and ignored `buildDir`; they now resolve it.
- Contests wrote intermediates to `build/statement_build/<name>`; problems use `build/statements/<name>`. Contests now use `build/statements/<name>` too.

New cached helpers in `contest_package.py` mirror the problem-side helpers in `package.py`:
- `get_contest_build_path()` → `find_contest(root) / environment.get_build_dir()`
- `get_contest_statements_build_path()` → that `/ 'statements'`

**Other contest sites that also hardcoded `build`** (now honor `buildDir`):
- `packaging/contest_main.py` — the contest package **output dir** (where the final contest `.zip` is written).
- `stats.py` — the `rbx stats` build-size report for contests.
- `cli.py` — `rbx clear` now also removes the resolved contest build dir.

**Preset/package cleanup** (`presets/__init__.py`) — when a preset (or a problem/contest created from one) is copied, build artifacts are stripped so they don't leak into the generated tree. This hardcoded `build`; it now reads the **preset's own** `env.rbx.yml` `buildDir` (via a new `get_preset_build_dir`, raw-reading just that field so stub/partial preset envs still resolve) and strips that dir. `clean_copied_{contest,problem}_dir` gained a `build_dir` param (default `build`).

**Deliberately left**: `testing/testing_package.py` (test-only helper; tests run with the default env).

Final output (`<buildDir>/<name>.<suffix>`) is unchanged. No on-disk migration — `build/` is gitignored and regenerable. The issue text describes an older state (`build.rbx/` for problems); since then the problem build dir became the configurable `buildDir` (default `build`), so the above is what actually remained to consolidate.

Design + plan docs: `docs/plans/2026-06-08-consolidate-build-folders-design.md`, `docs/plans/2026-06-08-consolidate-build-folders.md`.

## Test Plan

- [x] New unit tests for the contest path helpers (default + custom `buildDir`) and `get_statement_build_dir` → `build/statements/<name>`.
- [x] New `tests/rbx/box/test_stats.py` — contest/problem build size honors a custom `buildDir` and ignores stale default-name dirs.
- [x] New preset tests — `get_preset_build_dir` resolution, `clean_copied_*` with a custom `build_dir`, and an end-to-end `install_preset_from_dir` that strips a custom buildDir at root + each package.
- [x] `uv run pytest tests/rbx/box/presets tests/rbx/box/contest tests/rbx/box/statements tests/rbx/box/test_stats.py tests/rbx/box/test_naming.py` — 548 passed.
- [x] `uv run pytest tests/rbx/box/packaging` — 298 passed, 1 xfailed (3 docker-compose BOCA e2e errors are local infra, unrelated).
- [x] `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
