### PR TITLE
statements v2: Polygon API upload update (S12, #568)

### DIFF
--- a/docs/plans/2026-06-10-statements-v2-polygon-upload-design.md
+++ b/docs/plans/2026-06-10-statements-v2-polygon-upload-design.md
@@ -1,0 +1,111 @@
+# Statements v2 — Polygon API upload (S12, #568)
+
+Parent: [#556 — statements v2](https://github.com/rsalesc/rbx/issues/556).
+Depends on: #566 (S10, contest join — merged).
+Date: 2026-06-10
+Status: **approved design**, ready to implement.
+
+## 1. Scope
+
+S12 reworks the **Polygon API upload** path (`rbx package polygon --upload` /
+`--validate-statement`) onto statements v2: consume the now-portable,
+self-contained overlay TeX, drop the absolute-/temp-path special-casing, and keep
+forcing `externalize`/`demacro` at export time (they are no longer schema
+fields). It replicates the v1 behavior the setter relied on — **block production**
+(the `blocks.*.yml` files in the build dir, the source of truth for Polygon
+blocks) and **TikZ production** (externalized per-block figure PDFs uploaded as
+resources).
+
+**Out of scope (separate issue):** re-enabling statement embedding in the
+*offline* `problem.zip` / `contest.zip` packagers (`_process_statements`, today
+commented out). Filed as a follow-up.
+
+## 2. Key idea: the v2 overlay root *is* the "statement dir"
+
+v1's Polygon path keyed everything off
+`get_statement_dir(statement, builder_name)` — per-builder scratch subdirs under
+`build/statements/<name>/<builder>/` holding `blocks.*.yml` (rbxTeX builder),
+`macros.json` and `artifacts/tikz_figures/*.pdf` (TeX2PDF builder). Samples were
+injected by **absolute path**, which forced the packager into path special-casing
+(design §1).
+
+v2 already stages a single, self-contained overlay per `(language, variant)` at
+`build/statements/st/<lang>-<variant>/`, references everything by **relative**
+paths, runs `pdflatex` from that root, and — when `externalize`/`demacro` are on
+— already drops `macros.json` and `artifacts/tikz_figures/*.pdf` there. So we make
+**that overlay root the single Polygon source dir** and persist the block YAMLs
+beside the existing artifacts. The per-builder subdirs and absolute/temp paths
+collapse into one portable, relative-pathed directory (design §6.5).
+
+The orchestration is already correct: `run_packager` builds **every** statement
+with `externalize=True, demacro=True` forced for polygon (via
+`get_packager_extra_mergeable_params`) *before* `upload_problem` /
+`validate_statements` read the artifacts. The only gaps are (a) producing &
+persisting the blocks, and (b) repointing the Polygon readers at the overlay.
+
+The block↔PDF↔`\includegraphics` contract is unchanged and reused verbatim:
+`add_labels_to_tikz_nodes(prefix=<block>)` emits `\tikzsetnextfilename{<block>_<i>}`
+→ `\tikzexternalize[prefix=artifacts/tikz_figures/]` (added by
+`inject_externalization_for_tikz`) emits `artifacts/tikz_figures/<block>_<i>.pdf`
+→ `replace_labeled_tikz_nodes` rewrites the labeled TikZ to
+`\includegraphics{artifacts/tikz_figures/<block>_<i>}`. Because the externalized
+filenames come from labels in the body, **per-block labeling must happen before
+the full-doc compile** — so externalization is threaded through
+`render_problem_tex` (engine), exactly mirroring v1's `rbxTeXBuilder`.
+
+## 3. Changes
+
+1. **Block production + persistence — `engine.render_problem_tex`,
+   `build_statements.build_statement`.** Thread an `externalize` flag into
+   `render_problem_tex`. It already extracts blocks; additionally:
+   - always write `blocks.yml` (raw extracted blocks — the source of truth);
+   - when `externalize`: per-block TikZ labeling (`externalize_blocks` over blocks
+     **and** sample explanations) → write `blocks.ext.yml`; render the *labeled*
+     blocks into the compiled full doc (so `\tikzexternalize` produces the figure
+     PDFs); then `substitute_externalized_blocks` → write `blocks.sub.yml`.
+   - All three YAMLs are written for v1 parity / debuggability. They land in
+     `problem_root` (= the overlay root for the standalone build, which is the
+     only mode Polygon upload uses).
+   - Reuses the v1 helpers (`externalize_blocks` / `substitute_externalized_blocks`)
+     still in `builders.py`.
+
+2. **Un-stub the Polygon export entry points — `build_statements.py`.**
+   - `get_statement_dir(statement)` → the standalone overlay root for
+     `(language, variant)` (`_standalone_overlay_root`'s path, without re-wiping).
+   - `get_produced_tikz_pdfs(statement)` → glob
+     `<overlay>/artifacts/tikz_figures/**/*.pdf`, yielding `(abspath, relpath)`.
+   - delete the dead `build_statement_bytes` stub (nothing consumes it once the
+     block path is rebuilt; #580 sweeps remaining v1 code).
+
+3. **Rewrite `statement_block_utils.py`.** Read `blocks.sub.yml` + `macros.json`
+   from the **single** overlay root (no per-builder subdirs, no
+   `rbxTeXBuilder`/`TeX2PDFBuilder` imports). Keep the existing
+   defs-macro-collection → macro filter → `convert_to_polygon_tex` pipeline.
+
+4. **Fix `upload.py` for the v2 schema.** `statement.path` → `statement.file`;
+   drop the removed `statement.assets`. Statement resources become the whole
+   statement-file directory subtree (the v2 asset scope) plus
+   `get_produced_tikz_pdfs`. All paths relative.
+
+5. **Packager owns the toggle — `packager.py`.** Move the externalize/demacro
+   forcing out of the `if name == 'polygon'` branch in
+   `get_packager_extra_mergeable_params` into a `PolygonPackager` method,
+   resolving the existing `# TODO: migrate this into the packager class`.
+
+## 4. Testing
+
+- Integration over a contest+problem testdata fixture carrying a `defs` block and
+  an inline TikZ picture: `build_statement(..., externalize=True, demacro=True)`
+  persists `blocks.yml` / `blocks.ext.yml` / `blocks.sub.yml` + `macros.json` +
+  at least one `artifacts/tikz_figures/*.pdf`; `blocks.sub.yml`'s legend has the
+  TikZ replaced by `\includegraphics{artifacts/tikz_figures/...}`.
+- `get_processed_statement_blocks` returns legend/input/output/notes as
+  Polygon-valid TeX (macros expanded/filtered, Polygon conversion applied).
+- `get_statement_dir` / `get_produced_tikz_pdfs` overlay mapping.
+- Live `--upload` is Polygon-API-bound → verified manually against the authorized
+  POLYGON creds, not in CI.
+
+## 5. Follow-up
+
+- Offline Polygon packager statements (re-enable `_process_statements` for
+  `problem.zip` / `contest.zip`) — separate issue.

--- a/docs/plans/2026-06-10-statements-v2-polygon-upload.md
+++ b/docs/plans/2026-06-10-statements-v2-polygon-upload.md
@@ -1,0 +1,310 @@
+# Statements v2 — Polygon API upload (S12, #568) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for each task.
+
+**Goal:** Make `rbx package polygon --upload` / `--validate-statement` work on statements v2 by replicating v1's block + TikZ production on the portable overlay, persisting `blocks.*.yml` as the source of truth.
+
+**Architecture:** The standalone overlay root (`build/statements/st/<lang>-<variant>/`) becomes the single Polygon "statement dir". `render_problem_tex` gains an `externalize` flag that persists `blocks.yml` (always) plus `blocks.ext.yml`/`blocks.sub.yml` (when externalizing, via the existing v1 TikZ-label/substitute helpers). The stubbed `get_statement_dir`/`get_produced_tikz_pdfs` are repointed at that overlay; `statement_block_utils.py` and `upload.py` consume it.
+
+**Tech Stack:** Python, Pydantic v2, Typer, pytest, TexSoup, pdflatex (mocked in unit tests).
+
+Design: `docs/plans/2026-06-10-statements-v2-polygon-upload-design.md`.
+
+---
+
+### Task 1: Test fixture — a statement with `defs` + TikZ blocks
+
+**Files:**
+- Create: `rbx/testdata/contests/statements_v2_polygon/contest.rbx.yml`
+- Create: `rbx/testdata/contests/statements_v2_polygon/statements/contest.rbx.tex`
+- Create: `rbx/testdata/contests/statements_v2_polygon/statements/problem-standalone.rbx.tex`
+- Create: `rbx/testdata/contests/statements_v2_polygon/A/problem.rbx.yml`
+- Create: `rbx/testdata/contests/statements_v2_polygon/A/statement/statement.rbx.tex`
+
+A minimal contest + one problem A. The problem statement carries `defs`, `legend`,
+`input`, `output`, `notes` blocks; `legend` contains a `tikzpicture`. The
+standalone template is a full document splicing the blocks. Model it on
+`rbx/testdata/contests/statements_v2` (same contest/problem shape), adding:
+
+`A/statement/statement.rbx.tex`:
+```latex
+%- block defs
+\newcommand{\NN}{\mathbb{N}}
+%- endblock
+%- block legend
+Problem A by \VAR{vars.author}. Numbers in $\NN$.
+\begin{tikzpicture}\draw (0,0) -- (1,1);\end{tikzpicture}
+%- endblock
+%- block input
+A single integer $n$.
+%- endblock
+%- block output
+Print $n$.
+%- endblock
+%- block notes
+Be careful.
+%- endblock
+```
+
+The standalone template (`statements/problem-standalone.rbx.tex`) must
+`\documentclass`, load tikz, and emit `\BLOCK{ for ... }` of `blocks` — copy the
+structure from `rbx/testdata/contests/statements_v2/statements/problem-standalone.rbx.tex`
+and ensure it splices legend/input/output/notes.
+
+**Step 1:** Create the files. No test yet — used by later tasks.
+**Step 2:** Sanity: `uv run pytest tests/rbx/box/statements/test_standalone_build.py -q` still passes (existing fixture untouched).
+**Step 3:** Commit: `test(statements): add polygon-blocks v2 testdata fixture`.
+
+---
+
+### Task 2: `render_problem_tex` persists blocks YAML + per-block externalization
+
+**Files:**
+- Modify: `rbx/box/statements/engine.py` (`render_problem_tex`)
+- Test: `tests/rbx/box/statements/test_engine_blocks.py` (new)
+
+**Step 1: Write failing test** — build the problem statement to TeX with
+`externalize=True` and assert the three YAMLs land in the overlay and the
+substituted legend replaced TikZ with `\includegraphics`.
+
+```python
+import pathlib
+import pytest
+from rbx import utils
+from rbx.box import cd, package, package_utils
+from rbx.box.statements import build_statements
+from rbx.box.statements.builders import StatementBlocks
+from rbx.box.statements.schema import (
+    ConversionType, StatementType, TexToPDF, rbxToTeX)
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_render_persists_block_yamls_with_externalization(
+    cleandir_with_testdata,
+):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        pkg = package.find_problem_package_or_die()
+        statement = pkg.expanded_statements[0]
+        await build_statements.build_statement(
+            statement, pkg, output_type=StatementType.TeX, use_samples=False,
+            extra_mergeable_params=[
+                rbxToTeX(type=ConversionType.rbxToTex, externalize=True),
+                TexToPDF(type=ConversionType.TexToPDF, externalize=True, demacro=True),
+            ],
+        )
+        overlay = build_statements.get_statement_dir(statement)
+        assert (overlay / 'blocks.yml').is_file()
+        assert (overlay / 'blocks.ext.yml').is_file()
+        assert (overlay / 'blocks.sub.yml').is_file()
+        sub = utils.model_from_yaml(StatementBlocks, (overlay / 'blocks.sub.yml').read_text())
+        assert '\\includegraphics' in sub.blocks['legend']
+        assert 'tikzpicture' not in sub.blocks['legend']
+        raw = utils.model_from_yaml(StatementBlocks, (overlay / 'blocks.yml').read_text())
+        assert 'tikzpicture' in raw.blocks['legend']
+```
+
+**Step 2: Run, expect FAIL** (YAMLs not written; `get_statement_dir` stubbed —
+Task 3 un-stubs it, so until then this test will error on `get_statement_dir`. To
+keep Task 2 self-contained, compute the overlay path inline in the test as
+`pathlib.Path('build')/'statements'/'st'/f'{statement.language}-{statement.variant}'`
+and switch to `get_statement_dir` in Task 3.)
+
+Run: `uv run pytest tests/rbx/box/statements/test_engine_blocks.py -q`
+
+**Step 3: Implement** in `engine.py`:
+- Add `externalize: bool = False` param to `render_problem_tex`.
+- After block extraction (`blocks = render.extract_blocks(...)`), always write
+  `blocks.yml` to `problem_root` (`(problem_root/'blocks.yml').write_text(utils.model_to_yaml(blocks))`).
+- When `externalize`: build a labeled copy via
+  `builders.externalize_blocks(blocks.blocks)` and
+  `builders.externalize_blocks(blocks.explanations)`; write `blocks.ext.yml`;
+  set `problem.blocks` from the labeled blocks (so the compiled full doc carries
+  `\tikzsetnextfilename`); pass the labeled explanations to sample staging; after
+  the render, compute `builders.substitute_externalized_blocks(...)` on the
+  labeled blocks + explanations and write `blocks.sub.yml`.
+- Reuse the existing markdown handling (the rbxMarkdown path converts blocks to
+  LaTeX before splicing; externalization runs on the LaTeX-form blocks).
+
+Imports: `from rbx import utils`; `externalize_blocks` / `substitute_externalized_blocks`
+are already in `rbx.box.statements.builders`.
+
+**Step 4: Run, expect PASS.**
+**Step 5: Commit:** `feat(statements): persist block yamls + per-block tikz externalization`.
+
+---
+
+### Task 3: Un-stub `get_statement_dir` + `get_produced_tikz_pdfs`
+
+**Files:**
+- Modify: `rbx/box/statements/build_statements.py`
+- Test: `tests/rbx/box/statements/test_polygon_export.py` (new)
+
+**Step 1: Write failing tests:**
+```python
+import pathlib
+import pytest
+from rbx.box import cd, package, package_utils
+from rbx.box.statements import build_statements
+from rbx.box.statements.texsoup_utils import EXTERNALIZATION_DIR
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_get_statement_dir_is_overlay_root(cleandir_with_testdata):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        st = package.find_problem_package_or_die().expanded_statements[0]
+        d = build_statements.get_statement_dir(st)
+        assert d == pathlib.Path('build')/'statements'/'st'/'en-default'
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_get_produced_tikz_pdfs_globs_externalization_dir(cleandir_with_testdata):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        st = package.find_problem_package_or_die().expanded_statements[0]
+        d = build_statements.get_statement_dir(st)
+        (d/EXTERNALIZATION_DIR).mkdir(parents=True, exist_ok=True)
+        (d/EXTERNALIZATION_DIR/'legend_0.pdf').write_bytes(b'%PDF-1.5')
+        produced = list(build_statements.get_produced_tikz_pdfs(st))
+        assert len(produced) == 1
+        abspath, rel = produced[0]
+        assert rel == pathlib.Path(EXTERNALIZATION_DIR)/'legend_0.pdf'
+        assert abspath.is_file()
+```
+
+**Step 2: Run, expect FAIL** (`NotImplementedError`).
+
+**Step 3: Implement** (replace stubs):
+```python
+def _standalone_overlay_path(statement: Statement) -> pathlib.Path:
+    return (
+        package.get_statements_build_path()
+        / 'st'
+        / f'{statement.language}-{statement.variant}'
+    )
+
+def get_statement_dir(statement: Statement) -> pathlib.Path:
+    """The standalone overlay root for this statement — the v2 Polygon source dir
+    holding blocks.*.yml, macros.json and artifacts/tikz_figures/*.pdf."""
+    d = _standalone_overlay_path(statement)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+def get_produced_tikz_pdfs(statement):
+    from rbx.box.statements.texsoup_utils import EXTERNALIZATION_DIR
+    d = get_statement_dir(statement)
+    for pdf in sorted((d / EXTERNALIZATION_DIR).glob('**/*.pdf')):
+        yield d / pdf.relative_to(d), pdf.relative_to(d)
+```
+- Refactor `_standalone_overlay_root` to call `_standalone_overlay_path` then wipe+mkdir.
+- Delete the `build_statement_bytes` stub and its now-unused docstring constant references.
+
+**Step 4: Run, expect PASS.** Update Task 2's test to use `get_statement_dir`.
+**Step 5: Commit:** `feat(statements): un-stub polygon get_statement_dir/get_produced_tikz_pdfs`.
+
+---
+
+### Task 4: Rewrite `statement_block_utils.py` to read the overlay root
+
+**Files:**
+- Modify: `rbx/box/packaging/polygon/statement_block_utils.py`
+- Test: extend `tests/rbx/box/statements/test_polygon_export.py`
+
+**Step 1: Write failing test** — after building with externalize+demacro, the
+processed blocks are Polygon-valid TeX (legend/input/output present; TikZ became
+`\includegraphics`; the `\NN` macro expanded since it is not Polygon-allowed):
+```python
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_get_processed_statement_blocks_v2(cleandir_with_testdata):
+    from rbx.box.packaging.polygon import statement_block_utils as sbu
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        pkg = package.find_problem_package_or_die()
+        st = pkg.expanded_statements[0]
+        await build_statements.build_statement(
+            st, pkg, output_type=StatementType.TeX, use_samples=False,
+            extra_mergeable_params=[
+                rbxToTeX(type=ConversionType.rbxToTex, externalize=True),
+                TexToPDF(type=ConversionType.TexToPDF, externalize=True, demacro=True),
+            ],
+        )
+        blocks = sbu.get_processed_statement_blocks(st)
+        assert 'legend' in blocks.blocks and 'input' in blocks.blocks
+        assert '\\includegraphics' in blocks.blocks['legend']
+```
+(Uses TeX output → no pdflatex; `macros.json` absent → processor returns the
+substituted blocks, exercising the no-macros branch + polygon conversion.)
+
+**Step 2: Run, expect FAIL** (imports the stubbed `get_statement_dir(..., builder_name=...)`).
+
+**Step 3: Implement:**
+- `get_substituted_statement_blocks(statement)`: read `get_statement_dir(statement)/'blocks.sub.yml'`
+  (fallback to `blocks.yml` if `.sub` absent). Error message uses
+  `f'{statement.language}-{statement.variant}'` (problem statements have no `name`).
+- `get_processed_statement_blocks(statement)`: `macros_file = get_statement_dir(statement)/'macros.json'`;
+  drop the `'polygon'` debug subdir writes (or write into `get_statement_dir(statement)/'polygon'`).
+  Remove the `rbxTeXBuilder`/`TeX2PDFBuilder` imports.
+- `validate_statements` / `process_statements`: replace remaining `statement.name`
+  in messages with `f'{statement.language}/{statement.variant}'`.
+
+**Step 4: Run, expect PASS.**
+**Step 5: Commit:** `refactor(polygon): read v2 overlay blocks in statement_block_utils`.
+
+---
+
+### Task 5: Fix `upload.py` for the v2 schema
+
+**Files:**
+- Modify: `rbx/box/packaging/polygon/upload.py` (`_upload_statement_resources`)
+
+**Step 1:** No new unit test (API-bound). Replace
+`get_relative_assets(statement.path, statement.assets)` with v2 asset
+enumeration: walk the statement-file directory subtree
+(`statement.file.parent`), yielding `(abspath, relpath_to_that_dir)` for every
+file except the `.samples`/build artifacts, then `extend(get_produced_tikz_pdfs(statement))`.
+Implement a small helper `_statement_assets(statement)` in `upload.py` (or reuse
+the overlay: assets are everything under `get_statement_dir(statement)` excluding
+`blocks.*.yml`, `macros.json`, `statement.tex`, `.samples`, the externalization
+PDFs already added). Keep the resource-key normalization logic intact.
+
+**Step 2:** `import` fix: drop `statement.assets`/`statement.path` references; the
+file is `statement.file`. Verify module imports: `uv run python -c "import rbx.box.packaging.polygon.upload"`.
+
+**Step 3:** Commit: `fix(polygon): consume v2 statement assets + tikz pdfs in upload`.
+
+---
+
+### Task 6: `PolygonPackager` owns the externalize/demacro toggle
+
+**Files:**
+- Modify: `rbx/box/packaging/packager.py` (`get_packager_extra_mergeable_params`)
+- Modify: `rbx/box/packaging/polygon/packager.py` (add method)
+- Test: extend an existing packaging test or `test_polygon_export.py`
+
+**Step 1: Write test** asserting `PolygonPackager.statement_export_params()` returns
+externalize+demacro steps and `BocaPackager` returns `[]`.
+
+**Step 2: Run, expect FAIL.**
+
+**Step 3: Implement:** add classmethod/method
+`statement_export_params(self) -> List[ConversionStep]` on `BasePackager`
+(default `[]`) and override in `PolygonPackager` to return the rbxToTeX/TexToPDF
+externalize+demacro steps. In `run_packager`, call
+`packager.statement_export_params()` instead of
+`get_packager_extra_mergeable_params(packager_cls)`. Keep
+`get_packager_extra_mergeable_params` as a thin shim or delete it (update import).
+
+**Step 4: Run, expect PASS.**
+**Step 5: Commit:** `refactor(packaging): polygon packager owns statement export toggles`.
+
+---
+
+### Task 7: Full verification
+
+**Step 1:** `uv run pytest tests/rbx/box/statements tests/rbx/box/packaging -q`
+**Step 2:** `uv run ruff check rbx/box/statements rbx/box/packaging && uv run ruff format --check .`
+**Step 3:** `uv run python -c "import rbx.box.packaging.polygon.upload, rbx.box.packaging.polygon.statement_block_utils, rbx.box.packaging.main"`
+**Step 4:** Manual live smoke (not CI): `rbx package polygon --upload --validate-statement` against the authorized POLYGON creds on the fixture problem; confirm blocks + a TikZ resource upload. Report outcome.
+**Step 5:** Update `rbx/box/statements/CLAUDE.md` + `rbx/box/packaging/CLAUDE.md` to note S12 is done (overlay = polygon statement dir; entry points un-stubbed).
+**Step 6:** Commit docs; open PR referencing #568, mention #583 follow-up.

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -1111,6 +1111,123 @@ SPEC = {
         {
             'children': [
                 {
+                    'help': 'Build tutorials (editorials).',
+                    'is_group': False,
+                    'name': 'build, b',
+                    'panel': None,
+                    'params': [
+                        {
+                            'help': 'Verification level to use when building package.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--verification-level', '--verification', '-v'],
+                            'takes_value': True,
+                            'value': {
+                                'completer': 'verification_level',
+                                'kind': 'completer',
+                            },
+                        },
+                        {
+                            'help': None,
+                            'kind': 'argument',
+                            'multiple': False,
+                            'names': [],
+                            'takes_value': True,
+                            'value': {'kind': 'none'},
+                            'variadic': True,
+                        },
+                        {
+                            'help': 'Languages to build tutorials for. If not '
+                            'specified, build tutorials for all available '
+                            'languages.',
+                            'kind': 'option',
+                            'multiple': True,
+                            'names': ['--languages'],
+                            'takes_value': True,
+                            'value': {'kind': 'none'},
+                        },
+                        {
+                            'help': 'Output type to be generated.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--output'],
+                            'takes_value': True,
+                            'value': {
+                                'choices': [
+                                    'rbxTeX',
+                                    'rbxMarkdown',
+                                    'TeX',
+                                    'Markdown',
+                                    'JinjaTeX',
+                                    'JinjaMarkdown',
+                                    'PDF',
+                                ],
+                                'kind': 'choice',
+                            },
+                        },
+                        {
+                            'help': 'Whether to build the tutorial with samples or '
+                            'not.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--samples', '--no-samples'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        },
+                        {
+                            'help': 'Variables to be used in the tutorials.',
+                            'kind': 'option',
+                            'multiple': True,
+                            'names': ['--vars'],
+                            'takes_value': True,
+                            'value': {'kind': 'none'},
+                        },
+                        {
+                            'help': 'Whether to validate outputs for testcases or not.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--validate', '--no-validate'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        },
+                        {
+                            'help': 'Timing profile to render the tutorial against. '
+                            'Must exist in this problem.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['-p', '--profile'],
+                            'takes_value': True,
+                            'value': {'kind': 'none'},
+                        },
+                        {
+                            'help': 'Show this message and exit.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--help'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        },
+                    ],
+                }
+            ],
+            'help': 'Manage tutorials/editorials (sub-command).',
+            'is_group': True,
+            'name': 'tutorials, tut',
+            'panel': 'Deploying',
+            'params': [
+                {
+                    'help': 'Show this message and exit.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--help'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                }
+            ],
+        },
+        {
+            'children': [
+                {
                     'help': 'Download preset-declared libraries (omit...',
                     'is_group': False,
                     'name': 'lib, library',
@@ -2151,6 +2268,140 @@ SPEC = {
                     'help': 'Manage contest-level statements.',
                     'is_group': True,
                     'name': 'statements, st',
+                    'panel': None,
+                    'params': [
+                        {
+                            'help': 'Show this message and exit.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--help'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        }
+                    ],
+                },
+                {
+                    'children': [
+                        {
+                            'help': 'Build tutorials (editorials).',
+                            'is_group': False,
+                            'name': 'build, b',
+                            'panel': None,
+                            'params': [
+                                {
+                                    'help': 'Verification level to use when '
+                                    'building package.',
+                                    'kind': 'option',
+                                    'multiple': False,
+                                    'names': [
+                                        '--verification-level',
+                                        '--verification',
+                                        '-v',
+                                    ],
+                                    'takes_value': True,
+                                    'value': {
+                                        'completer': 'verification_level',
+                                        'kind': 'completer',
+                                    },
+                                },
+                                {
+                                    'help': None,
+                                    'kind': 'argument',
+                                    'multiple': False,
+                                    'names': [],
+                                    'takes_value': True,
+                                    'value': {'kind': 'none'},
+                                    'variadic': True,
+                                },
+                                {
+                                    'help': 'Languages to build tutorials for. '
+                                    'If not specified, build tutorials '
+                                    'for all available languages.',
+                                    'kind': 'option',
+                                    'multiple': True,
+                                    'names': ['--languages'],
+                                    'takes_value': True,
+                                    'value': {'kind': 'none'},
+                                },
+                                {
+                                    'help': 'Whether to validate outputs for '
+                                    'testcases or not.',
+                                    'kind': 'option',
+                                    'multiple': False,
+                                    'names': ['--validate', '--no-validate'],
+                                    'takes_value': False,
+                                    'value': {'kind': 'none'},
+                                },
+                                {
+                                    'help': 'Output type to be generated.',
+                                    'kind': 'option',
+                                    'multiple': False,
+                                    'names': ['--output'],
+                                    'takes_value': True,
+                                    'value': {
+                                        'choices': [
+                                            'rbxTeX',
+                                            'rbxMarkdown',
+                                            'TeX',
+                                            'Markdown',
+                                            'JinjaTeX',
+                                            'JinjaMarkdown',
+                                            'PDF',
+                                        ],
+                                        'kind': 'choice',
+                                    },
+                                },
+                                {
+                                    'help': 'Whether to build the tutorial with '
+                                    'samples or not.',
+                                    'kind': 'option',
+                                    'multiple': False,
+                                    'names': ['--samples', '--no-samples'],
+                                    'takes_value': False,
+                                    'value': {'kind': 'none'},
+                                },
+                                {
+                                    'help': 'Variables to be used in the tutorials.',
+                                    'kind': 'option',
+                                    'multiple': True,
+                                    'names': ['--vars'],
+                                    'takes_value': True,
+                                    'value': {'kind': 'none'},
+                                },
+                                {
+                                    'help': 'Whether to install missing LaTeX '
+                                    'packages.',
+                                    'kind': 'option',
+                                    'multiple': False,
+                                    'names': ['--install-tex', '--no-install-tex'],
+                                    'takes_value': False,
+                                    'value': {'kind': 'none'},
+                                },
+                                {
+                                    'help': 'Timing profile to render tutorials '
+                                    'against. Problems missing this '
+                                    'profile are skipped with a '
+                                    'warning.',
+                                    'kind': 'option',
+                                    'multiple': False,
+                                    'names': ['-p', '--profile'],
+                                    'takes_value': True,
+                                    'value': {'kind': 'none'},
+                                },
+                                {
+                                    'help': 'Show this message and exit.',
+                                    'kind': 'option',
+                                    'multiple': False,
+                                    'names': ['--help'],
+                                    'takes_value': False,
+                                    'value': {'kind': 'none'},
+                                },
+                            ],
+                        }
+                    ],
+                    'help': 'Manage contest-level tutorials/editorials.',
+                    'is_group': True,
+                    'name': 'tutorials, tut',
                     'panel': None,
                     'params': [
                         {

--- a/rbx/box/packaging/CLAUDE.md
+++ b/rbx/box/packaging/CLAUDE.md
@@ -54,7 +54,7 @@ Polygon (offline + upload) and BOCA/MOJ are **flat** judges: they compile each s
 - `upload_problem()` orchestrates: find/create problem, upload files, solutions, testcases, statements, commit
 - Uses `ThreadPoolExecutor(4)` for parallel solution uploads
 - Maps solutions to Polygon tags: MA (main accepted), OK, WA, TL, ML, RE, RJ
-- Statement upload: renders Jinja blocks to Polygon's structured format, uploads resources (images, TikZ PDFs)
+- Statement upload (statements v2, S12 #568): reads the per-statement block YAMLs (`blocks.sub.yml`) + `macros.json` + externalized TikZ PDFs straight from the v2 standalone overlay root (`build/statements/st/<lang>-<variant>/` = `build_statements.get_statement_dir`), which the packager populated by forcing externalize+demacro (`PolygonPackager.statement_export_params`). `statement_block_utils.get_processed_statement_blocks` does the macro-expand/filter → Polygon-TeX conversion; `upload.py` uploads the statement-dir assets + `get_produced_tikz_pdfs` as resources. Offline `problem.zip`/`contest.zip` statement embedding is a follow-up (#583)
 - API client in `polygon_api.py` with SHA-512 signed requests, env vars `POLYGON_API_KEY`/`POLYGON_API_SECRET`
 - `--upload-tests-raw` escape hatch: uploads built test inputs as raw files (1 MiB cap each), skips generator uploads, and clears the freemarker script. Use when Polygon-side generator compilation is failing.
 

--- a/rbx/box/packaging/packager.py
+++ b/rbx/box/packaging/packager.py
@@ -20,11 +20,8 @@ from rbx.box.statements.build_statements import (
 )
 from rbx.box.statements.schema import (
     ConversionStep,
-    ConversionType,
     Statement,
     StatementType,
-    TexToPDF,
-    rbxToTeX,
 )
 from rbx.box.testcase_extractors import (
     extract_generation_testcases_from_groups,
@@ -85,6 +82,12 @@ class BasePackager(ABC):
 
     def statement_types(self) -> List[StatementType]:
         return [StatementType.PDF]
+
+    def statement_export_params(self) -> List[ConversionStep]:
+        """Packager-forced statement conversion toggles applied at export time
+        (design §2 decision 6: externalize/demacro are not user schema). Default
+        is none; the Polygon packager overrides this."""
+        return []
 
     @abstractmethod
     def package(
@@ -196,19 +199,6 @@ class ContestZipper(BaseContestPackager):
         return build_path / pathlib.Path(self.filename).with_suffix('.zip')
 
 
-def get_packager_extra_mergeable_params(
-    packager_cls: Type[BasePackager],
-) -> List[ConversionStep]:
-    res = []
-    if packager_cls.name() == 'polygon':
-        # TODO: migrate this into the packager class
-        res.append(rbxToTeX(type=ConversionType.rbxToTex, externalize=True))
-        res.append(
-            TexToPDF(type=ConversionType.TexToPDF, externalize=True, demacro=True)
-        )
-    return res
-
-
 async def run_packager(
     packager_cls: Type[BasePackager],
     verification: environment.VerificationParam,
@@ -260,9 +250,7 @@ async def run_packager(
                 tracked_statements,
                 verification,
                 output=statement_type,
-                extra_mergeable_params=get_packager_extra_mergeable_params(
-                    packager_cls
-                ),
+                extra_mergeable_params=packager.statement_export_params(),
                 # Skip building samples since they were already
                 # built by the packager.
                 skip_building=True,

--- a/rbx/box/packaging/polygon/packager.py
+++ b/rbx/box/packaging/polygon/packager.py
@@ -19,6 +19,12 @@ from rbx.box.packaging.packager import (
 from rbx.box.packaging.polygon import xml_schema as polygon_schema
 from rbx.box.packaging.polygon.utils import get_polygon_language_from_code_item
 from rbx.box.schema import TaskType
+from rbx.box.statements.schema import (
+    ConversionStep,
+    ConversionType,
+    TexToPDF,
+    rbxToTeX,
+)
 from rbx.config import get_testlib
 
 DAT_TEMPLATE = """
@@ -63,6 +69,15 @@ class PolygonPackager(BasePackager):
     @classmethod
     def task_types(cls) -> List[TaskType]:
         return [TaskType.BATCH, TaskType.COMMUNICATION]
+
+    def statement_export_params(self) -> List[ConversionStep]:
+        # Polygon consumes structured blocks, so TikZ is externalized (uploaded
+        # as PDF resources) and macros are extracted (to expand non-Polygon
+        # commands out of the blocks). Forced at export — not user schema.
+        return [
+            rbxToTeX(type=ConversionType.rbxToTex, externalize=True),
+            TexToPDF(type=ConversionType.TexToPDF, externalize=True, demacro=True),
+        ]
 
     def _validate(self):
         langs = self.languages()

--- a/rbx/box/packaging/polygon/statement_block_utils.py
+++ b/rbx/box/packaging/polygon/statement_block_utils.py
@@ -11,18 +11,23 @@ from rbx.box.exception import RbxException
 from rbx.box.lang import code_to_langs, is_valid_lang_code
 from rbx.box.statements import demacro_utils, polygon_utils
 from rbx.box.statements.build_statements import get_statement_dir
-from rbx.box.statements.builders import (
-    StatementBlocks,
-    TeX2PDFBuilder,
-    rbxTeXBuilder,
-)
+from rbx.box.statements.builders import StatementBlocks
 from rbx.box.statements.demacro_utils import MacroDefinitions
 from rbx.box.statements.schema import Statement, StatementType
 
 
+def _statement_label(statement: Statement) -> str:
+    """A human-readable id for a problem statement (which has no ``name`` in v2 —
+    it is identified by ``(language, variant)``)."""
+    return f'{statement.language}/{statement.variant}'
+
+
 def get_substituted_statement_blocks(statement: Statement) -> StatementBlocks:
     assert statement.type == StatementType.rbxTeX
-    statement_dir = get_statement_dir(statement, builder_name=rbxTeXBuilder.name())
+    # The v2 overlay root is the single Polygon source dir; the substituted blocks
+    # (TikZ -> \includegraphics) live in blocks.sub.yml, written by the forced
+    # externalize build.
+    statement_dir = get_statement_dir(statement)
     substituted_blocks_path = statement_dir / 'blocks.sub.yml'
     if not substituted_blocks_path.is_file():
         console.console.print(
@@ -39,10 +44,9 @@ def get_substituted_statement_blocks(statement: Statement) -> StatementBlocks:
 
 def get_processed_statement_blocks(statement: Statement) -> StatementBlocks:
     statement_blocks = get_substituted_statement_blocks(statement)
-    macros_file = (
-        get_statement_dir(statement, builder_name=TeX2PDFBuilder.name()) / 'macros.json'
-    )
-    statement_dir = get_statement_dir(statement, builder_name='polygon')
+    overlay_dir = get_statement_dir(statement)
+    macros_file = overlay_dir / 'macros.json'
+    statement_dir = overlay_dir / 'polygon'
     shutil.rmtree(statement_dir, ignore_errors=True)
     statement_dir.mkdir(parents=True, exist_ok=True)
 
@@ -155,7 +159,7 @@ def process_statements(
 def validate_statements(main_language: Optional[str], upload_as_english: bool):
     def validate_statement(statement: Statement, language: str, uploaded_language: str):
         console.console.print(
-            f'Validating statement [item]{statement.name}[/item] for language [item]{language}[/item]...'
+            f'Validating statement [item]{_statement_label(statement)}[/item] for language [item]{language}[/item]...'
         )
         blocks = get_processed_statement_blocks(statement)
 
@@ -177,7 +181,7 @@ def validate_statements(main_language: Optional[str], upload_as_english: bool):
 
         if errors:
             console.console.print(
-                f'[error]Polygon unsupported TeX constructs found in statement [item]{statement.name}[/item] for language [item]{language}[/item]:[/error]'
+                f'[error]Polygon unsupported TeX constructs found in statement [item]{_statement_label(statement)}[/item] for language [item]{language}[/item]:[/error]'
             )
             for block_name, block_errors in errors:
                 console.console.print(

--- a/rbx/box/packaging/polygon/upload.py
+++ b/rbx/box/packaging/polygon/upload.py
@@ -1,7 +1,7 @@
 import asyncio
 import pathlib
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Literal, Optional, Set
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
 import rich
 import rich.markup
@@ -33,7 +33,6 @@ from rbx.box.statements.builders import (
     StatementSample,
 )
 from rbx.box.statements.schema import Statement
-from rbx.box.statements.statement_utils import get_relative_assets
 from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
 from rbx.box.testcase_sample_utils import get_statement_samples
 from rbx.box.testcase_utils import (
@@ -572,11 +571,35 @@ def _get_explanations(explanations: Dict[int, str]) -> str:
     return '\n\n'.join(entries)
 
 
+def _statement_asset_files(
+    statement: Statement,
+) -> List[Tuple[pathlib.Path, pathlib.Path]]:
+    """The statement's resource files: every file under the directory containing
+    its ``file`` (the v2 asset scope, design §3.1), except the statement source
+    itself, as ``(absolute_path, statement-dir-relative_path)`` pairs. The
+    relative path matches how blocks reference the asset, so the resource-key
+    remap in :func:`_upload_statement_resources` lines up."""
+    if statement.file is None:
+        return []
+    source = utils.abspath(statement.file)
+    base = source.parent
+    if not base.is_dir():
+        return []
+    res: List[Tuple[pathlib.Path, pathlib.Path]] = []
+    for path in sorted(base.rglob('*')):
+        if not path.is_file() or path == source:
+            continue
+        res.append((path, path.relative_to(base)))
+    return res
+
+
 def _upload_statement_resources(
     problem: api.Problem, statement: Statement
 ) -> Dict[str, str]:
     res: Dict[str, str] = {}
-    assets = get_relative_assets(statement.path, statement.assets)
+    # v2: assets are the statement-dir subtree (relative to the statement dir),
+    # plus the externalized TikZ figure PDFs (relative to the overlay root).
+    assets = _statement_asset_files(statement)
     assets.extend(get_produced_tikz_pdfs(statement))
     with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
         futures = []

--- a/rbx/box/statements/CLAUDE.md
+++ b/rbx/box/statements/CLAUDE.md
@@ -107,14 +107,37 @@ The build is a pipeline of small, unit-tested pieces:
 - `latex_jinja.py` — the LaTeX-flavored Jinja2 env (`\VAR{}`, `%-`, `\BLOCK{}`),
   `JinjaDictWrapper`/`JinjaGroupsGetter`, strict undefined.
 
-## `builders.py` (legacy, kept for the deferred Polygon path)
+## `builders.py` (legacy helpers, kept; classes pending #580)
 
 The v1 `StatementBuilder` classes + `StatementBuilderProblem/Contest` and the
 low-level helpers (`render_jinja`, `render_jinja_blocks`, `StatementBlocks`, TikZ
-externalize helpers) live here. v2 `render.py` reuses the helpers; the builder
-*classes* remain only because the Polygon export path (S12, #568) still imports
-them. `build_statements.get_statement_dir` / `get_produced_tikz_pdfs` /
-`build_statement_bytes` stay stubbed (`NotImplementedError`) until S12.
+externalize helpers `externalize_blocks` / `substitute_externalized_blocks`) live
+here. v2 `render.py` and `engine.py` reuse the helpers (the Polygon export path
+calls the TikZ externalize/substitute helpers directly — see below); the builder
+*classes* are unused and slated for deletion in #580.
+
+## Polygon export (S12, #568) — `build_statements` + `polygon/statement_block_utils`
+
+The Polygon API upload (`rbx package polygon --upload` / `--validate-statement`)
+consumes the v2 overlay directly. The standalone overlay root
+(`build/statements/st/<lang>-<variant>/`) **is** the Polygon "statement dir":
+
+- The packager forces `externalize`+`demacro` via
+  `PolygonPackager.statement_export_params()`; `run_packager` builds every
+  statement with them before reading the artifacts.
+- `engine.render_problem_tex(externalize=...)` always writes `blocks.yml` (the
+  raw blocks — source of truth) and, when externalizing, labels per-block TikZ
+  before the compile (so `\tikzexternalize` emits one PDF per figure) and writes
+  `blocks.ext.yml` (labeled) / `blocks.sub.yml` (TikZ → `\includegraphics`).
+- `build_statements.get_statement_dir(statement)` returns that overlay root;
+  `get_produced_tikz_pdfs` globs its `artifacts/tikz_figures/*.pdf`.
+- `polygon/statement_block_utils.get_processed_statement_blocks` reads
+  `blocks.sub.yml` + `macros.json` from that single dir, expands/filters macros
+  and converts to Polygon TeX (`polygon_utils.py`). No per-builder subdirs, no
+  absolute/temp paths.
+
+The **offline** Polygon packager (embedding PDFs in `problem.zip` /
+`contest.zip`) is a separate follow-up (#583).
 
 ## Template context namespaces (design §4)
 
@@ -132,5 +155,6 @@ Per-sample handles: `sample.input`/`output` (root-relative), `sample.dir` +
 
 ## Polygon integration (`polygon_utils.py`)
 
-Helpers extracting statement sections for Polygon upload — consumed by the
-deferred S12 export path.
+Helpers extracting/validating statement sections for Polygon upload
+(`convert_to_polygon_tex`, `validate_polygon_tex`, `PolygonTeXConfig`) — consumed
+by the S12 export path (see "Polygon export" above).

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -9,7 +9,6 @@ import typer
 from rbx import annotations, console, utils
 from rbx.box import environment, limits_info, naming, package
 from rbx.box.contest import contest_package
-from rbx.box.contest.schema import ContestStatement
 from rbx.box.formatting import href
 from rbx.box.schema import Package, expand_any_vars
 from rbx.box.statements import engine, overlay, render, resolver
@@ -34,14 +33,6 @@ app = typer.Typer(no_args_is_help=True, cls=annotations.AliasGroup)
 # tut`. It reuses the very same engine as `statements` — only the section read
 # and the output filename prefix differ (StatementKind).
 tutorials_app = typer.Typer(no_args_is_help=True, cls=annotations.AliasGroup)
-
-# statements v2: the Polygon export path (S12, #568) still consumes the v1
-# per-builder build dirs / TikZ artifacts. Those entry points stay stubbed until
-# the packager is reworked; the standalone build (this module) is rebuilt below.
-_V2_POLYGON_PENDING = (
-    'statements v2: the Polygon export build path is not wired yet; it lands in '
-    '#568 (S12). See docs/plans/2026-06-09-statements-v2-design.md §7.'
-)
 
 
 def get_environment_languages_for_statement() -> List[StatementCodeLanguage]:
@@ -245,39 +236,35 @@ def get_builders(
     return reconfigured_builders
 
 
-# --- Polygon export path (deferred to S12); kept importable. ---
+# --- Polygon export path (S12, #568). ---
+#
+# The v2 standalone overlay root IS the Polygon "statement dir": after the
+# packager builds a statement with externalize+demacro forced, that single,
+# all-relative directory holds blocks.*.yml (the source of truth), macros.json,
+# and artifacts/tikz_figures/*.pdf. These readers point the Polygon block/TikZ
+# extraction at it — no per-builder subdirs, no absolute/temp paths (design §6.5).
 
 
-def get_statement_dir(
-    statement: Statement, builder_name: Optional[str] = None
-) -> pathlib.Path:
-    """[deferred S12] The per-builder Polygon scratch dir. Stubbed until #568."""
-    raise NotImplementedError(_V2_POLYGON_PENDING)
+def get_statement_dir(statement: Statement) -> pathlib.Path:
+    """The standalone overlay root for this problem statement — the Polygon
+    source dir holding ``blocks.*.yml``, ``macros.json`` and
+    ``artifacts/tikz_figures/*.pdf`` after a forced-externalize build."""
+    d = _standalone_overlay_path(statement)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
 def get_produced_tikz_pdfs(
     statement: Statement,
 ) -> Iterable[Tuple[pathlib.Path, pathlib.Path]]:
-    """[deferred S12] Externalized TikZ PDFs for Polygon resource upload. Stubbed
-    until #568."""
-    raise NotImplementedError(_V2_POLYGON_PENDING)
+    """The externalized per-block TikZ figure PDFs produced by the forced
+    externalize build, yielded as ``(absolute_path, overlay_relative_path)`` for
+    Polygon resource upload."""
+    from rbx.box.statements.texsoup_utils import EXTERNALIZATION_DIR
 
-
-async def build_statement_bytes(
-    statement: Statement,
-    pkg: Package,
-    output_type: Optional[StatementType] = None,
-    short_name: Optional[str] = None,
-    overridden_params_root: pathlib.Path = pathlib.Path(),
-    overridden_params: Optional[Dict[ConversionType, ConversionStep]] = None,
-    overridden_assets: Optional[List[Tuple[pathlib.Path, pathlib.Path]]] = None,
-    use_samples: bool = True,
-    custom_vars: Optional[Dict[str, Any]] = None,
-    inherited_from: Optional['ContestStatement'] = None,
-) -> Tuple[bytes, StatementType]:
-    """[deferred S12] The v1 byte-level build the Polygon block extractor relied
-    on. Stubbed until #568; the v2 standalone build is :func:`build_statement`."""
-    raise NotImplementedError(_V2_POLYGON_PENDING)
+    d = get_statement_dir(statement)
+    for pdf in sorted((d / EXTERNALIZATION_DIR).glob('**/*.pdf')):
+        yield pdf, pdf.relative_to(d)
 
 
 # --- v2 standalone build (S9). ---
@@ -316,6 +303,18 @@ def needs_samples(statement: Statement) -> bool:
     return statement.samples
 
 
+def _standalone_overlay_path(statement: Statement) -> pathlib.Path:
+    """The standalone overlay root path for this statement, keyed by
+    ``(language, variant)`` under the shared ``build/statements`` dir. Pure path
+    computation (no side effects) so the Polygon readers
+    (:func:`get_statement_dir`) can locate the artifacts a build left behind."""
+    return (
+        package.get_statements_build_path()
+        / 'st'
+        / f'{statement.language}-{statement.variant}'
+    )
+
+
 def _standalone_overlay_root(statement: Statement) -> pathlib.Path:
     """The isolated *scratch* overlay root for this statement's standalone build.
 
@@ -327,11 +326,7 @@ def _standalone_overlay_root(statement: Statement) -> pathlib.Path:
     runs from it; it is wiped and recreated on every build. The final PDF is
     copied out to :func:`get_statement_build_path`.
     """
-    root = (
-        package.get_statements_build_path()
-        / 'st'
-        / f'{statement.language}-{statement.variant}'
-    )
+    root = _standalone_overlay_path(statement)
     shutil.rmtree(root, ignore_errors=True)
     root.mkdir(parents=True, exist_ok=True)
     return root

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -434,6 +434,9 @@ async def build_statement(
 
     overlay_root = _standalone_overlay_root(statement)
     problem_dir = utils.abspath(statement.file).parent
+    # Resolved up front: externalize drives per-block TikZ labeling during the
+    # render (engine), demacro drives macro extraction during the compile.
+    externalize, demacro = _externalize_demacro(extra_mergeable_params)
 
     if statement.type.is_rbx():
         contest = resolver.require_contest_for_problem()
@@ -501,6 +504,7 @@ async def build_statement(
             samples=samples,
             use_samples=use_samples,
             statement_type=statement.type,
+            externalize=externalize,
         )
     else:
         # Static tex / md: mirror the statement-dir subtree so assets resolve,
@@ -508,7 +512,6 @@ async def build_statement(
         overlay.mirror_tree(problem_dir, overlay_root)
         tex = statement.file.read_bytes()
 
-    externalize, demacro = _externalize_demacro(extra_mergeable_params)
     output_bytes = _emit_output(
         overlay_root,
         tex,

--- a/rbx/box/statements/engine.py
+++ b/rbx/box/statements/engine.py
@@ -73,6 +73,7 @@ def render_problem_tex(
     samples: List[StatementSample],
     use_samples: bool,
     statement_type: StatementType,
+    externalize: bool = False,
 ) -> bytes:
     """Render one problem statement to TeX bytes.
 
@@ -82,6 +83,13 @@ def render_problem_tex(
     isolated ``.problems/<SHORT>/`` for a join). ``root_prefix`` is
     ``problem_root`` relative to the overlay root, anchoring root-relative sample
     I/O for ``\\VerbatimInput``.
+
+    ``blocks.yml`` (the raw extracted blocks) is always persisted to
+    ``problem_root`` as the Polygon source of truth. When ``externalize`` is set
+    (the Polygon export path), per-block TikZ figures are labeled before the
+    full-doc compile so ``\\tikzexternalize`` emits one PDF per figure, and
+    ``blocks.ext.yml`` (labeled) / ``blocks.sub.yml`` (TikZ replaced by
+    ``\\includegraphics``) are persisted too — replicating the v1 rbxTeX builder.
     """
     mode = _mode_for(statement_type)
 
@@ -96,10 +104,39 @@ def render_problem_tex(
         contest=contest,
         mode=mode,
     )
+    # Always persist the raw blocks — the Polygon source of truth (design §1).
+    _write_blocks(problem_root, 'blocks.yml', blocks)
+
+    # LaTeX-form blocks/explanations: the (LaTeX) template and the TikZ
+    # externalization operate on TeX, so rbxMarkdown blocks are converted first
+    # (mirrors the v1 rbxMarkdown->rbxTeX step).
+    latex_blocks = (
+        {name: _md_to_latex(value) for name, value in blocks.blocks.items()}
+        if mode == 'markdown'
+        else dict(blocks.blocks)
+    )
+    latex_explanations = (
+        {i: _md_to_latex(value) for i, value in blocks.explanations.items()}
+        if mode == 'markdown'
+        else dict(blocks.explanations)
+    )
+
+    # Per-block TikZ labeling must happen before the full-doc compile so the
+    # externalized PDF filenames match the labels the substitution rewrites to.
+    if externalize:
+        latex_blocks = builders.externalize_blocks(latex_blocks)
+        latex_explanations = builders.externalize_blocks(latex_explanations)
+        _write_blocks(
+            problem_root,
+            'blocks.ext.yml',
+            builders.StatementBlocks(
+                blocks=latex_blocks, explanations=latex_explanations
+            ),
+        )
 
     # 2. Sample staging into <problem_root>/.samples/. Explanations are always
-    #    `\subimport`-ed by a LaTeX template, so for rbxMarkdown we convert the
-    #    rendered explanation (block- or file-sourced) to LaTeX before staging.
+    #    `\subimport`-ed by a LaTeX template; they carry the externalization
+    #    labels (when externalizing) so their figures externalize too.
     if use_samples and samples:
         kwargs = _problem_jinja_kwargs(
             lang=lang, languages=languages, problem=problem, contest=contest
@@ -116,35 +153,22 @@ def render_problem_tex(
                 problem_root, c, mode=m, **kwargs
             ).blocks
 
-        explanation_blocks = blocks.explanations
-        if mode == 'markdown':
-            explanation_blocks = {
-                i: _md_to_latex(value) for i, value in explanation_blocks.items()
-            }
-
         sources = [to_sample_source(s) for s in samples]
         problem.samples = sample_staging.stage_samples(
             problem_root,
             root_prefix,
             sources,
-            explanation_blocks=explanation_blocks,
+            explanation_blocks=latex_explanations,
             render_text=render_text,
             render_blocks=render_blocks,
             lang=lang,
             mode=mode,
         )
 
-    # rbxMarkdown: the extracted blocks are Markdown; convert them to LaTeX so the
-    # (LaTeX) template can splice them in (mirrors the v1 rbxMarkdown->rbxTeX step).
-    if mode == 'markdown':
-        problem.blocks = {
-            name: _md_to_latex(value) for name, value in blocks.blocks.items()
-        }
-    else:
-        problem.blocks = blocks.blocks
+    problem.blocks = latex_blocks
 
     # 3. Render the template (loaded from render_root where it was staged).
-    return render.render_problem_document(
+    tex = render.render_problem_document(
         render_root,
         template_rel,
         lang=lang,
@@ -152,6 +176,30 @@ def render_problem_tex(
         problem=problem,
         contest=contest,
     )
+
+    # The substituted blocks (TikZ -> \includegraphics) are what Polygon uploads;
+    # persist them next to the figure PDFs the compile produces.
+    if externalize:
+        _write_blocks(
+            problem_root,
+            'blocks.sub.yml',
+            builders.StatementBlocks(
+                blocks=builders.substitute_externalized_blocks(latex_blocks),
+                explanations=builders.substitute_externalized_blocks(
+                    latex_explanations
+                ),
+            ),
+        )
+
+    return tex
+
+
+def _write_blocks(
+    root: pathlib.Path, name: str, blocks: builders.StatementBlocks
+) -> None:
+    """Persist a :class:`StatementBlocks` as YAML in ``root`` (the overlay /
+    problem root), the source of truth the Polygon export path reads."""
+    (root / name).write_text(utils.model_to_yaml(blocks))
 
 
 def relativize_template(

--- a/rbx/box/statements/texsoup_utils.py
+++ b/rbx/box/statements/texsoup_utils.py
@@ -28,51 +28,22 @@ def parse_latex(latex_code: str) -> TexNode:
 
 
 def inject_in_preamble(soup: TexNode, latex_code: str):
+    r"""Inject ``latex_code`` into the preamble, right after ``\documentclass``.
+
+    Uses :meth:`TexNode.replace_with` on the ``\documentclass`` node itself rather
+    than sibling-index insertion: TexSoup's ``parent.insert`` indexes the
+    *children* space (which excludes comments), so a leading comment line — as in
+    every default-preset template — offsets the index and drops the preamble
+    *before* ``\documentclass`` (``! LaTeX Error: \usepackage before
+    \documentclass``, #568). Replacing the node sidesteps the index math
+    entirely. When there is no ``\documentclass`` the code is prepended.
     """
-    Injects LaTeX code into the preamble (after documentclass).
-    """
-    new_nodes = TexSoup(latex_code)
     doc_class = soup.find('documentclass')
-
-    if doc_class:
-        # Insert after documentclass.
-        # We access the parent (usually root) and insert at the correct index.
-        parent = doc_class.parent
-
-        # Find index robustly to handle potential TexSoup node wrapper issues
-        index = -1
-        contents = list(parent.contents)
-        target_pos = getattr(doc_class, 'position', None)
-        doc_str = str(doc_class)
-
-        for i, child in enumerate(contents):
-            # Try identity first
-            if child is doc_class:
-                index = i
-                break
-            # Fallback to position matching
-            if target_pos is not None:
-                if getattr(child, 'position', None) == target_pos:
-                    index = i
-                    break
-            # Fallback to string matching (safe for documentclass as it's typically unique)
-            if str(child) == doc_str:
-                index = i
-                break
-
-        if index != -1:
-            # Insert the new nodes (unpacked)
-            for node in reversed(list(new_nodes.contents)):
-                # TexSoup requires nodes to be parentless or copied when inserting
-                if isinstance(node, TexNode):
-                    node = node.copy()
-                parent.insert(index + 1, node)
-        else:
-            # Fallback if we couldn't find the node in parent (shouldn't happen usually)
-            soup.insert(0, new_nodes)
+    if doc_class is not None:
+        combined = TexSoup(str(doc_class) + '\n' + latex_code)
+        doc_class.replace_with(*combined.contents)
     else:
-        # No documentclass found, insert at top
-        soup.insert(0, new_nodes)
+        soup.insert(0, TexSoup(latex_code))
 
 
 def inject_externalization_for_tikz(soup: TexNode):

--- a/rbx/testdata/contests/statements_v2_polygon/A/problem.rbx.yml
+++ b/rbx/testdata/contests/statements_v2_polygon/A/problem.rbx.yml
@@ -1,0 +1,12 @@
+name: 'problem-a'
+timeLimit: 1000
+memoryLimit: 256
+vars:
+  author: 'Alice'
+statements:
+  - language: 'en'
+    title: 'Problem A'
+    file: 'statement/statement.rbx.tex'
+    type: 'rbxTeX'
+    params:
+      show_limits: true

--- a/rbx/testdata/contests/statements_v2_polygon/A/statement/statement.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_polygon/A/statement/statement.rbx.tex
@@ -1,0 +1,18 @@
+%- block defs
+\newcommand{\NN}{\mathbb{N}}
+%- endblock
+%- block legend
+Problem A by \VAR{vars.author}. Numbers live in $\NN$.
+\begin{tikzpicture}
+  \draw (0, 0) -- (1, 1);
+\end{tikzpicture}
+%- endblock
+%- block input
+A single integer $n$.
+%- endblock
+%- block output
+Print $n$.
+%- endblock
+%- block notes
+Be careful with $\NN$.
+%- endblock

--- a/rbx/testdata/contests/statements_v2_polygon/contest.rbx.yml
+++ b/rbx/testdata/contests/statements_v2_polygon/contest.rbx.yml
@@ -1,0 +1,15 @@
+---
+name: 'sv2poly'
+titles:
+  en: 'Statements v2 Polygon Contest'
+vars:
+  year: 2026
+problems:
+  - short_name: 'A'
+statements:
+  - name: 'main-en'
+    language: 'en'
+    file: 'statements/contest.rbx.tex'
+    type: 'rbxTeX'
+    standaloneProblemTemplate: 'statements/problem-standalone.rbx.tex'
+    contestProblemTemplate: 'statements/problem-in-contest.rbx.tex'

--- a/rbx/testdata/contests/statements_v2_polygon/statements/contest.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_polygon/statements/contest.rbx.tex
@@ -1,0 +1,24 @@
+\documentclass[a4paper,11pt]{article}
+\usepackage{import}
+\usepackage{graphicx}
+\usepackage{fancyvrb}
+\usepackage{tikz}
+\newcommand{\example}[2]{%
+  \par\noindent\textbf{Input}\par
+  \VerbatimInput{#1}%
+  \par\noindent\textbf{Output}\par
+  \VerbatimInput{#2}%
+  \par
+}
+\begin{document}
+
+\begin{center}
+  {\Large \VAR{contest.title | escape}}
+\end{center}
+
+%- for problem in problems
+  \subimport{\VAR{problem.import_dir}}{\VAR{problem.import_file}}
+  \clearpage
+%- endfor
+
+\end{document}

--- a/rbx/testdata/contests/statements_v2_polygon/statements/problem-in-contest.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_polygon/statements/problem-in-contest.rbx.tex
@@ -1,0 +1,9 @@
+\section*{Problem \VAR{problem.short_name}. \VAR{problem.title | escape}}
+
+\VAR{problem.blocks.legend}
+
+\subsection*{Input}
+\VAR{problem.blocks.input}
+
+\subsection*{Output}
+\VAR{problem.blocks.output}

--- a/rbx/testdata/contests/statements_v2_polygon/statements/problem-standalone.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_polygon/statements/problem-standalone.rbx.tex
@@ -1,0 +1,30 @@
+\documentclass[a4paper,11pt]{article}
+\usepackage{import}
+\usepackage{graphicx}
+\usepackage{fancyvrb}
+\usepackage{tikz}
+\newcommand{\example}[2]{%
+  \par\noindent\textbf{Input}\par
+  \VerbatimInput{#1}%
+  \par\noindent\textbf{Output}\par
+  \VerbatimInput{#2}%
+  \par
+}
+\begin{document}
+
+\section*{\VAR{problem.title | escape}}
+
+\VAR{problem.blocks.legend}
+
+\subsection*{Input}
+\VAR{problem.blocks.input}
+
+\subsection*{Output}
+\VAR{problem.blocks.output}
+
+%- if problem.blocks.notes is defined
+  \subsection*{Notes}
+  \VAR{problem.blocks.notes}
+%- endif
+
+\end{document}

--- a/tests/rbx/box/packaging/test_packager_export_params.py
+++ b/tests/rbx/box/packaging/test_packager_export_params.py
@@ -1,0 +1,16 @@
+from rbx.box.packaging.boca.packager import BocaPackager
+from rbx.box.packaging.polygon.packager import PolygonPackager
+from rbx.box.statements.schema import ConversionType
+
+
+def test_polygon_packager_forces_externalize_and_demacro():
+    poly = PolygonPackager(testcase_entries=[])
+    by_type = {step.type: step for step in poly.statement_export_params()}
+    assert by_type[ConversionType.rbxToTex].externalize is True
+    assert by_type[ConversionType.TexToPDF].externalize is True
+    assert by_type[ConversionType.TexToPDF].demacro is True
+
+
+def test_non_polygon_packager_has_no_export_params():
+    boca = BocaPackager(testcase_entries=[])
+    assert boca.statement_export_params() == []

--- a/tests/rbx/box/statements/test_engine_blocks.py
+++ b/tests/rbx/box/statements/test_engine_blocks.py
@@ -1,0 +1,80 @@
+import pathlib
+
+import pytest
+
+from rbx import utils
+from rbx.box import cd, package, package_utils
+from rbx.box.statements import build_statements
+from rbx.box.statements.builders import StatementBlocks
+from rbx.box.statements.schema import (
+    ConversionType,
+    StatementType,
+    TexToPDF,
+    rbxToTeX,
+)
+
+
+def _externalize_params():
+    return [
+        rbxToTeX(type=ConversionType.rbxToTex, externalize=True),
+        TexToPDF(type=ConversionType.TexToPDF, externalize=True, demacro=True),
+    ]
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_render_persists_block_yamls_with_externalization(
+    cleandir_with_testdata,
+):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        pkg = package.find_problem_package_or_die()
+        statement = pkg.expanded_statements[0]
+        await build_statements.build_statement(
+            statement,
+            pkg,
+            output_type=StatementType.TeX,
+            use_samples=False,
+            extra_mergeable_params=_externalize_params(),
+        )
+        overlay = pathlib.Path('build') / 'statements' / 'st' / 'en-default'
+        # All three block YAMLs persisted (source of truth, v1 parity).
+        assert (overlay / 'blocks.yml').is_file()
+        assert (overlay / 'blocks.ext.yml').is_file()
+        assert (overlay / 'blocks.sub.yml').is_file()
+
+        # Raw blocks keep the TikZ picture verbatim.
+        raw = utils.model_from_yaml(
+            StatementBlocks, (overlay / 'blocks.yml').read_text()
+        )
+        assert 'tikzpicture' in raw.blocks['legend']
+
+        # Substituted blocks replaced the TikZ with an \includegraphics handle.
+        sub = utils.model_from_yaml(
+            StatementBlocks, (overlay / 'blocks.sub.yml').read_text()
+        )
+        assert '\\includegraphics' in sub.blocks['legend']
+        assert 'tikzpicture' not in sub.blocks['legend']
+        # Non-figure blocks survive untouched.
+        assert 'integer' in sub.blocks['input']
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_render_without_externalize_writes_only_blocks_yml(
+    cleandir_with_testdata,
+):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        pkg = package.find_problem_package_or_die()
+        statement = pkg.expanded_statements[0]
+        await build_statements.build_statement(
+            statement,
+            pkg,
+            output_type=StatementType.TeX,
+            use_samples=False,
+        )
+        overlay = pathlib.Path('build') / 'statements' / 'st' / 'en-default'
+        # blocks.yml is the always-on source of truth ...
+        assert (overlay / 'blocks.yml').is_file()
+        # ... but the externalized variants are only produced on demand.
+        assert not (overlay / 'blocks.ext.yml').exists()
+        assert not (overlay / 'blocks.sub.yml').exists()

--- a/tests/rbx/box/statements/test_polygon_export.py
+++ b/tests/rbx/box/statements/test_polygon_export.py
@@ -1,0 +1,36 @@
+import pathlib
+
+import pytest
+
+from rbx.box import cd, package, package_utils
+from rbx.box.statements import build_statements
+from rbx.box.statements.texsoup_utils import EXTERNALIZATION_DIR
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_get_statement_dir_is_overlay_root(cleandir_with_testdata):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        st = package.find_problem_package_or_die().expanded_statements[0]
+        d = build_statements.get_statement_dir(st)
+        # Keyed by (language, variant) under the shared statements build dir.
+        assert d.parts[-3:] == ('statements', 'st', 'en-default')
+        assert d.is_dir()
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_get_produced_tikz_pdfs_globs_externalization_dir(
+    cleandir_with_testdata,
+):
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        st = package.find_problem_package_or_die().expanded_statements[0]
+        d = build_statements.get_statement_dir(st)
+        (d / EXTERNALIZATION_DIR).mkdir(parents=True, exist_ok=True)
+        (d / EXTERNALIZATION_DIR / 'legend_0.pdf').write_bytes(b'%PDF-1.5')
+
+        produced = list(build_statements.get_produced_tikz_pdfs(st))
+        assert len(produced) == 1
+        abspath, rel = produced[0]
+        assert rel == pathlib.Path(EXTERNALIZATION_DIR) / 'legend_0.pdf'
+        assert abspath.is_file()

--- a/tests/rbx/box/statements/test_polygon_export.py
+++ b/tests/rbx/box/statements/test_polygon_export.py
@@ -4,7 +4,20 @@ import pytest
 
 from rbx.box import cd, package, package_utils
 from rbx.box.statements import build_statements
+from rbx.box.statements.schema import (
+    ConversionType,
+    StatementType,
+    TexToPDF,
+    rbxToTeX,
+)
 from rbx.box.statements.texsoup_utils import EXTERNALIZATION_DIR
+
+
+def _externalize_params():
+    return [
+        rbxToTeX(type=ConversionType.rbxToTex, externalize=True),
+        TexToPDF(type=ConversionType.TexToPDF, externalize=True, demacro=True),
+    ]
 
 
 @pytest.mark.test_pkg('contests/statements_v2_polygon')
@@ -34,3 +47,57 @@ async def test_get_produced_tikz_pdfs_globs_externalization_dir(
         abspath, rel = produced[0]
         assert rel == pathlib.Path(EXTERNALIZATION_DIR) / 'legend_0.pdf'
         assert abspath.is_file()
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_get_processed_statement_blocks_reads_overlay(cleandir_with_testdata):
+    from rbx.box.packaging.polygon import statement_block_utils as sbu
+
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        pkg = package.find_problem_package_or_die()
+        st = pkg.expanded_statements[0]
+        await build_statements.build_statement(
+            st,
+            pkg,
+            output_type=StatementType.TeX,
+            use_samples=False,
+            extra_mergeable_params=_externalize_params(),
+        )
+
+        blocks = sbu.get_processed_statement_blocks(st)
+        # The Polygon-bound blocks come straight from the overlay's blocks.sub.yml.
+        assert 'legend' in blocks.blocks
+        assert 'input' in blocks.blocks
+        assert 'output' in blocks.blocks
+        # The legend's TikZ was substituted for an \includegraphics handle.
+        assert '\\includegraphics' in blocks.blocks['legend']
+        assert 'tikzpicture' not in blocks.blocks['legend']
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_processed_blocks_expand_macros_when_present(cleandir_with_testdata):
+    from rbx.box.packaging.polygon import statement_block_utils as sbu
+    from rbx.box.statements.demacro_utils import MacroDefinitions
+
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        pkg = package.find_problem_package_or_die()
+        st = pkg.expanded_statements[0]
+        await build_statements.build_statement(
+            st,
+            pkg,
+            output_type=StatementType.TeX,
+            use_samples=False,
+            extra_mergeable_params=_externalize_params(),
+        )
+        # Simulate what the demacro compile pass drops in the overlay; the defs
+        # block (\NN) is collected and expanded out of the Polygon blocks since
+        # \NN is not a Polygon-allowed command.
+        MacroDefinitions().to_json_file(
+            build_statements.get_statement_dir(st) / 'macros.json'
+        )
+
+        blocks = sbu.get_processed_statement_blocks(st)
+        assert '\\NN' not in blocks.blocks['notes']
+        assert 'mathbb' in blocks.blocks['notes']

--- a/tests/rbx/box/statements/test_polygon_export.py
+++ b/tests/rbx/box/statements/test_polygon_export.py
@@ -101,3 +101,25 @@ async def test_processed_blocks_expand_macros_when_present(cleandir_with_testdat
         blocks = sbu.get_processed_statement_blocks(st)
         assert '\\NN' not in blocks.blocks['notes']
         assert 'mathbb' in blocks.blocks['notes']
+
+
+@pytest.mark.test_pkg('contests/statements_v2_polygon')
+async def test_statement_asset_files_walks_source_dir(cleandir_with_testdata):
+    from rbx.box.packaging.polygon.upload import _statement_asset_files
+
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        st = package.find_problem_package_or_die().expanded_statements[0]
+        # Drop an image asset next to the statement source (the v2 asset scope is
+        # the whole statement-file directory).
+        (pathlib.Path('statement') / 'imgs').mkdir(parents=True, exist_ok=True)
+        (pathlib.Path('statement') / 'imgs' / 'fig.png').write_bytes(b'x')
+
+        assets = {
+            rel.as_posix(): abspath for abspath, rel in _statement_asset_files(st)
+        }
+        # The asset is enumerated relative to the statement directory ...
+        assert 'imgs/fig.png' in assets
+        assert assets['imgs/fig.png'].is_file()
+        # ... but the statement source file itself is not a resource.
+        assert 'statement.rbx.tex' not in assets

--- a/tests/rbx/box/statements/test_texsoup_utils.py
+++ b/tests/rbx/box/statements/test_texsoup_utils.py
@@ -113,6 +113,24 @@ Hello
     assert s.strip().startswith(r'\usepackage{bar}')
 
 
+def test_inject_in_preamble_after_leading_comment():
+    # Preset templates start with a `%%` comment before \documentclass; the
+    # preamble must still land AFTER \documentclass (regression for the Polygon
+    # externalize path emitting "\usepackage before \documentclass", #568).
+    latex = r"""%% header comment
+\documentclass[a4paper,11pt]{article}
+\begin{document}
+Hello
+\end{document}"""
+    soup = TexSoup(latex)
+    inject_in_preamble(soup, r'\usepackage{foo}')
+
+    s = str(soup)
+    assert r'\documentclass[a4paper,11pt]{article}' in s
+    assert r'\usepackage{foo}' in s
+    assert s.index(r'\documentclass') < s.index(r'\usepackage{foo}')
+
+
 def test_inject_externalization_for_tikz():
     latex = r"""\documentclass{article}
 \begin{document}
@@ -124,6 +142,20 @@ def test_inject_externalization_for_tikz():
     assert r'\usepackage{tikz}' in s
     assert r'\usetikzlibrary{external}' in s
     assert r'\tikzexternalize[prefix=artifacts/tikz_figures/]' in s
+
+
+def test_inject_externalization_after_leading_comment():
+    # The full externalization preamble must follow \documentclass even when a
+    # comment leads the document (the default-preset template shape).
+    latex = r"""%% Standalone problem template.
+\documentclass[a4paper,11pt]{article}
+\begin{document}
+\end{document}"""
+    soup = TexSoup(latex)
+    inject_externalization_for_tikz(soup)
+
+    s = str(soup)
+    assert s.index(r'\documentclass') < s.index(r'\usepackage{tikz}')
 
 
 def test_get_top_level_tikz_nodes_flat():


### PR DESCRIPTION
Closes #568 (S12 of the statements-v2 migration, design `docs/plans/2026-06-09-statements-v2-design.md` §2/§6.5). Depends on #566 (merged).

## What

Reworks the **Polygon API upload** path (`rbx package polygon --upload` / `--validate-statement`) onto statements v2: it consumes the now-portable, self-contained overlay TeX, drops the absolute-/temp-path special-casing, and keeps forcing `externalize`/`demacro` at export time (no longer schema fields). The v1 behaviors the setter relied on — **block production** (the `blocks.*.yml` files in the build dir, the source of truth for Polygon blocks) and **TikZ production** (externalized per-block figure PDFs uploaded as resources) — are replicated on the v2 overlay.

> Per discussion, scope here is the **API upload**. Re-enabling statement embedding in the *offline* `problem.zip` / `contest.zip` packagers is split to a follow-up: **#583**.

## Key idea: the v2 overlay root *is* the "statement dir"

The standalone overlay (`build/statements/st/<lang>-<variant>/`) already stages an all-relative, self-contained tree, runs `pdflatex` from it, and (with externalize+demacro) drops `macros.json` + `artifacts/tikz_figures/*.pdf` there. This PR makes that overlay the single Polygon source dir and persists the block YAMLs beside those artifacts — the per-builder scratch subdirs and absolute/temp paths collapse into one portable dir (design §6.5). `run_packager` already builds every statement with the toggles forced *before* the upload reads the artifacts.

## Changes

- **`engine.render_problem_tex`** — always writes `blocks.yml` (raw, source of truth); when externalizing, labels per-block TikZ before the full-doc compile (so `\tikzexternalize` emits one PDF per figure) and writes `blocks.ext.yml` (labeled) / `blocks.sub.yml` (TikZ → `\includegraphics`). Reuses the v1 helpers (`externalize_blocks` / `substitute_externalized_blocks`).
- **`build_statements`** — un-stubs `get_statement_dir` (→ the overlay root) and `get_produced_tikz_pdfs` (→ globs `artifacts/tikz_figures/*.pdf`); deletes the dead `build_statement_bytes` stub.
- **`polygon/statement_block_utils`** — reads `blocks.sub.yml` + `macros.json` from the single overlay root (no per-builder subdirs / builder imports).
- **`polygon/upload`** — drops the removed `statement.path` / `statement.assets`; statement resources = the statement-dir subtree (the v2 asset scope) + `get_produced_tikz_pdfs`.
- **`packaging/packager` + `polygon/packager`** — replaces the `name=='polygon'` special-case with a `BasePackager.statement_export_params()` hook, overridden by `PolygonPackager` to force externalize+demacro.

## Tests

New v2 testdata fixture (`contests/statements_v2_polygon`, a `defs` block + inline TikZ) drives:
- `test_engine_blocks.py` — block-YAML persistence + per-block TikZ substitution.
- `test_polygon_export.py` — `get_statement_dir` / `get_produced_tikz_pdfs` mapping, `get_processed_statement_blocks` (incl. macro expansion), asset enumeration.
- `test_packager_export_params.py` — Polygon forces externalize+demacro; others don't.

Statements (236), contest (90) and packaging-non-e2e (440) suites are green. Live `--upload` is Polygon-API-bound and verified manually, not in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)