### PR TITLE
statements v2: phase 2 + 3 — engine core, standalone & contest builds (#560-#566)

### DIFF
--- a/rbx/box/contest/build_contest_statements.py
+++ b/rbx/box/contest/build_contest_statements.py
@@ -28,6 +28,7 @@ from rbx.box.contest.contest_package import (
     get_contest_statements_build_path,
 )
 from rbx.box.contest.schema import Contest, ContestProblem, ContestStatement, Document
+from rbx.box.exception import RbxException
 from rbx.box.formatting import href
 from rbx.box.sanitizers import issue_stack
 from rbx.box.sanitizers.issue_stack import Issue
@@ -141,6 +142,11 @@ async def build_statement(
                 use_samples,
                 custom_vars,
             )
+        except (typer.Exit, RbxException):
+            # Hard config/abort errors (e.g. a missing matching statement, or
+            # conflicting explanation files) must surface, not be downgraded to a
+            # per-problem skip.
+            raise
         except Exception as exc:
             console.console.print(
                 f'[error]Error building statement for problem '

--- a/rbx/box/contest/build_contest_statements.py
+++ b/rbx/box/contest/build_contest_statements.py
@@ -1,28 +1,48 @@
-"""Contest statement building.
+"""Contest statement building (statements v2, design §6.2, issue #566).
 
-statements v2: this module is rebuilt in #566 (S10) — the recursive overlay
-join via `\\subimport` (design §6.2). The old v1 pipeline depended on the
-removed schema fields (`joiner`/`match`/`steps`/`configure`/`assets`/`override`)
-and on the deleted `statement_overriding` module, so its body is intentionally
-stubbed here. Only the symbols imported elsewhere are kept:
+Assembles the recursive overlay and joins the problems via ``\\subimport``:
 
-- ``StatementBuildIssue`` — used by ``contest/statements.py`` to flag failures.
-- ``build_statement`` — the contest-statement entry point.
-- ``get_statement_build_dir`` — the per-statement build directory (still valid).
+- contest chrome is overlaid at the shared root;
+- each problem is staged isolated under ``.problems/<SHORT>/`` and rendered with
+  the contest's ``contestProblemTemplate`` into a ``statement.tex`` *fragment*;
+- the contest ``file`` template is rendered with the ``problems`` list and
+  ``\\subimport``s each fragment via its ``import_dir`` / ``import_file`` handles;
+- the whole overlay is compiled from the root, so paths stay portable.
+
+``documents`` (infosheets etc.) are emitted with :func:`build_document` — they
+never join on problems.
 """
 
 import pathlib
+import shutil
+import typing
 from typing import Any, Dict, List, Optional, Tuple
 
-from rbx.box.contest.contest_package import get_contest_statements_build_path
-from rbx.box.contest.schema import Contest, ContestProblem, ContestStatement
-from rbx.box.sanitizers.issue_stack import Issue
-from rbx.box.statements.schema import StatementType
+import typer
 
-_V2_PENDING = (
-    'statements v2: the contest-statement join is not wired yet; it lands in '
-    '#566 (S10). See docs/plans/2026-06-09-statements-v2-design.md §6.2.'
+from rbx import console
+from rbx.box import cd, limits_info, naming, package, package_utils
+from rbx.box.contest.contest_package import (
+    find_contest,
+    get_contest_build_path,
+    get_contest_statements_build_path,
 )
+from rbx.box.contest.schema import Contest, ContestProblem, ContestStatement, Document
+from rbx.box.formatting import href
+from rbx.box.sanitizers import issue_stack
+from rbx.box.sanitizers.issue_stack import Issue
+from rbx.box.statements import engine, overlay, render, resolver
+from rbx.box.statements.build_statements import (
+    get_environment_languages_for_statement,
+)
+from rbx.box.statements.context import (
+    ContestRenderContext,
+    ProblemRenderContext,
+    contest_jinja_kwargs,
+)
+from rbx.box.statements.overlay import problem_overlay_dir
+from rbx.box.statements.schema import BaseStatement, StatementType
+from rbx.box.testcase_sample_utils import get_statement_samples
 
 
 class StatementBuildIssue(Issue):
@@ -36,8 +56,38 @@ class StatementBuildIssue(Issue):
         return f'Error building statement for problem [item]{self.problem.short_name}[/item].'
 
 
-def get_statement_build_dir(statement: ContestStatement) -> pathlib.Path:
-    return get_contest_statements_build_path() / statement.name
+def get_statement_build_dir(statement: BaseStatement) -> pathlib.Path:
+    return get_contest_statements_build_path() / statement.name  # type: ignore[attr-defined]
+
+
+def _explanation_suffix(statement_type: StatementType) -> str:
+    return '.md' if statement_type == StatementType.rbxMarkdown else '.tex'
+
+
+def _contest_output_path(name: str, output_type: StatementType) -> pathlib.Path:
+    path = (get_contest_build_path() / name).with_suffix(output_type.get_file_suffix())
+    active_profile = limits_info.get_active_profile()
+    if (
+        active_profile is not None
+        and limits_info.get_saved_limits_profile(active_profile) is not None
+    ):
+        path = path.with_stem(f'{path.stem}-{active_profile}')
+    return path
+
+
+def _fresh_dir(path: pathlib.Path) -> pathlib.Path:
+    shutil.rmtree(path, ignore_errors=True)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _problems_to_build(
+    contest: Contest, problems_of_interest: Optional[List[ContestProblem]]
+) -> List[ContestProblem]:
+    if problems_of_interest is None:
+        return list(contest.problems)
+    wanted = {p.short_name for p in problems_of_interest}
+    return [p for p in contest.problems if p.short_name in wanted]
 
 
 async def build_statement(
@@ -49,4 +99,238 @@ async def build_statement(
     custom_vars: Optional[Dict[str, Any]] = None,
     install_tex: bool = False,
 ) -> pathlib.Path:
-    raise NotImplementedError(_V2_PENDING)
+    output_type = output_type or StatementType.PDF
+    custom_vars = custom_vars or {}
+    languages = get_environment_languages_for_statement()
+    contest_root = find_contest()
+
+    if not statement.type.is_rbx():
+        # A non-rbx contest statement is emitted like a document (no join).
+        return _emit_simple(statement, contest, output_type, custom_vars)
+
+    assert statement.file is not None
+    overlay_root = _fresh_dir(get_statement_build_dir(statement))
+    chrome_dir = (contest_root / statement.file).resolve().parent
+    overlay.stage_chrome(overlay_root, chrome_dir)
+
+    contest_ctx = ContestRenderContext(
+        title=naming.get_contest_title(
+            lang=statement.language, statement=statement, contest=contest
+        ),
+        vars=contest.expanded_vars,
+        params=statement.expanded_vars,
+        location=statement.location,
+        date=statement.date,
+    )
+
+    problem_ctxs: List[ProblemRenderContext] = []
+    for problem in _problems_to_build(contest, problems_of_interest):
+        console.console.print(
+            f'Building statement for problem [item]{problem.short_name}[/item]...'
+        )
+        try:
+            problem_ctx = await _render_problem_fragment_async(
+                statement,
+                contest,
+                problem,
+                overlay_root,
+                chrome_dir,
+                contest_root,
+                contest_ctx,
+                languages,
+                use_samples,
+                custom_vars,
+            )
+        except Exception as exc:
+            console.console.print(
+                f'[error]Error building statement for problem '
+                f'[item]{problem.short_name}[/item]: {exc}[/error]'
+            )
+            issue_stack.add_issue(StatementBuildIssue(problem))
+            continue
+        if problem_ctx is not None:
+            problem_ctxs.append(problem_ctx)
+
+    template_rel = (contest_root / statement.file).resolve().name
+    contest_doc = render.render_contest_document(
+        overlay_root,
+        template_rel,
+        lang=statement.language,
+        languages=languages,
+        contest=contest_ctx,
+        problems=problem_ctxs,
+    )
+
+    if install_tex:
+        from rbx.box.statements import latex
+
+        tmp = overlay_root / '__install__.tex'
+        tmp.write_bytes(contest_doc)
+        latex.install_tex_packages(tmp, overlay_root)
+
+    output_bytes = _finish(overlay_root, contest_doc, output_type)
+    out_path = _contest_output_path(statement.name, output_type)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(output_bytes)
+    console.console.print(
+        f'[success]Contest statement [item]{statement.name}[/item] built for language '
+        f'[item]{statement.language}[/item] at {href(out_path)}[/success]'
+    )
+    return out_path
+
+
+async def _render_problem_fragment_async(
+    contest_statement: ContestStatement,
+    contest: Contest,
+    problem: ContestProblem,
+    overlay_root: pathlib.Path,
+    chrome_dir: pathlib.Path,
+    contest_root: pathlib.Path,
+    contest_ctx: ContestRenderContext,
+    languages,
+    use_samples: bool,
+    custom_vars: Dict[str, Any],
+) -> Optional[ProblemRenderContext]:
+    with cd.new_package_cd(problem.get_path()):
+        package_utils.clear_package_cache()
+        pkg = package.find_problem_package_or_die()
+        problem_statement = resolver.select_problem_statement(
+            contest_statement, pkg.expanded_statements, problem.short_name
+        )
+
+        assert problem_statement.file is not None
+        problem_dir = (problem_statement.file).resolve().parent
+
+        short = problem.short_name
+        problem_root = problem_overlay_dir(overlay_root, short)
+        root_prefix = f'.problems/{short}/'
+        overlay.stage_join_problem(overlay_root, problem_dir, short)
+
+        assert contest_statement.contestProblemTemplate is not None
+        template_rel = engine.relativize_template(
+            contest_root,
+            chrome_dir,
+            contest_statement.contestProblemTemplate,
+            overlay_root,
+        )
+
+        problem_ctx = ProblemRenderContext(
+            title=naming.get_problem_title(
+                problem_statement.language, problem_statement, pkg
+            ),
+            vars={**pkg.expanded_vars, **custom_vars},
+            params=problem_statement.expanded_params,
+            short_name=short,
+            limits=limits_info.get_limits_profile(
+                profile=limits_info.get_active_profile()
+            ),
+            profiles=limits_info.get_available_limits_profiles(),
+            groups={g.name: g for g in pkg.testcases},
+            import_dir=root_prefix,
+            import_file='statement',
+        )
+
+        samples = (
+            await get_statement_samples(
+                explanation_suffix=_explanation_suffix(problem_statement.type)
+            )
+            if use_samples
+            else []
+        )
+
+        fragment = engine.render_problem_tex(
+            render_root=overlay_root,
+            problem_root=problem_root,
+            root_prefix=root_prefix,
+            template_rel=template_rel,
+            content=problem_statement.file.read_bytes(),
+            lang=problem_statement.language,
+            languages=languages,
+            problem=problem_ctx,
+            contest=contest_ctx,
+            samples=samples,
+            use_samples=use_samples,
+            statement_type=problem_statement.type,
+        )
+        (problem_root / 'statement.tex').write_bytes(fragment)
+        return problem_ctx
+
+
+def _finish(
+    overlay_root: pathlib.Path, tex: bytes, output_type: StatementType
+) -> bytes:
+    if output_type == StatementType.PDF:
+        return render.compile_pdf(overlay_root, tex)
+    if output_type in (StatementType.TeX, StatementType.Markdown):
+        return tex
+    console.console.print(
+        f'[error]statements v2 cannot yet emit contest output type '
+        f'[item]{output_type}[/item].[/error]'
+    )
+    raise typer.Exit(1)
+
+
+def _emit_simple(
+    statement: BaseStatement,
+    contest: Contest,
+    output_type: StatementType,
+    custom_vars: Dict[str, Any],
+) -> pathlib.Path:
+    """Emit a non-joining contest statement/document (jinja or static)."""
+    name: str = statement.name  # type: ignore[attr-defined]
+    assert statement.file is not None
+    languages = get_environment_languages_for_statement()
+    contest_root = find_contest()
+    overlay_root = _fresh_dir(get_contest_statements_build_path() / name)
+    chrome_dir = (contest_root / statement.file).resolve().parent
+    overlay.stage_chrome(overlay_root, chrome_dir)
+    source_rel = (contest_root / statement.file).resolve().name
+
+    contest_ctx = ContestRenderContext(
+        title=naming.get_contest_title(
+            lang=statement.language, statement=None, contest=contest
+        ),
+        vars=contest.expanded_vars,
+        params=statement.expanded_params,
+        location=getattr(statement, 'location', None),
+        date=getattr(statement, 'date', None),
+    )
+
+    if statement.type in (StatementType.JinjaTeX, StatementType.JinjaMarkdown):
+        kwargs = contest_jinja_kwargs(
+            lang=statement.language,
+            languages=languages,
+            contest=contest_ctx,
+            problems=[],
+        )
+        content = render.render_jinja_document(overlay_root, source_rel, kwargs)
+    else:
+        content = (overlay_root / source_rel).read_bytes()
+
+    if statement.type == StatementType.PDF:
+        output_bytes = content
+    elif output_type == StatementType.PDF:
+        if statement.type in (StatementType.Markdown, StatementType.JinjaMarkdown):
+            output_bytes = render.md_to_pdf(overlay_root, content)
+        else:
+            output_bytes = render.compile_pdf(overlay_root, content)
+    else:
+        output_bytes = content
+
+    out_path = _contest_output_path(name, output_type)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(typing.cast(bytes, output_bytes))
+    console.console.print(
+        f'[success]Document [item]{name}[/item] built at {href(out_path)}[/success]'
+    )
+    return out_path
+
+
+async def build_document(
+    document: Document,
+    contest: Contest,
+    output_type: Optional[StatementType] = None,
+    custom_vars: Optional[Dict[str, Any]] = None,
+) -> pathlib.Path:
+    output_type = output_type or StatementType.PDF
+    return _emit_simple(document, contest, output_type, custom_vars or {})

--- a/rbx/box/contest/build_contest_statements.py
+++ b/rbx/box/contest/build_contest_statements.py
@@ -47,6 +47,9 @@ from rbx.box.testcase_sample_utils import get_statement_samples
 
 
 class StatementBuildIssue(Issue):
+    """An issue-stack entry flagging that a problem's statement failed to build,
+    surfaced in the contest build overview."""
+
     def __init__(self, problem: ContestProblem):
         self.problem = problem
 
@@ -58,14 +61,19 @@ class StatementBuildIssue(Issue):
 
 
 def get_statement_build_dir(statement: BaseStatement) -> pathlib.Path:
+    """The per-statement scratch overlay root under the contest's
+    ``build/statements`` dir (keyed by the contest statement/document name)."""
     return get_contest_statements_build_path() / statement.name  # type: ignore[attr-defined]
 
 
 def _explanation_suffix(statement_type: StatementType) -> str:
+    """The on-disk suffix of a sample's explanation file for this statement type."""
     return '.md' if statement_type == StatementType.rbxMarkdown else '.tex'
 
 
 def _contest_output_path(name: str, output_type: StatementType) -> pathlib.Path:
+    """The final output path for a contest statement/document at the contest
+    build root, e.g. ``build/<name>[-<profile>].pdf``."""
     path = (get_contest_build_path() / name).with_suffix(output_type.get_file_suffix())
     active_profile = limits_info.get_active_profile()
     if (
@@ -77,6 +85,7 @@ def _contest_output_path(name: str, output_type: StatementType) -> pathlib.Path:
 
 
 def _fresh_dir(path: pathlib.Path) -> pathlib.Path:
+    """Wipe and recreate ``path`` (a clean scratch overlay root)."""
     shutil.rmtree(path, ignore_errors=True)
     path.mkdir(parents=True, exist_ok=True)
     return path
@@ -85,6 +94,9 @@ def _fresh_dir(path: pathlib.Path) -> pathlib.Path:
 def _problems_to_build(
     contest: Contest, problems_of_interest: Optional[List[ContestProblem]]
 ) -> List[ContestProblem]:
+    """The contest problems to include in the join: all of them, or the subset in
+    ``problems_of_interest`` (e.g. those whose samples built, or that define the
+    selected timing profile) when provided."""
     if problems_of_interest is None:
         return list(contest.problems)
     wanted = {p.short_name for p in problems_of_interest}
@@ -100,6 +112,25 @@ async def build_statement(
     custom_vars: Optional[Dict[str, Any]] = None,
     install_tex: bool = False,
 ) -> pathlib.Path:
+    """Build one contest statement and return its output path.
+
+    For an *rbx* statement this assembles the join overlay (design §6.2): contest
+    chrome at the root, each problem staged isolated under ``.problems/<SHORT>/``
+    and rendered to a ``statement.tex`` *fragment* via the
+    ``contestProblemTemplate``, then the contest ``file`` template rendered with
+    the ``problems`` list ``\\subimport``-ing each fragment, compiled from the
+    root. A non-rbx contest statement is emitted like a document (no join).
+
+    Args:
+        statement: the (expanded) contest statement to build.
+        contest: the loaded contest package.
+        problems_of_interest: restrict the join to these problems (default: all);
+            see :func:`_problems_to_build`.
+        output_type: desired output (default ``PDF``).
+        use_samples: stage sample I/O (assumes samples were already built).
+        custom_vars: ``--vars`` overrides merged on top of each problem's vars.
+        install_tex: best-effort ``texliveonfly`` install before compiling.
+    """
     output_type = output_type or StatementType.PDF
     custom_vars = custom_vars or {}
     languages = get_environment_languages_for_statement()
@@ -197,6 +228,16 @@ async def _render_problem_fragment_async(
     use_samples: bool,
     custom_vars: Dict[str, Any],
 ) -> Optional[ProblemRenderContext]:
+    """Stage + render one problem's fragment for the join.
+
+    Runs inside the problem's directory (to resolve its package, samples and
+    limits), mirrors the problem statement-dir into ``.problems/<SHORT>/``,
+    renders the ``contestProblemTemplate`` fragment to
+    ``.problems/<SHORT>/statement.tex``, and returns the problem's render context
+    carrying the ``import_dir``/``import_file`` ``\\subimport`` handles for the
+    contest document. ``overlay_root``/``chrome_dir``/``contest_root`` are
+    absolute (computed at contest cwd) so they survive the ``cd``.
+    """
     with cd.new_package_cd(problem.get_path()):
         package_utils.clear_package_cache()
         pkg = package.find_problem_package_or_die()
@@ -265,6 +306,8 @@ async def _render_problem_fragment_async(
 def _finish(
     overlay_root: pathlib.Path, tex: bytes, output_type: StatementType
 ) -> bytes:
+    """Turn the rendered contest TeX into the requested output (compile to PDF, or
+    return the TeX as-is)."""
     if output_type == StatementType.PDF:
         return render.compile_pdf(overlay_root, tex)
     if output_type in (StatementType.TeX, StatementType.Markdown):
@@ -338,5 +381,10 @@ async def build_document(
     output_type: Optional[StatementType] = None,
     custom_vars: Optional[Dict[str, Any]] = None,
 ) -> pathlib.Path:
+    """Build a contest document (infosheet etc.) and return its output path.
+
+    Documents never join on problems; this renders the Jinja (or copies the
+    static) source against the contest context and emits it (default ``PDF``).
+    """
     output_type = output_type or StatementType.PDF
     return _emit_simple(document, contest, output_type, custom_vars or {})

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -7,6 +7,7 @@ from rbx import annotations, console
 from rbx.box import cd, environment, limits_info, package_utils
 from rbx.box.contest.build_contest_statements import (
     StatementBuildIssue,
+    build_document,
     build_statement,
 )
 from rbx.box.contest.contest_package import (
@@ -158,10 +159,27 @@ async def build(
                 )
             )
 
+    # Documents (infosheets etc.) are emitted without joining on problems.
+    built_documents = []
+    valid_documents = [doc for doc in contest.expanded_documents if should_process(doc)]
+    for document in valid_documents:
+        built_documents.append(
+            await build_document(
+                document,
+                contest,
+                output_type=output,
+                custom_vars=expand_any_vars(annotations.parse_dictionary_items(vars)),
+            )
+        )
+
     console.console.rule(title='Built statements')
     for statement, built_path in zip(valid_statements, built_statements):
         console.console.print(
             f'[item]{statement.name} {statement.language}[/item] -> {href(built_path)}'
+        )
+    for document, built_path in zip(valid_documents, built_documents):
+        console.console.print(
+            f'[item]{document.name} {document.language}[/item] (document) -> {href(built_path)}'
         )
 
 

--- a/rbx/box/packaging/contest_main.py
+++ b/rbx/box/packaging/contest_main.py
@@ -65,7 +65,7 @@ async def run_contest_packager(
             for language in languages:
                 statement = packager.get_statement_for_language(language)
                 statement_path = build_contest_statements.build_statement(
-                    statement, contest, statement_type
+                    statement, contest, output_type=statement_type
                 )
                 built_statements.append(
                     BuiltContestStatement(statement, statement_path, statement_type)

--- a/rbx/box/packaging/contest_main.py
+++ b/rbx/box/packaging/contest_main.py
@@ -64,7 +64,7 @@ async def run_contest_packager(
             languages = packager.languages()
             for language in languages:
                 statement = packager.get_statement_for_language(language)
-                statement_path = build_contest_statements.build_statement(
+                statement_path = await build_contest_statements.build_statement(
                     statement, contest, output_type=statement_type
                 )
                 built_statements.append(

--- a/rbx/box/statements/CLAUDE.md
+++ b/rbx/box/statements/CLAUDE.md
@@ -1,135 +1,125 @@
 # Statements Module (`rbx/box/statements/`)
 
-Builds problem statements from LaTeX/Jinja templates into PDF, HTML, or Markdown.
+Builds problem & contest statements (and contest documents) from rbxTeX / LaTeX /
+Markdown / Jinja sources into PDF (primarily; TeX/MD too).
 
-## Pipeline Overview
+This module is **statements v2** (design: `docs/plans/2026-06-09-statements-v2-design.md`,
+issue #556). v2 simplified the YAML surface and reworked path resolution around a
+**temp-dir overlay** that every asset resolves into by a plain relative path, joined
+with `\subimport`. There is **no migration** from v1.
 
-```
-problem.rbx.yml (statements config)
-  |
-  v
-schema.py: Statement models define source path, type, conversion steps, vars
-  |
-  v
-expander.py: expand_statements() resolves wildcards and preset inheritance
-  |
-  v
-build_statements.py: execute_build_on_statements() orchestrates the build
-  |
-  +-- For each statement × language × output type:
-  |     1. Copy statement source to build directory
-  |     2. Apply conversion steps in sequence
-  |     3. Produce final output (PDF, HTML, Markdown)
-  |
-  v
-Output files in build directory
-```
+## Core decisions (design §2)
+
+- **A contest is required** to build an *rbx* problem statement: the contest owns
+  the templates. Static types (`tex`/`md`/`pdf`) build standalone without one.
+- **Namespaces don't merge:** `params` (statement's own), `vars` (problem/package
+  or contest), `contest.*` are separate template namespaces (§4).
+- **Path resolution = full overlay, everything relative.** No user TeX is parsed
+  or rewritten; the only injected construct is `\subimport`. pdflatex runs from
+  the overlay **root**, so the generated TeX is portable (§6).
 
 ## Schema (`schema.py`)
 
-### Core Types
+- **`StatementType`** (AutoEnum): `rbxTeX` (default), `rbxMarkdown`, `TeX`,
+  `Markdown`, `JinjaTeX`, `JinjaMarkdown`, `PDF`. `is_rbx()` → the joinable types.
+- **`BaseStatement`** — shared fields: `language`, `variant`, `title`, `file`,
+  `type`, `params` (own namespace), `samples`. `expanded_params` expands `params`.
+- **`Statement`** (problem) — no `name`; identified by `(language, variant)`
+  (unique within a problem). `extends` by language string or `{language, variant}`.
+- **`ContestStatement`** (contest) — adds `name` (unique), `location`, `date`,
+  `standaloneProblemTemplate`, `contestProblemTemplate` (rbx-only). `(language,
+  variant)` need not be unique. `extends` by `name`.
+- **`Document`** (contest) — like a contest statement but never joins; restricted
+  to `DOCUMENT_TYPES` (jinja/static).
 
-- **`StatementType`** -- Enum: `PDF`, `HTML`, `MARKDOWN`
-- **`StatementLanguage`** -- ISO 639-1 language code + display name
-- **`Statement`** -- Pydantic model: `name`, `path` (source file), `type` (PDF/HTML/MD), `language`, `title`, `vars`, `steps`, `configure`
-- **`ConversionStep`** -- Discriminated union (via `type` field):
-  - `rbxToTeX` -- Convert rbxTeX format to standard LaTeX (the main custom format)
-  - `TexToPDF` -- Compile LaTeX to PDF via `pdflatex`
-  - `TexToHTML` -- Convert LaTeX to HTML via `pandoc`
-  - `TexToMarkdown` -- Convert LaTeX to Markdown via `pandoc`
-  - `HtmlToPDF` -- Convert HTML to PDF (via browser/wkhtmltopdf)
-  - `MarkdownToHTML` -- Convert Markdown to HTML via `pandoc`
-  - `MarkdownToPDF` -- Convert Markdown to PDF via `pandoc`
-- **`Joiner`** -- Joins multiple problem statements for contest output
+`expander.py` resolves `extends` via an **allowlist merge** (only the build recipe
+— `type`/`file`/`params` + contest templates — never identity); topo sort with
+cycle/dangling errors. Problem: `Package.expanded_statements`/`expanded_tutorials`;
+contest: `Contest.expanded_statements`/`expanded_tutorials`/`expanded_documents`.
 
-### rbxTeX Format
+## v2 engine modules
 
-The main custom format. An rbxTeX file is a LaTeX file with Jinja2 template syntax:
-- `\VAR{variable}` -- Variable substitution (from `vars` in problem.rbx.yml)
-- `%- for`, `%- if`, `%- block` -- Jinja control flow using `%` line prefix
-- Sample I/O auto-insertion from built test cases
-- `\subimport` for composing multi-file statements
+The build is a pipeline of small, unit-tested pieces:
 
-### Conversion Steps
+- **`resolver.py`** (S7) — contest-aware resolution. `require_contest_for_problem`
+  (hard error outside a contest); `select_standalone_contest_statement` (the single
+  contest statement whose `(language, variant)` carries a `standaloneProblemTemplate`
+  — 0/>1 are errors); `select_problem_statement` (join match by `(language, variant)`
+  + matching rbx type).
+- **`overlay.py`** (S4) — the stager. `mirror_tree`/`merge_tree`;
+  `stage_standalone_overlay` (merged root, collision-detected);
+  `stage_join_problem` (isolated `.problems/<SHORT>/`); `stage_chrome` (contest
+  chrome at root). The *directory containing a statement `file`* is its asset scope.
+- **`context.py`** (S5) — namespaced Jinja kwargs. `ProblemRenderContext` /
+  `ContestRenderContext` / `SampleHandle`; `problem_jinja_kwargs` /
+  `contest_jinja_kwargs` build the `params`/`vars`/`contest`/`problem`/`problems`
+  namespaces + `problem.import_dir`/`import_file` join handles.
+- **`sample_staging.py`** (S6) — per-sample `.samples/<idx>/` folders: `in`/`out`
+  mirrored (root-relative for `\VerbatimInput`), explanation rendered to
+  `explanation.tex` with its source dir overlaid for figures (base-relative for
+  `\subimport`), interactive chunks. Input is the light `SampleSource`.
+- **`render.py`** (S8) — reuses the v1 primitives (block extraction, the LaTeX
+  Jinja env, the `tex→pdf` pdflatex loop) driven by the v2 context.
+  `extract_blocks`, `render_problem_document` (full doc OR fragment),
+  `render_contest_document` (join), `render_jinja_document`, `compile_pdf`,
+  `md_to_pdf`.
+- **`engine.py`** — `render_problem_tex` ties extraction → sample staging →
+  template render for one problem; shared by standalone and join so the same
+  problem rendering is valid in both contexts.
 
-Steps are applied in sequence. Default flow for rbxTeX:
-1. `rbxToTeX` -- Jinja rendering with variable substitution, sample I/O injection
-2. `TexToPDF` -- pdflatex compilation (with optional TikZ externalization)
+## Build entry points
 
-Each step has a `configure` list for step-specific parameters (e.g., `externalize: true` for TikZ extraction in Polygon upload).
+- **`build_statements.py`** (S9) — standalone `rbx st b`:
+  `execute_build` → `execute_build_on_statements` → `build_statement`. For an rbx
+  statement it resolves the contest, stages the merged overlay (contest chrome +
+  problem dir), renders the `standaloneProblemTemplate` (a *full* document),
+  compiles, and writes `build/statement-<lang>[-<variant>].pdf`. Static types are
+  emitted directly.
+- **`contest/build_contest_statements.py`** (S10) — `rbx contest st b`:
+  `build_statement` stages chrome, renders each problem's `contestProblemTemplate`
+  into `.problems/<SHORT>/statement.tex` (a *fragment*), then renders the contest
+  `file` which `\subimport`s each via the import handles; compiles from the root.
+  `build_document` emits documents without joining.
 
-## Build Pipeline (`build_statements.py`)
+## Path resolution (design §6) — the contract proved by the spike (#557)
 
-**`execute_build_on_statements()`** -- Main entry point, called from `packager.py` and `cli.py`.
+- `\subimport`, `\includegraphics`, `\input` are **import-base-relative**;
+  `import.sty` rebases them at every nesting depth (no `\graphicspath`).
+- `\VerbatimInput` (sample I/O) does **not** honor the import base → sample
+  `input`/`output` handles are **root-relative**; the explanation goes through
+  `\subimport` (base-relative). Both are relative → the overlay is portable.
 
-For each statement:
-1. Resolves the statement source path
-2. Creates a build directory
-3. Applies conversion steps sequentially via `builders.py`
-4. Returns `BuiltStatement` objects with paths to output files
+## LaTeX integration (unchanged)
 
-## Builders (`builders.py`)
+- `latex.py` — `Latex.build_pdf(temp_dir)` writes `statement.tex` and runs
+  `pdflatex` with `cwd=temp_dir` (= the overlay root); rerun loop for cross-refs.
+- `latex_jinja.py` — the LaTeX-flavored Jinja2 env (`\VAR{}`, `%-`, `\BLOCK{}`),
+  `JinjaDictWrapper`/`JinjaGroupsGetter`, strict undefined.
 
-Each conversion step has a corresponding builder function:
+## `builders.py` (legacy, kept for the deferred Polygon path)
 
-- **`_build_rbx_to_tex()`** -- The most complex builder:
-  1. Copies source and included files to build dir
-  2. Sets up Jinja environment via `latex_jinja.py` (`jinja2.Environment` with `\VAR{}` syntax, `%-` blocks, `\BLOCK{}`)
-  3. Injects variables: problem vars, samples, language strings
-  4. Renders the template
-  5. Processes `\subimport` directives for multi-file statements
+The v1 `StatementBuilder` classes + `StatementBuilderProblem/Contest` and the
+low-level helpers (`render_jinja`, `render_jinja_blocks`, `StatementBlocks`, TikZ
+externalize helpers) live here. v2 `render.py` reuses the helpers; the builder
+*classes* remain only because the Polygon export path (S12, #568) still imports
+them. `build_statements.get_statement_dir` / `get_produced_tikz_pdfs` /
+`build_statement_bytes` stay stubbed (`NotImplementedError`) until S12.
 
-- **`_build_tex_to_pdf()`** -- Calls `latex.py` to run `pdflatex` (with retry for cross-references)
-- **`_build_tex_to_html()`** / **`_build_tex_to_md()`** -- Uses `pypandoc` for conversion
-- **`_build_html_to_pdf()`** -- HTML to PDF conversion
-- **`_build_md_to_html()`** / **`_build_md_to_pdf()`** -- Markdown conversions via `pypandoc`
+## Template context namespaces (design §4)
 
-## LaTeX Integration
+| Name | Contents | Where |
+|---|---|---|
+| `params` | the statement's own params | all renders |
+| `vars` | problem/package vars (problem) or contest vars (contest) | all renders |
+| `contest` | `title`, `location`, `date`, `contest.vars` | always |
+| `problem` | `title`, `short_name`, `limits`, `profiles`, `groups`, `samples`, `blocks`, `import_dir`, `import_file` | problem renders |
+| `problems` | list of the above | contest join |
+| `lang`, `languages`, `keyed_languages` | env languages | all renders |
 
-### `latex.py`
-- `compile_latex()` -- Runs `pdflatex` with configurable options
-- Handles build retries for cross-references
-- Error extraction from LaTeX log files
+Per-sample handles: `sample.input`/`output` (root-relative), `sample.dir` +
+`sample.explanation_file` (base-relative `\subimport`), `sample.interaction.chunks`.
 
-### `latex_jinja.py`
-- Custom Jinja2 environment configured for LaTeX:
-  - Variable syntax: `\VAR{...}` instead of `{{ ... }}`
-  - Block syntax: `\BLOCK{...}` instead of `{% ... %}`
-  - Comment syntax: `\#{...}`
-  - Line statement prefix: `%-`
-  - Line comment prefix: `%#`
-- `get_latex_jinja_env()` factory function
+## Polygon integration (`polygon_utils.py`)
 
-## Expander (`expander.py`)
-
-`expand_statements()` processes the raw statement list from `problem.rbx.yml`:
-- Resolves wildcard paths to actual files
-- Applies preset-defined default statements
-- Handles statement overrides from contest config
-
-## Joiners (`joiners.py`)
-
-Joins multiple problem statements into a single contest document:
-- Produces combined PDFs for contest printing
-- Handles table of contents, page numbering
-
-## Statement Templates (`rbx/resources/templates/`)
-
-Bundled LaTeX templates:
-- `statements/` -- Default problem statement templates (ICPC style with `icpc.sty`)
-- `contest/` -- Contest-level templates (cover pages, info sheets with limits tables)
-- Templates use Jinja syntax: `\VAR{problem.title}`, `\VAR{problem.limits.timelimit_for_language('cpp')}`
-
-## Polygon Integration (`polygon_utils.py`)
-
-Helpers for extracting statement sections (legend, input, output, notes) for Polygon API upload. Parses LaTeX to extract named blocks.
-
-## Context Variables Available in Templates
-
-- `vars` -- User-defined variables from `problem.rbx.yml`
-- `lang` -- Current language code
-- `problem` -- Problem metadata (title, limits, etc.)
-- `problems` -- (Contest only) List of all problems
-- `contest` -- (Contest only) Contest metadata
-- `samples` -- Auto-generated sample I/O from built test cases
-- `problem.groups` -- Name-keyed accessor over `package.testcases`. Iteration yields `TestcaseGroup` objects in declaration order; lookup by name (`problem.groups.subtask1.score`, `problem.groups['subtask1']`) returns the group or `StrictChainableUndefined` on miss
+Helpers extracting statement sections for Polygon upload — consumed by the
+deferred S12 export path.

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -40,6 +40,8 @@ _V2_POLYGON_PENDING = (
 
 
 def get_environment_languages_for_statement() -> List[StatementCodeLanguage]:
+    """The configured environment languages exposed to templates as ``languages``
+    (id, readable name, and the compile/run command shown in limit tables)."""
     env = environment.get_environment()
 
     res = []
@@ -69,6 +71,8 @@ def get_environment_languages_for_statement() -> List[StatementCodeLanguage]:
 def get_builder(
     name: ConversionType, builder_list: List[StatementBuilder]
 ) -> StatementBuilder:
+    """Look up the (legacy v1) builder for a conversion type, or exit. Kept for
+    the deferred Polygon export path; the v2 build uses ``render.py`` directly."""
     candidates = [builder for builder in builder_list if builder.name() == name]
     if not candidates:
         console.console.print(
@@ -81,6 +85,14 @@ def get_builder(
 def get_implicit_builders(
     input_type: StatementType, output_type: StatementType
 ) -> Optional[List[StatementBuilder]]:
+    """Shortest chain of (legacy v1) builders converting ``input_type`` to
+    ``output_type``, or None if unreachable.
+
+    A BFS over ``BUILDER_LIST`` treating each builder as an edge
+    ``input_type -> output_type``; ``par`` maps a reached type to the builder
+    that produced it, then the chain is walked back from ``output_type``. Legacy
+    v1 machinery kept for the deferred Polygon path.
+    """
     par: Dict[StatementType, Optional[StatementBuilder]] = {input_type: None}
 
     def _iterate() -> bool:
@@ -114,6 +126,8 @@ def get_implicit_builders(
 def _try_implicit_builders(
     statement_id: str, input_type: StatementType, output_type: StatementType
 ) -> List[StatementBuilder]:
+    """Like :func:`get_implicit_builders` but exits with an error message when no
+    conversion chain exists (legacy v1 path)."""
     implicit_builders = get_implicit_builders(input_type, output_type)
     if implicit_builders is None:
         console.console.print(
@@ -139,6 +153,7 @@ def _get_configured_params_for(
 
 
 def merge_conversion_steps(lhs: ConversionStep, rhs: ConversionStep) -> ConversionStep:
+    """Overlay the explicitly-set fields of ``rhs`` onto ``lhs`` (same type)."""
     assert lhs.type == rhs.type
     return lhs.model_copy(update=rhs.model_dump(exclude_unset=True), deep=True)
 
@@ -146,6 +161,8 @@ def merge_conversion_steps(lhs: ConversionStep, rhs: ConversionStep) -> Conversi
 def merge_conversion_configurations(
     configure: Iterable[ConversionStep],
 ) -> List[ConversionStep]:
+    """Collapse a list of conversion steps to one per type, later steps
+    overlaying earlier ones via :func:`merge_conversion_steps`."""
     mapping = {}
     for step in configure:
         if step.type not in mapping:
@@ -159,6 +176,7 @@ def merge_conversion_configuration_maps(
     lhs: Dict[ConversionType, ConversionStep],
     rhs: Dict[ConversionType, ConversionStep],
 ) -> Dict[ConversionType, ConversionStep]:
+    """Merge two type-keyed conversion-step maps, ``rhs`` overlaying ``lhs``."""
     consolidated = merge_conversion_configurations(
         list(lhs.values()) + list(rhs.values())
     )
@@ -180,6 +198,15 @@ def get_builders(
     output_type: Optional[StatementType],
     builder_list: List[StatementBuilder] = BUILDER_LIST,
 ) -> List[Tuple[StatementBuilder, ConversionStep]]:
+    """Resolve the ordered ``(builder, params)`` pipeline that turns
+    ``input_type`` into ``output_type`` (legacy v1 path).
+
+    Walks the explicit ``steps``, inserting implicit conversion builders
+    (:func:`get_implicit_builders`) wherever consecutive types don't line up,
+    then appends implicit builders to reach ``output_type``. Finally each step's
+    params are overridden by any matching entry in ``configure``. ``statement_id``
+    is only used for error messages. Kept for the deferred Polygon export path.
+    """
     last_output = input_type
     builders: List[Tuple[StatementBuilder, ConversionStep]] = []
 
@@ -219,12 +246,15 @@ def get_builders(
 def get_statement_dir(
     statement: Statement, builder_name: Optional[str] = None
 ) -> pathlib.Path:
+    """[deferred S12] The per-builder Polygon scratch dir. Stubbed until #568."""
     raise NotImplementedError(_V2_POLYGON_PENDING)
 
 
 def get_produced_tikz_pdfs(
     statement: Statement,
 ) -> Iterable[Tuple[pathlib.Path, pathlib.Path]]:
+    """[deferred S12] Externalized TikZ PDFs for Polygon resource upload. Stubbed
+    until #568."""
     raise NotImplementedError(_V2_POLYGON_PENDING)
 
 
@@ -240,6 +270,8 @@ async def build_statement_bytes(
     custom_vars: Optional[Dict[str, Any]] = None,
     inherited_from: Optional['ContestStatement'] = None,
 ) -> Tuple[bytes, StatementType]:
+    """[deferred S12] The v1 byte-level build the Polygon block extractor relied
+    on. Stubbed until #568; the v2 standalone build is :func:`build_statement`."""
     raise NotImplementedError(_V2_POLYGON_PENDING)
 
 
@@ -247,12 +279,19 @@ async def build_statement_bytes(
 
 
 def _variant_suffix(statement: Statement) -> str:
+    """The ``-<variant>`` filename suffix, empty for the default variant."""
     return '' if statement.variant == DEFAULT_VARIANT else f'-{statement.variant}'
 
 
 def get_statement_build_path(
     statement: Statement, output_type: StatementType, profile: Optional[str] = None
 ) -> pathlib.Path:
+    """The *final* output path for a built standalone statement, e.g.
+    ``build/statement-en[-<variant>][-<profile>].pdf`` (design §7.2).
+
+    This sits at the package build root (``get_build_path()``), NOT under the
+    statements scratch dir — it is the artifact a user opens.
+    """
     name = f'statement-{statement.language}{_variant_suffix(statement)}'
     path = (package.get_build_path() / name).with_suffix(output_type.get_file_suffix())
     if (
@@ -264,10 +303,21 @@ def get_statement_build_path(
 
 
 def needs_samples(statement: Statement) -> bool:
+    """Whether this statement should be built with sample I/O."""
     return statement.samples
 
 
-def _overlay_dir(statement: Statement) -> pathlib.Path:
+def _standalone_overlay_root(statement: Statement) -> pathlib.Path:
+    """The isolated *scratch* overlay root for this statement's standalone build.
+
+    ``package.get_statements_build_path()`` is the shared ``build/statements``
+    directory (it also holds e.g. interactive-sample chunk folders), so each
+    standalone build gets its own subtree under it, keyed by
+    ``(language, variant)``, to avoid clobbering other statements' overlays. The
+    merged contest-chrome + problem-dir overlay is staged here and ``pdflatex``
+    runs from it; it is wiped and recreated on every build. The final PDF is
+    copied out to :func:`get_statement_build_path`.
+    """
     root = (
         package.get_statements_build_path()
         / 'st'
@@ -279,6 +329,7 @@ def _overlay_dir(statement: Statement) -> pathlib.Path:
 
 
 def _explanation_suffix(statement: Statement) -> str:
+    """The on-disk suffix of a sample's explanation file for this statement type."""
     return '.md' if statement.type == StatementType.rbxMarkdown else '.tex'
 
 
@@ -319,6 +370,7 @@ def _emit_output(
 
 
 def _require_file(statement: Statement) -> None:
+    """Exit with an error if the statement's source ``file`` is missing."""
     if statement.file is None or not statement.file.is_file():
         console.console.print(
             f'[error]Statement file [item]{statement.file}[/item] does not exist.[/error]'
@@ -334,6 +386,24 @@ async def build_statement(
     custom_vars: Optional[Dict[str, Any]] = None,
     extra_mergeable_params: Optional[List[ConversionStep]] = None,
 ) -> pathlib.Path:
+    """Build one problem statement standalone and return its output path.
+
+    For an *rbx* statement: resolve the owning contest and its
+    ``standaloneProblemTemplate`` (a contest is required), stage the merged
+    overlay (contest chrome + the problem statement-dir), render the template as
+    a full document, compile, and write ``build/statement-<lang>[-<variant>].pdf``.
+    Static ``pdf`` is copied as-is; static ``tex``/``md`` are staged and emitted
+    without a contest.
+
+    Args:
+        statement: the (expanded) problem statement to build.
+        pkg: the loaded problem package (source of ``vars``, limits, groups).
+        output_type: the desired output (``PDF``/``TeX``/``Markdown``).
+        use_samples: stage sample I/O (assumes samples were already built).
+        custom_vars: ``--vars`` overrides merged on top of the package vars.
+        extra_mergeable_params: packager-supplied export toggles
+            (TikZ-externalize / demacro); empty for non-Polygon builds.
+    """
     languages = get_environment_languages_for_statement()
     custom_vars = custom_vars or {}
 
@@ -352,7 +422,7 @@ async def build_statement(
     _require_file(statement)
     assert statement.file is not None
 
-    overlay_root = _overlay_dir(statement)
+    overlay_root = _standalone_overlay_root(statement)
     problem_dir = utils.abspath(statement.file).parent
 
     if statement.type.is_rbx():
@@ -442,6 +512,7 @@ async def build_statement(
 
 
 def _report_built(statement: Statement, path: pathlib.Path) -> None:
+    """Print the success line with a clickable link to the built statement."""
     console.console.print(
         f'Statement for language [item]{statement.language}[/item]'
         f'{_variant_suffix(statement)} built successfully at {href(path)}'
@@ -458,6 +529,14 @@ async def execute_build_on_statements(
     extra_mergeable_params: Optional[List[ConversionStep]] = None,
     skip_building: bool = False,
 ) -> List[pathlib.Path]:
+    """Build samples once (if any statement needs them) then build each statement.
+
+    The shared entry point for both ``rbx st b`` and the packagers. ``vars`` are
+    raw ``key=value`` ``--vars`` strings. ``skip_building`` only checks/validates
+    pre-built samples instead of regenerating them (the packager builds them
+    first). ``extra_mergeable_params`` carries packager export toggles. Returns
+    the built output paths, one per statement.
+    """
     pkg = package.find_problem_package_or_die()
     samples = samples and any(needs_samples(st) for st in statements)
 
@@ -495,6 +574,13 @@ async def execute_build(
     validate: bool = True,
     profile: Optional[str] = None,
 ) -> None:
+    """Select and build this problem's statements (the ``rbx st b`` body).
+
+    Filters ``pkg.expanded_statements`` by ``languages`` and ``names`` (which, in
+    v2, match the statement *variant* since problem statements have no name),
+    optionally under a timing ``profile``, and delegates to
+    :func:`execute_build_on_statements`. Errors if nothing matches.
+    """
     if profile is not None:
         limits_info.get_limits_profile(profile, fallback_to_package_profile=False)
 
@@ -576,6 +662,11 @@ async def build(
         ),
     ] = None,
 ):
+    """``rbx st b`` — build this problem's statements (standalone).
+
+    Thin Typer wrapper over :func:`execute_build`; see the option help above for
+    each argument.
+    """
     await execute_build(
         verification,
         names,

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -282,17 +282,33 @@ def _explanation_suffix(statement: Statement) -> str:
     return '.md' if statement.type == StatementType.rbxMarkdown else '.tex'
 
 
+def _externalize_demacro(
+    extra_mergeable_params: Optional[List[ConversionStep]],
+) -> Tuple[bool, bool]:
+    """Resolve TikZ-externalize / demacro from packager-supplied steps (design
+    §6 decision 6: these are export-time toggles, not user schema)."""
+    externalize = False
+    demacro = False
+    for step in extra_mergeable_params or []:
+        externalize = externalize or bool(getattr(step, 'externalize', False))
+        demacro = demacro or bool(getattr(step, 'demacro', False))
+    return externalize, demacro
+
+
 def _emit_output(
     root: pathlib.Path,
     tex: bytes,
     statement: Statement,
     output_type: StatementType,
+    *,
+    externalize: bool = False,
+    demacro: bool = False,
 ) -> bytes:
     """Take rendered TeX (or Markdown) and produce the requested output bytes."""
     if output_type == StatementType.PDF:
         if statement.type == StatementType.Markdown:
             return render.md_to_pdf(root, tex)
-        return render.compile_pdf(root, tex)
+        return render.compile_pdf(root, tex, externalize=externalize, demacro=demacro)
     if output_type in (StatementType.TeX, StatementType.Markdown):
         return tex
     console.console.print(
@@ -407,7 +423,15 @@ async def build_statement(
         overlay.mirror_tree(problem_dir, overlay_root)
         tex = statement.file.read_bytes()
 
-    output_bytes = _emit_output(overlay_root, tex, statement, output_type)
+    externalize, demacro = _externalize_demacro(extra_mergeable_params)
+    output_bytes = _emit_output(
+        overlay_root,
+        tex,
+        statement,
+        output_type,
+        externalize=externalize,
+        demacro=demacro,
+    )
     out_path = get_statement_build_path(
         statement, output_type, limits_info.get_active_profile()
     )

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -1,36 +1,41 @@
 import pathlib
+import shutil
 import typing
 from typing import Annotated, Any, Dict, Iterable, List, Optional, Tuple
 
 import syncer
 import typer
 
-from rbx import annotations, console
-from rbx.box import environment, package
+from rbx import annotations, console, utils
+from rbx.box import environment, limits_info, naming, package
+from rbx.box.contest import contest_package
 from rbx.box.contest.schema import ContestStatement
-from rbx.box.schema import Package
+from rbx.box.formatting import href
+from rbx.box.schema import Package, expand_any_vars
+from rbx.box.statements import engine, overlay, render, resolver
 from rbx.box.statements.builders import (
     BUILDER_LIST,
     StatementBuilder,
     StatementCodeLanguage,
 )
+from rbx.box.statements.context import ContestRenderContext, ProblemRenderContext
 from rbx.box.statements.schema import (
+    DEFAULT_VARIANT,
     ConversionStep,
     ConversionType,
     Statement,
     StatementType,
 )
+from rbx.box.testcase_sample_utils import build_samples, get_statement_samples
 
 app = typer.Typer(no_args_is_help=True, cls=annotations.AliasGroup)
 
-# statements v2: the standalone build pipeline (resolver -> overlay stager ->
-# builders) is rebuilt in #560-#566 (S4-S9). Until then these orchestration
-# entry points are intentionally stubbed; the pure conversion-step helpers below
-# are kept because the v2 builders reuse them. See
-# docs/plans/2026-06-09-statements-v2-design.md §7.
-_V2_PENDING = (
-    'statements v2: the standalone build pipeline is not wired yet; it lands in '
-    '#565 (S9). See docs/plans/2026-06-09-statements-v2-design.md.'
+# statements v2: the Polygon export path (S12, #568) still consumes the v1
+# per-builder build dirs / TikZ artifacts. Those entry points stay stubbed until
+# the packager is reworked; the standalone build (this module) is rebuilt below.
+_V2_POLYGON_PENDING = (
+    'statements v2: the Polygon export build path is not wired yet; it lands in '
+    '#568 (S12). See docs/plans/2026-06-09-statements-v2-design.md §7.'
 )
 
 
@@ -167,18 +172,6 @@ def _get_overridden_configuration_list(
     return merge_conversion_configurations(configure + list(overridden_params.values()))
 
 
-def get_statement_dir(
-    statement: Statement, builder_name: Optional[str] = None
-) -> pathlib.Path:
-    raise NotImplementedError(_V2_PENDING)
-
-
-def get_produced_tikz_pdfs(
-    statement: Statement,
-) -> Iterable[Tuple[pathlib.Path, pathlib.Path]]:
-    raise NotImplementedError(_V2_PENDING)
-
-
 def get_builders(
     statement_id: str,
     steps: List[ConversionStep],
@@ -190,7 +183,6 @@ def get_builders(
     last_output = input_type
     builders: List[Tuple[StatementBuilder, ConversionStep]] = []
 
-    # Conversion steps to force during build.
     for step in steps:
         builder = get_builder(step.type, builder_list=builder_list)
         if builder.input_type() != last_output:
@@ -211,7 +203,6 @@ def get_builders(
             (builder, builder.default_params()) for builder in implicit_builders
         )
 
-    # Override statement configs.
     def reconfigure(params: ConversionStep) -> ConversionStep:
         new_params = _get_configured_params_for(configure, params.type)
         return new_params or params
@@ -220,6 +211,21 @@ def get_builders(
         (builder, reconfigure(params)) for builder, params in builders
     ]
     return reconfigured_builders
+
+
+# --- Polygon export path (deferred to S12); kept importable. ---
+
+
+def get_statement_dir(
+    statement: Statement, builder_name: Optional[str] = None
+) -> pathlib.Path:
+    raise NotImplementedError(_V2_POLYGON_PENDING)
+
+
+def get_produced_tikz_pdfs(
+    statement: Statement,
+) -> Iterable[Tuple[pathlib.Path, pathlib.Path]]:
+    raise NotImplementedError(_V2_POLYGON_PENDING)
 
 
 async def build_statement_bytes(
@@ -234,17 +240,74 @@ async def build_statement_bytes(
     custom_vars: Optional[Dict[str, Any]] = None,
     inherited_from: Optional['ContestStatement'] = None,
 ) -> Tuple[bytes, StatementType]:
-    raise NotImplementedError(_V2_PENDING)
+    raise NotImplementedError(_V2_POLYGON_PENDING)
+
+
+# --- v2 standalone build (S9). ---
+
+
+def _variant_suffix(statement: Statement) -> str:
+    return '' if statement.variant == DEFAULT_VARIANT else f'-{statement.variant}'
 
 
 def get_statement_build_path(
     statement: Statement, output_type: StatementType, profile: Optional[str] = None
 ) -> pathlib.Path:
-    raise NotImplementedError(_V2_PENDING)
+    name = f'statement-{statement.language}{_variant_suffix(statement)}'
+    path = (package.get_build_path() / name).with_suffix(output_type.get_file_suffix())
+    if (
+        profile is not None
+        and limits_info.get_saved_limits_profile(profile) is not None
+    ):
+        path = path.with_stem(f'{path.stem}-{profile}')
+    return path
 
 
 def needs_samples(statement: Statement) -> bool:
-    raise NotImplementedError(_V2_PENDING)
+    return statement.samples
+
+
+def _overlay_dir(statement: Statement) -> pathlib.Path:
+    root = (
+        package.get_statements_build_path()
+        / 'st'
+        / f'{statement.language}-{statement.variant}'
+    )
+    shutil.rmtree(root, ignore_errors=True)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _explanation_suffix(statement: Statement) -> str:
+    return '.md' if statement.type == StatementType.rbxMarkdown else '.tex'
+
+
+def _emit_output(
+    root: pathlib.Path,
+    tex: bytes,
+    statement: Statement,
+    output_type: StatementType,
+) -> bytes:
+    """Take rendered TeX (or Markdown) and produce the requested output bytes."""
+    if output_type == StatementType.PDF:
+        if statement.type == StatementType.Markdown:
+            return render.md_to_pdf(root, tex)
+        return render.compile_pdf(root, tex)
+    if output_type in (StatementType.TeX, StatementType.Markdown):
+        return tex
+    console.console.print(
+        f'[error]statements v2 cannot yet emit output type [item]{output_type}[/item] '
+        '(only pdf/tex/md). See #569 (S13).[/error]'
+    )
+    raise typer.Exit(1)
+
+
+def _require_file(statement: Statement) -> None:
+    if statement.file is None or not statement.file.is_file():
+        console.console.print(
+            f'[error]Statement file [item]{statement.file}[/item] does not exist.[/error]'
+        )
+        raise typer.Exit(1)
 
 
 async def build_statement(
@@ -255,7 +318,110 @@ async def build_statement(
     custom_vars: Optional[Dict[str, Any]] = None,
     extra_mergeable_params: Optional[List[ConversionStep]] = None,
 ) -> pathlib.Path:
-    raise NotImplementedError(_V2_PENDING)
+    languages = get_environment_languages_for_statement()
+    custom_vars = custom_vars or {}
+
+    # Static PDF: nothing to render, just publish the file.
+    if statement.type == StatementType.PDF:
+        _require_file(statement)
+        assert statement.file is not None
+        out_path = get_statement_build_path(
+            statement, StatementType.PDF, limits_info.get_active_profile()
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(statement.file, out_path)
+        _report_built(statement, out_path)
+        return out_path
+
+    _require_file(statement)
+    assert statement.file is not None
+
+    overlay_root = _overlay_dir(statement)
+    problem_dir = utils.abspath(statement.file).parent
+
+    if statement.type.is_rbx():
+        contest = resolver.require_contest_for_problem()
+        contest_statement = resolver.select_standalone_contest_statement(
+            statement, contest.expanded_statements
+        )
+        contest_root = contest_package.find_contest()
+        assert contest_statement.file is not None
+        chrome_dir = utils.abspath(contest_root / contest_statement.file).parent
+
+        overlay.stage_standalone_overlay(
+            overlay_root, chrome_dir=chrome_dir, problem_dir=problem_dir
+        )
+        assert contest_statement.standaloneProblemTemplate is not None
+        template_rel = engine.relativize_template(
+            contest_root,
+            chrome_dir,
+            contest_statement.standaloneProblemTemplate,
+            overlay_root,
+        )
+
+        problem_ctx = ProblemRenderContext(
+            title=naming.get_problem_title(statement.language, statement, pkg),
+            vars={**pkg.expanded_vars, **custom_vars},
+            params=statement.expanded_params,
+            short_name=naming.get_problem_shortname(),
+            limits=limits_info.get_limits_profile(
+                profile=limits_info.get_active_profile()
+            ),
+            profiles=limits_info.get_available_limits_profiles(),
+            groups={g.name: g for g in pkg.testcases},
+        )
+        contest_ctx = ContestRenderContext(
+            title=naming.get_contest_title(
+                lang=statement.language, statement=contest_statement, contest=contest
+            ),
+            vars=contest.expanded_vars,
+            params=contest_statement.expanded_vars,
+            location=contest_statement.location,
+            date=contest_statement.date,
+        )
+
+        samples = (
+            await get_statement_samples(
+                explanation_suffix=_explanation_suffix(statement)
+            )
+            if use_samples
+            else []
+        )
+        tex = engine.render_problem_tex(
+            render_root=overlay_root,
+            problem_root=overlay_root,
+            root_prefix='',
+            template_rel=template_rel,
+            content=statement.file.read_bytes(),
+            lang=statement.language,
+            languages=languages,
+            problem=problem_ctx,
+            contest=contest_ctx,
+            samples=samples,
+            use_samples=use_samples,
+            statement_type=statement.type,
+        )
+    else:
+        # Static tex / md: mirror the statement-dir subtree so assets resolve,
+        # then publish the (raw) content. No contest/template needed.
+        overlay.mirror_tree(problem_dir, overlay_root)
+        tex = statement.file.read_bytes()
+
+    output_bytes = _emit_output(overlay_root, tex, statement, output_type)
+    out_path = get_statement_build_path(
+        statement, output_type, limits_info.get_active_profile()
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(output_bytes)
+    _report_built(statement, out_path)
+    return out_path
+
+
+def _report_built(statement: Statement, path: pathlib.Path) -> None:
+    console.console.print(
+        f'Statement for language [item]{statement.language}[/item]'
+        f'{_variant_suffix(statement)} built successfully at {href(path)}'
+    )
 
 
 async def execute_build_on_statements(
@@ -268,7 +434,31 @@ async def execute_build_on_statements(
     extra_mergeable_params: Optional[List[ConversionStep]] = None,
     skip_building: bool = False,
 ) -> List[pathlib.Path]:
-    raise NotImplementedError(_V2_PENDING)
+    pkg = package.find_problem_package_or_die()
+    samples = samples and any(needs_samples(st) for st in statements)
+
+    if samples:
+        if not await build_samples(
+            verification, validate, check_outputs_only=skip_building
+        ):
+            console.console.print(
+                '[error]Failed to build statements with samples, aborting.[/error]'
+            )
+            raise typer.Exit(1)
+
+    res = []
+    for statement in statements:
+        res.append(
+            await build_statement(
+                statement,
+                pkg,
+                output_type=output,
+                use_samples=samples,
+                custom_vars=expand_any_vars(annotations.parse_dictionary_items(vars)),
+                extra_mergeable_params=extra_mergeable_params,
+            )
+        )
+    return res
 
 
 async def execute_build(
@@ -281,7 +471,37 @@ async def execute_build(
     validate: bool = True,
     profile: Optional[str] = None,
 ) -> None:
-    raise NotImplementedError(_V2_PENDING)
+    if profile is not None:
+        limits_info.get_limits_profile(profile, fallback_to_package_profile=False)
+
+    with limits_info.use_profile(profile, when=lambda: profile is not None):
+        pkg = package.find_problem_package_or_die()
+        candidate_languages = set(languages or [])
+        candidate_variants = set(names or [])
+
+        def should_process(st: Statement) -> bool:
+            if candidate_languages and st.language not in candidate_languages:
+                return False
+            if candidate_variants and st.variant not in candidate_variants:
+                return False
+            return True
+
+        valid_statements = [st for st in pkg.expanded_statements if should_process(st)]
+
+        if not valid_statements:
+            console.console.print(
+                '[error]No statement found according to the specified criteria.[/error]',
+            )
+            raise typer.Exit(1)
+
+        await execute_build_on_statements(
+            valid_statements,
+            verification,
+            output=output,
+            samples=samples,
+            vars=vars,
+            validate=validate,
+        )
 
 
 @app.command('build, b', help='Build statements.')
@@ -292,7 +512,7 @@ async def build(
     names: Annotated[
         Optional[List[str]],
         typer.Argument(
-            help='Names of statements to build.',
+            help='Variants of statements to build.',
         ),
     ] = None,
     languages: Annotated[

--- a/rbx/box/statements/context.py
+++ b/rbx/box/statements/context.py
@@ -1,0 +1,174 @@
+"""Statements v2 namespaced template context (design §4, issue #561).
+
+v1 collapsed everything into one merged ``vars``. v2 keeps three sources
+distinct and unmerged:
+
+- ``params`` — *this statement's* own params.
+- ``vars`` — the problem/package vars (problem renders) or contest vars
+  (contest renders).
+- ``contest`` — ``title`` / ``location`` / ``date`` / ``contest.vars`` (always
+  available — a contest is required).
+
+Plus per-iteration handles for the overlay join: ``problem.import_dir`` /
+``problem.import_file`` (the ``\\subimport`` handle for a problem in the contest
+doc) and the ``sample.*`` handles (§6.3, populated by the sample stager).
+
+The dataclasses here take primitive inputs (already-expanded var dicts, a title
+string, resolved limits) rather than the heavy ``Package``/``Statement``
+models, so context assembly is pure and unit-testable. The orchestration layer
+(``build_statements`` / ``build_contest_statements``) extracts those primitives.
+"""
+
+import dataclasses
+from typing import Any, Dict, List, Optional
+
+from rbx.box.fields import Vars
+from rbx.box.statements.latex_jinja import (
+    JinjaDictGetter,
+    JinjaDictWrapper,
+    JinjaGroupsGetter,
+)
+
+
+@dataclasses.dataclass
+class StatementCodeLanguage:
+    id: str
+    name: str
+    command: str
+
+
+def _wrap(vars: Vars, key: str) -> JinjaDictWrapper:
+    return JinjaDictWrapper.from_dict(dict(vars or {}), wrapper_key=key)
+
+
+@dataclasses.dataclass
+class SampleHandle:
+    """Per-sample handles exposed to templates (design §4/§6.3).
+
+    Paths are anchored differently on purpose: ``input``/``output`` are
+    **root-relative** for verbatim I/O (``\\VerbatimInput`` ignores the
+    ``\\subimport`` base), while ``dir``/``explanation_file`` are
+    **import-base-relative** for ``\\subimport`` of the explanation (§6.4).
+    """
+
+    index: int
+    input: str
+    output: Optional[str] = None
+    dir: Optional[str] = None
+    explanation_file: Optional[str] = None
+    explanation: Optional[str] = None
+    has_output: bool = True
+    interaction: Optional[Any] = None
+
+
+@dataclasses.dataclass
+class ContestRenderContext:
+    """The ``contest`` namespace, always available."""
+
+    title: str
+    vars: Vars = dataclasses.field(default_factory=dict)
+    params: Vars = dataclasses.field(default_factory=dict)
+    location: Optional[str] = None
+    date: Optional[str] = None
+    blocks: Dict[str, str] = dataclasses.field(default_factory=dict)
+
+    def namespace(self) -> Dict[str, Any]:
+        res: Dict[str, Any] = {
+            'title': self.title,
+            'vars': _wrap(self.vars, 'contest.vars'),
+        }
+        if self.location is not None:
+            res['location'] = self.location
+        if self.date is not None:
+            res['date'] = self.date
+        if self.blocks:
+            res['blocks'] = self.blocks
+        return res
+
+
+@dataclasses.dataclass
+class ProblemRenderContext:
+    """The ``problem`` namespace for one problem (standalone or a join member)."""
+
+    title: str
+    vars: Vars = dataclasses.field(default_factory=dict)
+    params: Vars = dataclasses.field(default_factory=dict)
+    short_name: Optional[str] = None
+    limits: Any = None
+    profiles: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    groups: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    samples: List[SampleHandle] = dataclasses.field(default_factory=list)
+    import_dir: Optional[str] = None
+    import_file: Optional[str] = None
+    blocks: Dict[str, str] = dataclasses.field(default_factory=dict)
+
+    def namespace(self) -> Dict[str, Any]:
+        res: Dict[str, Any] = {
+            'title': self.title,
+            'limits': self.limits,
+            'profiles': JinjaDictGetter('profiles', **self.profiles),
+            'groups': JinjaGroupsGetter('groups', dict(self.groups)),
+            'samples': self.samples,
+            'vars': _wrap(self.vars, 'vars'),
+            'params': _wrap(self.params, 'params'),
+            'blocks': self.blocks,
+        }
+        if self.short_name is not None:
+            res['short_name'] = self.short_name
+        if self.import_dir is not None:
+            res['import_dir'] = self.import_dir
+        if self.import_file is not None:
+            res['import_file'] = self.import_file
+        return res
+
+
+def _common(lang: str, languages: List[StatementCodeLanguage]) -> Dict[str, Any]:
+    return {
+        'lang': lang,
+        'languages': languages,
+        'keyed_languages': {language.id: language for language in languages},
+    }
+
+
+def problem_jinja_kwargs(
+    *,
+    lang: str,
+    languages: List[StatementCodeLanguage],
+    problem: ProblemRenderContext,
+    contest: ContestRenderContext,
+) -> Dict[str, Any]:
+    """Template context for a problem render (standalone full doc or a join
+    fragment): top-level ``params``/``vars``/``contest`` are distinct, with the
+    ``problem`` namespace carrying its own handles."""
+    res = _common(lang, languages)
+    res.update(
+        {
+            'params': _wrap(problem.params, 'params'),
+            'vars': _wrap(problem.vars, 'vars'),
+            'contest': contest.namespace(),
+            'problem': problem.namespace(),
+        }
+    )
+    return res
+
+
+def contest_jinja_kwargs(
+    *,
+    lang: str,
+    languages: List[StatementCodeLanguage],
+    contest: ContestRenderContext,
+    problems: List[ProblemRenderContext],
+) -> Dict[str, Any]:
+    """Template context for the joining contest document: ``params`` is the
+    contest statement's own params, ``vars`` is the contest vars, and
+    ``problems`` is the list of per-problem namespaces."""
+    res = _common(lang, languages)
+    res.update(
+        {
+            'params': _wrap(contest.params, 'params'),
+            'vars': _wrap(contest.vars, 'vars'),
+            'contest': contest.namespace(),
+            'problems': [problem.namespace() for problem in problems],
+        }
+    )
+    return res

--- a/rbx/box/statements/context.py
+++ b/rbx/box/statements/context.py
@@ -73,6 +73,8 @@ class ContestRenderContext:
     blocks: Dict[str, str] = dataclasses.field(default_factory=dict)
 
     def namespace(self) -> Dict[str, Any]:
+        """The ``contest`` template namespace: ``title``/``vars`` (always) plus
+        ``location``/``date``/``blocks`` when present."""
         res: Dict[str, Any] = {
             'title': self.title,
             'vars': _wrap(self.vars, 'contest.vars'),
@@ -103,6 +105,10 @@ class ProblemRenderContext:
     blocks: Dict[str, str] = dataclasses.field(default_factory=dict)
 
     def namespace(self) -> Dict[str, Any]:
+        """The ``problem`` template namespace: title/limits/profiles/groups/
+        samples/blocks plus its own ``vars``/``params`` (aliased here so the join
+        document can reach a member problem's vars), and the
+        ``short_name``/``import_dir``/``import_file`` handles when set."""
         res: Dict[str, Any] = {
             'title': self.title,
             'limits': self.limits,

--- a/rbx/box/statements/engine.py
+++ b/rbx/box/statements/engine.py
@@ -37,6 +37,12 @@ def _mode_for(statement_type: StatementType) -> str:
     return 'markdown' if statement_type == StatementType.rbxMarkdown else 'latex'
 
 
+def _md_to_latex(markdown: str) -> str:
+    import pypandoc
+
+    return pypandoc.convert_text(markdown, 'latex', 'markdown')
+
+
 def to_sample_source(sample: StatementSample) -> sample_staging.SampleSource:
     """Project the heavy ``StatementSample`` onto the lightweight staging input."""
     chunks: List = []
@@ -91,26 +97,37 @@ def render_problem_tex(
         mode=mode,
     )
 
-    # 2. Sample staging into <problem_root>/.samples/.
+    # 2. Sample staging into <problem_root>/.samples/. Explanations are always
+    #    `\subimport`-ed by a LaTeX template, so for rbxMarkdown we convert the
+    #    rendered explanation (block- or file-sourced) to LaTeX before staging.
     if use_samples and samples:
         kwargs = _problem_jinja_kwargs(
             lang=lang, languages=languages, problem=problem, contest=contest
         )
 
         def render_text(c: bytes, m: str) -> bytes:
-            return builders.render_jinja(problem_root, c, **kwargs)
+            rendered = builders.render_jinja(problem_root, c, **kwargs)
+            if m == 'markdown':
+                rendered = _md_to_latex(rendered.decode()).encode()
+            return rendered
 
         def render_blocks(c: bytes, m: str):
             return builders.render_jinja_blocks(
                 problem_root, c, mode=m, **kwargs
             ).blocks
 
+        explanation_blocks = blocks.explanations
+        if mode == 'markdown':
+            explanation_blocks = {
+                i: _md_to_latex(value) for i, value in explanation_blocks.items()
+            }
+
         sources = [to_sample_source(s) for s in samples]
         problem.samples = sample_staging.stage_samples(
             problem_root,
             root_prefix,
             sources,
-            explanation_blocks=blocks.explanations,
+            explanation_blocks=explanation_blocks,
             render_text=render_text,
             render_blocks=render_blocks,
             lang=lang,
@@ -120,11 +137,8 @@ def render_problem_tex(
     # rbxMarkdown: the extracted blocks are Markdown; convert them to LaTeX so the
     # (LaTeX) template can splice them in (mirrors the v1 rbxMarkdown->rbxTeX step).
     if mode == 'markdown':
-        import pypandoc
-
         problem.blocks = {
-            name: pypandoc.convert_text(value, 'latex', 'markdown')
-            for name, value in blocks.blocks.items()
+            name: _md_to_latex(value) for name, value in blocks.blocks.items()
         }
     else:
         problem.blocks = blocks.blocks
@@ -154,11 +168,28 @@ def relativize_template(
     """
     import shutil
 
+    from rbx.box.statements.overlay import OverlayCollisionError
+
     template_abs = utils.abspath(contest_root / template_path)
     chrome_abs = utils.abspath(chrome_dir)
     try:
         return str(template_abs.relative_to(chrome_abs))
     except ValueError:
+        # Template lives outside the contest statement-file dir, so it was not
+        # brought in by the chrome overlay. Stage it at the root by basename,
+        # erroring rather than silently clobbering an existing overlay asset.
         dest = overlay_root / template_abs.name
+        if dest.exists() and dest.read_bytes() != template_abs.read_bytes():
+            with OverlayCollisionError() as err:
+                err.print(
+                    f'[error]Template [item]{template_path}[/item] lives outside '
+                    f'the contest statement-file directory and its basename '
+                    f'[item]{template_abs.name}[/item] collides with an existing '
+                    f'overlay asset.[/error]'
+                )
+                err.print(
+                    '[warning]Move the template under the contest statement-file '
+                    'directory, or rename it.[/warning]'
+                )
         shutil.copyfile(template_abs, dest)
         return template_abs.name

--- a/rbx/box/statements/engine.py
+++ b/rbx/box/statements/engine.py
@@ -1,0 +1,164 @@
+"""Statements v2 build engine — shared problem rendering (design §6, §7).
+
+The piece common to both build modes: take one problem statement and render it
+into TeX against a staged overlay, by
+
+1. extracting the rbxTeX blocks (legend/input/... + per-sample explanations),
+2. staging the samples into ``<problem_root>/.samples/`` (root-relative I/O,
+   ``\\subimport``-able explanations), and
+3. rendering the chosen template — a *full document*
+   (``standaloneProblemTemplate``, ``rbx st b``) or a *fragment*
+   (``contestProblemTemplate``, joined by ``rbx contest st b``).
+
+``rbx.box.statements.build_statements`` (standalone) and
+``rbx.box.contest.build_contest_statements`` (join) drive this with the right
+overlay layout and ``root_prefix``; the same problem rendering is valid in both
+contexts, which is what makes the overlay portable (design §6.2).
+"""
+
+import pathlib
+from typing import List
+
+from rbx import utils
+from rbx.box.statements import builders, render, sample_staging
+from rbx.box.statements.context import (
+    ContestRenderContext,
+    ProblemRenderContext,
+    StatementCodeLanguage,
+)
+from rbx.box.statements.context import (
+    problem_jinja_kwargs as _problem_jinja_kwargs,
+)
+from rbx.box.statements.schema import StatementType
+from rbx.box.testcase_sample_utils import StatementSample
+
+
+def _mode_for(statement_type: StatementType) -> str:
+    return 'markdown' if statement_type == StatementType.rbxMarkdown else 'latex'
+
+
+def to_sample_source(sample: StatementSample) -> sample_staging.SampleSource:
+    """Project the heavy ``StatementSample`` onto the lightweight staging input."""
+    chunks: List = []
+    if sample.interaction is not None:
+        chunks = [(chunk.path, int(chunk.pipe)) for chunk in sample.interaction.chunks]
+    has_output = sample.outputPath is not None and sample.outputPath.is_file()
+    return sample_staging.SampleSource(
+        input_path=sample.inputPath,
+        output_path=sample.outputPath if has_output else None,
+        has_output=has_output,
+        explanation_path=sample.explanationPath,
+        explanation_from_blocks=sample.explanationFromBlocks,
+        interaction_chunks=chunks,
+    )
+
+
+def render_problem_tex(
+    *,
+    render_root: pathlib.Path,
+    problem_root: pathlib.Path,
+    root_prefix: str,
+    template_rel: str,
+    content: bytes,
+    lang: str,
+    languages: List[StatementCodeLanguage],
+    problem: ProblemRenderContext,
+    contest: ContestRenderContext,
+    samples: List[StatementSample],
+    use_samples: bool,
+    statement_type: StatementType,
+) -> bytes:
+    """Render one problem statement to TeX bytes.
+
+    ``render_root`` is where Jinja loads the (staged) template and writes temp
+    files — the overlay root in both modes. ``problem_root`` is where this
+    problem's assets and ``.samples/`` live (the overlay root for standalone, the
+    isolated ``.problems/<SHORT>/`` for a join). ``root_prefix`` is
+    ``problem_root`` relative to the overlay root, anchoring root-relative sample
+    I/O for ``\\VerbatimInput``.
+    """
+    mode = _mode_for(statement_type)
+
+    # 1. Block extraction — render in problem_root so any in-statement includes
+    #    resolve against the mirrored problem subtree.
+    blocks = render.extract_blocks(
+        problem_root,
+        content,
+        lang=lang,
+        languages=languages,
+        problem=problem,
+        contest=contest,
+        mode=mode,
+    )
+
+    # 2. Sample staging into <problem_root>/.samples/.
+    if use_samples and samples:
+        kwargs = _problem_jinja_kwargs(
+            lang=lang, languages=languages, problem=problem, contest=contest
+        )
+
+        def render_text(c: bytes, m: str) -> bytes:
+            return builders.render_jinja(problem_root, c, **kwargs)
+
+        def render_blocks(c: bytes, m: str):
+            return builders.render_jinja_blocks(
+                problem_root, c, mode=m, **kwargs
+            ).blocks
+
+        sources = [to_sample_source(s) for s in samples]
+        problem.samples = sample_staging.stage_samples(
+            problem_root,
+            root_prefix,
+            sources,
+            explanation_blocks=blocks.explanations,
+            render_text=render_text,
+            render_blocks=render_blocks,
+            lang=lang,
+            mode=mode,
+        )
+
+    # rbxMarkdown: the extracted blocks are Markdown; convert them to LaTeX so the
+    # (LaTeX) template can splice them in (mirrors the v1 rbxMarkdown->rbxTeX step).
+    if mode == 'markdown':
+        import pypandoc
+
+        problem.blocks = {
+            name: pypandoc.convert_text(value, 'latex', 'markdown')
+            for name, value in blocks.blocks.items()
+        }
+    else:
+        problem.blocks = blocks.blocks
+
+    # 3. Render the template (loaded from render_root where it was staged).
+    return render.render_problem_document(
+        render_root,
+        template_rel,
+        lang=lang,
+        languages=languages,
+        problem=problem,
+        contest=contest,
+    )
+
+
+def relativize_template(
+    contest_root: pathlib.Path,
+    chrome_dir: pathlib.Path,
+    template_path: pathlib.Path,
+    overlay_root: pathlib.Path,
+) -> str:
+    """Return the template path relative to the overlay root after staging.
+
+    Templates normally live under the contest statement-file directory (the
+    chrome dir), so they are already in the overlay; otherwise the template is
+    copied to the overlay root and referenced by name.
+    """
+    import shutil
+
+    template_abs = utils.abspath(contest_root / template_path)
+    chrome_abs = utils.abspath(chrome_dir)
+    try:
+        return str(template_abs.relative_to(chrome_abs))
+    except ValueError:
+        dest = overlay_root / template_abs.name
+        shutil.copyfile(template_abs, dest)
+        return template_abs.name

--- a/rbx/box/statements/overlay.py
+++ b/rbx/box/statements/overlay.py
@@ -1,0 +1,125 @@
+"""Statements v2 overlay stager (design §6.1/§6.2, issue #560).
+
+Mirrors the *directory subtree containing a statement `file`* into a build
+overlay, plus the contest chrome subtree, so that every asset resolves by a
+plain relative path. The only LaTeX construct the engine injects elsewhere is
+``\\subimport`` — this module never parses or rewrites TeX, it only places files
+on disk (design §6.5).
+
+Two layouts:
+
+- **Standalone** (`rbx st b`, §6.1): a single *merged* root — contest chrome +
+  the problem statement-dir subtree. Because there is exactly one problem and
+  one contest, the only collision risk is a problem file vs a chrome file with
+  the same relative path; we detect and error on it.
+- **Join** (`rbx contest st b`, §6.2): contest chrome at the shared root; each
+  problem isolated under ``.problems/<SHORT>/`` and ``\\subimport``-ed, so two
+  problems can both ship ``imgs/fig.png`` with zero collision.
+"""
+
+import pathlib
+import shutil
+from typing import List, Optional
+
+from rbx.box.exception import RbxException
+
+PROBLEMS_DIRNAME = '.problems'
+
+
+class OverlayCollisionError(RbxException):
+    pass
+
+
+def _iter_files(src_dir: pathlib.Path) -> List[pathlib.Path]:
+    """Relative paths of every regular file under ``src_dir`` (recursive)."""
+    if not src_dir.is_dir():
+        return []
+    return sorted(p.relative_to(src_dir) for p in src_dir.rglob('*') if p.is_file())
+
+
+def mirror_tree(src_dir: pathlib.Path, dest_dir: pathlib.Path) -> List[pathlib.Path]:
+    """Copy every file under ``src_dir`` into ``dest_dir``, preserving relative
+    structure. A missing ``src_dir`` is a no-op. Returns the relative paths
+    copied.
+    """
+    relatives = _iter_files(src_dir)
+    if not relatives and not src_dir.is_dir():
+        return []
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for rel in relatives:
+        out = dest_dir / rel
+        out.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src_dir / rel, out)
+    return relatives
+
+
+def merge_tree(
+    src_dir: pathlib.Path,
+    dest_dir: pathlib.Path,
+    *,
+    occupied: List[pathlib.Path],
+    src_label: str,
+    occupied_label: str,
+) -> List[pathlib.Path]:
+    """Mirror ``src_dir`` into ``dest_dir`` but error if any relative path is
+    already present in ``occupied`` (a real collision in the merged overlay)."""
+    relatives = _iter_files(src_dir)
+    occupied_set = set(occupied)
+    collisions = sorted(rel for rel in relatives if rel in occupied_set)
+    if collisions:
+        with OverlayCollisionError() as err:
+            err.print(
+                f'[error]Asset name collision while merging the {src_label} into '
+                f'the {occupied_label} overlay:[/error]'
+            )
+            for rel in collisions:
+                err.print(f'[error]  - [item]{rel}[/item][/error]')
+            err.print(
+                '[warning]Rename one of the conflicting files so the standalone '
+                'overlay stays unambiguous.[/warning]'
+            )
+    mirror_tree(src_dir, dest_dir)
+    return relatives
+
+
+def stage_standalone_overlay(
+    dest_root: pathlib.Path,
+    *,
+    chrome_dir: Optional[pathlib.Path],
+    problem_dir: pathlib.Path,
+) -> None:
+    """Build the merged standalone overlay (§6.1): the problem statement-dir
+    subtree plus the contest chrome subtree in one root, erroring on any
+    name collision between the two."""
+    problem_files = mirror_tree(problem_dir, dest_root)
+    if chrome_dir is not None:
+        merge_tree(
+            chrome_dir,
+            dest_root,
+            occupied=problem_files,
+            src_label='contest chrome',
+            occupied_label='problem',
+        )
+
+
+def problem_overlay_dir(dest_root: pathlib.Path, short_name: str) -> pathlib.Path:
+    """The isolated ``\\subimport`` base for a problem in the contest join."""
+    return dest_root / PROBLEMS_DIRNAME / short_name
+
+
+def stage_join_problem(
+    dest_root: pathlib.Path,
+    problem_dir: pathlib.Path,
+    short_name: str,
+) -> pathlib.Path:
+    """Mirror a problem's statement-dir subtree into its isolated join folder
+    ``.problems/<SHORT>/`` (§6.2). Returns that folder."""
+    target = problem_overlay_dir(dest_root, short_name)
+    mirror_tree(problem_dir, target)
+    return target
+
+
+def stage_chrome(dest_root: pathlib.Path, chrome_dir: Optional[pathlib.Path]) -> None:
+    """Overlay the contest chrome subtree at the shared overlay root (§6.2)."""
+    if chrome_dir is not None:
+        mirror_tree(chrome_dir, dest_root)

--- a/rbx/box/statements/render.py
+++ b/rbx/box/statements/render.py
@@ -1,0 +1,195 @@
+"""Statements v2 render core (design §7.1, issue #564).
+
+The "builders stay similar" half of the rework: this module reuses the v1
+low-level primitives — rbxTeX block extraction, the LaTeX Jinja env, and the
+``tex -> pdf`` pdflatex loop — but drives them with the v2 namespaced context
+(:mod:`rbx.box.statements.context`) and operates on the overlay produced by the
+stager. pdflatex always runs from the overlay **root** so the generated TeX is
+portable.
+
+Two problem render modes share the block-extraction core:
+
+- :func:`render_problem_document` — a *full* document (``standaloneProblemTemplate``),
+  compiled in place for ``rbx st b``.
+- the same function with the ``contestProblemTemplate`` produces a *fragment*
+  meant to be ``\\subimport``-ed by the contest join.
+
+The contest joining document is rendered by :func:`render_contest_document`.
+"""
+
+import pathlib
+import typing
+from typing import Any, Dict, List, Literal
+
+from rbx import console
+from rbx.box.statements import texsoup_utils
+from rbx.box.statements.builders import (
+    StatementBlocks,
+    render_jinja,
+    render_jinja_blocks,
+)
+from rbx.box.statements.context import (
+    ContestRenderContext,
+    ProblemRenderContext,
+    StatementCodeLanguage,
+    contest_jinja_kwargs,
+    problem_jinja_kwargs,
+)
+from rbx.box.statements.demacro_utils import collect_macro_definitions
+
+Mode = Literal['latex', 'markdown']
+
+
+def extract_blocks(
+    root: pathlib.Path,
+    content: bytes,
+    *,
+    lang: str,
+    languages: List[StatementCodeLanguage],
+    problem: ProblemRenderContext,
+    contest: ContestRenderContext,
+    mode: Mode = 'latex',
+) -> StatementBlocks:
+    """Extract the named rbxTeX blocks (legend/input/output/...) and any
+    per-sample ``explanation_<i>`` blocks from a problem statement file, using
+    the v2 namespaced context."""
+    kwargs = problem_jinja_kwargs(
+        lang=lang, languages=languages, problem=problem, contest=contest
+    )
+    return render_jinja_blocks(root, content, mode=mode, **kwargs)
+
+
+def render_problem_document(
+    root: pathlib.Path,
+    template_rel: str,
+    *,
+    lang: str,
+    languages: List[StatementCodeLanguage],
+    problem: ProblemRenderContext,
+    contest: ContestRenderContext,
+) -> bytes:
+    """Render a problem template (full standalone doc OR contest fragment) that
+    has already been staged into the overlay ``root``. ``problem.blocks`` must
+    be populated (via :func:`extract_blocks`)."""
+    kwargs = problem_jinja_kwargs(
+        lang=lang, languages=languages, problem=problem, contest=contest
+    )
+    return render_jinja(
+        root,
+        f'%- extends "{template_rel}"'.encode(),
+        **kwargs,
+        blocks=problem.blocks,
+    )
+
+
+def render_contest_document(
+    root: pathlib.Path,
+    template_rel: str,
+    *,
+    lang: str,
+    languages: List[StatementCodeLanguage],
+    contest: ContestRenderContext,
+    problems: List[ProblemRenderContext],
+) -> bytes:
+    """Render the joining contest document (the contest statement ``file``),
+    iterating ``problems`` and ``\\subimport``-ing each via its import handles."""
+    kwargs = contest_jinja_kwargs(
+        lang=lang, languages=languages, contest=contest, problems=problems
+    )
+    return render_jinja(
+        root,
+        f'%- extends "{template_rel}"'.encode(),
+        **kwargs,
+        blocks=contest.blocks,
+    )
+
+
+def render_jinja_document(
+    root: pathlib.Path,
+    source_rel: str,
+    jinja_kwargs: Dict[str, Any],
+) -> bytes:
+    """Render a plain Jinja document (jinja-tex / jinja-md) staged at ``root``;
+    no block extraction, just a direct template render."""
+    return render_jinja(
+        root,
+        f'%- extends "{source_rel}"'.encode(),
+        **jinja_kwargs,
+    )
+
+
+def compile_pdf(
+    root: pathlib.Path,
+    tex: bytes,
+    *,
+    demacro: bool = False,
+    externalize: bool = False,
+) -> bytes:
+    """Compile ``tex`` to PDF with pdflatex, running from the overlay ``root``
+    so that relative ``\\subimport`` / ``\\VerbatimInput`` paths resolve."""
+    from rbx.box.statements.latex import (
+        MAX_PDFLATEX_RUNS,
+        Latex,
+        decode_latex_output,
+        should_rerun,
+    )
+
+    input_str = tex.decode()
+    if externalize:
+        tex_node = texsoup_utils.parse_latex(input_str)
+        texsoup_utils.inject_externalization_for_tikz(tex_node)
+        (root / texsoup_utils.EXTERNALIZATION_DIR).mkdir(exist_ok=True, parents=True)
+        input_str = str(tex_node)
+
+    import typer
+
+    latex = Latex(input_str)
+    latex_result = latex.build_pdf(root)
+    pdf = latex_result.pdf
+    logs = decode_latex_output(latex_result.result.stdout)
+    runs = 1
+    while pdf is not None and should_rerun(logs) and runs < MAX_PDFLATEX_RUNS:
+        console.console.print('Re-running pdfLaTeX to get cross-references right...')
+        latex_result = latex.build_pdf(root)
+        pdf = latex_result.pdf
+        logs = decode_latex_output(latex_result.result.stdout)
+        runs += 1
+
+    if pdf is None:
+        console.console.print(f'{logs}')
+        console.console.print('[error]PdfLaTeX compilation failed.[/error]')
+        raise typer.Exit(1)
+
+    if demacro:
+        macro_defs = collect_macro_definitions(root / 'statement.tex')
+        macro_defs.to_json_file(root / 'macros.json')
+
+    return typing.cast(bytes, pdf)
+
+
+def md_to_pdf(root: pathlib.Path, md: bytes) -> bytes:
+    """Convert Markdown to PDF via pandoc (for plain ``md`` statements)."""
+    import pypandoc
+
+    output = root / 'statement.pdf'
+    pypandoc.convert_text(
+        md.decode(),
+        'pdf',
+        format='markdown',
+        outputfile=str(output),
+        extra_args=['--pdf-engine=pdflatex'],
+    )
+    return output.read_bytes()
+
+
+def md_blocks_to_rbxtex(blocks: StatementBlocks) -> bytes:
+    """Convert extracted Markdown blocks to an rbxTeX-blocks document (each block
+    pandoc-converted to LaTeX), so an rbxMarkdown statement can reuse the LaTeX
+    rendering path (mirrors the v1 rbxMarkdown->rbxTeX builder)."""
+    import pypandoc
+
+    result = ''
+    for name, content in blocks.blocks.items():
+        converted = pypandoc.convert_text(content, 'latex', 'markdown')
+        result += f'%- block {name}\n{converted}\n%- endblock\n\n'
+    return result.encode()

--- a/rbx/box/statements/resolver.py
+++ b/rbx/box/statements/resolver.py
@@ -1,0 +1,145 @@
+"""Statements v2 contest-aware resolver + matching (design §2/§3, issue #563).
+
+Two resolution problems live here, both pure over their inputs so they are
+unit-testable without a package on disk:
+
+- **Standalone** (`rbx st b`): a problem statement borrows the *template* from a
+  contest statement. The candidates are the contest statements that share the
+  problem statement's ``(language, variant)`` AND carry a
+  ``standaloneProblemTemplate``. Exactly one must exist — 0 or >1 is a hard
+  config error the user fixes (design §2, decision 3).
+- **Join** (`rbx contest st b`): a joinable (rbx*) contest statement pulls one
+  statement from each problem, matched by ``(language, variant)`` and required
+  to share the contest statement's rbx* type (design §3.2).
+
+Building a problem statement outside a contest is a hard error (design §2,
+decision 1); ``require_contest_for_problem`` enforces that.
+"""
+
+from typing import List, Optional
+
+from rbx.box.contest import contest_package, contest_state
+from rbx.box.contest.schema import Contest, ContestStatement
+from rbx.box.exception import RbxException
+from rbx.box.statements.schema import Statement
+
+
+class StatementResolverError(RbxException):
+    pass
+
+
+def _describe_key(language: str, variant: str) -> str:
+    return f'{language}/{variant}'
+
+
+def select_standalone_contest_statement(
+    statement: Statement,
+    contest_statements: List[ContestStatement],
+) -> ContestStatement:
+    """Pick the contest statement that provides the standalone template for this
+    problem statement's ``(language, variant)``.
+
+    Candidates carry a ``standaloneProblemTemplate`` and match the problem
+    statement on ``(language, variant)``. Exactly one is required.
+    """
+    candidates = [
+        cs
+        for cs in contest_statements
+        if cs.standaloneProblemTemplate is not None
+        and (cs.language, cs.variant) == (statement.language, statement.variant)
+    ]
+    key = _describe_key(statement.language, statement.variant)
+    if not candidates:
+        with StatementResolverError() as err:
+            err.print(
+                f'[error]No contest statement provides a standalone template for '
+                f'problem statement [item]{key}[/item].[/error]'
+            )
+            err.print(
+                '[warning]Add a contest statement with a matching '
+                '[item](language, variant)[/item] and a '
+                '[item]standaloneProblemTemplate[/item] to build this statement '
+                'standalone.[/warning]'
+            )
+    if len(candidates) > 1:
+        names = [cs.name for cs in candidates]
+        with StatementResolverError() as err:
+            err.print(
+                f'[error]Multiple contest statements provide a standalone template '
+                f'for problem statement [item]{key}[/item]: [item]{names}[/item]. '
+                f'Exactly one must carry a [item]standaloneProblemTemplate[/item] '
+                f'for this [item](language, variant)[/item].[/error]'
+            )
+    return candidates[0]
+
+
+def select_problem_statement(
+    contest_statement: ContestStatement,
+    problem_statements: List[Statement],
+    problem_label: str,
+) -> Statement:
+    """Pick the problem statement that joins into ``contest_statement``.
+
+    Matched by ``(language, variant)``; the matched statement must share the
+    contest statement's rbx* type. ``problem_label`` (usually the short name) is
+    used only for error messages.
+    """
+    key = (contest_statement.language, contest_statement.variant)
+    described = _describe_key(*key)
+    matching = [st for st in problem_statements if st.key == key]
+    if not matching:
+        with StatementResolverError() as err:
+            err.print(
+                f'[error]Problem [item]{problem_label}[/item] has no statement '
+                f'matching [item]{described}[/item], required by contest statement '
+                f'[item]{contest_statement.name}[/item].[/error]'
+            )
+    statement = matching[0]
+    if statement.type != contest_statement.type:
+        with StatementResolverError() as err:
+            err.print(
+                f'[error]Problem [item]{problem_label}[/item] statement '
+                f'[item]{described}[/item] has type [item]{statement.type}[/item], '
+                f'but contest statement [item]{contest_statement.name}[/item] joins '
+                f'[item]{contest_statement.type}[/item] statements. The types must '
+                f'match for the join.[/error]'
+            )
+    return statement
+
+
+def require_contest_for_problem() -> Contest:
+    """Return the contest the current problem belongs to, or hard-error.
+
+    Statements v2 requires a contest to build any problem statement (design §2,
+    decision 1). Gives a dispatcher-aware hint when the contest exists but no
+    variant is selected.
+    """
+    contest = contest_package.find_contest_package()
+    if contest is not None:
+        return contest
+
+    contest_root = contest_package.find_contest_root()
+    if contest_root is not None and contest_state.resolve_explicit_selection() is None:
+        variants = contest_package.discover_contest_variants(contest_root)
+        available = sorted(v for v in variants if v is not None)
+        if available:
+            with StatementResolverError() as err:
+                err.print(
+                    '[error]Building a problem statement requires a contest, but '
+                    'the contest here is a dispatcher with no explicit selection. '
+                    f'Pass [item]-C <id>[/item] or set [item]RBX_CONTEST=<id>[/item]. '
+                    f'Available contests: [item]{available}[/item].[/error]'
+                )
+
+    with StatementResolverError() as err:
+        err.print(
+            '[error]Building a problem statement requires a contest, but no '
+            'contest was found for this problem. Statements v2 cannot build a '
+            'problem statement standalone outside a contest.[/error]'
+        )
+    raise AssertionError('unreachable')  # pragma: no cover
+
+
+def find_contest_for_problem() -> Optional[Contest]:
+    """Best-effort contest lookup (no error). Used where a contest is optional."""
+    return contest_package.find_contest_package()

--- a/rbx/box/statements/sample_staging.py
+++ b/rbx/box/statements/sample_staging.py
@@ -1,0 +1,166 @@
+"""Statements v2 recursive sample staging (design §6.3, issue #562).
+
+Each sample gets its own hermetic folder ``<problem_root>/.samples/<idx>/``:
+
+- generated ``in`` / ``out`` are mirrored in; the handles expose them as
+  **root-relative** paths because ``\\VerbatimInput`` (sample I/O) ignores the
+  ``\\subimport`` base (§6.4);
+- the explanation — whether it comes from an inline ``explanation_<i>`` block or
+  an authored explanation file — is rendered into ``explanation.tex``; for a
+  *file* explanation the entire containing directory is overlaid so the
+  explanation can ``\\includegraphics`` its own figures. The handle exposes
+  ``dir`` / ``explanation_file`` as **import-base-relative** for ``\\subimport``;
+- interactive chunks are mirrored in and exposed root-relative.
+
+The input is the lightweight :class:`SampleSource` (plain paths) so the staging
+is decoupled from the heavy ``StatementSample`` model and unit-testable.
+"""
+
+import dataclasses
+import pathlib
+import shutil
+from typing import Callable, Dict, List, Optional, Tuple
+
+from rbx.box.statements import overlay
+from rbx.box.statements.context import SampleHandle
+
+SAMPLES_DIRNAME = '.samples'
+
+# (content: bytes, mode: 'latex'|'markdown') -> rendered bytes
+RenderText = Callable[[bytes, str], bytes]
+# (content: bytes, mode) -> {lang_block: content}
+RenderBlocks = Callable[[bytes, str], Dict[str, str]]
+
+
+@dataclasses.dataclass
+class SampleInteractionChunkHandle:
+    path: str
+    pipe: int
+    data: Optional[str] = None
+
+
+@dataclasses.dataclass
+class SampleInteractionHandle:
+    chunks: List[SampleInteractionChunkHandle]
+
+
+@dataclasses.dataclass
+class SampleSource:
+    """A single sample's source files, resolved from a ``StatementSample``."""
+
+    input_path: pathlib.Path
+    output_path: Optional[pathlib.Path] = None
+    has_output: bool = False
+    explanation_path: Optional[pathlib.Path] = None
+    explanation_from_blocks: bool = False
+    interaction_chunks: List[Tuple[pathlib.Path, int]] = dataclasses.field(
+        default_factory=list
+    )
+
+
+def _suffix_for_mode(mode: str) -> str:
+    return '.md' if mode == 'markdown' else '.tex'
+
+
+def _resolve_explanation(
+    index: int,
+    source: SampleSource,
+    explanation_blocks: Dict[int, str],
+    render_text: Optional[RenderText],
+    render_blocks: Optional[RenderBlocks],
+    lang: str,
+    mode: str,
+) -> Optional[bytes]:
+    """Return the final explanation content for a sample, or None.
+
+    Inline ``explanation_<i>`` blocks take precedence over an authored file.
+    """
+    if index in explanation_blocks:
+        return explanation_blocks[index].encode()
+    if source.explanation_path is None or not source.explanation_path.is_file():
+        return None
+    raw = source.explanation_path.read_bytes()
+    if source.explanation_from_blocks and render_blocks is not None:
+        blocks = render_blocks(raw, mode)
+        selected = blocks.get(lang)
+        return selected.encode() if selected is not None else None
+    if render_text is not None:
+        return render_text(raw, mode)
+    return raw
+
+
+def stage_samples(
+    problem_root: pathlib.Path,
+    root_prefix: str,
+    sources: List[SampleSource],
+    *,
+    explanation_blocks: Optional[Dict[int, str]] = None,
+    render_text: Optional[RenderText] = None,
+    render_explanation_text: Optional[RenderText] = None,
+    render_blocks: Optional[RenderBlocks] = None,
+    lang: str = 'en',
+    mode: str = 'latex',
+) -> List[SampleHandle]:
+    """Stage every sample under ``<problem_root>/.samples/<idx>/`` and return the
+    template handles.
+
+    ``root_prefix`` is the problem root's path relative to the overlay root
+    (``''`` for standalone, ``'.problems/<SHORT>/'`` for a join member); it
+    anchors the root-relative I/O / chunk paths. ``render_explanation_text`` (a
+    back-compat alias of ``render_text``) renders an authored explanation file's
+    Jinja before it is written into the sample folder.
+    """
+    explanation_blocks = explanation_blocks or {}
+    render_text = render_text or render_explanation_text
+    suffix = _suffix_for_mode(mode)
+    samples_root = problem_root / SAMPLES_DIRNAME
+
+    handles: List[SampleHandle] = []
+    for index, source in enumerate(sources):
+        folder_name = f'{index:03d}'
+        folder = samples_root / folder_name
+        folder.mkdir(parents=True, exist_ok=True)
+        rel = f'{root_prefix}{SAMPLES_DIRNAME}/{folder_name}'
+
+        shutil.copyfile(source.input_path, folder / 'in')
+        handle = SampleHandle(index=index, input=f'{rel}/in')
+
+        if source.has_output and source.output_path is not None:
+            shutil.copyfile(source.output_path, folder / 'out')
+            handle.output = f'{rel}/out'
+        else:
+            handle.has_output = False
+
+        explanation = _resolve_explanation(
+            index,
+            source,
+            explanation_blocks,
+            render_text,
+            render_blocks,
+            lang,
+            mode,
+        )
+        if explanation is not None:
+            if (
+                index not in explanation_blocks
+                and source.explanation_path is not None
+                and source.explanation_path.is_file()
+            ):
+                overlay.mirror_tree(source.explanation_path.parent, folder)
+            (folder / f'explanation{suffix}').write_bytes(explanation)
+            handle.dir = f'{SAMPLES_DIRNAME}/{folder_name}/'
+            handle.explanation_file = 'explanation'
+
+        if source.interaction_chunks:
+            chunks: List[SampleInteractionChunkHandle] = []
+            for chunk_index, (chunk_path, pipe) in enumerate(source.interaction_chunks):
+                chunk_name = f'chunk_{chunk_index:03d}.txt'
+                shutil.copyfile(chunk_path, folder / chunk_name)
+                chunks.append(
+                    SampleInteractionChunkHandle(path=f'{rel}/{chunk_name}', pipe=pipe)
+                )
+            handle.interaction = SampleInteractionHandle(chunks=chunks)
+
+        handles.append(handle)
+
+    return handles

--- a/rbx/box/statements/sample_staging.py
+++ b/rbx/box/statements/sample_staging.py
@@ -58,10 +58,6 @@ class SampleSource:
     )
 
 
-def _suffix_for_mode(mode: str) -> str:
-    return '.md' if mode == 'markdown' else '.tex'
-
-
 def _resolve_explanation(
     index: int,
     source: SampleSource,
@@ -112,7 +108,6 @@ def stage_samples(
     """
     explanation_blocks = explanation_blocks or {}
     render_text = render_text or render_explanation_text
-    suffix = _suffix_for_mode(mode)
     samples_root = problem_root / SAMPLES_DIRNAME
 
     handles: List[SampleHandle] = []
@@ -121,15 +116,6 @@ def stage_samples(
         folder = samples_root / folder_name
         folder.mkdir(parents=True, exist_ok=True)
         rel = f'{root_prefix}{SAMPLES_DIRNAME}/{folder_name}'
-
-        shutil.copyfile(source.input_path, folder / 'in')
-        handle = SampleHandle(index=index, input=f'{rel}/in')
-
-        if source.has_output and source.output_path is not None:
-            shutil.copyfile(source.output_path, folder / 'out')
-            handle.output = f'{rel}/out'
-        else:
-            handle.has_output = False
 
         explanation = _resolve_explanation(
             index,
@@ -140,14 +126,34 @@ def stage_samples(
             lang,
             mode,
         )
+
+        # Overlay the authored explanation's directory FIRST (for its figures);
+        # the staged I/O / chunks / explanation below then overwrite anything the
+        # mirror brought in (e.g. a source file literally named `in`/`out`), so
+        # the generated sample data is always authoritative.
+        if (
+            explanation is not None
+            and index not in explanation_blocks
+            and source.explanation_path is not None
+            and source.explanation_path.is_file()
+        ):
+            overlay.mirror_tree(source.explanation_path.parent, folder)
+
+        shutil.copyfile(source.input_path, folder / 'in')
+        handle = SampleHandle(index=index, input=f'{rel}/in')
+
+        if source.has_output and source.output_path is not None:
+            shutil.copyfile(source.output_path, folder / 'out')
+            handle.output = f'{rel}/out'
+        else:
+            handle.has_output = False
+
         if explanation is not None:
-            if (
-                index not in explanation_blocks
-                and source.explanation_path is not None
-                and source.explanation_path.is_file()
-            ):
-                overlay.mirror_tree(source.explanation_path.parent, folder)
-            (folder / f'explanation{suffix}').write_bytes(explanation)
+            # The explanation is always `\subimport`-ed by a LaTeX template (both
+            # the standalone and the contest-problem templates are LaTeX), so it
+            # is written as `.tex` regardless of the source format; rbxMarkdown
+            # explanations are converted upstream (see engine.render_problem_tex).
+            (folder / 'explanation.tex').write_bytes(explanation)
             handle.dir = f'{SAMPLES_DIRNAME}/{folder_name}/'
             handle.explanation_file = 'explanation'
 

--- a/rbx/testdata/contests/statements_v2/A/problem.rbx.yml
+++ b/rbx/testdata/contests/statements_v2/A/problem.rbx.yml
@@ -1,0 +1,12 @@
+name: 'problem-a'
+timeLimit: 1000
+memoryLimit: 256
+vars:
+  author: 'Alice'
+statements:
+  - language: 'en'
+    title: 'Problem A'
+    file: 'statement/statement.rbx.tex'
+    type: 'rbxTeX'
+    params:
+      show_limits: true

--- a/rbx/testdata/contests/statements_v2/A/statement/statement.rbx.tex
+++ b/rbx/testdata/contests/statements_v2/A/statement/statement.rbx.tex
@@ -1,0 +1,4 @@
+%- block legend
+Problem A, authored by \VAR{vars.author}. Limits shown: \VAR{params.show_limits}.
+This problem belongs to \VAR{contest.title}.
+%- endblock

--- a/rbx/testdata/contests/statements_v2/B/problem.rbx.yml
+++ b/rbx/testdata/contests/statements_v2/B/problem.rbx.yml
@@ -1,0 +1,12 @@
+name: 'problem-b'
+timeLimit: 2000
+memoryLimit: 256
+vars:
+  author: 'Bob'
+statements:
+  - language: 'en'
+    title: 'Problem B'
+    file: 'statement/statement.rbx.tex'
+    type: 'rbxTeX'
+    params:
+      show_limits: false

--- a/rbx/testdata/contests/statements_v2/B/statement/statement.rbx.tex
+++ b/rbx/testdata/contests/statements_v2/B/statement/statement.rbx.tex
@@ -1,0 +1,3 @@
+%- block legend
+Problem B, authored by \VAR{vars.author}. Limits shown: \VAR{params.show_limits}.
+%- endblock

--- a/rbx/testdata/contests/statements_v2/contest.rbx.yml
+++ b/rbx/testdata/contests/statements_v2/contest.rbx.yml
@@ -1,0 +1,21 @@
+---
+name: 'sv2'
+titles:
+  en: 'Statements v2 Contest'
+vars:
+  year: 2026
+problems:
+  - short_name: 'A'
+  - short_name: 'B'
+statements:
+  - name: 'main-en'
+    language: 'en'
+    file: 'statements/contest.rbx.tex'
+    type: 'rbxTeX'
+    standaloneProblemTemplate: 'statements/problem-standalone.rbx.tex'
+    contestProblemTemplate: 'statements/problem-in-contest.rbx.tex'
+documents:
+  - name: 'info-en'
+    language: 'en'
+    file: 'statements/info.jinja.tex'
+    type: 'jinja-tex'

--- a/rbx/testdata/contests/statements_v2/statements/contest.rbx.tex
+++ b/rbx/testdata/contests/statements_v2/statements/contest.rbx.tex
@@ -1,0 +1,24 @@
+\documentclass[a4paper,11pt]{article}
+\usepackage{import}
+\usepackage{graphicx}
+\usepackage{fancyvrb}
+\newcommand{\example}[2]{%
+  \par\noindent\textbf{Input}\par
+  \VerbatimInput{#1}%
+  \par\noindent\textbf{Output}\par
+  \VerbatimInput{#2}%
+  \par
+}
+\begin{document}
+
+\begin{center}
+  {\Large \VAR{contest.title | escape}}\\[1ex]
+  Year \VAR{contest.vars.year}
+\end{center}
+
+%- for problem in problems
+  \subimport{\VAR{problem.import_dir}}{\VAR{problem.import_file}}
+  \clearpage
+%- endfor
+
+\end{document}

--- a/rbx/testdata/contests/statements_v2/statements/info.jinja.tex
+++ b/rbx/testdata/contests/statements_v2/statements/info.jinja.tex
@@ -1,0 +1,5 @@
+\documentclass[a4paper,11pt]{article}
+\begin{document}
+\section*{Information}
+This is the info sheet for \VAR{contest.title | escape} (year \VAR{contest.vars.year}).
+\end{document}

--- a/rbx/testdata/contests/statements_v2/statements/problem-in-contest.rbx.tex
+++ b/rbx/testdata/contests/statements_v2/statements/problem-in-contest.rbx.tex
@@ -1,0 +1,13 @@
+\section*{Problem \VAR{problem.short_name}. \VAR{problem.title | escape}}
+
+\VAR{problem.blocks.legend}
+
+%- if problem.samples
+  \subsection*{Examples}
+  %- for sample in problem.samples
+    \example{\VAR{sample.input}}{\VAR{sample.output if sample.output is not none else ''}}
+    %- if sample.explanation_file is not none
+      \subimport{\VAR{sample.dir}}{\VAR{sample.explanation_file}}
+    %- endif
+  %- endfor
+%- endif

--- a/rbx/testdata/contests/statements_v2/statements/problem-standalone.rbx.tex
+++ b/rbx/testdata/contests/statements_v2/statements/problem-standalone.rbx.tex
@@ -1,0 +1,28 @@
+\documentclass[a4paper,11pt]{article}
+\usepackage{import}
+\usepackage{graphicx}
+\usepackage{fancyvrb}
+\newcommand{\example}[2]{%
+  \par\noindent\textbf{Input}\par
+  \VerbatimInput{#1}%
+  \par\noindent\textbf{Output}\par
+  \VerbatimInput{#2}%
+  \par
+}
+\begin{document}
+
+\section*{\VAR{problem.title | escape}}
+
+\VAR{problem.blocks.legend}
+
+%- if problem.samples
+  \subsection*{Examples}
+  %- for sample in problem.samples
+    \example{\VAR{sample.input}}{\VAR{sample.output if sample.output is not none else ''}}
+    %- if sample.explanation_file is not none
+      \subimport{\VAR{sample.dir}}{\VAR{sample.explanation_file}}
+    %- endif
+  %- endfor
+%- endif
+
+\end{document}

--- a/tests/rbx/box/contest/test_contest_build_v2.py
+++ b/tests/rbx/box/contest/test_contest_build_v2.py
@@ -1,0 +1,65 @@
+import inspect
+
+import pytest
+
+from rbx.box.contest import statements as contest_statements_cli
+from rbx.box.statements.schema import StatementType
+
+_build_async = inspect.unwrap(contest_statements_cli.build)
+
+
+async def _run(output=StatementType.TeX):
+    await _build_async(
+        verification=0,
+        names=None,
+        languages=None,
+        validate=False,
+        output=output,
+        samples=False,
+        vars=None,
+        install_tex=False,
+        profile=None,
+    )
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_contest_join_subimports_each_problem(cleandir_with_testdata):
+    await _run(output=StatementType.TeX)
+
+    contest_tex = (cleandir_with_testdata / 'build' / 'main-en.tex').read_text()
+    assert 'Statements v2 Contest' in contest_tex
+    assert '\\subimport{.problems/A/}{statement}' in contest_tex
+    assert '\\subimport{.problems/B/}{statement}' in contest_tex
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_contest_fragments_are_isolated_per_problem(cleandir_with_testdata):
+    await _run(output=StatementType.TeX)
+
+    overlay = cleandir_with_testdata / 'build' / 'statements' / 'main-en'
+    frag_a = (overlay / '.problems' / 'A' / 'statement.tex').read_text()
+    frag_b = (overlay / '.problems' / 'B' / 'statement.tex').read_text()
+
+    # Fragment uses the contestProblemTemplate (a fragment, no \documentclass).
+    assert '\\documentclass' not in frag_a
+    assert 'Problem A. Problem A' in frag_a
+    assert 'authored by Alice' in frag_a
+    assert 'Problem B. Problem B' in frag_b
+    assert 'authored by Bob' in frag_b
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_documents_emitted_without_joining(cleandir_with_testdata):
+    await _run(output=StatementType.TeX)
+
+    info = (cleandir_with_testdata / 'build' / 'info-en.tex').read_text()
+    assert 'info sheet' in info
+    assert 'Statements v2 Contest' in info
+    assert '\\subimport' not in info
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_contest_build_pdf_with_mocked_pdflatex(cleandir_with_testdata):
+    await _run(output=StatementType.PDF)
+    assert (cleandir_with_testdata / 'build' / 'main-en.pdf').is_file()
+    assert (cleandir_with_testdata / 'build' / 'info-en.pdf').is_file()

--- a/tests/rbx/box/statements/test_context.py
+++ b/tests/rbx/box/statements/test_context.py
@@ -1,0 +1,112 @@
+from rbx.box.statements import context
+from rbx.box.statements.context import (
+    ContestRenderContext,
+    ProblemRenderContext,
+    SampleHandle,
+    StatementCodeLanguage,
+)
+
+
+def _langs():
+    return [StatementCodeLanguage(id='cpp', name='C++', command='g++')]
+
+
+def _contest_ctx(**kwargs):
+    return ContestRenderContext(
+        title=kwargs.pop('title', 'My Contest'),
+        vars=kwargs.pop('vars', {'year': 2026}),
+        params=kwargs.pop('params', {}),
+        **kwargs,
+    )
+
+
+def _problem_ctx(**kwargs):
+    return ProblemRenderContext(
+        title=kwargs.pop('title', 'My Problem'),
+        vars=kwargs.pop('vars', {'author': 'alice'}),
+        params=kwargs.pop('params', {'show_limits': True}),
+        **kwargs,
+    )
+
+
+class TestProblemNamespaces:
+    def test_params_vars_contest_are_separate_namespaces(self):
+        kwargs = context.problem_jinja_kwargs(
+            lang='en',
+            languages=_langs(),
+            problem=_problem_ctx(
+                params={'show_limits': True}, vars={'author': 'alice'}
+            ),
+            contest=_contest_ctx(vars={'year': 2026}),
+        )
+        # Distinct, unmerged.
+        assert kwargs['params']['show_limits'] is True
+        assert kwargs['vars']['author'] == 'alice'
+        assert kwargs['contest']['vars']['year'] == 2026
+        # No cross-contamination.
+        assert 'author' not in kwargs['params']
+        assert 'show_limits' not in kwargs['vars']
+        assert 'year' not in kwargs['vars']
+
+    def test_problem_namespace_exposes_title_and_samples(self):
+        sample = SampleHandle(
+            index=0, input='.samples/000/in', output='.samples/000/out'
+        )
+        kwargs = context.problem_jinja_kwargs(
+            lang='en',
+            languages=_langs(),
+            problem=_problem_ctx(samples=[sample], short_name='A'),
+            contest=_contest_ctx(),
+        )
+        assert kwargs['problem']['title'] == 'My Problem'
+        assert kwargs['problem']['short_name'] == 'A'
+        assert kwargs['problem']['samples'][0].input == '.samples/000/in'
+
+    def test_import_handles_present_when_set(self):
+        kwargs = context.problem_jinja_kwargs(
+            lang='en',
+            languages=_langs(),
+            problem=_problem_ctx(import_dir='.problems/A/', import_file='statement'),
+            contest=_contest_ctx(),
+        )
+        assert kwargs['problem']['import_dir'] == '.problems/A/'
+        assert kwargs['problem']['import_file'] == 'statement'
+
+    def test_import_handles_absent_by_default(self):
+        kwargs = context.problem_jinja_kwargs(
+            lang='en',
+            languages=_langs(),
+            problem=_problem_ctx(),
+            contest=_contest_ctx(),
+        )
+        assert 'import_dir' not in kwargs['problem']
+        assert 'import_file' not in kwargs['problem']
+
+
+class TestContestNamespaces:
+    def test_contest_render_exposes_problems_list(self):
+        problems = [
+            _problem_ctx(title='A', import_dir='.problems/A/', import_file='statement'),
+            _problem_ctx(title='B', import_dir='.problems/B/', import_file='statement'),
+        ]
+        kwargs = context.contest_jinja_kwargs(
+            lang='en',
+            languages=_langs(),
+            contest=_contest_ctx(vars={'year': 2026}, params={'cover': True}),
+            problems=problems,
+        )
+        assert kwargs['contest']['title'] == 'My Contest'
+        assert kwargs['contest']['vars']['year'] == 2026
+        # For a contest render, params is the contest statement's own params.
+        assert kwargs['params']['cover'] is True
+        assert [p['title'] for p in kwargs['problems']] == ['A', 'B']
+        assert kwargs['problems'][0]['import_dir'] == '.problems/A/'
+
+    def test_keyed_languages_present(self):
+        kwargs = context.contest_jinja_kwargs(
+            lang='en',
+            languages=_langs(),
+            contest=_contest_ctx(),
+            problems=[],
+        )
+        assert 'cpp' in kwargs['keyed_languages']

--- a/tests/rbx/box/statements/test_engine.py
+++ b/tests/rbx/box/statements/test_engine.py
@@ -1,0 +1,62 @@
+import pathlib
+
+import pytest
+
+from rbx.box.statements import engine
+from rbx.box.statements.overlay import OverlayCollisionError
+
+
+def _write(path: pathlib.Path, content: str = 'x') -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestRelativizeTemplate:
+    def test_template_under_chrome_dir_is_referenced_relative(self, tmp_path):
+        contest_root = tmp_path / 'contest'
+        chrome_dir = contest_root / 'statements'
+        _write(chrome_dir / 'tpl.rbx.tex', 'T')
+        overlay_root = tmp_path / 'overlay'
+        overlay_root.mkdir()
+
+        rel = engine.relativize_template(
+            contest_root,
+            chrome_dir,
+            pathlib.Path('statements/tpl.rbx.tex'),
+            overlay_root,
+        )
+        assert rel == 'tpl.rbx.tex'
+
+    def test_template_outside_chrome_is_copied_to_root(self, tmp_path):
+        contest_root = tmp_path / 'contest'
+        chrome_dir = contest_root / 'statements'
+        chrome_dir.mkdir(parents=True)
+        _write(contest_root / 'shared' / 'tpl.rbx.tex', 'OUTSIDE')
+        overlay_root = tmp_path / 'overlay'
+        overlay_root.mkdir()
+
+        rel = engine.relativize_template(
+            contest_root,
+            chrome_dir,
+            pathlib.Path('shared/tpl.rbx.tex'),
+            overlay_root,
+        )
+        assert rel == 'tpl.rbx.tex'
+        assert (overlay_root / 'tpl.rbx.tex').read_text() == 'OUTSIDE'
+
+    def test_outside_template_basename_collision_errors(self, tmp_path):
+        contest_root = tmp_path / 'contest'
+        chrome_dir = contest_root / 'statements'
+        chrome_dir.mkdir(parents=True)
+        _write(contest_root / 'shared' / 'tpl.rbx.tex', 'OUTSIDE')
+        overlay_root = tmp_path / 'overlay'
+        overlay_root.mkdir()
+        _write(overlay_root / 'tpl.rbx.tex', 'EXISTING CHROME ASSET')
+
+        with pytest.raises(OverlayCollisionError):
+            engine.relativize_template(
+                contest_root,
+                chrome_dir,
+                pathlib.Path('shared/tpl.rbx.tex'),
+                overlay_root,
+            )

--- a/tests/rbx/box/statements/test_overlay.py
+++ b/tests/rbx/box/statements/test_overlay.py
@@ -1,0 +1,113 @@
+import pathlib
+
+import pytest
+
+from rbx.box.statements import overlay
+from rbx.box.statements.overlay import OverlayCollisionError
+
+
+def _write(path: pathlib.Path, content: str = 'x') -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestMirrorTree:
+    def test_copies_nested_files_preserving_structure(self, tmp_path):
+        src = tmp_path / 'src'
+        _write(src / 'a.tex', 'a')
+        _write(src / 'imgs' / 'fig.png', 'png')
+        _write(src / 'inc' / 'deep' / 'part.tex', 'part')
+
+        dest = tmp_path / 'dest'
+        overlay.mirror_tree(src, dest)
+
+        assert (dest / 'a.tex').read_text() == 'a'
+        assert (dest / 'imgs' / 'fig.png').read_text() == 'png'
+        assert (dest / 'inc' / 'deep' / 'part.tex').read_text() == 'part'
+
+    def test_returns_relative_paths_copied(self, tmp_path):
+        src = tmp_path / 'src'
+        _write(src / 'a.tex')
+        _write(src / 'imgs' / 'fig.png')
+
+        dest = tmp_path / 'dest'
+        copied = overlay.mirror_tree(src, dest)
+
+        assert set(copied) == {
+            pathlib.Path('a.tex'),
+            pathlib.Path('imgs') / 'fig.png',
+        }
+
+    def test_missing_source_dir_is_noop(self, tmp_path):
+        dest = tmp_path / 'dest'
+        copied = overlay.mirror_tree(tmp_path / 'does-not-exist', dest)
+        assert copied == []
+
+
+class TestStageStandaloneOverlay:
+    def test_merges_chrome_and_problem_into_one_root(self, tmp_path):
+        chrome = tmp_path / 'chrome'
+        _write(chrome / 'icpc.sty', 'sty')
+        _write(chrome / 'logo.png', 'logo')
+
+        problem = tmp_path / 'problem'
+        _write(problem / 'statement.rbx.tex', 'tex')
+        _write(problem / 'imgs' / 'fig.png', 'fig')
+
+        root = tmp_path / 'root'
+        overlay.stage_standalone_overlay(root, chrome_dir=chrome, problem_dir=problem)
+
+        assert (root / 'icpc.sty').read_text() == 'sty'
+        assert (root / 'logo.png').read_text() == 'logo'
+        assert (root / 'statement.rbx.tex').read_text() == 'tex'
+        assert (root / 'imgs' / 'fig.png').read_text() == 'fig'
+
+    def test_errors_on_collision_between_chrome_and_problem(self, tmp_path):
+        chrome = tmp_path / 'chrome'
+        _write(chrome / 'common.tex', 'from-chrome')
+
+        problem = tmp_path / 'problem'
+        _write(problem / 'common.tex', 'from-problem')
+
+        root = tmp_path / 'root'
+        with pytest.raises(OverlayCollisionError):
+            overlay.stage_standalone_overlay(
+                root, chrome_dir=chrome, problem_dir=problem
+            )
+
+    def test_no_chrome_is_allowed(self, tmp_path):
+        problem = tmp_path / 'problem'
+        _write(problem / 'statement.rbx.tex', 'tex')
+
+        root = tmp_path / 'root'
+        overlay.stage_standalone_overlay(root, chrome_dir=None, problem_dir=problem)
+        assert (root / 'statement.rbx.tex').read_text() == 'tex'
+
+
+class TestStageJoin:
+    def test_isolates_problems_under_dot_problems(self, tmp_path):
+        problem_a = tmp_path / 'a'
+        _write(problem_a / 'statement.rbx.tex', 'A')
+        _write(problem_a / 'fig.png', 'A-fig')
+
+        problem_b = tmp_path / 'b'
+        _write(problem_b / 'statement.rbx.tex', 'B')
+        _write(problem_b / 'fig.png', 'B-fig')  # same name as A's asset
+
+        root = tmp_path / 'root'
+        dir_a = overlay.stage_join_problem(root, problem_a, 'A')
+        dir_b = overlay.stage_join_problem(root, problem_b, 'B')
+
+        # Same-named assets across problems must NOT collide.
+        assert (dir_a / 'fig.png').read_text() == 'A-fig'
+        assert (dir_b / 'fig.png').read_text() == 'B-fig'
+        assert dir_a == root / '.problems' / 'A'
+        assert dir_b == root / '.problems' / 'B'
+
+    def test_chrome_overlaid_at_root(self, tmp_path):
+        chrome = tmp_path / 'chrome'
+        _write(chrome / 'icpc.sty', 'sty')
+
+        root = tmp_path / 'root'
+        overlay.stage_chrome(root, chrome)
+        assert (root / 'icpc.sty').read_text() == 'sty'

--- a/tests/rbx/box/statements/test_render.py
+++ b/tests/rbx/box/statements/test_render.py
@@ -1,0 +1,111 @@
+import pathlib
+
+from rbx.box.statements import render
+from rbx.box.statements.context import ContestRenderContext, ProblemRenderContext
+
+
+def _write(path: pathlib.Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestExtractBlocks:
+    def test_extracts_named_blocks_with_namespaced_vars(self, tmp_path):
+        content = (
+            '%- block legend\n'
+            'Hello \\VAR{vars.author}, show=\\VAR{params.show}\n'
+            '%- endblock\n'
+            '%- block input\n'
+            'the input\n'
+            '%- endblock\n'
+        ).encode()
+        problem = ProblemRenderContext(
+            title='P', vars={'author': 'alice'}, params={'show': 'YES'}
+        )
+        contest = ContestRenderContext(title='C')
+        blocks = render.extract_blocks(
+            tmp_path, content, lang='en', languages=[], problem=problem, contest=contest
+        )
+        assert 'alice' in blocks.blocks['legend']
+        assert 'YES' in blocks.blocks['legend']
+        assert 'the input' in blocks.blocks['input']
+
+    def test_extracts_per_sample_explanation_blocks(self, tmp_path):
+        content = ('%- block explanation_0\nwhy sample zero\n%- endblock\n').encode()
+        problem = ProblemRenderContext(title='P')
+        contest = ContestRenderContext(title='C')
+        blocks = render.extract_blocks(
+            tmp_path, content, lang='en', languages=[], problem=problem, contest=contest
+        )
+        assert 0 in blocks.explanations
+        assert 'why sample zero' in blocks.explanations[0]
+
+
+class TestRenderProblemDocument:
+    def test_fills_template_with_blocks_and_namespaces(self, tmp_path):
+        # Template lives in the overlay root (staged by the stager).
+        _write(
+            tmp_path / 'tpl.rbx.tex',
+            '\\documentclass{article}\n'
+            '\\begin{document}\n'
+            'TITLE=\\VAR{problem.title}\n'
+            'LEGEND=\\VAR{problem.blocks.legend}\n'
+            'CONTEST=\\VAR{contest.title}\n'
+            '\\end{document}\n',
+        )
+        problem = ProblemRenderContext(title='My Problem')
+        problem.blocks = {'legend': 'LEG'}
+        contest = ContestRenderContext(title='My Contest')
+        out = render.render_problem_document(
+            tmp_path,
+            'tpl.rbx.tex',
+            lang='en',
+            languages=[],
+            problem=problem,
+            contest=contest,
+        ).decode()
+        assert 'TITLE=My Problem' in out
+        assert 'LEGEND=LEG' in out
+        assert 'CONTEST=My Contest' in out
+
+
+class TestRenderContestDocument:
+    def test_joins_problems_via_import_handles(self, tmp_path):
+        _write(
+            tmp_path / 'contest.rbx.tex',
+            '\\documentclass{article}\n'
+            '\\usepackage{import}\n'
+            '\\begin{document}\n'
+            '%- for problem in problems\n'
+            '\\subimport{\\VAR{problem.import_dir}}{\\VAR{problem.import_file}}\n'
+            '%- endfor\n'
+            '\\end{document}\n',
+        )
+        contest = ContestRenderContext(title='C')
+        problems = [
+            ProblemRenderContext(
+                title='A', import_dir='.problems/A/', import_file='statement'
+            ),
+            ProblemRenderContext(
+                title='B', import_dir='.problems/B/', import_file='statement'
+            ),
+        ]
+        out = render.render_contest_document(
+            tmp_path,
+            'contest.rbx.tex',
+            lang='en',
+            languages=[],
+            contest=contest,
+            problems=problems,
+        ).decode()
+        assert '\\subimport{.problems/A/}{statement}' in out
+        assert '\\subimport{.problems/B/}{statement}' in out
+
+
+class TestCompilePdf:
+    def test_returns_pdf_bytes(self, tmp_path):
+        # mock_pdflatex (autouse) makes build_pdf return an empty PDF.
+        pdf = render.compile_pdf(
+            tmp_path, b'\\documentclass{article}\\begin{document}x\\end{document}'
+        )
+        assert isinstance(pdf, bytes)

--- a/tests/rbx/box/statements/test_resolver.py
+++ b/tests/rbx/box/statements/test_resolver.py
@@ -1,0 +1,126 @@
+import pathlib
+
+import pytest
+
+from rbx.box.contest.schema import ContestStatement
+from rbx.box.statements import resolver
+from rbx.box.statements.resolver import StatementResolverError
+from rbx.box.statements.schema import Statement, StatementType
+
+
+def _problem_statement(
+    language: str = 'en',
+    variant: str = 'default',
+    type: StatementType = StatementType.rbxTeX,
+) -> Statement:
+    return Statement(
+        language=language,
+        variant=variant,
+        file=pathlib.Path('statement/statement.rbx.tex'),
+        type=type,
+    )
+
+
+def _contest_statement(
+    name: str,
+    language: str = 'en',
+    variant: str = 'default',
+    type: StatementType = StatementType.rbxTeX,
+    standalone: bool = True,
+) -> ContestStatement:
+    kwargs = {}
+    if standalone:
+        kwargs['standaloneProblemTemplate'] = pathlib.Path(
+            'statements/problem-standalone.rbx.tex'
+        )
+    return ContestStatement(
+        name=name,
+        language=language,
+        variant=variant,
+        file=pathlib.Path('statements/contest.rbx.tex'),
+        type=type,
+        contestProblemTemplate=pathlib.Path('statements/problem-in-contest.rbx.tex'),
+        **kwargs,
+    )
+
+
+class TestSelectStandaloneContestStatement:
+    def test_returns_single_matching_candidate(self):
+        st = _problem_statement(language='en', variant='default')
+        contest_statements = [
+            _contest_statement('main-en', language='en', variant='default'),
+            _contest_statement('main-pt', language='pt', variant='default'),
+        ]
+        selected = resolver.select_standalone_contest_statement(st, contest_statements)
+        assert selected.name == 'main-en'
+
+    def test_matches_on_variant_too(self):
+        st = _problem_statement(language='en', variant='short')
+        contest_statements = [
+            _contest_statement('main-en', language='en', variant='default'),
+            _contest_statement('short-en', language='en', variant='short'),
+        ]
+        selected = resolver.select_standalone_contest_statement(st, contest_statements)
+        assert selected.name == 'short-en'
+
+    def test_errors_when_zero_candidates(self):
+        st = _problem_statement(language='fr', variant='default')
+        contest_statements = [
+            _contest_statement('main-en', language='en', variant='default'),
+        ]
+        with pytest.raises(StatementResolverError):
+            resolver.select_standalone_contest_statement(st, contest_statements)
+
+    def test_zero_candidates_when_no_standalone_template(self):
+        # A contest statement matching (language, variant) but WITHOUT a
+        # standaloneProblemTemplate is not a candidate.
+        st = _problem_statement(language='en', variant='default')
+        contest_statements = [
+            _contest_statement(
+                'main-en', language='en', variant='default', standalone=False
+            ),
+        ]
+        with pytest.raises(StatementResolverError):
+            resolver.select_standalone_contest_statement(st, contest_statements)
+
+    def test_errors_when_multiple_candidates(self):
+        st = _problem_statement(language='en', variant='default')
+        contest_statements = [
+            _contest_statement('main-en', language='en', variant='default'),
+            _contest_statement('alt-en', language='en', variant='default'),
+        ]
+        with pytest.raises(StatementResolverError):
+            resolver.select_standalone_contest_statement(st, contest_statements)
+
+
+class TestSelectProblemStatement:
+    def test_returns_matching_problem_statement(self):
+        cs = _contest_statement('main-en', language='en', variant='default')
+        problem_statements = [
+            _problem_statement(language='en', variant='default'),
+            _problem_statement(language='pt', variant='default'),
+        ]
+        selected = resolver.select_problem_statement(cs, problem_statements, 'A')
+        assert selected.key == ('en', 'default')
+
+    def test_errors_when_no_matching_language_variant(self):
+        cs = _contest_statement('main-en', language='en', variant='short')
+        problem_statements = [
+            _problem_statement(language='en', variant='default'),
+        ]
+        with pytest.raises(StatementResolverError):
+            resolver.select_problem_statement(cs, problem_statements, 'A')
+
+    def test_errors_when_type_mismatch(self):
+        # Contest statement is rbxTeX; the problem statement at the same
+        # (language, variant) is rbxMarkdown -> cannot join.
+        cs = _contest_statement(
+            'main-en', language='en', variant='default', type=StatementType.rbxTeX
+        )
+        problem_statements = [
+            _problem_statement(
+                language='en', variant='default', type=StatementType.rbxMarkdown
+            ),
+        ]
+        with pytest.raises(StatementResolverError):
+            resolver.select_problem_statement(cs, problem_statements, 'A')

--- a/tests/rbx/box/statements/test_sample_staging.py
+++ b/tests/rbx/box/statements/test_sample_staging.py
@@ -1,0 +1,155 @@
+import pathlib
+
+from rbx.box.statements import sample_staging
+from rbx.box.statements.sample_staging import SampleSource
+
+
+def _write(path: pathlib.Path, content: str = 'x') -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestStageSamples:
+    def test_mirrors_io_and_sets_root_relative_paths_standalone(self, tmp_path):
+        src = tmp_path / 'src'
+        _write(src / '000.in', 'INPUT')
+        _write(src / '000.out', 'OUTPUT')
+        source = SampleSource(
+            input_path=src / '000.in',
+            output_path=src / '000.out',
+            has_output=True,
+        )
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        handles = sample_staging.stage_samples(
+            problem_root=root, root_prefix='', sources=[source]
+        )
+
+        assert (root / '.samples' / '000' / 'in').read_text() == 'INPUT'
+        assert (root / '.samples' / '000' / 'out').read_text() == 'OUTPUT'
+        # Root-relative for verbatim I/O.
+        assert handles[0].input == '.samples/000/in'
+        assert handles[0].output == '.samples/000/out'
+
+    def test_root_prefix_anchors_io_for_join(self, tmp_path):
+        src = tmp_path / 'src'
+        _write(src / '000.in', 'INPUT')
+        source = SampleSource(
+            input_path=src / '000.in', output_path=None, has_output=False
+        )
+
+        root = tmp_path / 'overlay' / '.problems' / 'A'
+        root.mkdir(parents=True)
+        handles = sample_staging.stage_samples(
+            problem_root=root, root_prefix='.problems/A/', sources=[source]
+        )
+        assert handles[0].input == '.problems/A/.samples/000/in'
+        assert handles[0].output is None
+
+    def test_no_explanation_leaves_handle_blank(self, tmp_path):
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        source = SampleSource(input_path=src / '000.in')
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        handles = sample_staging.stage_samples(
+            problem_root=root, root_prefix='', sources=[source]
+        )
+        assert handles[0].explanation_file is None
+        assert handles[0].dir is None
+
+
+class TestExplanations:
+    def test_inline_block_explanation_written_to_sample_folder(self, tmp_path):
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        source = SampleSource(input_path=src / '000.in')
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        handles = sample_staging.stage_samples(
+            problem_root=root,
+            root_prefix='',
+            sources=[source],
+            explanation_blocks={0: 'WHY ZERO'},
+        )
+        explanation = root / '.samples' / '000' / 'explanation.tex'
+        assert explanation.read_text() == 'WHY ZERO'
+        # Base-relative \subimport handles.
+        assert handles[0].dir == '.samples/000/'
+        assert handles[0].explanation_file == 'explanation'
+
+    def test_file_explanation_overlays_its_directory_for_figures(self, tmp_path):
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        _write(src / '000.tex', 'see \\includegraphics{diagram}')
+        _write(src / 'diagram.png', 'PNG')
+        source = SampleSource(
+            input_path=src / '000.in',
+            explanation_path=src / '000.tex',
+        )
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        handles = sample_staging.stage_samples(
+            problem_root=root,
+            root_prefix='',
+            sources=[source],
+            render_explanation_text=lambda content, mode: content,
+        )
+        folder = root / '.samples' / '000'
+        # Explanation rendered into the hermetic sample folder.
+        assert (
+            folder / 'explanation.tex'
+        ).read_text() == 'see \\includegraphics{diagram}'
+        # The explanation's figure is overlaid alongside it so \includegraphics resolves.
+        assert (folder / 'diagram.png').read_text() == 'PNG'
+        assert handles[0].explanation_file == 'explanation'
+
+    def test_inline_block_takes_precedence_over_file(self, tmp_path):
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        _write(src / '000.tex', 'FROM FILE')
+        source = SampleSource(
+            input_path=src / '000.in', explanation_path=src / '000.tex'
+        )
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        handles = sample_staging.stage_samples(
+            problem_root=root,
+            root_prefix='',
+            sources=[source],
+            explanation_blocks={0: 'FROM BLOCK'},
+            render_explanation_text=lambda content, mode: content,
+        )
+        assert (
+            root / '.samples' / '000' / 'explanation.tex'
+        ).read_text() == 'FROM BLOCK'
+        assert handles[0].explanation_file == 'explanation'
+
+
+class TestInteractiveChunks:
+    def test_chunks_staged_with_root_relative_paths(self, tmp_path):
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        _write(src / 'chunk0.txt', 'reads')
+        _write(src / 'chunk1.txt', 'writes')
+        source = SampleSource(
+            input_path=src / '000.in',
+            interaction_chunks=[(src / 'chunk0.txt', 0), (src / 'chunk1.txt', 1)],
+        )
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        handles = sample_staging.stage_samples(
+            problem_root=root, root_prefix='', sources=[source]
+        )
+        chunks = handles[0].interaction.chunks
+        assert chunks[0].path == '.samples/000/chunk_000.txt'
+        assert chunks[0].pipe == 0
+        assert chunks[1].path == '.samples/000/chunk_001.txt'
+        assert chunks[1].pipe == 1
+        assert (root / '.samples' / '000' / 'chunk_000.txt').read_text() == 'reads'

--- a/tests/rbx/box/statements/test_sample_staging.py
+++ b/tests/rbx/box/statements/test_sample_staging.py
@@ -108,6 +108,53 @@ class TestExplanations:
         assert (folder / 'diagram.png').read_text() == 'PNG'
         assert handles[0].explanation_file == 'explanation'
 
+    def test_staged_io_wins_over_explanation_dir_mirror(self, tmp_path):
+        # The explanation's source dir happens to contain files named in/out;
+        # the generated sample I/O must remain authoritative (regression).
+        src = tmp_path / 'src'
+        _write(src / '000.in', 'REAL_INPUT')
+        _write(src / '000.out', 'REAL_OUTPUT')
+        _write(src / '000.tex', 'explanation body')
+        _write(src / 'in', 'BOGUS')
+        _write(src / 'out', 'BOGUS')
+        source = SampleSource(
+            input_path=src / '000.in',
+            output_path=src / '000.out',
+            has_output=True,
+            explanation_path=src / '000.tex',
+        )
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        sample_staging.stage_samples(
+            problem_root=root,
+            root_prefix='',
+            sources=[source],
+            render_explanation_text=lambda content, mode: content,
+        )
+        folder = root / '.samples' / '000'
+        assert (folder / 'in').read_text() == 'REAL_INPUT'
+        assert (folder / 'out').read_text() == 'REAL_OUTPUT'
+
+    def test_explanation_written_as_tex_even_in_markdown_mode(self, tmp_path):
+        # Explanations are \subimport-ed by a LaTeX template regardless of the
+        # statement format, so the staged file is always explanation.tex.
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        source = SampleSource(input_path=src / '000.in')
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        handles = sample_staging.stage_samples(
+            problem_root=root,
+            root_prefix='',
+            sources=[source],
+            explanation_blocks={0: 'already latex'},
+            mode='markdown',
+        )
+        assert (root / '.samples' / '000' / 'explanation.tex').is_file()
+        assert handles[0].explanation_file == 'explanation'
+
     def test_inline_block_takes_precedence_over_file(self, tmp_path):
         src = tmp_path / 'src'
         _write(src / '000.in')

--- a/tests/rbx/box/statements/test_standalone_build.py
+++ b/tests/rbx/box/statements/test_standalone_build.py
@@ -1,0 +1,74 @@
+import pathlib
+
+import pytest
+
+from rbx.box import cd, package_utils
+from rbx.box.statements import build_statements
+from rbx.box.statements.resolver import StatementResolverError
+from rbx.box.statements.schema import StatementType
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_standalone_renders_full_document_with_namespaces(
+    cleandir_with_testdata,
+):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        await build_statements.execute_build(
+            verification=0,
+            samples=False,
+            validate=False,
+            output=StatementType.TeX,
+        )
+
+    out = cleandir_with_testdata / 'A' / 'build' / 'statement-en.tex'
+    text = out.read_text()
+    # The standalone template (a FULL document) was applied.
+    assert '\\documentclass' in text
+    assert '\\begin{document}' in text
+    # Problem namespace + the extracted legend block.
+    assert 'Problem A' in text
+    # vars (problem) and params (statement) are distinct namespaces.
+    assert 'authored by Alice' in text
+    assert 'Limits shown: True' in text
+    # contest namespace available in the block.
+    assert 'Statements v2 Contest' in text
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_standalone_builds_pdf_with_mocked_pdflatex(cleandir_with_testdata):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        await build_statements.execute_build(
+            verification=0,
+            samples=False,
+            validate=False,
+            output=StatementType.PDF,
+        )
+    assert (cleandir_with_testdata / 'A' / 'build' / 'statement-en.pdf').is_file()
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_standalone_overlay_merges_contest_chrome(cleandir_with_testdata):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        await build_statements.execute_build(
+            verification=0,
+            samples=False,
+            validate=False,
+            output=StatementType.TeX,
+        )
+        overlay_root = pathlib.Path('build') / 'statements' / 'st' / 'en-default'
+        # Contest chrome (the templates) was merged into the problem overlay root.
+        assert (overlay_root / 'problem-standalone.rbx.tex').is_file()
+
+
+@pytest.mark.test_pkg('problems/rooted-tree-detective')
+async def test_standalone_outside_contest_is_hard_error(pkg_from_testdata):
+    with pytest.raises(StatementResolverError):
+        await build_statements.execute_build(
+            verification=0,
+            samples=False,
+            validate=False,
+            output=StatementType.TeX,
+        )


### PR DESCRIPTION
Implements **Phase 2 (engine core)** and **Phase 3 (builders & build modes)** of the statements v2 plan ([#556](https://github.com/rsalesc/rbx/issues/556)), per `docs/plans/2026-06-09-statements-v2-design.md`. Builds on the schema/`extends` work from #572. The builders stay similar (block extraction, the LaTeX Jinja env, and the `tex→pdf` pdflatex loop are reused); what changed is the configuration surface and the path-resolution model.

## Phase 2 — engine core (new modules)
- **`resolver.py` (S4→#563):** contest-required hard error; standalone candidate resolution (`0`/`>1` are distinct config errors); join matcher by `(language, variant)` + matching rbx type.
- **`overlay.py` (#560):** the stager — merged standalone overlay with name-collision detection, isolated `.problems/<SHORT>/` join layout, contest-chrome overlay. Never parses/rewrites TeX, only places files.
- **`context.py` (#561):** namespaced template context — `params` (statement) / `vars` (problem or contest) / `contest.vars` kept **distinct, unmerged**, plus `problem.import_dir`/`import_file` and the `sample.*` handles.
- **`sample_staging.py` (#562):** per-sample `.samples/<idx>/` folders — `in`/`out` mirrored (root-relative for `\VerbatimInput`), explanation rendered to `explanation.tex` with its source dir overlaid for figures (base-relative for `\subimport`), interactive chunks.

## Phase 3 — builders & build modes
- **`render.py` + `engine.py` (#564):** full-document vs fragment render modes sharing the block-extraction core; pdflatex runs from the overlay **root** so the generated TeX is portable.
- **`build_statements.py` (#565):** `rbx st b` end-to-end — resolve contest → stage merged overlay → render `standaloneProblemTemplate` → compile → `build/statement-<lang>[-<variant>].pdf`.
- **`contest/build_contest_statements.py` (#566):** `rbx contest st b` — per-problem fragments via `contestProblemTemplate` joined through `\subimport`, plus `documents` emitted without joining. CLI wired to also build documents; fixed the packaging contest-build call site to pass `output_type` by keyword.

## Path-resolution contract (proved by the #557 spike)
- `\subimport` / `\includegraphics` / `\input` are import-base-relative (`import.sty` rebases at every depth — no `\graphicspath`).
- `\VerbatimInput` (sample I/O) does **not** honor the import base → I/O handles are root-relative; explanations go through `\subimport` (base-relative). Both relative → portable overlay.

## Out of scope (deferred per plan)
Phase 4: preset template rewrite (#567), Polygon packager update (#568 — its build path stays stubbed and keeps importing `builders.py`'s v1 classes), full test/e2e port (#569), docs site (#570). `tutorials` build commands and the contest-less default-template fallback remain deferred.

## Test plan
- 42 new unit + integration tests (resolver / overlay / context / sample staging / render / standalone build / contest join). Full statements+contest+packaging (non-docker) suite: **507 passed**.
- Both paths verified against **real `pdflatex`**: standalone overlay (`\example` root-relative I/O + `\subimport` explanation + figure via `import.sty`) and the contest join (two problems via `\subimport`) compile to valid PDFs.
- `ruff check`/`format` clean; `rbx --help`, `rbx st --help`, `rbx contest st --help` load.
- Full default suite: 47 pre-existing failures only (C++/checker/validator/sandbox/walltime/docker), confirmed by re-running the suspicious subset on the stashed baseline — zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
