### PR TITLE
feat(completion): dynamic completers for run/irun/stress/on + shared flags (#575)

### DIFF
--- a/docs/plans/2026-06-09-completers-design.md
+++ b/docs/plans/2026-06-09-completers-design.md
@@ -109,7 +109,7 @@ Then regenerate and commit: `mise run gen-completion-spec` → commit `_spec.py`
 | `--testcase/-t` | `irun` | `_adapt('testgroup')` |
 | `--fuzz-on` | `stress` | `_adapt('testgroup')` |
 | `--finder`, `--reference` | `stress` | `_adapt('solutions', file=True)` |
-| `--verification-level` | shared `VerificationParam` (9 sites) | `_adapt('verification_level')` |
+| `--verification-level` | shared `VerificationParam` (all `-v` sites) | `_adapt('verification_level')` |
 | `--profile` | 4 sites | `_adapt('profile')` |
 | `-C/--contest` | `cli.py` + `contest/main.py` callbacks | `_adapt('contest_variant')` |
 | `on` first arg | `cli.py` + `contest/main.py` | wrap bare `str` → `Argument(autocompletion=_adapt('problem'))` |

--- a/docs/plans/2026-06-09-completers-design.md
+++ b/docs/plans/2026-06-09-completers-design.md
@@ -1,0 +1,141 @@
+# Dynamic shell completers design
+
+- **Issue:** [#575 — Add a few interesting autocompleters](https://github.com/rsalesc/rbx/issues/575)
+- **Date:** 2026-06-09
+- **Status:** Design approved; implementation pending
+- **Builds on:** [fast-completion design](2026-06-09-fast-completion-design.md) (#333 / #573)
+
+## Problem
+
+The fast-completion engine (#573) ships a static spec plus a lazy completer
+registry, but only `--language` is wired to a dynamic completer; `checker` and
+`problem` are registered but mostly unused. Issue #575 asks for a batch of
+high-value dynamic completers across `rbx run`/`irun`/`stress`/`on` and several
+cross-cutting flags.
+
+## Constraints (from the existing completion architecture)
+
+These shape every decision below; see
+[`rbx/box/completion/CLAUDE.md`](../../rbx/box/completion/CLAUDE.md).
+
+1. **Completers must stay light.** `firewall_test.py` asserts the completion
+   path imports none of `rbx.box.cli`, `rbx.box.solutions`, `rbx.box.packaging`,
+   `textual`, `mechanize`, `bs4`, `git`, … So a completer may **not** import
+   `schema`, `environment`, `remote`, or `contest.*`. Enum-derived value sets
+   (outcomes, verification levels, `@`-prefixes) are therefore **hardcoded small
+   tables** in `completers.py`, each guarded by a *consistency test* that imports
+   the real enum and asserts the table is complete and valid.
+2. **Differential parity.** `differential_test.py` holds the fast engine
+   byte-equal to real Typer on `(value, type)` pairs across a spec-derived
+   corpus. It compares value+type only — **not** `help` — but the fast engine
+   *does* surface `help` to users (zsh/fish). Rich descriptions are therefore
+   free for plain completers.
+3. **Typer callbacks can only emit plain, prefix-filtered items.** Verified in
+   `typer.core.compat_autocompletion` (typer 0.21.1): an `autocompletion=`
+   callback may return only `str` or `(value, help)` tuples; Typer always builds
+   a **plain** `CompletionItem` and prefix-filters by the incomplete. It can
+   never emit a `file`/`dir` directive. So a "dynamic candidates + file
+   completion" union needs explicit engine/spec/test support — Typer can never
+   reproduce it, and the parity test must carve out a documented exemption.
+4. **Corpus probes value positions only with `incomplete=''`.** So completers
+   need not prefix-filter to pass parity (the shell filters at runtime); this
+   matches the existing `language`/`checker`/`problem` completers, which return
+   full lists.
+
+## Completers
+
+All read package YAML via the cheap `peek.peek()` (no pydantic) and stay light.
+
+| key | source | candidates (help) |
+|---|---|---|
+| `solutions` | `problem.rbx.yml` → `solutions[]` | each `path` (help = `outcome`) + `@main`, `@boca/` |
+| `outcome` | hardcoded table | `ac`, `wa`, `tle`, `rte`, `mle`, `ole`, `ac/tle`, `tle/rte`, `incorrect`, `any`, … (help = full name) |
+| `verification_level` | hardcoded table | `0`–`4` (help = `NONE`/`VALIDATE`/`FAST_SOLUTIONS`/`ALL_SOLUTIONS`/`FULL`) |
+| `profile` | glob `.limits/*.yml` | profile basenames |
+| `testgroup` | `problem.rbx.yml` → `testcases[].name` | group names |
+| `contest_variant` | glob `contest.*.rbx.yml` (+ canonical), up-tree | variant ids |
+| `problem` (extend) | `contest.rbx.yml` → `problems[]` | `short_name` **+ `aliases`** |
+
+`stress --finder` and `stress --reference` reuse the `solutions` completer (the
+finder grammar is a superset; we complete its solution-expression part).
+
+### Hardcoded tables + consistency tests
+
+`outcome` and `verification_level` cannot import their source enums
+(`ExpectedOutcome` in `schema.py`, `VerificationLevel` in `environment.py`) on
+the light path. Each is a literal table in `completers.py`. A consistency test
+(allowed to import the heavy app) asserts:
+
+- every `outcome` value parses to a valid `ExpectedOutcome`, and every
+  `ExpectedOutcome` member is represented by exactly one offered token;
+- the `verification_level` tokens are exactly the `VerificationLevel` int values
+  with matching names.
+
+This keeps the runtime light while failing loudly if the enums drift.
+
+## File-union mechanism
+
+The chosen approach (over dynamic-only) lets `rbx run`/`irun` solution
+positionals and `stress --finder`/`--reference` complete **registered solutions
++ `@`-prefixes + ordinary files** as a single union.
+
+- `annotations._adapt(key, *, file=False)` — when `file=True`, tags the closure
+  with `_completer_file='file'`. The Typer-oracle path still returns plain
+  values (no directive), as it must.
+- `generate._value_spec` reads that tag → spec value becomes
+  `{'kind': 'completer', 'completer': key, 'file': 'file'}`.
+- `engine._value_items` appends the `FILE` directive after the completer's items
+  when `value.get('file')` is set.
+- **Variadic arguments.** `solutions` is an `Optional[List[str]]` argument
+  (Click `nargs == -1`); real Typer re-offers it on every positional
+  (`rbx run a b<tab>`). The static spec gains `variadic: bool` on argument
+  params (from `nargs == -1`); the engine clamps the positional index to the
+  last argument when it is variadic, so each position re-offers
+  solutions + files.
+- **Differential exemption.** `differential_test.py` detects a file-union value
+  position, strips `file`/`dir` directives from the engine output, asserts the
+  remainder equals the Typer oracle, and asserts the directive *is* appended — a
+  documented, tested divergence, mirroring the existing command-name divergence.
+
+## Wiring
+
+Then regenerate and commit: `mise run gen-completion-spec` → commit `_spec.py`
+(`drift_test.py` enforces it).
+
+| param | sites | adapter |
+|---|---|---|
+| `solutions` arg | `run`, `irun` | `_adapt('solutions', file=True)` |
+| `--outcome` | `run`, `irun` | `_adapt('outcome')` |
+| `--testcase/-t` | `irun` | `_adapt('testgroup')` |
+| `--fuzz-on` | `stress` | `_adapt('testgroup')` |
+| `--finder`, `--reference` | `stress` | `_adapt('solutions', file=True)` |
+| `--verification-level` | shared `VerificationParam` (9 sites) | `_adapt('verification_level')` |
+| `--profile` | 4 sites | `_adapt('profile')` |
+| `-C/--contest` | `cli.py` + `contest/main.py` callbacks | `_adapt('contest_variant')` |
+| `on` first arg | `cli.py` + `contest/main.py` | wrap bare `str` → `Argument(autocompletion=_adapt('problem'))` |
+
+The existing `problem` completer is extended to also offer `aliases` (valid
+problem references everywhere per the contest schema), which benefits `rbx on`
+and every other site already wired to it.
+
+## Tests (TDD)
+
+- `completers_test.py`: tmp package/contest fixtures → assert each completer's
+  items (values + help where relevant).
+- consistency tests: hardcoded `outcome`/`verification_level` tables ≡ real
+  `ExpectedOutcome`/`VerificationLevel`.
+- wiring test: parametrized over (command-path, param, expected key) — every
+  issue param resolves to its completer in the generated spec.
+- engine tests: `file` flag appends `FILE`; variadic positional re-offers the
+  completer on repeated positions.
+- differential exemption for file-union positions (above).
+- extend `firewall_test.py` to probe `rbx run <tab>`, `rbx run --outcome <tab>`,
+  `rbx irun -t <tab>`, etc. — proving the new completers import nothing heavy.
+- `drift_test.py` passes after regeneration.
+
+## Out of scope (YAGNI)
+
+- `@boca/<run>` cannot enumerate run numbers — we offer only the `@boca/` prefix
+  and `@main`.
+- No cross-variant problem merging for `rbx on` — canonical `contest.rbx.yml`
+  only, matching the existing `complete_problem`.

--- a/docs/plans/2026-06-09-completers.md
+++ b/docs/plans/2026-06-09-completers.md
@@ -1,0 +1,1190 @@
+# Dynamic Completers Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add the dynamic shell completers from issue #575 (solutions, outcome, verification-level, profile, testgroup, contest-variant, contest-problem) and a file-union mechanism so `rbx run`/`stress` solution positions complete registered solutions + `@`-prefixes + files.
+
+**Architecture:** Light completers in `rbx/box/completion/completers.py` (read package YAML via `peek`, hardcode enum tables guarded by consistency tests). Wire them to Typer params via `rbx.annotations._adapt(key)`. Extend the spec/engine/parity-test trio so a completer value may also hand off to shell file-completion (`file` flag) and so variadic arguments re-offer their completer. Regenerate the committed `_spec.py`.
+
+**Tech Stack:** Python 3.13, Typer 0.21 / Click 8.3, pytest, ruff, `uv`/`mise`.
+
+**Design doc:** `docs/plans/2026-06-09-completers-design.md`
+
+**Conventions:** single quotes; absolute imports; completers MUST stay light (no `schema`/`environment`/`remote`/`contest`/`cli` imports). Commit with the `/commit` skill (conventional commits, `Co-Authored-By: Claude <noreply@anthropic.com>`). Run tests with `uv run pytest`.
+
+---
+
+## Phase A — File-union + variadic infrastructure
+
+### Task A1: `_adapt(key, *, file=False)` carries a file flag
+
+**Files:**
+- Modify: `rbx/annotations.py` (the `_adapt` function, ~line 16-39)
+- Test: `tests/rbx/box/completion/annotations_light_test.py`
+
+**Step 1: Write the failing test** (append to `annotations_light_test.py`)
+
+```python
+def test_adapt_file_flag_tags_callback():
+    from rbx import annotations
+
+    cb = annotations._adapt('solutions', file=True)  # noqa: SLF001
+    assert cb._completer_key == 'solutions'  # noqa: SLF001
+    assert cb._completer_file == 'file'  # noqa: SLF001
+
+
+def test_adapt_without_file_flag_has_no_file_attr():
+    from rbx import annotations
+
+    cb = annotations._adapt('language')  # noqa: SLF001
+    assert getattr(cb, '_completer_file', None) is None
+```
+
+**Step 2: Run, expect FAIL**
+
+`uv run pytest tests/rbx/box/completion/annotations_light_test.py -q`
+Expected: FAIL (`_adapt() got an unexpected keyword argument 'file'`).
+
+**Step 3: Implement.** Change the signature and tag the closure:
+
+```python
+def _adapt(key: str, *, file: bool = False):
+    """Typer autocompletion callback that delegates to the registry completer `key`.
+
+    Builds the same CompletionContext the fast engine builds, so real-Typer and
+    fast-path completions agree. Returns plain string values (Typer wraps them).
+
+    When `file=True`, the param's value position should ALSO hand off to the
+    shell's default file completion after the dynamic candidates. Typer's callback
+    contract cannot emit a file directive, so we only TAG the callback here; the
+    spec generator records the flag and the fast engine appends the directive.
+    """
+
+    def _cb(incomplete: str = ''):
+        from rbx.box.completion import (
+            completers,  # noqa: F401  (registers keys)
+            context,
+        )
+        from rbx.box.completion.registry import CompletionContext, load_completer
+
+        ctx = CompletionContext(
+            args=[],
+            command=(),
+            option_values={},
+            package_root=context.find_package_root(),
+        )
+        return [item.value for item in load_completer(key)(ctx, incomplete)]
+
+    _cb._completer_key = key  # noqa: SLF001  read by the spec generator to recover the key
+    if file:
+        _cb._completer_file = 'file'  # noqa: SLF001  read by the spec generator
+    return _cb
+```
+
+**Step 4: Run, expect PASS.** Same command.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/annotations.py tests/rbx/box/completion/annotations_light_test.py
+# /commit -> feat(completion): let _adapt tag a file-union completer
+```
+
+---
+
+### Task A2: generator records `variadic` args and the `file` value flag
+
+**Files:**
+- Modify: `rbx/box/completion/generate.py` (`_value_spec` ~line 95-108, `_param_spec` ~line 111-124)
+- Test: `tests/rbx/box/completion/generate_test.py`
+
+**Step 1: Write failing tests** (append to `generate_test.py`)
+
+```python
+def test_variadic_argument_flagged():
+    from typing import List, Optional
+
+    app = typer.Typer()
+
+    @app.command()
+    def run(
+        names: Optional[List[str]] = typer.Argument(None),
+    ):
+        pass
+
+    spec = build_spec(_cli(app), name='run')
+    arg = next(p for p in spec['params'] if p['kind'] == 'argument')
+    assert arg['variadic'] is True
+
+
+def test_file_union_completer_value_flagged():
+    @registry.register_completer('gen_sol')
+    def _gen_sol(ctx, incomplete):
+        return []
+
+    cb = _gen_sol
+    cb._completer_file = 'file'  # noqa: SLF001  emulate _adapt(file=True)
+
+    app = typer.Typer()
+
+    @app.command()
+    def run(
+        sols: Annotated[str, typer.Argument(autocompletion=cb)] = '',
+    ):
+        pass
+
+    spec = build_spec(_cli(app), name='run')
+    arg = next(p for p in spec['params'] if p['kind'] == 'argument')
+    assert arg['value'] == {'kind': 'completer', 'completer': 'gen_sol', 'file': 'file'}
+```
+
+**Step 2: Run, expect FAIL.**
+`uv run pytest tests/rbx/box/completion/generate_test.py -q`
+Expected: FAIL (`KeyError: 'variadic'` / missing `'file'`).
+
+**Step 3: Implement.**
+
+In `_value_spec`, after computing `key`:
+
+```python
+def _value_spec(param: click.Parameter) -> Dict[str, Any]:
+    key = _completer_key(param)
+    if key is not None:
+        spec: Dict[str, Any] = {'kind': 'completer', 'completer': key}
+        file_flag = _completer_file(param)
+        if file_flag is not None:
+            spec['file'] = file_flag
+        return spec
+    ...  # unchanged
+```
+
+Add the probe helper next to `_completer_key`:
+
+```python
+def _completer_file(param: click.Parameter) -> Optional[str]:
+    """Return the file-union flag ('file'/'dir') a completer callback was tagged
+    with via `_adapt(file=...)`, or None. Mirrors `_completer_key`'s candidate
+    probe so it survives Typer's wrapper chain."""
+    for fn in _completer_candidates(param):
+        flag = getattr(fn, '_completer_file', None)
+        if flag is not None:
+            return flag
+    return None
+```
+
+In `_param_spec`, add `variadic` for arguments (`nargs == -1`):
+
+```python
+def _param_spec(param: click.Parameter) -> Dict[str, Any]:
+    is_opt = isinstance(param, click.Option)
+    is_flag = bool(getattr(param, 'is_flag', False))
+    names = list(param.opts) + list(getattr(param, 'secondary_opts', []))
+    spec: Dict[str, Any] = {
+        'kind': 'option' if is_opt else 'argument',
+        'names': names if is_opt else [],
+        'takes_value': not is_flag,
+        'multiple': bool(getattr(param, 'multiple', False)),
+        'help': getattr(param, 'help', None) if is_opt else None,
+        'value': {'kind': 'none'} if is_flag else _value_spec(param),
+    }
+    if not is_opt and getattr(param, 'nargs', 1) == -1:
+        spec['variadic'] = True
+    return spec
+```
+
+Also update the module docstring `Param = {...}` block to mention the optional
+`'variadic'` key and the value's optional `'file'` key.
+
+**Step 4: Run, expect PASS.**
+`uv run pytest tests/rbx/box/completion/generate_test.py -q`
+
+**Step 5: Commit**
+```bash
+git add rbx/box/completion/generate.py tests/rbx/box/completion/generate_test.py
+# /commit -> feat(completion): generate variadic + file-union spec flags
+```
+
+---
+
+### Task A3: engine appends FILE for the file flag and re-offers variadic args
+
+**Files:**
+- Modify: `rbx/box/completion/engine.py` (`_value_items` ~line 100-110, `resolve` positional block ~line 213-216)
+- Test: `tests/rbx/box/completion/engine_test.py`
+
+**Step 1: Write failing tests** (append to the synthetic section of `engine_test.py`)
+
+```python
+def test_completer_with_file_flag_appends_file_directive():
+    module_name = 'tests.rbx.box.completion._fixture_completer'
+    registry.register_completer_path('engine_fu', f'{module_name}:fixture_completer')
+    spec = _leaf(
+        [
+            {
+                'kind': 'argument',
+                'names': [],
+                'takes_value': True,
+                'help': None,
+                'variadic': True,
+                'value': {'kind': 'completer', 'completer': 'engine_fu', 'file': 'file'},
+            }
+        ]
+    )
+    items = resolve(spec, [], '')
+    assert _values(items) == ['from-fixture', '']
+    assert items[-1].type == 'file'
+
+
+def test_variadic_argument_reoffered_on_later_positionals():
+    module_name = 'tests.rbx.box.completion._fixture_completer'
+    registry.register_completer_path('engine_fu2', f'{module_name}:fixture_completer')
+    spec = _leaf(
+        [
+            {
+                'kind': 'argument',
+                'names': [],
+                'takes_value': True,
+                'help': None,
+                'variadic': True,
+                'value': {'kind': 'completer', 'completer': 'engine_fu2'},
+            }
+        ]
+    )
+    # Two positionals already consumed, but the (only) argument is variadic, so
+    # the completer is still offered.
+    items = resolve(spec, ['a', 'b'], '')
+    assert _values(items) == ['from-fixture']
+```
+
+**Step 2: Run, expect FAIL.**
+`uv run pytest tests/rbx/box/completion/engine_test.py -q`
+
+**Step 3: Implement.**
+
+`_value_items` — append the directive when `file` is set:
+
+```python
+def _value_items(
+    value: Dict[str, Any], ctx: CompletionContext, incomplete: str
+) -> List[CompletionItem]:
+    kind = value.get('kind')
+    if kind == 'choice':
+        return [CompletionItem(c) for c in value['choices'] if c.startswith(incomplete)]
+    if kind == 'completer':
+        items = list(load_completer(value['completer'])(ctx, incomplete))
+        file_flag = value.get('file')
+        if file_flag == 'dir':
+            items = items + DIR
+        elif file_flag == 'file':
+            items = items + FILE
+        return items
+    if kind == 'path':
+        return DIR if value.get('path') == 'dir' else FILE
+    return FILE  # 'none'/unknown -> shell default file completion
+```
+
+`resolve` positional block — clamp to the last argument when it is variadic:
+
+```python
+        arguments = [p for p in node['params'] if p['kind'] == 'argument']
+        if positional < len(arguments):
+            return _value_items(arguments[positional]['value'], ctx, incomplete)
+        if arguments and arguments[-1].get('variadic'):
+            # A variadic last argument keeps consuming positionals, so the real CLI
+            # re-offers its completer at every position past it.
+            return _value_items(arguments[-1]['value'], ctx, incomplete)
+        return FILE
+```
+
+**Step 4: Run, expect PASS.** Same command. Also run the full engine + robustness suite:
+`uv run pytest tests/rbx/box/completion/engine_test.py tests/rbx/box/completion/robustness_test.py -q`
+
+**Step 5: Commit**
+```bash
+git add rbx/box/completion/engine.py tests/rbx/box/completion/engine_test.py
+# /commit -> feat(completion): engine file-union directive + variadic re-offer
+```
+
+---
+
+### Task A4: differential-test exemption for file-union positions
+
+**Files:**
+- Modify: `tests/rbx/box/completion/differential_test.py`
+
+**Step 1: Add a helper + branch.** After `_is_command_name_position`, add a resolver
+for the value the cursor sits on, then exempt file-union positions.
+
+```python
+def _cursor_value(args, incomplete):
+    """The spec 'value' dict the cursor is completing, or None (option-name,
+    group, or past-the-end position)."""
+    node, _cmd, _opts, pending, positional, _seen = _walk(_spec.SPEC, list(args))
+    if pending is not None:
+        return pending['value']
+    if incomplete.startswith('-') and '=' in incomplete:
+        name = incomplete.split('=', 1)[0]
+        for p in node['params']:
+            if p['kind'] == 'option' and name in p['names'] and p['takes_value']:
+                return p['value']
+        return None
+    if incomplete.startswith('-') or node.get('is_group'):
+        return None
+    arguments = [p for p in node['params'] if p['kind'] == 'argument']
+    if positional < len(arguments):
+        return arguments[positional]['value']
+    if arguments and arguments[-1].get('variadic'):
+        return arguments[-1]['value']
+    return None
+```
+
+In `test_engine_matches_typer`, right after computing `ours` and BEFORE the
+command-name branch, add:
+
+```python
+    value = _cursor_value(args, incomplete)
+    if value is not None and value.get('kind') == 'completer' and value.get('file'):
+        # File-union: the engine intentionally appends a shell file/dir directive
+        # that Typer's callback contract can never emit. Assert the dynamic part
+        # matches Typer exactly and that the directive IS appended.
+        gold = _pairs(typer_completions(args, incomplete))
+        non_dir = [p for p in ours if p not in _DIRECTIVES]
+        assert non_dir == gold, f'args={args} inc={incomplete!r}: {non_dir} vs {gold}'
+        assert set(ours) & _DIRECTIVES, f'args={args} inc={incomplete!r}: no file directive'
+        return
+```
+
+**Step 2: Run** the differential test now (no file-union completer is wired yet,
+so the new branch is dormant but must not break existing parity):
+`uv run pytest tests/rbx/box/completion/differential_test.py -q`
+Expected: PASS (unchanged behavior).
+
+**Step 3: Commit**
+```bash
+git add tests/rbx/box/completion/differential_test.py
+# /commit -> test(completion): exempt file-union positions from strict parity
+```
+
+---
+
+## Phase B — The completers (light; in `completers.py`)
+
+> All completers go in `rbx/box/completion/completers.py` with `@register_completer`.
+> Unit tests go in `tests/rbx/box/completion/completers_test.py` using the existing
+> `_ctx(**kw)` helper. Consistency tests (allowed to import the heavy app) go in a
+> NEW file `tests/rbx/box/completion/enum_consistency_test.py`.
+
+### Task B1: `solutions` completer
+
+**Files:** Modify `rbx/box/completion/completers.py`; test `completers_test.py`.
+
+**Step 1: Write failing test**
+
+```python
+def test_solutions_completer_lists_paths_with_outcome_help_and_prefixes(tmp_path):
+    (tmp_path / 'problem.rbx.yml').write_text(
+        'solutions:\n'
+        '  - path: sols/main.cpp\n'
+        '    outcome: ac\n'
+        '  - path: sols/wa.cpp\n'
+        '    outcome: wa\n'
+    )
+    items = completers.complete_solutions(_ctx(package_root=tmp_path), '')
+    by_value = {i.value: i for i in items}
+    assert 'sols/main.cpp' in by_value
+    assert by_value['sols/main.cpp'].help == 'ac'
+    assert '@main' in by_value
+    assert '@boca/' in by_value
+
+
+def test_solutions_completer_without_package_offers_prefixes(tmp_path):
+    values = {i.value for i in completers.complete_solutions(_ctx(package_root=None), '')}
+    assert {'@main', '@boca/'} <= values
+```
+
+**Step 2: Run, expect FAIL.**
+`uv run pytest tests/rbx/box/completion/completers_test.py -q`
+
+**Step 3: Implement** (add to `completers.py`):
+
+```python
+# Built-in solution-path expanders (kept in sync with rbx/box/remote.py via
+# enum_consistency_test.py). @boca needs a run id we cannot enumerate, so we
+# offer only the prefix.
+_SOLUTION_PREFIXES = (
+    ('@main', 'first accepted solution'),
+    ('@boca/', 'download a BOCA submission, e.g. @boca/123'),
+)
+
+
+@register_completer('solutions')
+def complete_solutions(
+    ctx: CompletionContext, incomplete: str
+) -> List[CompletionItem]:
+    items: List[CompletionItem] = []
+    root = ctx.package_root
+    if root is not None:
+        data = peek.peek(Path(root) / 'problem.rbx.yml')
+        for sol in data.get('solutions', []):
+            if isinstance(sol, dict) and sol.get('path'):
+                outcome = sol.get('outcome')
+                help_text = str(outcome) if outcome is not None else None
+                items.append(CompletionItem(str(sol['path']), help=help_text))
+    items += [CompletionItem(v, help=h) for v, h in _SOLUTION_PREFIXES]
+    return items
+```
+
+**Step 4: Run, expect PASS.**
+
+**Step 5: Commit**
+```bash
+git add rbx/box/completion/completers.py tests/rbx/box/completion/completers_test.py
+# /commit -> feat(completion): solutions completer (paths + outcomes + @prefixes)
+```
+
+---
+
+### Task B2: `outcome` completer + consistency test
+
+**Files:** Modify `completers.py`; tests in `completers_test.py` and new `enum_consistency_test.py`.
+
+**Step 1: Write failing tests**
+
+In `completers_test.py`:
+
+```python
+def test_outcome_completer_offers_canonical_tokens():
+    values = {i.value for i in completers.complete_outcome(_ctx(), '')}
+    assert {'ac', 'wa', 'tle', 'any'} <= values
+    helps = {i.value: i.help for i in completers.complete_outcome(_ctx(), '')}
+    assert helps['ac']  # has descriptive help
+```
+
+In NEW `tests/rbx/box/completion/enum_consistency_test.py`:
+
+```python
+from rbx.box.completion import completers
+
+
+def test_outcome_table_matches_expected_outcome_enum():
+    from rbx.box.schema import ExpectedOutcome
+
+    tokens = [v for v, _ in completers._OUTCOME_TABLE]  # noqa: SLF001
+    # Every offered token parses to a valid ExpectedOutcome...
+    parsed = {ExpectedOutcome(t) for t in tokens}
+    # ...and every enum member is represented exactly once.
+    assert parsed == set(ExpectedOutcome)
+    assert len(tokens) == len(set(tokens)) == len(set(ExpectedOutcome))
+```
+
+**Step 2: Run, expect FAIL** (both files).
+
+**Step 3: Implement** (add to `completers.py`):
+
+```python
+# (token, human description). Kept complete vs ExpectedOutcome by
+# enum_consistency_test.py -- exactly one token per enum member.
+_OUTCOME_TABLE = (
+    ('any', 'matches any verdict'),
+    ('ac', 'accepted'),
+    ('ac/tle', 'accepted or time limit exceeded'),
+    ('wa', 'wrong answer'),
+    ('incorrect', 'any incorrect verdict (WA/RTE/MLE/OLE/TLE)'),
+    ('rte', 'runtime error'),
+    ('tle', 'time limit exceeded'),
+    ('mle', 'memory limit exceeded'),
+    ('ole', 'output limit exceeded'),
+    ('tle/rte', 'time limit exceeded or runtime error'),
+    ('jf', 'judge failed'),
+    ('ce', 'compilation error'),
+)
+
+
+@register_completer('outcome')
+def complete_outcome(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
+    return [CompletionItem(v, help=h) for v, h in _OUTCOME_TABLE]
+```
+
+**Step 4: Run, expect PASS.** If the consistency test fails because a token maps
+to the wrong/duplicate member, adjust the token to the canonical alias for that
+member (see `rbx/box/schema.py` `ExpectedOutcome`). Do NOT import the enum into
+`completers.py`.
+
+**Step 5: Commit**
+```bash
+git add rbx/box/completion/completers.py tests/rbx/box/completion/completers_test.py tests/rbx/box/completion/enum_consistency_test.py
+# /commit -> feat(completion): outcome completer with descriptive help
+```
+
+---
+
+### Task B3: `verification_level` completer + consistency test
+
+**Files:** Modify `completers.py`; tests in `completers_test.py` + `enum_consistency_test.py`.
+
+**Step 1: Write failing tests**
+
+`completers_test.py`:
+
+```python
+def test_verification_level_completer_offers_int_values_with_names():
+    items = completers.complete_verification_level(_ctx(), '')
+    by_value = {i.value: i.help for i in items}
+    assert by_value['0'] == 'NONE'
+    assert by_value['4'] == 'FULL'
+```
+
+`enum_consistency_test.py`:
+
+```python
+def test_verification_table_matches_verification_level_enum():
+    from rbx.box.environment import VerificationLevel
+
+    table = dict(completers._VERIFICATION_TABLE)  # noqa: SLF001
+    expected = {str(level.value): level.name for level in VerificationLevel}
+    assert table == expected
+```
+
+**Step 2: Run, expect FAIL.**
+
+**Step 3: Implement** (add to `completers.py`):
+
+```python
+# (value, level name). Kept in sync with environment.VerificationLevel by
+# enum_consistency_test.py.
+_VERIFICATION_TABLE = (
+    ('0', 'NONE'),
+    ('1', 'VALIDATE'),
+    ('2', 'FAST_SOLUTIONS'),
+    ('3', 'ALL_SOLUTIONS'),
+    ('4', 'FULL'),
+)
+
+
+@register_completer('verification_level')
+def complete_verification_level(
+    ctx: CompletionContext, incomplete: str
+) -> List[CompletionItem]:
+    return [CompletionItem(v, help=h) for v, h in _VERIFICATION_TABLE]
+```
+
+**Step 4: Run, expect PASS.**
+
+**Step 5: Commit**
+```bash
+git add rbx/box/completion/completers.py tests/rbx/box/completion/completers_test.py tests/rbx/box/completion/enum_consistency_test.py
+# /commit -> feat(completion): verification-level completer
+```
+
+---
+
+### Task B4: `profile` completer
+
+**Files:** Modify `completers.py`; test `completers_test.py`.
+
+**Step 1: Write failing test**
+
+```python
+def test_profile_completer_lists_limits_files(tmp_path):
+    limits = tmp_path / '.limits'
+    limits.mkdir()
+    (limits / 'local.yml').write_text('')
+    (limits / 'codeforces.yml').write_text('')
+    (limits / 'notes.txt').write_text('')  # ignored
+    values = {i.value for i in completers.complete_profile(_ctx(package_root=tmp_path), '')}
+    assert values == {'local', 'codeforces'}
+```
+
+**Step 2: Run, expect FAIL.**
+
+**Step 3: Implement**
+
+```python
+@register_completer('profile')
+def complete_profile(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
+    root = ctx.package_root
+    if root is None:
+        return []
+    limits_dir = Path(root) / '.limits'
+    if not limits_dir.is_dir():
+        return []
+    return _items(p.stem for p in limits_dir.glob('*.yml'))
+```
+
+**Step 4: Run, expect PASS.**
+
+**Step 5: Commit**
+```bash
+git add rbx/box/completion/completers.py tests/rbx/box/completion/completers_test.py
+# /commit -> feat(completion): profile completer from .limits/*.yml
+```
+
+---
+
+### Task B5: `testgroup` completer
+
+**Files:** Modify `completers.py`; test `completers_test.py`.
+
+**Step 1: Write failing test**
+
+```python
+def test_testgroup_completer_lists_group_names(tmp_path):
+    (tmp_path / 'problem.rbx.yml').write_text(
+        'testcases:\n'
+        '  - name: samples\n'
+        '  - name: main\n'
+        '  - name: edge\n'
+    )
+    values = {i.value for i in completers.complete_testgroup(_ctx(package_root=tmp_path), '')}
+    assert {'samples', 'main', 'edge'} <= values
+```
+
+**Step 2: Run, expect FAIL.**
+
+**Step 3: Implement**
+
+```python
+@register_completer('testgroup')
+def complete_testgroup(
+    ctx: CompletionContext, incomplete: str
+) -> List[CompletionItem]:
+    root = ctx.package_root
+    if root is None:
+        return []
+    data = peek.peek(Path(root) / 'problem.rbx.yml')
+    names = {
+        g.get('name')
+        for g in data.get('testcases', [])
+        if isinstance(g, dict)
+    }
+    return _items(n for n in names if n)
+```
+
+**Step 4: Run, expect PASS.**
+
+**Step 5: Commit**
+```bash
+git add rbx/box/completion/completers.py tests/rbx/box/completion/completers_test.py
+# /commit -> feat(completion): testgroup completer
+```
+
+---
+
+### Task B6: `contest_variant` completer
+
+**Files:** Modify `completers.py`; test `completers_test.py`.
+
+**Step 1: Write failing test**
+
+```python
+def test_contest_variant_completer_lists_sibling_ids(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text('name: c\n')
+    (tmp_path / 'contest.div1.rbx.yml').write_text('name: d1\n')
+    (tmp_path / 'contest.div2.rbx.yml').write_text('name: d2\n')
+    values = {
+        i.value
+        for i in completers.complete_contest_variant(_ctx(package_root=tmp_path), '')
+    }
+    assert values == {'div1', 'div2'}
+
+
+def test_contest_variant_completer_walks_up_from_problem_dir(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text('name: c\n')
+    (tmp_path / 'contest.div1.rbx.yml').write_text('name: d1\n')
+    prob = tmp_path / 'A'
+    prob.mkdir()
+    (prob / 'problem.rbx.yml').write_text('name: A\n')
+    values = {
+        i.value
+        for i in completers.complete_contest_variant(_ctx(package_root=prob), '')
+    }
+    assert values == {'div1'}
+```
+
+**Step 2: Run, expect FAIL.**
+
+**Step 3: Implement**
+
+```python
+_CONTEST_PREFIX = 'contest.'
+_CONTEST_SUFFIX = '.rbx.yml'
+
+
+def _find_contest_root(start: Optional[Path]) -> Optional[Path]:
+    """Nearest ancestor (incl. start) holding a contest.rbx.yml. Light, no load."""
+    if start is None:
+        return None
+    cur = Path(start)
+    for d in [cur, *cur.parents]:
+        if (d / 'contest.rbx.yml').exists():
+            return d
+    return None
+
+
+@register_completer('contest_variant')
+def complete_contest_variant(
+    ctx: CompletionContext, incomplete: str
+) -> List[CompletionItem]:
+    root = _find_contest_root(ctx.package_root)
+    if root is None:
+        return []
+    ids = []
+    for p in root.glob(f'{_CONTEST_PREFIX}*{_CONTEST_SUFFIX}'):
+        name = p.name[len(_CONTEST_PREFIX) : -len(_CONTEST_SUFFIX)]
+        if name:
+            ids.append(name)
+    return _items(ids)
+```
+
+Add `Optional` to the existing `typing` import in `completers.py` if not present.
+
+**Step 4: Run, expect PASS.**
+
+**Step 5: Commit**
+```bash
+git add rbx/box/completion/completers.py tests/rbx/box/completion/completers_test.py
+# /commit -> feat(completion): contest-variant completer
+```
+
+---
+
+### Task B7: extend `problem` completer with aliases
+
+**Files:** Modify `completers.py` (`complete_problem`); test `completers_test.py`.
+
+**Step 1: Write failing test**
+
+```python
+def test_problem_completer_includes_aliases(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text(
+        'problems:\n'
+        '  - short_name: A\n'
+        '    aliases: [apple, alpha]\n'
+        '  - short_name: B\n'
+    )
+    values = {
+        i.value for i in completers.complete_problem(_ctx(package_root=tmp_path), '')
+    }
+    assert {'A', 'B', 'apple', 'alpha'} <= values
+```
+
+**Step 2: Run, expect FAIL.**
+
+**Step 3: Implement.** Replace the body of `complete_problem`:
+
+```python
+@register_completer('problem')
+def complete_problem(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
+    root = ctx.package_root
+    if root is None:
+        return []
+    data = peek.peek(Path(root) / 'contest.rbx.yml')
+    names = set()
+    for p in data.get('problems', []):
+        if not isinstance(p, dict):
+            continue
+        if p.get('short_name'):
+            names.add(p['short_name'])
+        for alias in p.get('aliases', []) or []:
+            if alias:
+                names.add(alias)
+    return _items(names)
+```
+
+**Step 4: Run, expect PASS.** Also rerun the existing problem test:
+`uv run pytest tests/rbx/box/completion/completers_test.py -q`
+
+**Step 5: Commit**
+```bash
+git add rbx/box/completion/completers.py tests/rbx/box/completion/completers_test.py
+# /commit -> feat(completion): include problem aliases in problem completer
+```
+
+---
+
+## Phase C — Wiring, regen, and guards
+
+> After wiring (Tasks C1-C5) regenerate the spec ONCE (Task C6). Wiring before
+> regen makes `drift_test.py` red — that is expected until C6.
+
+### Task C1: wire `rbx run` / `rbx irun` (solutions, outcome)
+
+**Files:** Modify `rbx/box/cli.py` (run ~311-325, irun ~646-689).
+
+Add `from rbx import annotations` import if not already present (it likely is —
+check the top of `cli.py`).
+
+- `solutions` argument (both `run` and `irun`): add
+  `autocompletion=annotations._adapt('solutions', file=True)` to the
+  `typer.Argument(...)`.
+- `outcome` option (both): add `autocompletion=annotations._adapt('outcome')`.
+
+Example (run's `solutions`):
+
+```python
+    solutions: Annotated[
+        Optional[List[str]],
+        PackagePath,
+        typer.Argument(
+            help='Path to solutions to run. If not specified, will run all solutions.',
+            autocompletion=annotations._adapt('solutions', file=True),  # noqa: SLF001
+        ),
+    ] = None,
+```
+
+Example (run's `outcome`):
+
+```python
+    outcome: Optional[str] = typer.Option(
+        None,
+        '--outcome',
+        '-o',
+        help='Include only solutions whose expected outcomes intersect with this.',
+        autocompletion=annotations._adapt('outcome'),  # noqa: SLF001
+    ),
+```
+
+**Verify import light:** `_adapt` is in `rbx/annotations.py` (light). Calling it
+at module import returns a closure; no heavy import triggered.
+
+**Test:** none yet (spec not regen'd). Just ensure `uv run rbx run --help` works:
+`uv run rbx run --help | head -3` → no error.
+
+**Commit**
+```bash
+git add rbx/box/cli.py
+# /commit -> feat(completion): wire run/irun solutions + outcome completers
+```
+
+---
+
+### Task C2: wire `irun -t` and `stress` (finder, fuzz-on, reference)
+
+**Files:** Modify `rbx/box/cli.py` (irun `testcase` ~682-689, stress ~849-943).
+
+- `testcase` option (irun): `autocompletion=annotations._adapt('testgroup')`.
+- `finder` (stress): `autocompletion=annotations._adapt('solutions', file=True)`.
+- `fuzz_on` (stress): `autocompletion=annotations._adapt('testgroup')`.
+- `reference_solution` (stress `--reference`):
+  `autocompletion=annotations._adapt('solutions', file=True)`.
+
+**Test:** `uv run rbx stress --help | head -3` and `uv run rbx irun --help | head -3`
+→ no error.
+
+**Commit**
+```bash
+git add rbx/box/cli.py
+# /commit -> feat(completion): wire testcase + stress finder/fuzz-on/reference
+```
+
+---
+
+### Task C3: wire `--verification-level` (shared `VerificationParam`)
+
+**Files:** Modify `rbx/box/environment.py` (`VerificationParam` ~42-51).
+
+```python
+VerificationParam = Annotated[
+    int,
+    typer.Option(
+        '--verification-level',
+        '--verification',
+        '-v',
+        help='Verification level to use when building package.',
+        default_factory=lambda: VerificationLevel.FULL.value,
+        autocompletion=_verification_autocompletion(),
+    ),
+]
+```
+
+To keep `environment.py`'s import light AND avoid a circular import, define a
+tiny local indirection at the top of `environment.py`:
+
+```python
+def _verification_autocompletion():
+    from rbx import annotations
+
+    return annotations._adapt('verification_level')  # noqa: SLF001
+```
+
+(Importing `rbx.annotations` is light; it does not import `rbx.config` — see
+`annotations_light_test.py`.) If `environment.py` already imports `rbx.annotations`
+elsewhere, call `annotations._adapt('verification_level')` directly instead.
+
+**Test:** `uv run rbx build --help | head -3` → no error. This wires all 9 sites.
+
+**Commit**
+```bash
+git add rbx/box/environment.py
+# /commit -> feat(completion): wire verification-level completer everywhere
+```
+
+---
+
+### Task C4: wire `--profile` (4 sites) and `-C/--contest` (2 sites)
+
+**Files:** Modify
+- `rbx/box/cli.py` (global `--profile` ~153-160, `time --profile` ~527-532; global `-C` ~166-177)
+- `rbx/box/statements/build_statements.py` (`--profile` ~326-333)
+- `rbx/box/contest/statements.py` (`--profile` ~68-75)
+- `rbx/box/contest/main.py` (`-C` callback ~38-46)
+
+For each `--profile` `typer.Option(...)` add `autocompletion=annotations._adapt('profile')`.
+For each `-C/--contest` `typer.Option(...)` add `autocompletion=annotations._adapt('contest_variant')`.
+
+Ensure each of those four files imports `rbx.annotations` (light). Check the file
+header; add `from rbx import annotations` if missing.
+
+**Test:** `uv run rbx time --help | head -3`, `uv run rbx --help | head -3`,
+`uv run rbx statements build --help | head -3` → no error.
+
+**Commit**
+```bash
+git add rbx/box/cli.py rbx/box/statements/build_statements.py rbx/box/contest/statements.py rbx/box/contest/main.py
+# /commit -> feat(completion): wire profile + contest-variant completers
+```
+
+---
+
+### Task C5: wire `rbx on` first positional (cli.py + contest/main.py)
+
+**Files:** Modify `rbx/box/cli.py` (`on` ~239) and `rbx/box/contest/main.py` (`on` ~377).
+
+Wrap the bare `problems: str` in an Annotated Argument with the completer.
+
+`cli.py`:
+
+```python
+def on(
+    ctx: typer.Context,
+    problems: Annotated[
+        str, typer.Argument(autocompletion=annotations._adapt('problem'))  # noqa: SLF001
+    ],
+) -> None:
+    contest.on(ctx, problems)
+```
+
+`contest/main.py` (`on`): same wrapping of its `problems: str` param. Ensure
+`from rbx import annotations` and `from typing_extensions import Annotated` are
+imported in both files (check headers).
+
+**Test:** `uv run rbx on --help | head -3` → no error.
+
+**Commit**
+```bash
+git add rbx/box/cli.py rbx/box/contest/main.py
+# /commit -> feat(completion): wire rbx on problem completer
+```
+
+---
+
+### Task C6: regenerate the committed spec
+
+**Files:** Modify `rbx/box/completion/_spec.py` (generated).
+
+**Step 1:** `mise run gen-completion-spec`
+(equivalently `uv run python -m rbx.box.completion.serialize`).
+
+**Step 2:** Verify the new keys/completers landed:
+
+```bash
+uv run python - <<'PY'
+from rbx.box.completion import _spec
+print('COMPLETERS:', sorted(_spec.COMPLETERS))
+PY
+```
+
+Expected `COMPLETERS` includes: `checker, contest_variant, language, outcome,
+problem, profile, solutions, testgroup, verification_level`.
+
+**Step 3:** Drift test passes:
+`uv run pytest tests/rbx/box/completion/drift_test.py -q` → PASS.
+
+**Step 4: Commit**
+```bash
+git add rbx/box/completion/_spec.py
+# /commit -> feat(completion): regenerate spec with new completers
+```
+
+---
+
+### Task C7: differential parity + firewall guards
+
+**Files:** Modify `tests/rbx/box/completion/firewall_test.py`.
+
+**Step 1: Run the full differential test** against the regenerated spec — this now
+exercises the file-union exemption and every new completer at `incomplete=''`:
+`uv run pytest tests/rbx/box/completion/differential_test.py -q` → PASS.
+
+If a file-union position mismatches: confirm `_cursor_value` detects it and the
+engine appends exactly one directive. If a plain completer mismatches: the
+completer's no-package output must equal what `_adapt` returns (same function) —
+check for stray `type`/filtering differences.
+
+**Step 2: Extend the firewall probe** to hit the new completers. Parametrize the
+existing test so each scenario stays light:
+
+```python
+import pytest
+
+SCENARIOS = [
+    ('rbx ', '1'),
+    ('rbx run ', '2'),           # solutions completer
+    ('rbx run --outcome ', '3'), # outcome completer
+    ('rbx irun --testcase ', '3'),  # testgroup completer
+    ('rbx build --verification-level ', '3'),  # verification_level
+    ('rbx time --profile ', '3'),  # profile
+    ('rbx stress --finder ', '3'),  # solutions (file-union)
+]
+
+
+def _modules_after_completion(comp_args: str, cword: str) -> set:
+    probe = (
+        'import os, sys\n'
+        "os.environ['_RBX_COMPLETE'] = 'complete_bash'\n"
+        f"os.environ['_TYPER_COMPLETE_ARGS'] = {comp_args!r}\n"
+        f"os.environ['COMP_WORDS'] = {comp_args!r}\n"
+        f"os.environ['COMP_CWORD'] = {cword!r}\n"
+        'from rbx.box import main\n'
+        'try:\n'
+        '    main.app()\n'
+        'except SystemExit:\n'
+        '    pass\n'
+        "sys.stderr.write('MODULES_START\\n')\n"
+        'sys.stderr.write(chr(10).join(sorted(sys.modules)))\n'
+    )
+    out = subprocess.run([sys.executable, '-c', probe], capture_output=True, text=True)
+    _, _, mods = out.stderr.partition('MODULES_START\n')
+    return set(mods.splitlines())
+
+
+@pytest.mark.parametrize('comp_args,cword', SCENARIOS)
+def test_completion_path_imports_nothing_heavy(comp_args, cword):
+    mods = _modules_after_completion(comp_args, cword)
+    leaked = [m for m in DENYLIST if any(x == m or x.startswith(m + '.') for x in mods)]
+    assert not leaked, f'{comp_args!r} imported heavy modules: {leaked}'
+```
+
+Keep `DENYLIST` and the `_PROBE`-replaced helper; remove the now-unused old
+single-scenario `_PROBE`/`_modules_after_completion` if replaced.
+
+**Step 3: Run** `uv run pytest tests/rbx/box/completion/firewall_test.py -q` → PASS.
+
+**Step 4: Commit**
+```bash
+git add tests/rbx/box/completion/firewall_test.py
+# /commit -> test(completion): probe new completers stay import-light
+```
+
+---
+
+### Task C8: wiring assertion test
+
+**Files:** Create `tests/rbx/box/completion/wiring_test.py`.
+
+**Step 1: Write the test** — assert every issue param resolves to its completer in
+the committed spec.
+
+```python
+import pytest
+
+from rbx.box.completion import _spec
+
+
+def _node(path):
+    node = _spec.SPEC
+    for token in path:
+        node = next(
+            c for c in node['children']
+            if token in [s.strip() for s in c['name'].split(',')]
+        )
+    return node
+
+
+def _arg_value(node):
+    return next(p for p in node['params'] if p['kind'] == 'argument')['value']
+
+
+def _opt_value(node, name):
+    return next(p for p in node['params'] if p['kind'] == 'option' and name in p['names'])['value']
+
+
+WIRINGS = [
+    (['run'], 'arg', None, 'solutions', 'file'),
+    (['irun'], 'arg', None, 'solutions', 'file'),
+    (['run'], 'opt', '--outcome', 'outcome', None),
+    (['irun'], 'opt', '--testcase', 'testgroup', None),
+    (['build'], 'opt', '--verification-level', 'verification_level', None),
+    (['time'], 'opt', '--profile', 'profile', None),
+    (['stress'], 'opt', '--finder', 'solutions', 'file'),
+    (['stress'], 'opt', '--fuzz-on', 'testgroup', None),
+    (['stress'], 'opt', '--reference', 'solutions', 'file'),
+    (['on'], 'arg', None, 'problem', None),
+]
+
+
+@pytest.mark.parametrize('path,kind,name,completer,file_flag', WIRINGS)
+def test_param_wired_to_completer(path, kind, name, completer, file_flag):
+    node = _node(path)
+    value = _arg_value(node) if kind == 'arg' else _opt_value(node, name)
+    assert value.get('kind') == 'completer'
+    assert value.get('completer') == completer
+    assert value.get('file') == file_flag
+
+
+def test_contest_variant_flag_wired():
+    value = _opt_value(_spec.SPEC, '-C')
+    assert value.get('completer') == 'contest_variant'
+```
+
+**Step 2: Run, expect PASS** (spec already regenerated):
+`uv run pytest tests/rbx/box/completion/wiring_test.py -q`
+
+If a path/name does not match the registered command/option name, adjust the
+`WIRINGS` entry to the real spec (inspect with the snippet from C6).
+
+**Step 3: Commit**
+```bash
+git add tests/rbx/box/completion/wiring_test.py
+# /commit -> test(completion): assert issue #575 params wired to completers
+```
+
+---
+
+### Task C9: full verification + docs
+
+**Step 1: Full completion suite + lint**
+
+```bash
+uv run pytest tests/rbx/box/completion -q
+uv run ruff check rbx tests && uv run ruff format --check rbx tests
+```
+
+Expected: all PASS. (Benchmark `mise run bench-completion` is informational; run
+it to confirm `<tab>` latency hasn't regressed materially.)
+
+**Step 2: Update the module guide.** In `rbx/box/completion/CLAUDE.md`, replace the
+final "Gotchas" bullet ("Today only `--language` is wired…") with the new reality:
+list the wired completers, note the file-union mechanism (`file` value flag +
+engine FILE directive + `variadic` arg re-offer + differential exemption), and
+the hardcoded-table + consistency-test pattern for `outcome`/`verification_level`.
+
+**Step 3: Commit**
+```bash
+git add rbx/box/completion/CLAUDE.md
+# /commit -> docs(completion): document the new completers and file-union
+```
+
+**Step 4: Manual smoke (optional).** In a real problem package:
+`rbx run <tab>` lists solutions + `@main`/`@boca/` + files; `rbx run --outcome <tab>`
+lists outcome tokens; `rbx build -v <tab>` lists `0`-`4`.
+
+---
+
+## Done criteria
+
+- All `tests/rbx/box/completion` pass (differential, firewall, drift, wiring,
+  enum-consistency, completers, engine).
+- `_spec.py` regenerated and committed; drift test green.
+- `ruff check` + `ruff format --check` clean.
+- Every param in issue #575 resolves to its completer (wiring_test).

--- a/mise.toml
+++ b/mise.toml
@@ -68,4 +68,6 @@ run = "python scripts/bench_completion.py"
 
 [tasks.gen-completion-spec]
 description = "Regenerate the committed completion spec from the Typer app"
-run = "python -m rbx.box.completion.serialize"
+# serialize writes raw pprint output; ruff-format it so the committed file is
+# textually reproducible (the drift test is dict-based, but this avoids churn).
+run = "python -m rbx.box.completion.serialize && ruff format rbx/box/completion/_spec.py"

--- a/rbx/annotations.py
+++ b/rbx/annotations.py
@@ -13,11 +13,16 @@ class _PackagePathMarker:
 PackagePath = _PackagePathMarker()
 
 
-def _adapt(key: str):
+def _adapt(key: str, *, file: bool = False):
     """Typer autocompletion callback that delegates to the registry completer `key`.
 
     Builds the same CompletionContext the fast engine builds, so real-Typer and
     fast-path completions agree. Returns plain string values (Typer wraps them).
+
+    When `file=True`, the param's value position should ALSO hand off to the
+    shell's default file completion after the dynamic candidates. Typer's callback
+    contract cannot emit a file directive, so we only TAG the callback here; the
+    spec generator records the flag and the fast engine appends the directive.
     """
 
     def _cb(incomplete: str = ''):
@@ -36,6 +41,8 @@ def _adapt(key: str):
         return [item.value for item in load_completer(key)(ctx, incomplete)]
 
     _cb._completer_key = key  # noqa: SLF001  read by the spec generator to recover the key
+    if file:
+        _cb._completer_file = 'file'  # noqa: SLF001  read by the spec generator
     return _cb
 
 

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -156,6 +156,7 @@ def main(
             '-p',
             '--profile',
             help='Which timing profile to use when running solutions.',
+            autocompletion=annotations._adapt('profile'),  # noqa: SLF001
         ),
     ] = None,
     profiling: bool = typer.Option(
@@ -173,6 +174,7 @@ def main(
                 'use_variants: true). Defaults to the RBX_CONTEST env var.'
             ),
             envvar='RBX_CONTEST',
+            autocompletion=annotations._adapt('contest_variant'),  # noqa: SLF001
         ),
     ] = None,
     version: Annotated[
@@ -531,6 +533,7 @@ async def time(
         '--profile',
         '-p',
         help='Profile to use for time limit estimation.',
+        autocompletion=annotations._adapt('profile'),  # noqa: SLF001
     ),
     integrate: bool = typer.Option(
         False,

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -238,7 +238,13 @@ def ui():
     help='Run a command in the context of a problem (or a set of problems) of a contest.',
     context_settings={'allow_extra_args': True, 'ignore_unknown_options': True},
 )
-def on(ctx: typer.Context, problems: str) -> None:
+def on(
+    ctx: typer.Context,
+    problems: Annotated[
+        str,
+        typer.Argument(autocompletion=annotations._adapt('problem')),  # noqa: SLF001
+    ],
+) -> None:
     contest.on(ctx, problems)
 
 

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -314,7 +314,8 @@ async def run(
         Optional[List[str]],
         PackagePath,
         typer.Argument(
-            help='Path to solutions to run. If not specified, will run all solutions.'
+            help='Path to solutions to run. If not specified, will run all solutions.',
+            autocompletion=annotations._adapt('solutions', file=True),  # noqa: SLF001
         ),
     ] = None,
     outcome: Optional[str] = typer.Option(
@@ -322,6 +323,7 @@ async def run(
         '--outcome',
         '-o',
         help='Include only solutions whose expected outcomes intersect with this.',
+        autocompletion=annotations._adapt('outcome'),  # noqa: SLF001
     ),
     tags: Annotated[
         Optional[List[str]],
@@ -649,7 +651,8 @@ async def irun(
         Optional[List[str]],
         PackagePath,
         typer.Argument(
-            help='Path to solutions to run. If not specified, will run all solutions.'
+            help='Path to solutions to run. If not specified, will run all solutions.',
+            autocompletion=annotations._adapt('solutions', file=True),  # noqa: SLF001
         ),
     ] = None,
     outcome: Optional[str] = typer.Option(
@@ -657,6 +660,7 @@ async def irun(
         '--outcome',
         '-o',
         help='Include only solutions whose expected outcomes intersect with this.',
+        autocompletion=annotations._adapt('outcome'),  # noqa: SLF001
     ),
     tags: Annotated[
         Optional[List[str]],

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -690,6 +690,7 @@ async def irun(
         '-tc',
         '-t',
         help='Testcase to run, in the format "[group]/[index]". If not specified, will run interactively.',
+        autocompletion=annotations._adapt('testgroup'),  # noqa: SLF001
     ),
     output: bool = typer.Option(
         False,
@@ -856,6 +857,7 @@ async def stress(
             '--finder',
             '-f',
             help='Run a stress with this finder expression.',
+            autocompletion=annotations._adapt('solutions', file=True),  # noqa: SLF001
         ),
     ] = None,
     timeout: Annotated[
@@ -933,6 +935,7 @@ async def stress(
         typer.Option(
             '--fuzz-on',
             help='Testgroups to fuzz generator calls from.',
+            autocompletion=annotations._adapt('testgroup'),  # noqa: SLF001
         ),
     ] = None,
     validate: bool = typer.Option(
@@ -944,6 +947,7 @@ async def stress(
         '--reference',
         '-r',
         help='Reference solution to use for the stress test.',
+        autocompletion=annotations._adapt('solutions', file=True),  # noqa: SLF001
     ),
 ):
     if generator_args and (fuzz or fuzz_on):

--- a/rbx/box/completion/CLAUDE.md
+++ b/rbx/box/completion/CLAUDE.md
@@ -51,8 +51,9 @@ CI if the committed module is stale.
   Click's **native** ShellComplete classes by name.
 - `registry.py` — `register_completer` / `register_completer_path` / `register_all`
   / `load_completer` / `key_for_function`, and the `CompletionContext` dataclass.
-- `completers.py` — the dynamic completers (`language`, `checker`, `problem`).
-  Must stay light: heavy imports are local to each function.
+- `completers.py` — the dynamic completers (`language`, `checker`, `problem`,
+  `solutions`, `outcome`, `verification_level`, `profile`, `testgroup`,
+  `contest_variant`). Must stay light: heavy imports are local to each function.
 - `peek.py` — `peek(path)`: cheap, tolerant, mtime-cached `yaml.safe_load` of
   package YAML (no pydantic, no full load).
 - `context.py` — `find_package_root()`: cheap upward walk for
@@ -123,5 +124,26 @@ CI if the committed module is stale.
   handled in `generate.py`: hidden commands are skipped; Click's auto `--help`
   (not in `cmd.params`) is added explicitly; boolean `secondary_opts` (`--no-*`)
   are included.
-- Today only `--language` is wired to a dynamic completer (the demonstrated
-  hook). `checker`/`problem` are registered and ready; wire more via the recipe.
+- Wired completers (issue #575): `language` (`--language`), `solutions`
+  (`run`/`irun` positional, `stress --finder`/`--reference`), `outcome`
+  (`run`/`irun --outcome`), `testgroup` (`irun --testcase`, `stress --fuzz-on`),
+  `verification_level` (the shared `VerificationParam`, i.e. every `-v`),
+  `profile` (global `--profile`, `time --profile`, statement builds),
+  `contest_variant` (`-C/--contest`), `problem` (`on` positional). `checker` is
+  registered but not currently attached to a live CLI param, so it is absent from
+  the committed `COMPLETERS` until something wires it. Wire more via the recipe.
+- **File-union** lets a value position offer dynamic candidates AND hand off to
+  the shell's default file completion. Tag the callback with
+  `annotations._adapt(key, file=True)`; the generator records a `'file'` key on
+  the value spec, the engine appends a `FILE` directive after the dynamic items
+  (`_value_items`), and a **variadic** last argument (`nargs == -1`, recorded as
+  `'variadic': True`) keeps re-offering its completer past its position
+  (`resolve`). `differential_test.py` can't compare these against Typer (its
+  callback contract can't emit a file directive), so `_cursor_value` **exempts**
+  file-union positions: it asserts the dynamic part matches Typer exactly AND that
+  exactly one shell directive is appended.
+- `outcome` and `verification_level` are **hardcoded tables** in `completers.py`
+  (`_OUTCOME_TABLE`, `_VERIFICATION_TABLE`) to keep the completer light (no enum
+  import). `enum_consistency_test.py` (allowed to import the heavy app) pins each
+  table to its source enum (`ExpectedOutcome` / `VerificationLevel`) — exactly one
+  token per member — so a new enum member fails CI until the table is updated.

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -31,7 +31,7 @@ SPEC = {
                     'multiple': False,
                     'names': [],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'problem', 'kind': 'completer'},
                 },
                 {
                     'help': 'Show this message and exit.',
@@ -87,7 +87,7 @@ SPEC = {
                     'multiple': False,
                     'names': ['--verification-level', '--verification', '-v'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'verification_level', 'kind': 'completer'},
                 },
                 {
                     'help': 'Whether to validate outputs for tests.',
@@ -127,7 +127,7 @@ SPEC = {
                     'multiple': False,
                     'names': ['--verification-level', '--verification', '-v'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'verification_level', 'kind': 'completer'},
                 },
                 {
                     'help': None,
@@ -135,7 +135,12 @@ SPEC = {
                     'multiple': False,
                     'names': [],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {
+                        'completer': 'solutions',
+                        'file': 'file',
+                        'kind': 'completer',
+                    },
+                    'variadic': True,
                 },
                 {
                     'help': 'Include only solutions whose expected outcomes intersect with '
@@ -144,7 +149,7 @@ SPEC = {
                     'multiple': False,
                     'names': ['--outcome', '-o'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'outcome', 'kind': 'completer'},
                 },
                 {
                     'help': 'Include only solutions whose tags intersect with this.',
@@ -299,7 +304,7 @@ SPEC = {
                     'multiple': False,
                     'names': ['--profile', '-p'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'profile', 'kind': 'completer'},
                 },
                 {
                     'help': 'Integrate the given limits profile into the package.',
@@ -341,7 +346,7 @@ SPEC = {
                     'multiple': False,
                     'names': ['--verification-level', '--verification', '-v'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'verification_level', 'kind': 'completer'},
                 },
                 {
                     'help': None,
@@ -349,7 +354,12 @@ SPEC = {
                     'multiple': False,
                     'names': [],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {
+                        'completer': 'solutions',
+                        'file': 'file',
+                        'kind': 'completer',
+                    },
+                    'variadic': True,
                 },
                 {
                     'help': 'Include only solutions whose expected outcomes intersect with '
@@ -358,7 +368,7 @@ SPEC = {
                     'multiple': False,
                     'names': ['--outcome', '-o'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'outcome', 'kind': 'completer'},
                 },
                 {
                     'help': 'Include only solutions whose tags intersect with this.',
@@ -399,7 +409,7 @@ SPEC = {
                     'multiple': False,
                     'names': ['--testcase', '--test', '-tc', '-t'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'testgroup', 'kind': 'completer'},
                 },
                 {
                     'help': 'Whether to ask user for custom output.',
@@ -533,7 +543,11 @@ SPEC = {
                     'multiple': False,
                     'names': ['--finder', '-f'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {
+                        'completer': 'solutions',
+                        'file': 'file',
+                        'kind': 'completer',
+                    },
                 },
                 {
                     'help': 'For how many seconds to run the stress test.',
@@ -623,7 +637,7 @@ SPEC = {
                     'multiple': True,
                     'names': ['--fuzz-on'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'testgroup', 'kind': 'completer'},
                 },
                 {
                     'help': 'Whether to validate inputs.',
@@ -639,7 +653,11 @@ SPEC = {
                     'multiple': False,
                     'names': ['--reference', '-r'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {
+                        'completer': 'solutions',
+                        'file': 'file',
+                        'kind': 'completer',
+                    },
                 },
                 {
                     'help': 'Show this message and exit.',
@@ -987,7 +1005,10 @@ SPEC = {
                             'multiple': False,
                             'names': ['--verification-level', '--verification', '-v'],
                             'takes_value': True,
-                            'value': {'kind': 'none'},
+                            'value': {
+                                'completer': 'verification_level',
+                                'kind': 'completer',
+                            },
                         },
                         {
                             'help': None,
@@ -996,6 +1017,7 @@ SPEC = {
                             'names': [],
                             'takes_value': True,
                             'value': {'kind': 'none'},
+                            'variadic': True,
                         },
                         {
                             'help': 'Languages to build statements for. If not '
@@ -1018,7 +1040,9 @@ SPEC = {
                                     'rbxTeX',
                                     'rbxMarkdown',
                                     'TeX',
+                                    'Markdown',
                                     'JinjaTeX',
+                                    'JinjaMarkdown',
                                     'PDF',
                                 ],
                                 'kind': 'choice',
@@ -1056,7 +1080,7 @@ SPEC = {
                             'multiple': False,
                             'names': ['-p', '--profile'],
                             'takes_value': True,
-                            'value': {'kind': 'none'},
+                            'value': {'completer': 'profile', 'kind': 'completer'},
                         },
                         {
                             'help': 'Show this message and exit.',
@@ -1528,7 +1552,10 @@ SPEC = {
                             'multiple': False,
                             'names': ['--verification-level', '--verification', '-v'],
                             'takes_value': True,
-                            'value': {'kind': 'none'},
+                            'value': {
+                                'completer': 'verification_level',
+                                'kind': 'completer',
+                            },
                         },
                         {
                             'help': 'If set, will upload the package to Polygon.',
@@ -1617,7 +1644,10 @@ SPEC = {
                             'multiple': False,
                             'names': ['--verification-level', '--verification', '-v'],
                             'takes_value': True,
-                            'value': {'kind': 'none'},
+                            'value': {
+                                'completer': 'verification_level',
+                                'kind': 'completer',
+                            },
                         },
                         {
                             'help': 'If set, will upload the package to BOCA.',
@@ -1659,7 +1689,10 @@ SPEC = {
                             'multiple': False,
                             'names': ['--verification-level', '--verification', '-v'],
                             'takes_value': True,
-                            'value': {'kind': 'none'},
+                            'value': {
+                                'completer': 'verification_level',
+                                'kind': 'completer',
+                            },
                         },
                         {
                             'help': 'Build a package for BOCA instead of MOJ.',
@@ -1691,7 +1724,10 @@ SPEC = {
                             'multiple': False,
                             'names': ['--verification-level', '--verification', '-v'],
                             'takes_value': True,
-                            'value': {'kind': 'none'},
+                            'value': {
+                                'completer': 'verification_level',
+                                'kind': 'completer',
+                            },
                         },
                         {
                             'help': 'Show this message and exit.',
@@ -1946,7 +1982,7 @@ SPEC = {
                             'multiple': False,
                             'names': [],
                             'takes_value': True,
-                            'value': {'kind': 'none'},
+                            'value': {'completer': 'problem', 'kind': 'completer'},
                         },
                         {
                             'help': 'Show this message and exit.',
@@ -2009,7 +2045,10 @@ SPEC = {
                                         '-v',
                                     ],
                                     'takes_value': True,
-                                    'value': {'kind': 'none'},
+                                    'value': {
+                                        'completer': 'verification_level',
+                                        'kind': 'completer',
+                                    },
                                 },
                                 {
                                     'help': None,
@@ -2018,6 +2057,7 @@ SPEC = {
                                     'names': [],
                                     'takes_value': True,
                                     'value': {'kind': 'none'},
+                                    'variadic': True,
                                 },
                                 {
                                     'help': 'Languages to build statements for. '
@@ -2049,7 +2089,9 @@ SPEC = {
                                             'rbxTeX',
                                             'rbxMarkdown',
                                             'TeX',
+                                            'Markdown',
                                             'JinjaTeX',
+                                            'JinjaMarkdown',
                                             'PDF',
                                         ],
                                         'kind': 'choice',
@@ -2090,7 +2132,10 @@ SPEC = {
                                     'multiple': False,
                                     'names': ['-p', '--profile'],
                                     'takes_value': True,
-                                    'value': {'kind': 'none'},
+                                    'value': {
+                                        'completer': 'profile',
+                                        'kind': 'completer',
+                                    },
                                 },
                                 {
                                     'help': 'Show this message and exit.',
@@ -2137,7 +2182,10 @@ SPEC = {
                                         '-v',
                                     ],
                                     'takes_value': True,
-                                    'value': {'kind': 'none'},
+                                    'value': {
+                                        'completer': 'verification_level',
+                                        'kind': 'completer',
+                                    },
                                 },
                                 {
                                     'help': 'If set, will use the given '
@@ -2178,7 +2226,10 @@ SPEC = {
                                         '-v',
                                     ],
                                     'takes_value': True,
-                                    'value': {'kind': 'none'},
+                                    'value': {
+                                        'completer': 'verification_level',
+                                        'kind': 'completer',
+                                    },
                                 },
                                 {
                                     'help': 'Show this message and exit.',
@@ -2207,7 +2258,10 @@ SPEC = {
                                         '-v',
                                     ],
                                     'takes_value': True,
-                                    'value': {'kind': 'none'},
+                                    'value': {
+                                        'completer': 'verification_level',
+                                        'kind': 'completer',
+                                    },
                                 },
                                 {
                                     'help': 'Show this message and exit.',
@@ -2247,7 +2301,7 @@ SPEC = {
                     'multiple': False,
                     'names': ['-C', '--contest'],
                     'takes_value': True,
-                    'value': {'kind': 'none'},
+                    'value': {'completer': 'contest_variant', 'kind': 'completer'},
                 },
                 {
                     'help': 'Show this message and exit.',
@@ -2340,6 +2394,7 @@ SPEC = {
                             'names': [],
                             'takes_value': True,
                             'value': {'kind': 'none'},
+                            'variadic': True,
                         },
                         {
                             'help': 'Destination manual test group.',
@@ -2579,7 +2634,7 @@ SPEC = {
             'multiple': False,
             'names': ['-p', '--profile'],
             'takes_value': True,
-            'value': {'kind': 'none'},
+            'value': {'completer': 'profile', 'kind': 'completer'},
         },
         {
             'help': 'Whether to profile (capture performance statistics) of the execution.',
@@ -2596,7 +2651,7 @@ SPEC = {
             'multiple': False,
             'names': ['-C', '--contest'],
             'takes_value': True,
-            'value': {'kind': 'none'},
+            'value': {'completer': 'contest_variant', 'kind': 'completer'},
         },
         {
             'help': None,
@@ -2617,4 +2672,13 @@ SPEC = {
     ],
 }
 
-COMPLETERS = {'language': 'rbx.box.completion.completers:complete_language'}
+COMPLETERS = {
+    'contest_variant': 'rbx.box.completion.completers:complete_contest_variant',
+    'language': 'rbx.box.completion.completers:complete_language',
+    'outcome': 'rbx.box.completion.completers:complete_outcome',
+    'problem': 'rbx.box.completion.completers:complete_problem',
+    'profile': 'rbx.box.completion.completers:complete_profile',
+    'solutions': 'rbx.box.completion.completers:complete_solutions',
+    'testgroup': 'rbx.box.completion.completers:complete_testgroup',
+    'verification_level': 'rbx.box.completion.completers:complete_verification_level',
+}

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -94,3 +94,21 @@ _OUTCOME_TABLE = (
 @register_completer('outcome')
 def complete_outcome(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
     return [CompletionItem(v, help=h) for v, h in _OUTCOME_TABLE]
+
+
+# (value, level name). Kept in sync with environment.VerificationLevel by
+# enum_consistency_test.py.
+_VERIFICATION_TABLE = (
+    ('0', 'NONE'),
+    ('1', 'VALIDATE'),
+    ('2', 'FAST_SOLUTIONS'),
+    ('3', 'ALL_SOLUTIONS'),
+    ('4', 'FULL'),
+)
+
+
+@register_completer('verification_level')
+def complete_verification_level(
+    ctx: CompletionContext, incomplete: str
+) -> List[CompletionItem]:
+    return [CompletionItem(v, help=h) for v, h in _VERIFICATION_TABLE]

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -68,24 +68,47 @@ def complete_problem(ctx: CompletionContext, incomplete: str) -> List[Completion
 
 # Built-in solution-path expanders, mirroring rbx/box/remote.py's
 # REGISTERED_EXPANDERS (guarded by enum_consistency_test.py). @boca needs a run
-# id we cannot enumerate, so we offer only the prefix.
-_SOLUTION_PREFIXES = (
-    ('@main', 'first accepted solution'),
-    ('@boca/', 'download a BOCA submission, e.g. @boca/123'),
-)
+# id we cannot enumerate, so we offer only the prefix. `@main` leads the list and
+# `@boca/` trails it (the order the engine emits, preserved by the shell scripts).
+_MAIN_PREFIX = ('@main', 'first accepted solution')
+_BOCA_PREFIX = ('@boca/', 'download a BOCA submission, e.g. @boca/123')
+_SOLUTION_PREFIXES = (_MAIN_PREFIX, _BOCA_PREFIX)
+
+
+def _expand_solution_paths(root: Path, sol: dict):
+    """Yield the concrete solution files a `solutions[]` entry refers to.
+
+    Mirrors rbx/box/package.py:get_globbed_code_items lightly: a `*` path is
+    globbed against the package root (like the real CLI), anything else is taken
+    verbatim. No language-extension filtering (that needs the heavy app)."""
+    path = str(sol['path'])
+    if '*' in path:
+        for f in sorted(root.glob(path)):
+            if f.is_file():
+                yield str(f.relative_to(root))
+    else:
+        yield path
 
 
 @register_completer('solutions')
 def complete_solutions(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
-    items: List[CompletionItem] = []
+    items: List[CompletionItem] = [
+        CompletionItem(_MAIN_PREFIX[0], help=_MAIN_PREFIX[1])
+    ]
     root = ctx.package_root
     if root is not None:
-        for sol in _peek_list(Path(root), 'problem.rbx.yml', 'solutions'):
-            if isinstance(sol, dict) and sol.get('path'):
-                outcome = sol.get('outcome')
-                help_text = str(outcome) if outcome is not None else None
-                items.append(CompletionItem(str(sol['path']), help=help_text))
-    items += [CompletionItem(v, help=h) for v, h in _SOLUTION_PREFIXES]
+        root = Path(root)
+        seen = set()
+        for sol in _peek_list(root, 'problem.rbx.yml', 'solutions'):
+            if not (isinstance(sol, dict) and sol.get('path')):
+                continue
+            outcome = sol.get('outcome')
+            help_text = str(outcome) if outcome is not None else None
+            for value in _expand_solution_paths(root, sol):
+                if value not in seen:
+                    seen.add(value)
+                    items.append(CompletionItem(value, help=help_text))
+    items.append(CompletionItem(_BOCA_PREFIX[0], help=_BOCA_PREFIX[1]))
     return items
 
 

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -43,10 +43,16 @@ def complete_problem(ctx: CompletionContext, incomplete: str) -> List[Completion
     if root is None:
         return []
     data = peek.peek(Path(root) / 'contest.rbx.yml')
-    shorts = {
-        p.get('short_name') for p in data.get('problems', []) if isinstance(p, dict)
-    }
-    return _items(s for s in shorts if s)
+    names = set()
+    for p in data.get('problems', []):
+        if not isinstance(p, dict):
+            continue
+        if p.get('short_name'):
+            names.add(p['short_name'])
+        for alias in p.get('aliases', []) or []:
+            if alias:
+                names.add(alias)
+    return _items(names)
 
 
 # Built-in solution-path expanders (kept in sync with rbx/box/remote.py via

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -123,3 +123,13 @@ def complete_profile(ctx: CompletionContext, incomplete: str) -> List[Completion
     if not limits_dir.is_dir():
         return []
     return _items(p.stem for p in limits_dir.glob('*.yml'))
+
+
+@register_completer('testgroup')
+def complete_testgroup(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
+    root = ctx.package_root
+    if root is None:
+        return []
+    data = peek.peek(Path(root) / 'problem.rbx.yml')
+    names = {g.get('name') for g in data.get('testcases', []) if isinstance(g, dict)}
+    return _items(n for n in names if n)

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -2,7 +2,7 @@
 
 import importlib.resources
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from click.shell_completion import CompletionItem
 
@@ -133,3 +133,33 @@ def complete_testgroup(ctx: CompletionContext, incomplete: str) -> List[Completi
     data = peek.peek(Path(root) / 'problem.rbx.yml')
     names = {g.get('name') for g in data.get('testcases', []) if isinstance(g, dict)}
     return _items(n for n in names if n)
+
+
+_CONTEST_PREFIX = 'contest.'
+_CONTEST_SUFFIX = '.rbx.yml'
+
+
+def _find_contest_root(start: Optional[Path]) -> Optional[Path]:
+    """Nearest ancestor (incl. start) holding a contest.rbx.yml. Light, no load."""
+    if start is None:
+        return None
+    cur = Path(start)
+    for d in [cur, *cur.parents]:
+        if (d / 'contest.rbx.yml').exists():
+            return d
+    return None
+
+
+@register_completer('contest_variant')
+def complete_contest_variant(
+    ctx: CompletionContext, incomplete: str
+) -> List[CompletionItem]:
+    root = _find_contest_root(ctx.package_root)
+    if root is None:
+        return []
+    ids = []
+    for p in root.glob(f'{_CONTEST_PREFIX}*{_CONTEST_SUFFIX}'):
+        name = p.name[len(_CONTEST_PREFIX) : -len(_CONTEST_SUFFIX)]
+        if name:
+            ids.append(name)
+    return _items(ids)

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -112,3 +112,14 @@ def complete_verification_level(
     ctx: CompletionContext, incomplete: str
 ) -> List[CompletionItem]:
     return [CompletionItem(v, help=h) for v, h in _VERIFICATION_TABLE]
+
+
+@register_completer('profile')
+def complete_profile(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
+    root = ctx.package_root
+    if root is None:
+        return []
+    limits_dir = Path(root) / '.limits'
+    if not limits_dir.is_dir():
+        return []
+    return _items(p.stem for p in limits_dir.glob('*.yml'))

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -47,3 +47,27 @@ def complete_problem(ctx: CompletionContext, incomplete: str) -> List[Completion
         p.get('short_name') for p in data.get('problems', []) if isinstance(p, dict)
     }
     return _items(s for s in shorts if s)
+
+
+# Built-in solution-path expanders (kept in sync with rbx/box/remote.py via
+# enum_consistency_test.py). @boca needs a run id we cannot enumerate, so we
+# offer only the prefix.
+_SOLUTION_PREFIXES = (
+    ('@main', 'first accepted solution'),
+    ('@boca/', 'download a BOCA submission, e.g. @boca/123'),
+)
+
+
+@register_completer('solutions')
+def complete_solutions(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
+    items: List[CompletionItem] = []
+    root = ctx.package_root
+    if root is not None:
+        data = peek.peek(Path(root) / 'problem.rbx.yml')
+        for sol in data.get('solutions', []):
+            if isinstance(sol, dict) and sol.get('path'):
+                outcome = sol.get('outcome')
+                help_text = str(outcome) if outcome is not None else None
+                items.append(CompletionItem(str(sol['path']), help=help_text))
+    items += [CompletionItem(v, help=h) for v, h in _SOLUTION_PREFIXES]
+    return items

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -71,3 +71,26 @@ def complete_solutions(ctx: CompletionContext, incomplete: str) -> List[Completi
                 items.append(CompletionItem(str(sol['path']), help=help_text))
     items += [CompletionItem(v, help=h) for v, h in _SOLUTION_PREFIXES]
     return items
+
+
+# (token, human description). Kept complete vs ExpectedOutcome by
+# enum_consistency_test.py -- exactly one token per enum member.
+_OUTCOME_TABLE = (
+    ('any', 'matches any verdict'),
+    ('ac', 'accepted'),
+    ('ac/tle', 'accepted or time limit exceeded'),
+    ('wa', 'wrong answer'),
+    ('incorrect', 'any incorrect verdict (WA/RTE/MLE/OLE/TLE)'),
+    ('rte', 'runtime error'),
+    ('tle', 'time limit exceeded'),
+    ('mle', 'memory limit exceeded'),
+    ('ole', 'output limit exceeded'),
+    ('tle/rte', 'time limit exceeded or runtime error'),
+    ('jf', 'judge failed'),
+    ('ce', 'compilation error'),
+)
+
+
+@register_completer('outcome')
+def complete_outcome(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
+    return [CompletionItem(v, help=h) for v, h in _OUTCOME_TABLE]

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -14,6 +14,16 @@ def _items(values) -> List[CompletionItem]:
     return [CompletionItem(v) for v in sorted(values)]
 
 
+def _peek_list(root: Path, filename: str, key: str) -> list:
+    """A top-level list field from a package YAML, tolerant of malformed input.
+
+    `peek` already swallows IO/parse errors; this additionally coerces a
+    missing/None/scalar field to `[]` so callers never iterate a non-list.
+    """
+    value = peek.peek(root / filename).get(key)
+    return value if isinstance(value, list) else []
+
+
 @register_completer('language')
 def complete_language(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
     from rbx.config import get_config  # local import keeps module light
@@ -42,22 +52,23 @@ def complete_problem(ctx: CompletionContext, incomplete: str) -> List[Completion
     root = ctx.package_root
     if root is None:
         return []
-    data = peek.peek(Path(root) / 'contest.rbx.yml')
     names = set()
-    for p in data.get('problems', []):
+    for p in _peek_list(Path(root), 'contest.rbx.yml', 'problems'):
         if not isinstance(p, dict):
             continue
         if p.get('short_name'):
             names.add(p['short_name'])
-        for alias in p.get('aliases', []) or []:
-            if alias:
-                names.add(alias)
+        aliases = p.get('aliases')
+        if isinstance(aliases, list):
+            for alias in aliases:
+                if alias:
+                    names.add(alias)
     return _items(names)
 
 
-# Built-in solution-path expanders (kept in sync with rbx/box/remote.py via
-# enum_consistency_test.py). @boca needs a run id we cannot enumerate, so we
-# offer only the prefix.
+# Built-in solution-path expanders, mirroring rbx/box/remote.py's
+# REGISTERED_EXPANDERS (guarded by enum_consistency_test.py). @boca needs a run
+# id we cannot enumerate, so we offer only the prefix.
 _SOLUTION_PREFIXES = (
     ('@main', 'first accepted solution'),
     ('@boca/', 'download a BOCA submission, e.g. @boca/123'),
@@ -69,8 +80,7 @@ def complete_solutions(ctx: CompletionContext, incomplete: str) -> List[Completi
     items: List[CompletionItem] = []
     root = ctx.package_root
     if root is not None:
-        data = peek.peek(Path(root) / 'problem.rbx.yml')
-        for sol in data.get('solutions', []):
+        for sol in _peek_list(Path(root), 'problem.rbx.yml', 'solutions'):
             if isinstance(sol, dict) and sol.get('path'):
                 outcome = sol.get('outcome')
                 help_text = str(outcome) if outcome is not None else None
@@ -86,7 +96,7 @@ _OUTCOME_TABLE = (
     ('ac', 'accepted'),
     ('ac/tle', 'accepted or time limit exceeded'),
     ('wa', 'wrong answer'),
-    ('incorrect', 'any incorrect verdict (WA/RTE/MLE/OLE/TLE)'),
+    ('incorrect', 'any incorrect (non-AC) verdict'),
     ('rte', 'runtime error'),
     ('tle', 'time limit exceeded'),
     ('mle', 'memory limit exceeded'),
@@ -136,8 +146,8 @@ def complete_testgroup(ctx: CompletionContext, incomplete: str) -> List[Completi
     root = ctx.package_root
     if root is None:
         return []
-    data = peek.peek(Path(root) / 'problem.rbx.yml')
-    names = {g.get('name') for g in data.get('testcases', []) if isinstance(g, dict)}
+    groups = _peek_list(Path(root), 'problem.rbx.yml', 'testcases')
+    names = {g.get('name') for g in groups if isinstance(g, dict)}
     return _items(n for n in names if n)
 
 

--- a/rbx/box/completion/engine.py
+++ b/rbx/box/completion/engine.py
@@ -105,10 +105,9 @@ def _value_items(
         return [CompletionItem(c) for c in value['choices'] if c.startswith(incomplete)]
     if kind == 'completer':
         items = list(load_completer(value['completer'])(ctx, incomplete))
-        file_flag = value.get('file')
-        if file_flag == 'dir':
-            items = items + DIR
-        elif file_flag == 'file':
+        # A file-union completer hands off to the shell's default file completion
+        # AFTER its dynamic candidates (e.g. `rbx run` solutions + arbitrary paths).
+        if value.get('file'):
             items = items + FILE
         return items
     if kind == 'path':

--- a/rbx/box/completion/engine.py
+++ b/rbx/box/completion/engine.py
@@ -104,9 +104,18 @@ def _value_items(
     if kind == 'choice':
         return [CompletionItem(c) for c in value['choices'] if c.startswith(incomplete)]
     if kind == 'completer':
-        items = list(load_completer(value['completer'])(ctx, incomplete))
+        # Prefix-filter the dynamic candidates by the incomplete, exactly like
+        # Click/Typer do. The shell scripts add these with `-U` (no re-filtering),
+        # so without this, typing a prefix would offer everything and reset the
+        # word instead of narrowing. Filtering here keeps every shell consistent.
+        items = [
+            item
+            for item in load_completer(value['completer'])(ctx, incomplete)
+            if item.value.startswith(incomplete)
+        ]
         # A file-union completer hands off to the shell's default file completion
         # AFTER its dynamic candidates (e.g. `rbx run` solutions + arbitrary paths).
+        # The directive is appended unfiltered -- the shell matches files itself.
         if value.get('file'):
             items = items + FILE
         return items
@@ -166,17 +175,22 @@ def complete_to_string(shell: str, spec) -> str:
     return comp.complete()
 
 
-# Reordered zsh completion function: identical to Click's native template except
-# the file/dir handoff (`_path_files`) is deferred until AFTER the dynamic
-# candidates are described. In a file-union position (e.g. `rbx run`), this makes
-# the solutions/`@`-prefixes rank ahead of the directory listing in the zsh menu
-# instead of being buried under it (issue #575). Placeholders match Click's
-# `.source()` (`prog_name`, `complete_func`, `complete_var`).
+# Custom zsh completion function. Two deliberate departures from Click's native
+# template (issue #575):
+#   1. The file/dir handoff (`_path_files`) is deferred until AFTER the dynamic
+#      candidates are added, so in a file-union position (e.g. `rbx run`) the
+#      solutions/`@`-prefixes rank ahead of the directory listing.
+#   2. Described candidates are added via `compadd -d` (parallel display array)
+#      instead of `_describe`, which re-sorts items that share a description
+#      (e.g. several "ACCEPTED" solutions) alphabetically -- that reordering is
+#      what pushed `@boca` ahead of `@main`. `compadd -V` preserves the engine's
+#      insertion order (`@main`, then solutions, then `@boca`).
+# Placeholders match Click's `.source()` (`prog_name`, `complete_func`, `complete_var`).
 _ZSH_SOURCE_TEMPLATE = """#compdef %(prog_name)s
 
 %(complete_func)s() {
     local -a completions
-    local -a completions_with_descriptions
+    local -a desc_values desc_displays
     local -a response
     local want_files want_dirs
     (( ! $+commands[%(prog_name)s] )) && return 1
@@ -188,7 +202,8 @@ _ZSH_SOURCE_TEMPLATE = """#compdef %(prog_name)s
             if [[ "$descr" == "_" ]]; then
                 completions+=("$key")
             else
-                completions_with_descriptions+=("$key":"$descr")
+                desc_values+=("$key")
+                desc_displays+=("$key -- $descr")
             fi
         elif [[ "$type" == "dir" ]]; then
             want_dirs=1
@@ -197,16 +212,13 @@ _ZSH_SOURCE_TEMPLATE = """#compdef %(prog_name)s
         fi
     done
 
-    # Offer dynamic candidates (e.g. solutions) BEFORE handing off to file
-    # completion, so they rank ahead of the directory listing in the menu.
-    if [ -n "$completions_with_descriptions" ]; then
-        _describe -V unsorted completions_with_descriptions -U
+    # Add dynamic candidates (preserving insertion order) BEFORE the file handoff.
+    if [ -n "$desc_values" ]; then
+        compadd -U -V unsorted -l -d desc_displays -a desc_values
     fi
-
     if [ -n "$completions" ]; then
         compadd -U -V unsorted -a completions
     fi
-
     [[ -n "$want_dirs" ]] && _path_files -/
     [[ -n "$want_files" ]] && _path_files -f
 }

--- a/rbx/box/completion/engine.py
+++ b/rbx/box/completion/engine.py
@@ -104,7 +104,13 @@ def _value_items(
     if kind == 'choice':
         return [CompletionItem(c) for c in value['choices'] if c.startswith(incomplete)]
     if kind == 'completer':
-        return list(load_completer(value['completer'])(ctx, incomplete))
+        items = list(load_completer(value['completer'])(ctx, incomplete))
+        file_flag = value.get('file')
+        if file_flag == 'dir':
+            items = items + DIR
+        elif file_flag == 'file':
+            items = items + FILE
+        return items
     if kind == 'path':
         return DIR if value.get('path') == 'dir' else FILE
     return FILE  # 'none'/unknown -> shell default file completion
@@ -213,6 +219,10 @@ def resolve(
         arguments = [p for p in node['params'] if p['kind'] == 'argument']
         if positional < len(arguments):
             return _value_items(arguments[positional]['value'], ctx, incomplete)
+        if arguments and arguments[-1].get('variadic'):
+            # A variadic last argument keeps consuming positionals, so the real CLI
+            # re-offers its completer at every position past it.
+            return _value_items(arguments[-1]['value'], ctx, incomplete)
         return FILE
     except Exception:
         if os.environ.get('_RBX_COMPLETE_DEBUG'):

--- a/rbx/box/completion/engine.py
+++ b/rbx/box/completion/engine.py
@@ -166,6 +166,61 @@ def complete_to_string(shell: str, spec) -> str:
     return comp.complete()
 
 
+# Reordered zsh completion function: identical to Click's native template except
+# the file/dir handoff (`_path_files`) is deferred until AFTER the dynamic
+# candidates are described. In a file-union position (e.g. `rbx run`), this makes
+# the solutions/`@`-prefixes rank ahead of the directory listing in the zsh menu
+# instead of being buried under it (issue #575). Placeholders match Click's
+# `.source()` (`prog_name`, `complete_func`, `complete_var`).
+_ZSH_SOURCE_TEMPLATE = """#compdef %(prog_name)s
+
+%(complete_func)s() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    local want_files want_dirs
+    (( ! $+commands[%(prog_name)s] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) %(complete_var)s=zsh_complete %(prog_name)s)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            want_dirs=1
+        elif [[ "$type" == "file" ]]; then
+            want_files=1
+        fi
+    done
+
+    # Offer dynamic candidates (e.g. solutions) BEFORE handing off to file
+    # completion, so they rank ahead of the directory listing in the menu.
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+
+    [[ -n "$want_dirs" ]] && _path_files -/
+    [[ -n "$want_files" ]] && _path_files -f
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    %(complete_func)s "$@"
+else
+    # eval/source/. command, register function for later
+    compdef %(complete_func)s %(prog_name)s
+fi
+"""
+
+
 def source_to_string(shell: str) -> str:
     """Render the shell completion install script (the `source_<shell>` instruction)."""
     import click
@@ -174,6 +229,10 @@ def source_to_string(shell: str) -> str:
     if base is None:
         return ''
     comp = base(click.Command('rbx'), {}, 'rbx', '_RBX_COMPLETE')
+    if shell == 'zsh':
+        # Use our reordered template (solutions before file completion); everything
+        # else is Click's native source.
+        comp.source_template = _ZSH_SOURCE_TEMPLATE
     return comp.source()
 
 

--- a/rbx/box/completion/generate.py
+++ b/rbx/box/completion/generate.py
@@ -22,6 +22,11 @@ Spec schema (minimal -- exactly these keys):
       'multiple': bool,           # True if the option may be repeated (Click re-offers it)
       'help': Optional[str],
       'value': dict,              # {'kind': 'choice'|'completer'|'path'|'none', ...}
+                                  # a 'completer' value may carry an optional
+                                  # 'file'/'dir' key (file-union: append a shell
+                                  # file/dir directive after the dynamic candidates)
+      'variadic': bool,           # OPTIONAL, arguments only: True when nargs == -1
+                                  # (the engine re-offers it past its position)
     }
 """
 
@@ -92,10 +97,25 @@ def _completer_key(param: click.Parameter) -> Optional[str]:
     raise UnregisteredCompleterError(f'completer for {param.name!r} is not registered')
 
 
+def _completer_file(param: click.Parameter) -> Optional[str]:
+    """Return the file-union flag ('file'/'dir') a completer callback was tagged
+    with via `_adapt(file=...)`, or None. Mirrors `_completer_key`'s candidate
+    probe so it survives Typer's wrapper chain."""
+    for fn in _completer_candidates(param):
+        flag = getattr(fn, '_completer_file', None)
+        if flag is not None:
+            return flag
+    return None
+
+
 def _value_spec(param: click.Parameter) -> Dict[str, Any]:
     key = _completer_key(param)
     if key is not None:
-        return {'kind': 'completer', 'completer': key}
+        spec: Dict[str, Any] = {'kind': 'completer', 'completer': key}
+        file_flag = _completer_file(param)
+        if file_flag is not None:
+            spec['file'] = file_flag
+        return spec
     t = param.type
     choices = getattr(t, 'choices', None)
     if choices:
@@ -114,7 +134,7 @@ def _param_spec(param: click.Parameter) -> Dict[str, Any]:
     # Boolean flags declared as ``--check/--no-check`` carry the negation form in
     # ``secondary_opts``; Click completes BOTH, so include them in the names.
     names = list(param.opts) + list(getattr(param, 'secondary_opts', []))
-    return {
+    spec: Dict[str, Any] = {
         'kind': 'option' if is_opt else 'argument',
         'names': names if is_opt else [],
         'takes_value': not is_flag,
@@ -122,6 +142,9 @@ def _param_spec(param: click.Parameter) -> Dict[str, Any]:
         'help': getattr(param, 'help', None) if is_opt else None,
         'value': {'kind': 'none'} if is_flag else _value_spec(param),
     }
+    if not is_opt and getattr(param, 'nargs', 1) == -1:
+        spec['variadic'] = True
+    return spec
 
 
 def _panel(cmd: click.Command) -> Optional[str]:

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -375,7 +375,13 @@ def each(ctx: typer.Context) -> None:
     context_settings={'allow_extra_args': True, 'ignore_unknown_options': True},
 )
 @within_contest
-def on(ctx: typer.Context, problems: str) -> None:
+def on(
+    ctx: typer.Context,
+    problems: Annotated[
+        str,
+        typer.Argument(autocompletion=annotations._adapt('problem')),  # noqa: SLF001
+    ],
+) -> None:
     problems_of_interest = contest_utils.get_problems_of_interest(problems)
 
     if not problems_of_interest:

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -42,6 +42,7 @@ def contest_main(
             '--contest',
             help='Select a contest variant by id.',
             envvar='RBX_CONTEST',
+            autocompletion=annotations._adapt('contest_variant'),  # noqa: SLF001
         ),
     ] = None,
 ):

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -71,6 +71,7 @@ async def build(
             '-p',
             '--profile',
             help='Timing profile to render statements against. Problems missing this profile are skipped with a warning.',
+            autocompletion=annotations._adapt('profile'),  # noqa: SLF001
         ),
     ] = None,
 ):

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -39,6 +39,12 @@ class VerificationLevel(Enum):
     FULL = 4
 
 
+def _verification_autocompletion():
+    from rbx import annotations
+
+    return annotations._adapt('verification_level')  # noqa: SLF001
+
+
 VerificationParam = Annotated[
     int,
     typer.Option(
@@ -47,6 +53,7 @@ VerificationParam = Annotated[
         '-v',
         help='Verification level to use when building package.',
         default_factory=lambda: VerificationLevel.FULL.value,
+        autocompletion=_verification_autocompletion(),
     ),
 ]
 

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -40,6 +40,9 @@ class VerificationLevel(Enum):
 
 
 def _verification_autocompletion():
+    # Indirect through a function so module load doesn't eagerly depend on
+    # rbx.annotations (keeps this module's import surface decoupled; the import
+    # is light either way).
     from rbx import annotations
 
     return annotations._adapt('verification_level')  # noqa: SLF001

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -329,6 +329,7 @@ async def build(
             '-p',
             '--profile',
             help='Timing profile to render the statement against. Must exist in this problem.',
+            autocompletion=annotations._adapt('profile'),  # noqa: SLF001
         ),
     ] = None,
 ):

--- a/scripts/try-completion-bash.sh
+++ b/scripts/try-completion-bash.sh
@@ -11,13 +11,24 @@
 # Note: this only changes how <tab> COMPLETES `rbx`; actually running `rbx ...`
 # still uses whatever `rbx` is on your PATH.
 
-# Resolve the rbx binary to complete against (defaults to this worktree's venv build).
+# Resolve the rbx binary to complete against (defaults to THIS worktree's venv build).
 if [ -n "${BASH_SOURCE[0]:-}" ]; then
     _rbx_try_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 else
     _rbx_try_dir="$(pwd)"
 fi
-RBX_BIN="${RBX_BIN:-$_rbx_try_dir/.venv/bin/rbx}"
+_rbx_try_bin="$_rbx_try_dir/.venv/bin/rbx"
+# `source` is a special builtin, so `RBX_BIN=... source ...` (or a previous
+# source) leaves RBX_BIN set in the shell -- a value left over from sourcing a
+# DIFFERENT worktree's script would shadow this one. Default to this worktree's
+# binary, and if an inherited RBX_BIN points at another worktree, treat it as
+# stale and recompute. A genuine override outside any worktree is still honored.
+if [ -z "${RBX_BIN:-}" ]; then
+    RBX_BIN="$_rbx_try_bin"
+elif [[ "$RBX_BIN" == *"/.claude/worktrees/"* && "$RBX_BIN" != "$_rbx_try_bin" ]]; then
+    echo "note: ignoring stale RBX_BIN from another worktree ($RBX_BIN)" >&2
+    RBX_BIN="$_rbx_try_bin"
+fi
 
 if [ ! -x "$RBX_BIN" ]; then
     echo "rbx binary not found/executable at: $RBX_BIN" >&2

--- a/scripts/try-completion-zsh.sh
+++ b/scripts/try-completion-zsh.sh
@@ -11,11 +11,23 @@
 # Note: this only changes how <tab> COMPLETES `rbx`; actually running `rbx ...`
 # still uses whatever `rbx` is on your PATH.
 
-# Resolve the rbx binary to complete against (defaults to this worktree's venv build).
+# Resolve the rbx binary to complete against (defaults to THIS worktree's venv build).
 _rbx_try_src="${(%):-%x}"
 [ -z "$_rbx_try_src" ] && _rbx_try_src="$0"
 _rbx_try_dir="${_rbx_try_src:A:h:h}"
-: ${RBX_BIN:="$_rbx_try_dir/.venv/bin/rbx"}
+_rbx_try_bin="$_rbx_try_dir/.venv/bin/rbx"
+# `source` is a special builtin, so `RBX_BIN=... source ...` (or a previous
+# source) leaves RBX_BIN set in the shell. That means a value left over from
+# sourcing a DIFFERENT worktree's script would shadow this one. Default to this
+# worktree's binary, and if an inherited RBX_BIN points at another worktree,
+# treat it as stale and recompute. A genuine override outside any worktree is
+# still honored.
+if [[ -z "$RBX_BIN" ]]; then
+    RBX_BIN="$_rbx_try_bin"
+elif [[ "$RBX_BIN" == *"/.claude/worktrees/"* && "$RBX_BIN" != "$_rbx_try_bin" ]]; then
+    print -u2 "note: ignoring stale RBX_BIN from another worktree ($RBX_BIN)"
+    RBX_BIN="$_rbx_try_bin"
+fi
 
 if [[ ! -x "$RBX_BIN" ]]; then
     print -u2 "rbx binary not found/executable at: $RBX_BIN"

--- a/scripts/try-completion-zsh.sh
+++ b/scripts/try-completion-zsh.sh
@@ -30,6 +30,7 @@ fi
 
 _rbx_fast_completion() {
     local -a completions completions_with_descriptions response
+    local want_files want_dirs
     response=("${(@f)$(
         env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT - 1)) \
             _RBX_COMPLETE=complete_zsh "$RBX_BIN" 2>/dev/null
@@ -45,18 +46,22 @@ _rbx_fast_completion() {
                 completions_with_descriptions+=("$key":"$descr")
             fi
         elif [[ "$type" == "dir" ]]; then
-            _path_files -/
+            want_dirs=1
         elif [[ "$type" == "file" ]]; then
-            _path_files -f
+            want_files=1
         fi
     done
 
+    # Describe dynamic candidates (e.g. solutions) BEFORE handing off to file
+    # completion so they rank ahead of the directory listing (file-union, #575).
     if [ -n "$completions_with_descriptions" ]; then
         _describe -V unsorted completions_with_descriptions -U
     fi
     if [ -n "$completions" ]; then
         compadd -U -V unsorted -a completions
     fi
+    [[ -n "$want_dirs" ]] && _path_files -/
+    [[ -n "$want_files" ]] && _path_files -f
 }
 
 compdef _rbx_fast_completion rbx

--- a/scripts/try-completion-zsh.sh
+++ b/scripts/try-completion-zsh.sh
@@ -41,7 +41,7 @@ if ! whence compdef >/dev/null 2>&1; then
 fi
 
 _rbx_fast_completion() {
-    local -a completions completions_with_descriptions response
+    local -a completions desc_values desc_displays response
     local want_files want_dirs
     response=("${(@f)$(
         env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT - 1)) \
@@ -55,7 +55,8 @@ _rbx_fast_completion() {
             if [[ "$descr" == "_" ]]; then
                 completions+=("$key")
             else
-                completions_with_descriptions+=("$key":"$descr")
+                desc_values+=("$key")
+                desc_displays+=("$key -- $descr")
             fi
         elif [[ "$type" == "dir" ]]; then
             want_dirs=1
@@ -64,10 +65,13 @@ _rbx_fast_completion() {
         fi
     done
 
-    # Describe dynamic candidates (e.g. solutions) BEFORE handing off to file
+    # Add dynamic candidates (e.g. solutions) BEFORE handing off to file
     # completion so they rank ahead of the directory listing (file-union, #575).
-    if [ -n "$completions_with_descriptions" ]; then
-        _describe -V unsorted completions_with_descriptions -U
+    # Use `compadd -d` (not _describe) so insertion order survives even when items
+    # share a description (several "ACCEPTED" solutions) -- @main stays first,
+    # @boca last.
+    if [ -n "$desc_values" ]; then
+        compadd -U -V unsorted -l -d desc_displays -a desc_values
     fi
     if [ -n "$completions" ]; then
         compadd -U -V unsorted -a completions

--- a/tests/rbx/box/completion/annotations_light_test.py
+++ b/tests/rbx/box/completion/annotations_light_test.py
@@ -16,3 +16,18 @@ def test_checker_adapter_lists_checkers():
     assert any(v.endswith('.cpp') for v in values)
     assert 'boilerplate.cpp' not in values
     assert cb._completer_key == 'checker'  # noqa: SLF001
+
+
+def test_adapt_file_flag_tags_callback():
+    from rbx import annotations
+
+    cb = annotations._adapt('solutions', file=True)  # noqa: SLF001
+    assert cb._completer_key == 'solutions'  # noqa: SLF001
+    assert cb._completer_file == 'file'  # noqa: SLF001
+
+
+def test_adapt_without_file_flag_has_no_file_attr():
+    from rbx import annotations
+
+    cb = annotations._adapt('language')  # noqa: SLF001
+    assert getattr(cb, '_completer_file', None) is None

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -76,3 +76,13 @@ def test_profile_completer_lists_limits_files(tmp_path):
         i.value for i in completers.complete_profile(_ctx(package_root=tmp_path), '')
     }
     assert values == {'local', 'codeforces'}
+
+
+def test_testgroup_completer_lists_group_names(tmp_path):
+    (tmp_path / 'problem.rbx.yml').write_text(
+        'testcases:\n  - name: samples\n  - name: main\n  - name: edge\n'
+    )
+    values = {
+        i.value for i in completers.complete_testgroup(_ctx(package_root=tmp_path), '')
+    }
+    assert {'samples', 'main', 'edge'} <= values

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -86,3 +86,27 @@ def test_testgroup_completer_lists_group_names(tmp_path):
         i.value for i in completers.complete_testgroup(_ctx(package_root=tmp_path), '')
     }
     assert {'samples', 'main', 'edge'} <= values
+
+
+def test_contest_variant_completer_lists_sibling_ids(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text('name: c\n')
+    (tmp_path / 'contest.div1.rbx.yml').write_text('name: d1\n')
+    (tmp_path / 'contest.div2.rbx.yml').write_text('name: d2\n')
+    values = {
+        i.value
+        for i in completers.complete_contest_variant(_ctx(package_root=tmp_path), '')
+    }
+    assert values == {'div1', 'div2'}
+
+
+def test_contest_variant_completer_walks_up_from_problem_dir(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text('name: c\n')
+    (tmp_path / 'contest.div1.rbx.yml').write_text('name: d1\n')
+    prob = tmp_path / 'A'
+    prob.mkdir()
+    (prob / 'problem.rbx.yml').write_text('name: A\n')
+    values = {
+        i.value
+        for i in completers.complete_contest_variant(_ctx(package_root=prob), '')
+    }
+    assert values == {'div1'}

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -120,3 +120,20 @@ def test_problem_completer_includes_aliases(tmp_path):
         i.value for i in completers.complete_problem(_ctx(package_root=tmp_path), '')
     }
     assert {'A', 'B', 'apple', 'alpha'} <= values
+
+
+def test_testgroup_completer_tolerates_scalar_testcases_field(tmp_path):
+    # Malformed YAML where `testcases` is a scalar, not a list: must not raise.
+    (tmp_path / 'problem.rbx.yml').write_text('testcases: 5\n')
+    assert completers.complete_testgroup(_ctx(package_root=tmp_path), '') == []
+
+
+def test_problem_completer_tolerates_scalar_aliases_field(tmp_path):
+    # A scalar `aliases` must not leak its characters as completions.
+    (tmp_path / 'contest.rbx.yml').write_text(
+        'problems:\n  - short_name: A\n    aliases: notalist\n'
+    )
+    values = {
+        i.value for i in completers.complete_problem(_ctx(package_root=tmp_path), '')
+    }
+    assert values == {'A'}

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -110,3 +110,13 @@ def test_contest_variant_completer_walks_up_from_problem_dir(tmp_path):
         for i in completers.complete_contest_variant(_ctx(package_root=prob), '')
     }
     assert values == {'div1'}
+
+
+def test_problem_completer_includes_aliases(tmp_path):
+    (tmp_path / 'contest.rbx.yml').write_text(
+        'problems:\n  - short_name: A\n    aliases: [apple, alpha]\n  - short_name: B\n'
+    )
+    values = {
+        i.value for i in completers.complete_problem(_ctx(package_root=tmp_path), '')
+    }
+    assert {'A', 'B', 'apple', 'alpha'} <= values

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -137,3 +137,37 @@ def test_problem_completer_tolerates_scalar_aliases_field(tmp_path):
         i.value for i in completers.complete_problem(_ctx(package_root=tmp_path), '')
     }
     assert values == {'A'}
+
+
+def test_solutions_completer_expands_globs_to_actual_files(tmp_path):
+    (tmp_path / 'problem.rbx.yml').write_text(
+        'solutions:\n  - path: sols/main*.*\n    outcome: ac\n'
+    )
+    sols = tmp_path / 'sols'
+    sols.mkdir()
+    (sols / 'main.cpp').write_text('')
+    (sols / 'main2.cpp').write_text('')
+    (sols / 'other.cpp').write_text('')  # not matched by the glob
+    items = completers.complete_solutions(_ctx(package_root=tmp_path), '')
+    by_value = {i.value: i for i in items}
+    assert 'sols/main.cpp' in by_value
+    assert 'sols/main2.cpp' in by_value
+    assert 'sols/other.cpp' not in by_value
+    assert 'sols/main*.*' not in by_value  # the glob itself is not offered
+    assert by_value['sols/main.cpp'].help == 'ac'  # outcome carries to each match
+
+
+def test_solutions_completer_orders_main_first_boca_last(tmp_path):
+    (tmp_path / 'problem.rbx.yml').write_text(
+        'solutions:\n  - path: sols/z.cpp\n  - path: sols/a.cpp\n'
+    )
+    sols = tmp_path / 'sols'
+    sols.mkdir()
+    (sols / 'z.cpp').write_text('')
+    (sols / 'a.cpp').write_text('')
+    values = [
+        i.value for i in completers.complete_solutions(_ctx(package_root=tmp_path), '')
+    ]
+    assert values[0] == '@main'
+    assert values[-1] == '@boca/'
+    assert set(values[1:-1]) == {'sols/z.cpp', 'sols/a.cpp'}

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -64,3 +64,15 @@ def test_verification_level_completer_offers_int_values_with_names():
     by_value = {i.value: i.help for i in items}
     assert by_value['0'] == 'NONE'
     assert by_value['4'] == 'FULL'
+
+
+def test_profile_completer_lists_limits_files(tmp_path):
+    limits = tmp_path / '.limits'
+    limits.mkdir()
+    (limits / 'local.yml').write_text('')
+    (limits / 'codeforces.yml').write_text('')
+    (limits / 'notes.txt').write_text('')  # ignored
+    values = {
+        i.value for i in completers.complete_profile(_ctx(package_root=tmp_path), '')
+    }
+    assert values == {'local', 'codeforces'}

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -50,3 +50,10 @@ def test_solutions_completer_without_package_offers_prefixes(tmp_path):
         i.value for i in completers.complete_solutions(_ctx(package_root=None), '')
     }
     assert {'@main', '@boca/'} <= values
+
+
+def test_outcome_completer_offers_canonical_tokens():
+    values = {i.value for i in completers.complete_outcome(_ctx(), '')}
+    assert {'ac', 'wa', 'tle', 'any'} <= values
+    helps = {i.value: i.help for i in completers.complete_outcome(_ctx(), '')}
+    assert helps['ac']  # has descriptive help

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -27,3 +27,26 @@ def test_problem_completer_reads_contest_problems(tmp_path):
         i.value for i in completers.complete_problem(_ctx(package_root=tmp_path), '')
     }
     assert {'A', 'B'} <= values
+
+
+def test_solutions_completer_lists_paths_with_outcome_help_and_prefixes(tmp_path):
+    (tmp_path / 'problem.rbx.yml').write_text(
+        'solutions:\n'
+        '  - path: sols/main.cpp\n'
+        '    outcome: ac\n'
+        '  - path: sols/wa.cpp\n'
+        '    outcome: wa\n'
+    )
+    items = completers.complete_solutions(_ctx(package_root=tmp_path), '')
+    by_value = {i.value: i for i in items}
+    assert 'sols/main.cpp' in by_value
+    assert by_value['sols/main.cpp'].help == 'ac'
+    assert '@main' in by_value
+    assert '@boca/' in by_value
+
+
+def test_solutions_completer_without_package_offers_prefixes(tmp_path):
+    values = {
+        i.value for i in completers.complete_solutions(_ctx(package_root=None), '')
+    }
+    assert {'@main', '@boca/'} <= values

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -57,3 +57,10 @@ def test_outcome_completer_offers_canonical_tokens():
     assert {'ac', 'wa', 'tle', 'any'} <= values
     helps = {i.value: i.help for i in completers.complete_outcome(_ctx(), '')}
     assert helps['ac']  # has descriptive help
+
+
+def test_verification_level_completer_offers_int_values_with_names():
+    items = completers.complete_verification_level(_ctx(), '')
+    by_value = {i.value: i.help for i in items}
+    assert by_value['0'] == 'NONE'
+    assert by_value['4'] == 'FULL'

--- a/tests/rbx/box/completion/differential_test.py
+++ b/tests/rbx/box/completion/differential_test.py
@@ -57,6 +57,9 @@ def test_engine_matches_typer(args, incomplete):
         # that Typer's callback contract can never emit. Assert the dynamic part
         # matches Typer exactly and that the directive IS appended.
         gold = _pairs(typer_completions(args, incomplete))
+        # Stripping directives is safe because the dynamic completers only ever
+        # emit `plain` items with non-empty values -- never directive-shaped
+        # (empty value + file/dir type) candidates that this would mask.
         non_dir = [p for p in ours if p not in _DIRECTIVES]
         assert non_dir == gold, f'args={args} inc={incomplete!r}: {non_dir} vs {gold}'
         assert set(ours) & _DIRECTIVES, (

--- a/tests/rbx/box/completion/differential_test.py
+++ b/tests/rbx/box/completion/differential_test.py
@@ -25,9 +25,44 @@ def _is_command_name_position(args, incomplete):
     )
 
 
+def _cursor_value(args, incomplete):
+    """The spec 'value' dict the cursor is completing, or None (option-name,
+    group, or past-the-end position)."""
+    node, _cmd, _opts, pending, positional, _seen = _walk(_spec.SPEC, list(args))
+    if pending is not None:
+        return pending['value']
+    if incomplete.startswith('-') and '=' in incomplete:
+        name = incomplete.split('=', 1)[0]
+        for p in node['params']:
+            if p['kind'] == 'option' and name in p['names'] and p['takes_value']:
+                return p['value']
+        return None
+    if incomplete.startswith('-') or node.get('is_group'):
+        return None
+    arguments = [p for p in node['params'] if p['kind'] == 'argument']
+    if positional < len(arguments):
+        return arguments[positional]['value']
+    if arguments and arguments[-1].get('variadic'):
+        return arguments[-1]['value']
+    return None
+
+
 @pytest.mark.parametrize('args,incomplete', command_lines(_spec.SPEC))
 def test_engine_matches_typer(args, incomplete):
     ours = _pairs(engine.resolve(_spec.SPEC, args, incomplete))
+
+    value = _cursor_value(args, incomplete)
+    if value is not None and value.get('kind') == 'completer' and value.get('file'):
+        # File-union: the engine intentionally appends a shell file/dir directive
+        # that Typer's callback contract can never emit. Assert the dynamic part
+        # matches Typer exactly and that the directive IS appended.
+        gold = _pairs(typer_completions(args, incomplete))
+        non_dir = [p for p in ours if p not in _DIRECTIVES]
+        assert non_dir == gold, f'args={args} inc={incomplete!r}: {non_dir} vs {gold}'
+        assert set(ours) & _DIRECTIVES, (
+            f'args={args} inc={incomplete!r}: no file directive'
+        )
+        return
 
     if _is_command_name_position(args, incomplete):
         # Command-name completion: each alias is its own prefix-filtered candidate.

--- a/tests/rbx/box/completion/engine_test.py
+++ b/tests/rbx/box/completion/engine_test.py
@@ -233,16 +233,51 @@ def test_variadic_argument_reoffered_on_later_positionals():
     assert _values(items) == ['from-fixture']
 
 
-def test_zsh_source_describes_candidates_before_file_completion():
-    # File-union: dynamic candidates (e.g. solutions) must be described BEFORE the
+def test_zsh_source_adds_candidates_before_file_completion():
+    # File-union: dynamic candidates (e.g. solutions) must be added BEFORE the
     # `_path_files` handoff so they rank ahead of the directory listing in the
     # zsh menu (issue #575 follow-up: "solutions first").
     from rbx.box.completion.engine import source_to_string
 
     src = source_to_string('zsh')
-    assert '_describe' in src and '_path_files' in src
-    assert src.index('_describe') < src.index('_path_files'), (
-        'zsh source must _describe candidates before _path_files'
+    assert 'compadd' in src and '_path_files' in src
+    assert src.index('compadd') < src.index('_path_files'), (
+        'zsh source must add candidates before _path_files'
     )
     # The file/dir handoff is deferred via flags rather than called in the parse loop.
     assert 'want_files' in src
+    # Described candidates use `compadd -d` (order-preserving), NOT `_describe`
+    # (which re-sorts items that share a description, e.g. several "ACCEPTED").
+    assert '_describe' not in src
+    assert '-d desc_displays' in src
+
+
+def test_completer_values_are_prefix_filtered_by_incomplete():
+    from click.shell_completion import CompletionItem
+
+    from rbx.box.completion.registry import register_completer
+
+    @register_completer('engine_prefix_demo')
+    def _c(ctx, incomplete):  # registered as a live object (defined in <locals>)
+        return [
+            CompletionItem('@main'),
+            CompletionItem('@boca/'),
+            CompletionItem('sols/a.cpp'),
+        ]
+
+    spec = _leaf(
+        [
+            {
+                'kind': 'argument',
+                'names': [],
+                'takes_value': True,
+                'help': None,
+                'value': {'kind': 'completer', 'completer': 'engine_prefix_demo'},
+            }
+        ]
+    )
+    # Empty incomplete -> all candidates, in order.
+    assert _values(resolve(spec, [], '')) == ['@main', '@boca/', 'sols/a.cpp']
+    # Typing a prefix narrows to the matching candidate(s).
+    assert _values(resolve(spec, [], '@m')) == ['@main']
+    assert _values(resolve(spec, [], 'sols/')) == ['sols/a.cpp']

--- a/tests/rbx/box/completion/engine_test.py
+++ b/tests/rbx/box/completion/engine_test.py
@@ -186,3 +186,48 @@ def test_malformed_spec_swallows_exception_and_returns_file_directive():
     items = resolve({'name': 'broken'}, ['x'], '')
     assert len(items) == 1
     assert items[0].type == 'file'
+
+
+def test_completer_with_file_flag_appends_file_directive():
+    module_name = 'tests.rbx.box.completion._fixture_completer'
+    registry.register_completer_path('engine_fu', f'{module_name}:fixture_completer')
+    spec = _leaf(
+        [
+            {
+                'kind': 'argument',
+                'names': [],
+                'takes_value': True,
+                'help': None,
+                'variadic': True,
+                'value': {
+                    'kind': 'completer',
+                    'completer': 'engine_fu',
+                    'file': 'file',
+                },
+            }
+        ]
+    )
+    items = resolve(spec, [], '')
+    assert _values(items) == ['from-fixture', '']
+    assert items[-1].type == 'file'
+
+
+def test_variadic_argument_reoffered_on_later_positionals():
+    module_name = 'tests.rbx.box.completion._fixture_completer'
+    registry.register_completer_path('engine_fu2', f'{module_name}:fixture_completer')
+    spec = _leaf(
+        [
+            {
+                'kind': 'argument',
+                'names': [],
+                'takes_value': True,
+                'help': None,
+                'variadic': True,
+                'value': {'kind': 'completer', 'completer': 'engine_fu2'},
+            }
+        ]
+    )
+    # Two positionals already consumed, but the (only) argument is variadic, so
+    # the completer is still offered.
+    items = resolve(spec, ['a', 'b'], '')
+    assert _values(items) == ['from-fixture']

--- a/tests/rbx/box/completion/engine_test.py
+++ b/tests/rbx/box/completion/engine_test.py
@@ -231,3 +231,18 @@ def test_variadic_argument_reoffered_on_later_positionals():
     # the completer is still offered.
     items = resolve(spec, ['a', 'b'], '')
     assert _values(items) == ['from-fixture']
+
+
+def test_zsh_source_describes_candidates_before_file_completion():
+    # File-union: dynamic candidates (e.g. solutions) must be described BEFORE the
+    # `_path_files` handoff so they rank ahead of the directory listing in the
+    # zsh menu (issue #575 follow-up: "solutions first").
+    from rbx.box.completion.engine import source_to_string
+
+    src = source_to_string('zsh')
+    assert '_describe' in src and '_path_files' in src
+    assert src.index('_describe') < src.index('_path_files'), (
+        'zsh source must _describe candidates before _path_files'
+    )
+    # The file/dir handoff is deferred via flags rather than called in the parse loop.
+    assert 'want_files' in src

--- a/tests/rbx/box/completion/enum_consistency_test.py
+++ b/tests/rbx/box/completion/enum_consistency_test.py
@@ -10,3 +10,11 @@ def test_outcome_table_matches_expected_outcome_enum():
     # ...and every enum member is represented exactly once.
     assert parsed == set(ExpectedOutcome)
     assert len(tokens) == len(set(tokens)) == len(set(ExpectedOutcome))
+
+
+def test_verification_table_matches_verification_level_enum():
+    from rbx.box.environment import VerificationLevel
+
+    table = dict(completers._VERIFICATION_TABLE)  # noqa: SLF001
+    expected = {str(level.value): level.name for level in VerificationLevel}
+    assert table == expected

--- a/tests/rbx/box/completion/enum_consistency_test.py
+++ b/tests/rbx/box/completion/enum_consistency_test.py
@@ -18,3 +18,15 @@ def test_verification_table_matches_verification_level_enum():
     table = dict(completers._VERIFICATION_TABLE)  # noqa: SLF001
     expected = {str(level.value): level.name for level in VerificationLevel}
     assert table == expected
+
+
+def test_solution_prefixes_cover_registered_expanders():
+    # If an expander is added/removed in remote.py, this fails so _SOLUTION_PREFIXES
+    # (the @-prefixes the solutions completer offers) gets revisited.
+    from rbx.box.remote import REGISTERED_EXPANDERS
+
+    expander_names = {type(e).__name__ for e in REGISTERED_EXPANDERS}
+    assert expander_names == {'MainExpander', 'BocaExpander'}
+
+    prefixes = {p for p, _ in completers._SOLUTION_PREFIXES}  # noqa: SLF001
+    assert prefixes == {'@main', '@boca/'}

--- a/tests/rbx/box/completion/enum_consistency_test.py
+++ b/tests/rbx/box/completion/enum_consistency_test.py
@@ -1,0 +1,12 @@
+from rbx.box.completion import completers
+
+
+def test_outcome_table_matches_expected_outcome_enum():
+    from rbx.box.schema import ExpectedOutcome
+
+    tokens = [v for v, _ in completers._OUTCOME_TABLE]  # noqa: SLF001
+    # Every offered token parses to a valid ExpectedOutcome...
+    parsed = {ExpectedOutcome(t) for t in tokens}
+    # ...and every enum member is represented exactly once.
+    assert parsed == set(ExpectedOutcome)
+    assert len(tokens) == len(set(tokens)) == len(set(ExpectedOutcome))

--- a/tests/rbx/box/completion/firewall_test.py
+++ b/tests/rbx/box/completion/firewall_test.py
@@ -1,6 +1,8 @@
 import subprocess
 import sys
 
+import pytest
+
 DENYLIST = [
     'textual',
     'mechanize',
@@ -15,33 +17,46 @@ DENYLIST = [
     'rbx.box.packaging',
 ]
 
-# Child process: set completion env, trigger TODAY's completion path, print
-# imported modules. The module list is emitted on stderr after a marker so it
-# never mixes with the completion output written to stdout.
-_PROBE = (
-    'import os, sys\n'
-    "os.environ['_RBX_COMPLETE'] = 'complete_bash'\n"
-    "os.environ['_TYPER_COMPLETE_ARGS'] = 'rbx '\n"
-    "os.environ['COMP_WORDS'] = 'rbx '\n"
-    "os.environ['COMP_CWORD'] = '1'\n"
-    'from rbx.box import main\n'
-    'try:\n'
-    '    main.app()\n'
-    'except SystemExit:\n'
-    '    pass\n'
-    "sys.stderr.write('MODULES_START\\n')\n"
-    'sys.stderr.write(chr(10).join(sorted(sys.modules)))\n'
-)
+# Each scenario lands the cursor on a different completer position so the probe
+# exercises the real fast-path for every wired completer (issue #575). The pair
+# is (full command line in COMP_WORDS, COMP_CWORD index of the word completed).
+SCENARIOS = [
+    ('rbx ', '1'),  # subcommand names (no dynamic completer)
+    ('rbx run ', '2'),  # solutions completer (file-union)
+    ('rbx run --outcome ', '3'),  # outcome completer
+    ('rbx irun --testcase ', '3'),  # testgroup completer
+    ('rbx build --verification-level ', '3'),  # verification_level completer
+    ('rbx time --profile ', '3'),  # profile completer
+    ('rbx stress --finder ', '3'),  # solutions completer (file-union)
+]
 
 
-def _modules_after_completion() -> set:
-    out = subprocess.run([sys.executable, '-c', _PROBE], capture_output=True, text=True)
+def _modules_after_completion(comp_args: str, cword: str) -> set:
+    # Child process: set completion env, trigger the completion path, print the
+    # imported modules. The module list is emitted on stderr after a marker so it
+    # never mixes with the completion output written to stdout.
+    probe = (
+        'import os, sys\n'
+        "os.environ['_RBX_COMPLETE'] = 'complete_bash'\n"
+        f'os.environ[{"_TYPER_COMPLETE_ARGS"!r}] = {comp_args!r}\n'
+        f'os.environ[{"COMP_WORDS"!r}] = {comp_args!r}\n'
+        f'os.environ[{"COMP_CWORD"!r}] = {cword!r}\n'
+        'from rbx.box import main\n'
+        'try:\n'
+        '    main.app()\n'
+        'except SystemExit:\n'
+        '    pass\n'
+        "sys.stderr.write('MODULES_START\\n')\n"
+        'sys.stderr.write(chr(10).join(sorted(sys.modules)))\n'
+    )
+    out = subprocess.run([sys.executable, '-c', probe], capture_output=True, text=True)
     # The module list is emitted on stderr to avoid mixing with completion stdout.
     _, _, mods = out.stderr.partition('MODULES_START\n')
     return set(mods.splitlines())
 
 
-def test_completion_path_imports_nothing_heavy():
-    mods = _modules_after_completion()
+@pytest.mark.parametrize('comp_args,cword', SCENARIOS)
+def test_completion_path_imports_nothing_heavy(comp_args, cword):
+    mods = _modules_after_completion(comp_args, cword)
     leaked = [m for m in DENYLIST if any(x == m or x.startswith(m + '.') for x in mods)]
-    assert not leaked, f'completion path imported heavy modules: {leaked}'
+    assert not leaked, f'{comp_args!r} imported heavy modules: {leaked}'

--- a/tests/rbx/box/completion/firewall_test.py
+++ b/tests/rbx/box/completion/firewall_test.py
@@ -28,6 +28,8 @@ SCENARIOS = [
     ('rbx build --verification-level ', '3'),  # verification_level completer
     ('rbx time --profile ', '3'),  # profile completer
     ('rbx stress --finder ', '3'),  # solutions completer (file-union)
+    ('rbx -C ', '2'),  # contest_variant completer
+    ('rbx on ', '2'),  # problem completer
 ]
 
 

--- a/tests/rbx/box/completion/generate_test.py
+++ b/tests/rbx/box/completion/generate_test.py
@@ -98,3 +98,40 @@ def test_real_app_captures_raw_alias_names_and_recurses():
     assert pkg['is_group'] is True
     # Recursion descends into the group's children.
     assert any(c['name'] == 'polygon' for c in pkg['children'])
+
+
+def test_variadic_argument_flagged():
+    from typing import List, Optional
+
+    app = typer.Typer()
+
+    @app.command()
+    def run(
+        names: Optional[List[str]] = typer.Argument(None),  # noqa: B008
+    ):
+        pass
+
+    spec = build_spec(_cli(app), name='run')
+    arg = next(p for p in spec['params'] if p['kind'] == 'argument')
+    assert arg['variadic'] is True
+
+
+def test_file_union_completer_value_flagged():
+    @registry.register_completer('gen_sol')
+    def _gen_sol(ctx, incomplete):
+        return []
+
+    cb = _gen_sol
+    cb._completer_file = 'file'  # noqa: SLF001  emulate _adapt(file=True)
+
+    app = typer.Typer()
+
+    @app.command()
+    def run(
+        sols: Annotated[str, typer.Argument(autocompletion=cb)] = '',
+    ):
+        pass
+
+    spec = build_spec(_cli(app), name='run')
+    arg = next(p for p in spec['params'] if p['kind'] == 'argument')
+    assert arg['value'] == {'kind': 'completer', 'completer': 'gen_sol', 'file': 'file'}

--- a/tests/rbx/box/completion/wiring_test.py
+++ b/tests/rbx/box/completion/wiring_test.py
@@ -1,0 +1,59 @@
+"""Assert every issue #575 param resolves to its completer in the committed spec.
+
+This guards the wiring (annotations._adapt(...) on CLI params) end-to-end: it
+reads the regenerated _spec.py, so a removed/misspelled wiring fails here even if
+drift_test stays green.
+"""
+
+import pytest
+
+from rbx.box.completion import _spec
+
+
+def _node(path):
+    node = _spec.SPEC
+    for token in path:
+        node = next(
+            c
+            for c in node['children']
+            if token in [s.strip() for s in c['name'].split(',')]
+        )
+    return node
+
+
+def _arg_value(node):
+    return next(p for p in node['params'] if p['kind'] == 'argument')['value']
+
+
+def _opt_value(node, name):
+    return next(
+        p for p in node['params'] if p['kind'] == 'option' and name in p['names']
+    )['value']
+
+
+WIRINGS = [
+    (['run'], 'arg', None, 'solutions', 'file'),
+    (['irun'], 'arg', None, 'solutions', 'file'),
+    (['run'], 'opt', '--outcome', 'outcome', None),
+    (['irun'], 'opt', '--testcase', 'testgroup', None),
+    (['build'], 'opt', '--verification-level', 'verification_level', None),
+    (['time'], 'opt', '--profile', 'profile', None),
+    (['stress'], 'opt', '--finder', 'solutions', 'file'),
+    (['stress'], 'opt', '--fuzz-on', 'testgroup', None),
+    (['stress'], 'opt', '--reference', 'solutions', 'file'),
+    (['on'], 'arg', None, 'problem', None),
+]
+
+
+@pytest.mark.parametrize('path,kind,name,completer,file_flag', WIRINGS)
+def test_param_wired_to_completer(path, kind, name, completer, file_flag):
+    node = _node(path)
+    value = _arg_value(node) if kind == 'arg' else _opt_value(node, name)
+    assert value.get('kind') == 'completer'
+    assert value.get('completer') == completer
+    assert value.get('file') == file_flag
+
+
+def test_contest_variant_flag_wired():
+    value = _opt_value(_spec.SPEC, '-C')
+    assert value.get('completer') == 'contest_variant'


### PR DESCRIPTION
Closes #575.

Adds the dynamic shell completers requested in #575 to the fast static-completion engine (`rbx/box/completion/`, from #573), wires them to every relevant CLI param, and regenerates the committed spec.

## Completers added
| key | where | offers |
|---|---|---|
| `solutions` | `run`/`irun` positional, `stress --finder`/`--reference` | registered solution paths (outcome shown as help) + `@main`/`@boca/` prefixes **+ shell file completion** (file-union) |
| `outcome` | `run`/`irun --outcome` | `ac`, `wa`, `tle`, … (full verdict name as help) |
| `verification_level` | shared `VerificationParam` (every `-v`) | `0`–`4` with `NONE`/`VALIDATE`/`FAST_SOLUTIONS`/`ALL_SOLUTIONS`/`FULL` help |
| `profile` | global/`time`/statement-build `--profile` | profile names from `.limits/*.yml` |
| `testgroup` | `irun --testcase`, `stress --fuzz-on` | testgroup names |
| `contest_variant` | `-C/--contest` | registered contest variant ids |
| `problem` (extended) | `rbx on` positional | contest letters **+ aliases** |

## File-union mechanism
`rbx run`/`irun`/`stress --finder`/`--reference` need dynamic candidates **and** ordinary file completion. Typer's callback contract can't emit a file directive, so this is done at the engine level: `annotations._adapt(key, file=True)` tags the callback → the generator records a `file` flag on the value spec → the engine appends a `FILE` directive after the dynamic items → a **variadic** `nargs == -1` argument keeps re-offering its completer at each position. `differential_test.py` documents and tests this divergence (it asserts the dynamic part matches Typer exactly and that exactly one shell directive is appended).

## Invariants preserved
- **Import-light:** completers read package YAML via the cheap `peek` and hardcode the `outcome`/`verification_level` tables (so they don't import `schema`/`environment`); `firewall_test.py` probes every wired position and asserts no heavy import leaks. Drift-guarded by `enum_consistency_test.py`, which *does* import the real enums and fails loudly on drift.
- **Typer parity:** `differential_test.py` keeps the engine byte-equal to real Typer; `drift_test.py` keeps the committed `_spec.py` in sync (the regeneration is now self-formatting).

## Test plan
- [x] `uv run pytest tests/rbx/box/completion -q` → 834 passed
- [x] `uv run ruff check rbx tests` && `uv run ruff format --check rbx tests` → clean
- [x] End-to-end: `rbx run <tab>` offers solutions + `@main`/`@boca/` + files; `rbx run --outcome <tab>` lists verdicts; `rbx build -v <tab>` lists levels; `rbx run a b<tab>` (variadic) re-offers solutions
- [ ] Manual smoke in a real problem/contest package across bash/zsh

Notes: `checker` stays out of `COMPLETERS` (no live param uses it). The broad local suite has pre-existing C++/sandbox/rendering failures unrelated to this change (none in touched files). Design + plan in `docs/plans/2026-06-09-completers*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)