### PR TITLE
fix(completion): dedupe command/option aliases to one candidate

### DIFF
--- a/rbx/box/completion/CLAUDE.md
+++ b/rbx/box/completion/CLAUDE.md
@@ -109,14 +109,20 @@ CI if the committed module is stale.
   `completion_init()` would change the output format and break byte-parity. (It
   also avoids global-registry pollution when tests import the heavy app.)
 - Command names are stored **raw**, comma-joined (`'package, pkg'`); the engine
-  splits on `', '` both for descent AND for completion. Subcommand completion
-  (`_command_name_items`) offers each name/alias as its OWN prefix-filtered
-  candidate (deduped in registration order), so a typed prefix completes to a
-  single concrete name (`pa` → `package`, `pkg` → `pkg`) instead of inserting the
-  unusable `'package, pkg'` string. This is a deliberate divergence from Typer
-  (which offers the raw joined string); `differential_test.py` checks command
-  names against a spec-derived expectation and keeps strict Typer-parity only for
-  option names and values.
+  splits on `', '` both for descent AND for completion. **Alias dedup:** both
+  subcommand-name completion (`_command_name_items`) and option-name completion
+  emit ONE candidate per command/option, via `_first_match` — the first name (in
+  declaration order) that matches the incomplete. A broad prefix (`''`, `-`,
+  `--`) yields the canonical full name (`package`, `--verification-level`); a
+  prefix typed toward a specific alias or `--no-` form completes that exact
+  spelling (`pkg`, `-v`, `--no-check`). This keeps `rbx <tab>` / `rbx run -<tab>`
+  from listing every alias on its own line — important because zsh alias
+  *grouping* (`_describe`) renders badly under some user configs (fzf TAB
+  wrapper, oh-my-zsh `matcher-list`), so dedup is done at the application level
+  instead of relying on the shell. This is a deliberate divergence from Typer
+  (which offers every alias / the raw joined string); `differential_test.py`
+  asserts each offered name is a REAL Typer name and that we show exactly one per
+  command/option, keeping strict Typer-parity only for VALUES.
 - Children are kept in **registration order** (not sorted): for ambiguous aliases
   (`t` registered by both `time, t` and `testcases, tc, t`), Click's `AliasGroup`
   resolves to the first match, so the engine must descend in the same order.

--- a/rbx/box/completion/engine.py
+++ b/rbx/box/completion/engine.py
@@ -19,24 +19,36 @@ def _match_names(raw_name: str) -> List[str]:
     return [s.strip() for s in raw_name.split(',')]
 
 
+def _first_match(names: List[str], incomplete: str) -> Optional[str]:
+    """The first name (in declaration order) that the cursor could be completing.
+
+    This is how we collapse aliases to a SINGLE candidate per command/option: for
+    a broad prefix (`''`, `-`, `--`) it returns the canonical first-declared name
+    (the full `build` / `--verification-level` form); for a prefix typed toward a
+    specific alias or `--no-` form it returns that exact spelling (so `pkg`, `-v`,
+    `--no-check` still complete). Returns None when no alias matches.
+    """
+    return next((n for n in names if n.startswith(incomplete)), None)
+
+
 def _command_name_items(node: Dict[str, Any], incomplete: str) -> List[CompletionItem]:
     """Completions for a subcommand position.
 
-    Unlike Typer (which offers the raw ``'name, alias'`` string as a single
-    candidate), we offer each name/alias as its OWN candidate, prefix-filtered.
-    So a typed prefix completes to a single concrete name (`pa` -> `package`,
-    `pkg` -> `pkg`) instead of inserting the unusable comma-joined string, while
-    an ambiguous prefix still lists every matching name. Names are deduped in
-    registration order, so an alias shared by two commands (e.g. `t` ->
-    `time`/`testcases`) maps to the same command the descent resolves it to.
+    Each command contributes ONE candidate (not one per alias): the first of its
+    names that matches the incomplete (`_first_match`). So `rbx <tab>` lists the
+    canonical names only (`build`, `package`, …) instead of every alias
+    (`build b package pkg …`), while `pkg<tab>` still completes the `pkg` alias.
+    This is a deliberate divergence from Typer (which offers the raw
+    ``'name, alias'`` string); aliases sharing a representative are deduped in
+    registration order, matching how AliasGroup resolves an ambiguous prefix.
     """
     out: List[CompletionItem] = []
     seen: Set[str] = set()
     for child in node.get('children', []):
-        for name in _match_names(child['name']):
-            if name.startswith(incomplete) and name not in seen:
-                seen.add(name)
-                out.append(CompletionItem(name, help=child.get('help')))
+        name = _first_match(_match_names(child['name']), incomplete)
+        if name is not None and name not in seen:
+            seen.add(name)
+            out.append(CompletionItem(name, help=child.get('help')))
     return out
 
 
@@ -278,11 +290,12 @@ def resolve(
                 # Click does not re-offer a non-`multiple` option already supplied.
                 if not p.get('multiple', False) and p['names'][0] in seen_options:
                     continue
-                out += [
-                    CompletionItem(n, help=p.get('help'))
-                    for n in p['names']
-                    if n.startswith(incomplete)
-                ]
+                # ONE candidate per option (not one per alias): the first matching
+                # name. `-` shows the canonical `--verification-level`; `-v` still
+                # completes `-v`; `--no-check` still completes when typed toward.
+                name = _first_match(p['names'], incomplete)
+                if name is not None:
+                    out.append(CompletionItem(name, help=p.get('help')))
             return out
         if node.get('is_group'):
             return _command_name_items(node, incomplete)

--- a/scripts/try-completion-bash.sh
+++ b/scripts/try-completion-bash.sh
@@ -19,14 +19,17 @@ else
 fi
 _rbx_try_bin="$_rbx_try_dir/.venv/bin/rbx"
 # `source` is a special builtin, so `RBX_BIN=... source ...` (or a previous
-# source) leaves RBX_BIN set in the shell -- a value left over from sourcing a
-# DIFFERENT worktree's script would shadow this one. Default to this worktree's
-# binary, and if an inherited RBX_BIN points at another worktree, treat it as
-# stale and recompute. A genuine override outside any worktree is still honored.
+# source of THIS or another checkout's script) leaves RBX_BIN set in the shell --
+# an inherited value then silently shadows the binary you mean to test (e.g. the
+# main checkout's `.venv/bin/rbx` shadowing this worktree's build). Every
+# try-completion script sets RBX_BIN to some `<checkout>/.venv/bin/rbx`, so when
+# THIS checkout has its own built binary, treat any inherited value of that shape
+# that isn't ours as stale and prefer ours. A genuine custom override -- a path
+# that is NOT a `.venv/bin/rbx` -- is still honored.
 if [ -z "${RBX_BIN:-}" ]; then
     RBX_BIN="$_rbx_try_bin"
-elif [[ "$RBX_BIN" == *"/.claude/worktrees/"* && "$RBX_BIN" != "$_rbx_try_bin" ]]; then
-    echo "note: ignoring stale RBX_BIN from another worktree ($RBX_BIN)" >&2
+elif [[ -x "$_rbx_try_bin" && "$RBX_BIN" != "$_rbx_try_bin" && "$RBX_BIN" == *"/.venv/bin/rbx" ]]; then
+    echo "note: ignoring stale RBX_BIN ($RBX_BIN); using this checkout's binary" >&2
     RBX_BIN="$_rbx_try_bin"
 fi
 

--- a/scripts/try-completion-zsh.sh
+++ b/scripts/try-completion-zsh.sh
@@ -17,15 +17,17 @@ _rbx_try_src="${(%):-%x}"
 _rbx_try_dir="${_rbx_try_src:A:h:h}"
 _rbx_try_bin="$_rbx_try_dir/.venv/bin/rbx"
 # `source` is a special builtin, so `RBX_BIN=... source ...` (or a previous
-# source) leaves RBX_BIN set in the shell. That means a value left over from
-# sourcing a DIFFERENT worktree's script would shadow this one. Default to this
-# worktree's binary, and if an inherited RBX_BIN points at another worktree,
-# treat it as stale and recompute. A genuine override outside any worktree is
-# still honored.
+# source of THIS or another checkout's script) leaves RBX_BIN set in the shell --
+# an inherited value then silently shadows the binary you mean to test (e.g. the
+# main checkout's `.venv/bin/rbx` shadowing this worktree's build). Every
+# try-completion script sets RBX_BIN to some `<checkout>/.venv/bin/rbx`, so when
+# THIS checkout has its own built binary, treat any inherited value of that shape
+# that isn't ours as stale and prefer ours. A genuine custom override -- a path
+# that is NOT a `.venv/bin/rbx` -- is still honored.
 if [[ -z "$RBX_BIN" ]]; then
     RBX_BIN="$_rbx_try_bin"
-elif [[ "$RBX_BIN" == *"/.claude/worktrees/"* && "$RBX_BIN" != "$_rbx_try_bin" ]]; then
-    print -u2 "note: ignoring stale RBX_BIN from another worktree ($RBX_BIN)"
+elif [[ -x "$_rbx_try_bin" && "$RBX_BIN" != "$_rbx_try_bin" && "$RBX_BIN" == *"/.venv/bin/rbx" ]]; then
+    print -u2 "note: ignoring stale RBX_BIN ($RBX_BIN); using this checkout's binary"
     RBX_BIN="$_rbx_try_bin"
 fi
 

--- a/tests/rbx/box/completion/differential_test.py
+++ b/tests/rbx/box/completion/differential_test.py
@@ -15,14 +15,29 @@ def _pairs(items):
 def _is_command_name_position(args, incomplete):
     """True when the cursor completes a subcommand NAME (a group node, not an
     option or an option value). At those positions the engine intentionally
-    diverges from Typer (it splits 'name, alias' into separate candidates), so we
-    check it against a spec-derived expectation instead of the Typer oracle."""
+    diverges from Typer (it offers ONE deduped candidate per command, not Typer's
+    comma-joined string), so we check it against a spec-derived expectation
+    instead of the Typer oracle."""
     node, _command, _opts, pending, _positional, _seen = _walk(_spec.SPEC, list(args))
     return (
         pending is None
         and not incomplete.startswith('-')
         and bool(node.get('is_group'))
     )
+
+
+def _is_option_name_position(args, incomplete):
+    """True when the cursor completes an option NAME (not its value). Here the
+    engine intentionally dedupes aliases to ONE candidate per option."""
+    node, _command, _opts, pending, _positional, _seen = _walk(_spec.SPEC, list(args))
+    if pending is not None or not incomplete.startswith('-'):
+        return False
+    if '=' in incomplete:
+        name = incomplete.split('=', 1)[0]
+        for p in node['params']:
+            if p['kind'] == 'option' and name in p['names'] and p['takes_value']:
+                return False  # completing `--opt=<value>`, not a name
+    return True
 
 
 def _cursor_value(args, incomplete):
@@ -68,11 +83,11 @@ def test_engine_matches_typer(args, incomplete):
         return
 
     if _is_command_name_position(args, incomplete):
-        # Command-name completion: each alias is its own prefix-filtered candidate.
-        # `_command_name_items` IS the engine's own helper, so this asserts the
-        # node it resolved to yields exactly those names -- and, as a cross-check,
-        # that every name the real CLI would offer (its comma-joined values, split)
-        # is covered.
+        # Command-name completion: ONE deduped candidate per command (not one per
+        # alias). `_command_name_items` IS the engine's own helper, so this asserts
+        # the node it resolved to yields exactly those names. Cross-check against
+        # Typer: every name we offer is a REAL Typer command name (we never invent
+        # one), though we intentionally offer FEWER (deduped) than Typer's aliases.
         node, *_ = _walk(_spec.SPEC, list(args))
         expected = _pairs(_command_name_items(node, incomplete))
         assert ours == expected, f'args={args} inc={incomplete!r}: ours={ours}'
@@ -81,14 +96,44 @@ def test_engine_matches_typer(args, incomplete):
         for value, _t in _pairs(typer_completions(args, incomplete)):
             for name in _match_names(value):
                 if name.startswith(incomplete):
-                    typer_names.add((name, 'plain'))
-        assert typer_names <= set(ours), (
-            f'args={args} inc={incomplete!r}: missing Typer commands {typer_names - set(ours)}'
+                    typer_names.add(name)
+        ours_names = {v for v, _t in ours}
+        assert ours_names <= typer_names, (
+            f'args={args} inc={incomplete!r}: invented names {ours_names - typer_names}'
         )
         return
 
-    # Everywhere else (option names, option values, positional values) the engine
-    # must match Typer EXACTLY.
+    if _is_option_name_position(args, incomplete):
+        # Option-name completion: ONE deduped candidate per option (not Typer's
+        # every-alias). Verify against Typer that (a) we never invent a name,
+        # (b) every name starts with the incomplete, and (c) for each option Typer
+        # would offer we show EXACTLY one name -- its first matching (canonical)
+        # alias -- and none for options Typer drops (e.g. already-supplied).
+        node, *_ = _walk(_spec.SPEC, list(args))
+        gold = {v for v, _t in _pairs(typer_completions(args, incomplete))}
+        ours_vals = [v for v, _t in ours]
+        assert set(ours_vals) <= gold, (
+            f'args={args} inc={incomplete!r}: invented option names {set(ours_vals) - gold}'
+        )
+        assert all(v.startswith(incomplete) for v in ours_vals)
+        for p in node['params']:
+            if p['kind'] != 'option':
+                continue
+            p_gold = [n for n in p['names'] if n in gold]
+            p_ours = [v for v in ours_vals if v in p['names']]
+            if p_gold:
+                assert p_ours == [p_gold[0]], (
+                    f'args={args} inc={incomplete!r}: option {p["names"]} -> {p_ours}, '
+                    f'expected [{p_gold[0]!r}] (one deduped candidate)'
+                )
+            else:
+                assert not p_ours, (
+                    f'args={args} inc={incomplete!r}: option {p["names"]} shown but Typer drops it'
+                )
+        return
+
+    # Everywhere else (option values, positional values) the engine must match
+    # Typer EXACTLY (only NAME completion is deduped, never values).
     gold = _pairs(typer_completions(args, incomplete))
     if gold:
         assert ours == gold, f'args={args} inc={incomplete!r}: ours={ours} gold={gold}'

--- a/tests/rbx/box/completion/engine_output_test.py
+++ b/tests/rbx/box/completion/engine_output_test.py
@@ -66,9 +66,10 @@ def test_root_bash_output_shape_and_known_entries(monkeypatch):
     for line in lines:
         assert _BASH_LINE.match(line), f'unexpected bash line format: {line!r}'
     assert 'plain,ui' in lines
-    # Aliased commands are emitted as separate candidates, never comma-joined.
+    # Aliased commands are deduped to ONE candidate (the canonical name) at a broad
+    # prefix -- `package`, not also `pkg` -- and never the comma-joined string.
     assert 'plain,package' in lines
-    assert 'plain,pkg' in lines
+    assert 'plain,pkg' not in lines
     assert 'plain,package, pkg' not in lines
 
 
@@ -82,22 +83,28 @@ def test_unknown_shell_emits_file_directive():
 # ---------------------------------------------------------------------------
 
 
-def test_root_command_names_are_split_not_comma_joined(monkeypatch):
+def test_root_command_names_are_deduped_not_comma_joined(monkeypatch):
     # The root has aliased commands ('build, b', ...). We intentionally diverge
-    # from the real CLI here: each alias is its own candidate. Assert the real
-    # CLI's comma-joined names, once split, are all present in our output.
+    # from the real CLI: each command contributes ONE deduped candidate (the
+    # canonical name), never the raw comma-joined string. Assert every name we
+    # offer is a REAL Typer command name (we never invent one) -- though we offer
+    # fewer (deduped) than Typer's full alias set.
     monkeypatch.setenv('_RBX_COMPLETE', 'complete_bash')
     monkeypatch.setenv('_TYPER_COMPLETE_ARGS', 'rbx ')
     monkeypatch.setenv('COMP_WORDS', 'rbx ')
     monkeypatch.setenv('COMP_CWORD', '1')
     fast = _bash_lines(complete_to_string('bash', _spec.SPEC))
     assert 'plain,build, b' not in fast  # never the raw joined form
-    expected_split = set()
+    real_names = set()
     for line in _real_bash('rbx ', 1):
         value = line.split(',', 1)[1]
         for name in value.split(','):
-            expected_split.add('plain,' + name.strip())
-    assert expected_split <= fast
+            real_names.add('plain,' + name.strip())
+    fast_names = {line for line in fast if line.startswith('plain,')}
+    assert fast_names <= real_names, f'invented names: {fast_names - real_names}'
+    # The canonical full names are present; the short aliases are deduped away.
+    assert 'plain,build' in fast_names
+    assert 'plain,b' not in fast_names
 
 
 def test_bash_parity_package_subcommand(monkeypatch):

--- a/tests/rbx/box/completion/engine_test.py
+++ b/tests/rbx/box/completion/engine_test.py
@@ -11,18 +11,20 @@ def _values(items):
 
 
 # ---------------------------------------------------------------------------
-# A) Command-name completion offers each alias as its own candidate (so a typed
-#    prefix completes to a single concrete name, never the raw 'name, alias').
+# A) Command-name completion offers ONE deduped candidate per command (never the
+#    raw 'name, alias'): a broad prefix yields the canonical name; a prefix typed
+#    toward a specific alias completes that alias.
 # ---------------------------------------------------------------------------
 
 
-def test_root_command_names_split_aliases():
+def test_root_command_names_dedupe_to_canonical():
     values = _values(resolve(SPEC, [], ''))
-    # Canonical names AND their aliases appear as separate candidates...
+    # The canonical names appear...
     assert 'build' in values
-    assert 'b' in values
     assert 'package' in values
-    assert 'pkg' in values
+    # ...but their short aliases are deduped away at a broad prefix...
+    assert 'b' not in values
+    assert 'pkg' not in values
     # ...and the unusable comma-joined string is never emitted.
     assert 'build, b' not in values
     assert 'package, pkg' not in values
@@ -33,16 +35,21 @@ def test_root_prefix_pac_completes_to_single_name():
 
 
 def test_root_prefix_pkg_completes_via_alias():
-    # An improvement over Typer: Typer offered the raw 'package, pkg', so a 'pkg'
-    # prefix matched nothing; we complete the alias to a single concrete name.
+    # Typing toward an alias still completes it: 'pkg' is not a prefix of the
+    # canonical 'package', so the matching alias 'pkg' is offered.
     assert _values(resolve(SPEC, [], 'pkg')) == ['pkg']
 
 
-def test_ambiguous_alias_dedups_to_first_in_registration_order():
-    # 't' is registered by both 'time, t' and 'testcases, tc, t'; descent resolves
-    # it to the first (time), so the completion list must contain 't' exactly once.
+def test_ambiguous_alias_dedups_per_command():
+    # 't' is registered by both 'time, t' and 'testcases, tc, t'. Each command
+    # contributes ONE candidate (its first name matching 't'): the canonical
+    # 'time'/'testcases'. The bare ambiguous alias 't' is never offered twice.
     values = _values(resolve(SPEC, [], 't'))
-    assert values.count('t') == 1
+    assert 'time' in values
+    assert 'testcases' in values
+    assert values.count('t') == 0
+    # No duplicates in the deduped list.
+    assert len(values) == len(set(values))
 
 
 def test_package_group_children_via_canonical_and_alias():
@@ -56,6 +63,35 @@ def test_package_group_children_via_canonical_and_alias():
 
 def test_package_polygon_option_name_completion():
     assert _values(resolve(SPEC, ['package', 'polygon'], '--la')) == ['--language']
+
+
+# ---------------------------------------------------------------------------
+# A') Option-name completion dedupes aliases the same way: ONE candidate per
+#     option at a broad prefix; the specific alias / `--no-` form completes when
+#     typed toward.
+# ---------------------------------------------------------------------------
+
+
+def test_option_names_dedupe_to_canonical():
+    # `rbx run -<tab>`: one candidate per option (its canonical long form), not
+    # one per alias spelling.
+    values = _values(resolve(SPEC, ['run'], '-'))
+    assert '--verification-level' in values  # canonical
+    assert '--verification' not in values  # alias deduped away
+    assert '-v' not in values  # short alias deduped away
+    assert len(values) == len(set(values))  # one entry per option
+
+
+def test_option_short_alias_completes_when_typed_toward():
+    assert _values(resolve(SPEC, ['run'], '-v')) == ['-v']
+
+
+def test_option_negation_form_completes_when_typed_toward():
+    # `--no-*` (secondary opts) are deduped at a broad prefix but still complete
+    # when the user types toward them.
+    values = _values(resolve(SPEC, ['run'], '--no-'))
+    assert '--no-check' in values
+    assert '--no-validate' in values
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`rbx <tab>` and `rbx run -<tab>` list **every alias** of each command/option on its own line — `build b … package pkg …`, `--verification-level --verification -v …` — which is noisy and disorganized.

## Why not group them in the shell

The original attempt (earlier commits, now reverted) tried zsh `_describe` grouping. Two problems surfaced when testing against a real oh-my-zsh + fzf config:

1. A **custom directive type** (`grouped`) emitted by the binary breaks any *already-installed* completion function — it drops the unknown type and falls back to listing the whole directory (100+ bogus entries).
2. `_describe` itself **renders as a broken two-block layout** (all names, then all descriptions) under that config (fzf rebinds TAB; oh-my-zsh's `matcher-list` reorders), even though it renders fine in a vanilla shell.

## Fix: application-level dedup

Collapse aliases in the engine instead of the shell. `_first_match` returns the first name (in declaration order) matching the incomplete, and both subcommand- and option-name completion emit **one candidate per command/option**:

- broad prefix (``, `-`, `--`) → canonical full name (`package`, `--verification-level`)
- prefix typed toward a specific alias / `--no-` form → that exact spelling still completes (`pkg`, `-v`, `--no-check`)

The wire protocol and the zsh template are **unchanged** (`plain`/`file`/`dir` + `compadd -d`), so it's robust across shells, needs no new completion install, and degrades gracefully. Only NAME completion is deduped — option/positional **values** still match Typer exactly.

## Verification

- 841 completion tests pass. `differential_test` now asserts every offered name is a real Typer name and that exactly one is shown per command/option (values keep strict Typer parity).
- Rendered end-to-end in the reporter's real oh-my-zsh + fzf config: `rbx <tab>` → one clean inline line per command; `rbx run --<tab>` → one line per option, alphabetically sorted; aliases/`--no-` forms still complete when typed toward. No two-block, no directory-listing blowup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)