### PR TITLE
feat(contest): configurable problem label in rbx on/each command app

### DIFF
--- a/docs/plans/2026-06-10-configurable-contest-problem-label-design.md
+++ b/docs/plans/2026-06-10-configurable-contest-problem-label-design.md
@@ -1,0 +1,177 @@
+# Configurable contest problem label — Design
+
+Tracking issue: [#582 — The command app UI shown by `rbx on` and `rbx each` should show problem names](https://github.com/rsalesc/rbx/issues/582)
+Status: **approved design**, ready for implementation.
+Date: 2026-06-10
+
+## 1. Motivation
+
+The command app launched by `rbx on` and `rbx each` shows a sidebar listing the
+contest problems. Since #467 each entry already reads `A. {problem_name}` (via
+`naming.get_contest_problem_label`), not just the bare short name. The remaining
+ask in #582 is to make **what is shown after the short name configurable and
+persistent**, with three modes:
+
+- `name` — the problem name from `problem.rbx.yml` (default, current behavior)
+- `title` — the problem's statement title, falling back to the name
+- `path` — the problem path relative to the contest
+
+## 2. Decisions (resolved during brainstorming)
+
+1. **Config home = `SetterConfig`.** The setting lives in
+   `~/.config/rbx/setter_config.yml` (editable via `rbx config edit`), matching
+   the existing persistent-preference pattern and the issue's `ui` label. Not in
+   `config.json` (that file is about languages/credentials).
+2. **In-app cycle key.** Besides the config file, the command app gets a key
+   (`l`, mnemonic = **l**abel) that cycles `name → title → path` live and
+   persists the choice. Chosen over a config-file-only approach for TUI
+   ergonomics.
+3. **Separator unchanged.** Labels stay `A. {suffix}` (period + space). The
+   issue's `A - {name}` was described loosely ("something like"); keeping `. `
+   avoids churn and keeps the three existing `test_naming.py` assertions green.
+4. **Title language = auto.** No language-selection field. `title` mode uses the
+   problem's title only when the package has **exactly one** title; with zero or
+   multiple titles it falls back to the name. (`config.defaultLanguage` is a
+   *programming* language, so it cannot drive this; an explicit human-language
+   field was rejected as YAGNI for now.)
+5. **No new CLI subcommand.** Editing the config file plus the `l` key satisfy
+   "persistent option to configure"; a dedicated `rbx config set ...` command is
+   out of scope.
+
+## 3. Components
+
+### 3.1 `SetterConfig` (`rbx/box/setter_config.py`)
+
+```python
+class ProblemLabelMode(str, enum.Enum):   # iteration order defines the cycle
+    NAME = 'name'
+    TITLE = 'title'
+    PATH = 'path'
+
+class UIConfig(BaseModel):
+    problem_label: ProblemLabelMode = Field(
+        default=ProblemLabelMode.NAME,
+        description=...,
+    )
+
+class SetterConfig(BaseModel):
+    ...
+    ui: UIConfig = Field(default_factory=UIConfig, ...)
+```
+
+Documented (with the three modes and the `l`-to-cycle hint) in both
+`rbx/resources/default_setter_config.yml` and `default_setter_config.mac.yml`.
+Because `ui` has a `default_factory`, existing on-disk configs without a `ui:`
+key keep working (defaults to `name`).
+
+### 3.2 Label logic (`rbx/box/naming.py`)
+
+Split the current `get_contest_problem_label` into a pure formatter plus thin
+wrappers:
+
+```python
+def format_contest_problem_label(
+    short_name: str, *, name: Optional[str], title: Optional[str],
+    path: Optional[pathlib.Path], mode: ProblemLabelMode,
+) -> str:
+    if mode is ProblemLabelMode.PATH:
+        suffix = str(path) if path is not None else None
+    elif mode is ProblemLabelMode.TITLE:
+        suffix = title or name
+    else:
+        suffix = name
+    if not suffix:
+        return short_name           # preserves today's fallback
+    return f'{short_name}. {suffix}'
+
+def _single_title(pkg: Package) -> Optional[str]:
+    return next(iter(pkg.titles.values())) if len(pkg.titles) == 1 else None
+
+def get_contest_problem_label(problem: ContestProblem) -> str:
+    mode = setter_config.get_setter_config().ui.problem_label
+    pkg = package.find_problem_package(problem.get_path())
+    return format_contest_problem_label(
+        problem.short_name,
+        name=pkg.name if pkg else None,
+        title=_single_title(pkg) if pkg else None,
+        path=problem.get_path(),
+        mode=mode,
+    )
+
+def get_contest_problem_labels(problem: ContestProblem) -> Dict[ProblemLabelMode, str]:
+    """All three variants, computed from a single package load, for the UI."""
+    pkg = package.find_problem_package(problem.get_path())
+    name = pkg.name if pkg else None
+    title = _single_title(pkg) if pkg else None
+    return {
+        mode: format_contest_problem_label(
+            problem.short_name, name=name, title=title,
+            path=problem.get_path(), mode=mode)
+        for mode in ProblemLabelMode
+    }
+```
+
+`get_contest_problem_label` keeps driving the single-problem status line
+(`contest/main.py:402`). No import cycle: `setter_config` does not import
+`naming`.
+
+### 3.3 Live cycle key (`rbx/box/ui/command_app.py`)
+
+- `CommandEntry` gains `labels: Optional[Dict[ProblemLabelMode, str]] = None`.
+- `rbxCommandApp.__init__` seeds `self._label_mode` from
+  `get_setter_config().ui.problem_label`.
+- `_make_tab_label` renders `entry.labels[self._label_mode]` when `labels` is
+  set, else falls back to `entry.display_name` (so the non-contest demo and any
+  label-less entry are unaffected).
+- `on_key`, when the sidebar is focused and at least one entry has `labels`,
+  intercepts `l`: advances `self._label_mode`, calls `save_setter_config`,
+  refreshes every sidebar item (`_update_sidebar`), and toasts the new mode.
+  Guarding on "any entry has labels" keeps `l` falling through to vim-nav
+  elsewhere. The new key is added to `HelpModal`.
+
+### 3.4 Call sites (`rbx/box/contest/main.py`)
+
+The two `start_command_app` builders (`each`, multi-problem `on`) add
+`labels=naming.get_contest_problem_labels(p)` alongside the existing
+`name=naming.get_contest_problem_label(p)`. The package load is
+`@functools.cache`d, so computing both is one disk read.
+
+## 4. Data flow
+
+```
+contest.rbx.yml problems[]  ─▶ ContestProblem(short_name, path)
+  rbx on/each ─▶ naming.get_contest_problem_labels(p)  (loads pkg once)
+            ─▶ {NAME: 'A. aplusb', TITLE: 'A. A+B', PATH: 'A. probs/aplusb'}
+  CommandEntry(labels=…) ─▶ rbxCommandApp._label_mode (from config)
+  sidebar Label = icon + labels[_label_mode]
+  press `l` ─▶ advance _label_mode ─▶ save_setter_config ─▶ refresh sidebar
+```
+
+## 5. Error handling / edge cases
+
+- Package missing or unloadable ⇒ `name`/`title` are `None`; the formatter
+  returns the bare short name (current behavior).
+- Empty `pkg.name` ⇒ bare short name (covered by an existing test).
+- `title` mode with 0 or ≥2 titles ⇒ falls back to the name.
+- `path` mode works even when the package can't load (path comes from
+  `ContestProblem.get_path()`).
+- On-disk configs predating this change have no `ui:` key ⇒ default `name`.
+
+## 6. Testing
+
+- Pure `format_contest_problem_label`: all three modes × {present, missing}
+  name/title/path, plus empty-suffix fallback.
+- `_single_title`: 0 / 1 / ≥2 titles.
+- `get_contest_problem_labels`: returns the correct three-entry dict (mocking
+  `find_problem_package`).
+- `get_contest_problem_label`: honors a patched `ui.problem_label` (auto-title
+  with 0/1/≥2 titles; path mode). Existing three assertions stay green under the
+  default `name` mode.
+- The TUI cycle key has no existing harness; its logic is exercised indirectly
+  and the keybinding is verified manually.
+
+## 7. Out of scope
+
+- Per-language title selection field.
+- A dedicated `rbx config set` command.
+- Changing the `A. ` separator.

--- a/docs/plans/2026-06-10-configurable-contest-problem-label.md
+++ b/docs/plans/2026-06-10-configurable-contest-problem-label.md
@@ -1,0 +1,603 @@
+# Configurable Contest Problem Label Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the problem label shown in the `rbx on` / `rbx each` command-app sidebar configurable (name / title / path) and persistent, with an in-app key to cycle the mode live.
+
+**Architecture:** Add a `ui.problem_label` setting (enum) to the persisted `SetterConfig`. Refactor `naming.get_contest_problem_label` into a pure formatter plus wrappers that read the config and expose all three label variants. Thread the three precomputed variants into `CommandEntry` so the Textual `rbxCommandApp` can swap them with an `l` keybinding that persists the choice.
+
+**Tech Stack:** Python 3, Pydantic v2, Typer, Textual, pytest. Single quotes, absolute imports only (ruff `TID`). Tests via `uv run pytest`.
+
+Design doc: `docs/plans/2026-06-10-configurable-contest-problem-label-design.md`.
+
+---
+
+## Task 1: Add `ProblemLabelMode` + `UIConfig` to SetterConfig
+
+**Files:**
+- Modify: `rbx/box/setter_config.py` (add enum, model, field; `enum` is already imported? check — add `import enum` if missing)
+- Modify: `rbx/resources/default_setter_config.yml`
+- Modify: `rbx/resources/default_setter_config.mac.yml`
+- Test: `tests/rbx/box/test_setter_config.py` (create if absent)
+
+**Step 1: Write the failing test**
+
+Check whether `tests/rbx/box/test_setter_config.py` exists. If not, create it. Add:
+
+```python
+from rbx.box import setter_config
+from rbx.box.setter_config import ProblemLabelMode, SetterConfig
+
+
+def test_ui_problem_label_defaults_to_name():
+    cfg = SetterConfig()
+    assert cfg.ui.problem_label is ProblemLabelMode.NAME
+
+
+def test_ui_config_absent_key_defaults_to_name():
+    # Configs predating this change have no `ui:` key.
+    cfg = SetterConfig.model_validate({})
+    assert cfg.ui.problem_label is ProblemLabelMode.NAME
+
+
+def test_default_resource_setter_config_parses_with_ui():
+    cfg = setter_config.get_default_setter_config()
+    assert cfg.ui.problem_label is ProblemLabelMode.NAME
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_setter_config.py -v`
+Expected: FAIL with `ImportError` / `AttributeError` (no `ProblemLabelMode` / no `cfg.ui`).
+
+**Step 3: Write minimal implementation**
+
+In `rbx/box/setter_config.py`, ensure `import enum` is present at the top. Add near the other config models (before `class SetterConfig`):
+
+```python
+class ProblemLabelMode(str, enum.Enum):
+    """What to display after the short name in the contest command-app sidebar.
+
+    Iteration order defines the in-app cycle order.
+    """
+
+    NAME = 'name'
+    TITLE = 'title'
+    PATH = 'path'
+
+
+class UIConfig(BaseModel):
+    problem_label: ProblemLabelMode = Field(
+        default=ProblemLabelMode.NAME,
+        description='What to show after the short name in the `rbx on`/`rbx each` '
+        'sidebar: `name` (problem name), `title` (the single problem title, '
+        'falling back to the name), or `path` (problem path relative to the '
+        'contest). Press `l` in that UI to cycle this live.',
+    )
+```
+
+Add the field to `SetterConfig` (after `judging`):
+
+```python
+    ui: UIConfig = Field(
+        default_factory=UIConfig,
+        description='Configuration for the interactive UI.',
+    )
+```
+
+In BOTH `rbx/resources/default_setter_config.yml` and `default_setter_config.mac.yml`, append:
+
+```yaml
+
+# How problems are labeled in the `rbx on` / `rbx each` command-app sidebar.
+# Press `l` in that UI to cycle this setting live.
+#
+# name:  problem name from problem.rbx.yml (default)
+# title: the problem's title, if it has exactly one; otherwise the name
+# path:  problem path relative to the contest
+ui:
+  problem_label: name
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_setter_config.py -v`
+Expected: PASS (all three).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/setter_config.py rbx/resources/default_setter_config.yml \
+        rbx/resources/default_setter_config.mac.yml tests/rbx/box/test_setter_config.py
+git commit -m "feat(config): add ui.problem_label setter setting"
+```
+
+---
+
+## Task 2: Pure label formatter + helpers in `naming.py`
+
+**Files:**
+- Modify: `rbx/box/naming.py` (add `Dict` to typing import; add `setter_config` import; refactor `get_contest_problem_label`; add `format_contest_problem_label`, `_single_title`, `get_contest_problem_labels`)
+- Test: `tests/rbx/box/test_naming.py` (extend `TestGetContestProblemLabel`, add new test classes)
+
+**Step 1: Write the failing tests**
+
+In `tests/rbx/box/test_naming.py`, add `from rbx.box.setter_config import ProblemLabelMode` to imports. Add:
+
+```python
+class TestFormatContestProblemLabel:
+    def test_name_mode(self):
+        assert (
+            naming.format_contest_problem_label(
+                'A', name='Two Sum', title='T', path=pathlib.Path('A'),
+                mode=ProblemLabelMode.NAME,
+            )
+            == 'A. Two Sum'
+        )
+
+    def test_title_mode_uses_title(self):
+        assert (
+            naming.format_contest_problem_label(
+                'A', name='two-sum', title='Two Sum', path=pathlib.Path('A'),
+                mode=ProblemLabelMode.TITLE,
+            )
+            == 'A. Two Sum'
+        )
+
+    def test_title_mode_falls_back_to_name(self):
+        assert (
+            naming.format_contest_problem_label(
+                'A', name='two-sum', title=None, path=pathlib.Path('A'),
+                mode=ProblemLabelMode.TITLE,
+            )
+            == 'A. two-sum'
+        )
+
+    def test_path_mode(self):
+        assert (
+            naming.format_contest_problem_label(
+                'A', name='two-sum', title='Two Sum',
+                path=pathlib.Path('probs/two-sum'), mode=ProblemLabelMode.PATH,
+            )
+            == 'A. probs/two-sum'
+        )
+
+    def test_empty_suffix_falls_back_to_short_name(self):
+        assert (
+            naming.format_contest_problem_label(
+                'B', name=None, title=None, path=None, mode=ProblemLabelMode.NAME,
+            )
+            == 'B'
+        )
+
+
+class TestSingleTitle:
+    def test_one_title(self):
+        pkg = Package(name='n', timeLimit=1000, memoryLimit=256, titles={'en': 'Hello'})
+        assert naming._single_title(pkg) == 'Hello'
+
+    def test_no_titles(self):
+        pkg = Package(name='n', timeLimit=1000, memoryLimit=256)
+        assert naming._single_title(pkg) is None
+
+    def test_multiple_titles(self):
+        pkg = Package(
+            name='n', timeLimit=1000, memoryLimit=256,
+            titles={'en': 'Hello', 'pt': 'Ola'},
+        )
+        assert naming._single_title(pkg) is None
+
+
+class TestGetContestProblemLabels:
+    def test_returns_all_three_variants(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('probs/two-sum'))
+        pkg = Package(
+            name='two-sum', timeLimit=1000, memoryLimit=256, titles={'en': 'Two Sum'},
+        )
+        with patch('rbx.box.naming.package.find_problem_package', return_value=pkg):
+            labels = naming.get_contest_problem_labels(problem)
+        assert labels == {
+            ProblemLabelMode.NAME: 'A. two-sum',
+            ProblemLabelMode.TITLE: 'A. Two Sum',
+            ProblemLabelMode.PATH: 'A. probs/two-sum',
+        }
+```
+
+> Verify the `Package` constructor's required fields by checking an existing
+> `Package(...)` call in `tests/rbx/box/test_naming.py::TestGetTitle`
+> (around line 287). Match its required kwargs (e.g. `timeLimit`, `memoryLimit`)
+> exactly; adjust the snippets above if they differ.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_naming.py -k "Format or SingleTitle or Labels" -v`
+Expected: FAIL with `AttributeError` (functions not defined yet).
+
+**Step 3: Write minimal implementation**
+
+In `rbx/box/naming.py`:
+- Change `from typing import List, Optional, Tuple` → add `Dict`.
+- Add `from rbx.box import setter_config` (alongside `from rbx.box import package`). Import `ProblemLabelMode` lazily inside functions OR at top: `from rbx.box.setter_config import ProblemLabelMode`. Verify no import cycle (`setter_config` does not import `naming`).
+
+Replace the existing `get_contest_problem_label` body with:
+
+```python
+def format_contest_problem_label(
+    short_name: str,
+    *,
+    name: Optional[str],
+    title: Optional[str],
+    path: Optional[pathlib.Path],
+    mode: ProblemLabelMode,
+) -> str:
+    """Pure formatter: '<short_name>. <suffix>' or bare short name when empty."""
+    if mode is ProblemLabelMode.PATH:
+        suffix = str(path) if path is not None else None
+    elif mode is ProblemLabelMode.TITLE:
+        suffix = title or name
+    else:
+        suffix = name
+    if not suffix:
+        return short_name
+    return f'{short_name}. {suffix}'
+
+
+def _single_title(pkg: Package) -> Optional[str]:
+    if len(pkg.titles) == 1:
+        return next(iter(pkg.titles.values()))
+    return None
+
+
+def get_contest_problem_label(problem: ContestProblem) -> str:
+    """Human-readable label for a contest problem, honoring the configured mode.
+
+    Falls back to just the short name when the problem package cannot be
+    loaded (e.g. missing or broken problem.rbx.yml) or has no usable suffix.
+    """
+    mode = setter_config.get_setter_config().ui.problem_label
+    pkg = package.find_problem_package(problem.get_path())
+    return format_contest_problem_label(
+        problem.short_name,
+        name=pkg.name if pkg is not None else None,
+        title=_single_title(pkg) if pkg is not None else None,
+        path=problem.get_path(),
+        mode=mode,
+    )
+
+
+def get_contest_problem_labels(
+    problem: ContestProblem,
+) -> Dict[ProblemLabelMode, str]:
+    """All label variants from a single package load, for the command-app UI."""
+    pkg = package.find_problem_package(problem.get_path())
+    name = pkg.name if pkg is not None else None
+    title = _single_title(pkg) if pkg is not None else None
+    return {
+        mode: format_contest_problem_label(
+            problem.short_name, name=name, title=title,
+            path=problem.get_path(), mode=mode,
+        )
+        for mode in ProblemLabelMode
+    }
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_naming.py -v`
+Expected: PASS, including the pre-existing `TestGetContestProblemLabel` (default mode is `name`, so `'A. Two Sum'` / `'B'` / `'C'` still hold). If those three now require a `ui` config: they patch `find_problem_package` and `get_setter_config()` defaults to `name`, so they pass unchanged. Confirm.
+
+**Step 5: Run ruff**
+
+Run: `uv run ruff check rbx/box/naming.py && uv run ruff format --check rbx/box/naming.py`
+Expected: clean (fix import ordering if flagged).
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/naming.py tests/rbx/box/test_naming.py
+git commit -m "refactor(naming): configurable contest problem label formatter"
+```
+
+---
+
+## Task 3: Honor configured mode in `get_contest_problem_label`
+
+This validates the wiring end-to-end through the config (Task 2 added the code;
+this task adds the behavioral test that proves the mode is read).
+
+**Files:**
+- Test: `tests/rbx/box/test_naming.py` (add a class that patches the config)
+
+**Step 1: Write the failing/again-passing test**
+
+```python
+class TestGetContestProblemLabelHonorsConfig:
+    def _patch_mode(self, mode):
+        cfg = setter_config.SetterConfig()
+        cfg.ui.problem_label = mode
+        return patch('rbx.box.naming.setter_config.get_setter_config', return_value=cfg)
+
+    def test_title_mode_single_title(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('a'))
+        pkg = Package(name='two-sum', timeLimit=1000, memoryLimit=256,
+                      titles={'en': 'Two Sum'})
+        with patch('rbx.box.naming.package.find_problem_package', return_value=pkg), \
+             self._patch_mode(setter_config.ProblemLabelMode.TITLE):
+            assert naming.get_contest_problem_label(problem) == 'A. Two Sum'
+
+    def test_title_mode_multiple_titles_falls_back_to_name(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('a'))
+        pkg = Package(name='two-sum', timeLimit=1000, memoryLimit=256,
+                      titles={'en': 'Two Sum', 'pt': 'Dois Numeros'})
+        with patch('rbx.box.naming.package.find_problem_package', return_value=pkg), \
+             self._patch_mode(setter_config.ProblemLabelMode.TITLE):
+            assert naming.get_contest_problem_label(problem) == 'A. two-sum'
+
+    def test_path_mode(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('probs/a'))
+        pkg = Package(name='two-sum', timeLimit=1000, memoryLimit=256)
+        with patch('rbx.box.naming.package.find_problem_package', return_value=pkg), \
+             self._patch_mode(setter_config.ProblemLabelMode.PATH):
+            assert naming.get_contest_problem_label(problem) == 'A. probs/a'
+```
+
+Add `from rbx.box import setter_config` to the test imports if not present.
+
+**Step 2: Run to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_naming.py::TestGetContestProblemLabelHonorsConfig -v`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/rbx/box/test_naming.py
+git commit -m "test(naming): cover configured label modes"
+```
+
+---
+
+## Task 4: Thread label variants into `CommandEntry` (contest call sites)
+
+**Files:**
+- Modify: `rbx/box/ui/command_app.py` (`CommandEntry` dataclass: add `labels` field + import)
+- Modify: `rbx/box/contest/main.py:366-374` (`each`) and `:408-415` (`on`)
+
+**Step 1: Add the field**
+
+In `rbx/box/ui/command_app.py`:
+- Import at top: `from rbx.box.setter_config import ProblemLabelMode`. Verify no cycle (setter_config imports `rbx.config`, `console`, `utils`, grading — not `box.ui`).
+- Add to the `CommandEntry` dataclass (after `placeholder_prefix`):
+
+```python
+    labels: Optional[Dict[ProblemLabelMode, str]] = None
+```
+
+- Add `Dict` to the typing import line (`from typing import Dict, List, Optional, Tuple`).
+
+**Step 2: Wire the call sites**
+
+In `rbx/box/contest/main.py`, both `CommandEntry(...)` builders (`each` and the
+multi-problem branch of `on`) add a `labels=` kwarg:
+
+```python
+        CommandEntry(
+            argv=argv,
+            placeholder_prefix=placeholder_prefix,
+            name=naming.get_contest_problem_label(problem),
+            labels=naming.get_contest_problem_labels(problem),
+            cwd=str(problem.get_path()),
+        )
+```
+
+(Use `p` instead of `problem` in the `on` branch to match the existing loop var.)
+
+**Step 3: Verify it imports / runs**
+
+Run: `uv run python -c "import rbx.box.ui.command_app, rbx.box.contest.main"`
+Expected: no ImportError (no cycle).
+
+Run: `uv run ruff check rbx/box/ui/command_app.py rbx/box/contest/main.py`
+Expected: clean.
+
+**Step 4: Commit**
+
+```bash
+git add rbx/box/ui/command_app.py rbx/box/contest/main.py
+git commit -m "feat(contest): pass all label variants to command app"
+```
+
+---
+
+## Task 5: Render the configured label in the sidebar
+
+**Files:**
+- Modify: `rbx/box/ui/command_app.py` (`rbxCommandApp.__init__`, `_make_tab_label`, add `_entry_label`)
+
+**Step 1: Seed the mode in `__init__`**
+
+Import at top: `from rbx.box.setter_config import get_setter_config, save_setter_config`
+(keep the `ProblemLabelMode` import from Task 4).
+
+In `rbxCommandApp.__init__`, after `self._active_tab = 0`, add:
+
+```python
+        self._label_mode = get_setter_config().ui.problem_label
+```
+
+**Step 2: Use it when rendering**
+
+Add a helper and update `_make_tab_label`:
+
+```python
+    def _entry_label(self, entry: CommandEntry) -> str:
+        if entry.labels:
+            return entry.labels.get(self._label_mode) or entry.display_name
+        return entry.display_name
+
+    def _make_tab_label(self, index: int) -> str:
+        tab = self._tabs[index]
+        icon = _STATUS_MARKUP[tab.aggregate_status]
+        name = self._entry_label(tab.entry)
+        return f'{icon} {name}'
+```
+
+**Step 3: Verify import/format**
+
+Run: `uv run python -c "import rbx.box.ui.command_app"` → no error.
+Run: `uv run ruff check rbx/box/ui/command_app.py` → clean.
+
+**Step 4: Commit**
+
+```bash
+git add rbx/box/ui/command_app.py
+git commit -m "feat(ui): render configured problem label in command app sidebar"
+```
+
+---
+
+## Task 6: `l` keybinding cycles + persists the label mode
+
+**Files:**
+- Modify: `rbx/box/ui/command_app.py` (`on_key`, add `_cycle_problem_label`, update `HelpModal`)
+
+**Step 1: Add the cycle action**
+
+In `rbxCommandApp`, add:
+
+```python
+    def _cycle_problem_label(self) -> None:
+        modes = list(ProblemLabelMode)
+        nxt = modes[(modes.index(self._label_mode) + 1) % len(modes)]
+        self._label_mode = nxt
+        cfg = get_setter_config()
+        cfg.ui.problem_label = nxt
+        save_setter_config(cfg)
+        for i in range(len(self._tabs)):
+            self._update_sidebar(i)
+        self.notify(f'Problem label: {nxt.value}')
+```
+
+**Step 2: Intercept `l` when the sidebar is focused**
+
+In `on_key`, inside the `focused is sidebar` region (after the `right` handler,
+before the `?` handler), add:
+
+```python
+        if event.character == 'l' and any(t.entry.labels for t in self._tabs):
+            event.stop()
+            event.prevent_default()
+            self._cycle_problem_label()
+            return
+```
+
+The `any(... labels ...)` guard keeps `l` falling through to vim-nav for
+label-less entries (e.g. the `__main__` demo).
+
+**Step 3: Document it in `HelpModal`**
+
+In `HelpModal.compose`, in the "Sidebar (command list)" `Label`, add a line
+after the `← / →` row:
+
+```
+                '  [b]l[/b]           Cycle problem label (name/title/path)\n'
+```
+
+**Step 4: Manual smoke check (no automated TUI harness)**
+
+Run: `uv run python rbx/box/ui/command_app.py`
+- The demo entries have no `labels`, so `l` is inert (correct).
+- Confirm the app launches, sidebar shows `echo1/echo2/echo3`, `?` shows help,
+  `q` quits. (The `l` behavior with real labels is verified via `rbx on`/`each`
+  in a contest fixture in Task 8.)
+
+Run: `uv run ruff check rbx/box/ui/command_app.py && uv run ruff format --check rbx/box/ui/command_app.py`
+Expected: clean.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/ui/command_app.py
+git commit -m "feat(ui): cycle and persist problem label with l key"
+```
+
+---
+
+## Task 7: Full test + lint sweep
+
+**Step 1: Run the affected suites**
+
+Run:
+```bash
+uv run pytest tests/rbx/box/test_naming.py tests/rbx/box/test_setter_config.py -v
+```
+Expected: all PASS.
+
+**Step 2: Broader regression (config + naming consumers)**
+
+Run: `uv run pytest tests/rbx/box -k "naming or setter or config or contest" -n auto`
+Expected: PASS (or only the known pre-existing failures noted in memory — none
+expected to touch this area).
+
+**Step 3: Lint + format the whole change**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: clean.
+
+**Step 4: Commit any formatting fixups (if needed)**
+
+```bash
+git add -u
+git commit -m "style: ruff format"
+```
+
+(Skip if nothing changed.)
+
+---
+
+## Task 8: Manual end-to-end verification in a contest fixture
+
+**Goal:** Prove the label modes + `l` cycling work against a real contest.
+
+**Step 1: Find or build a contest fixture**
+
+Look under `tests/` / `testdata/` for a contest package with ≥2 problems and at
+least one problem that has a single `titles:` entry. If none exists, create a
+throwaway one in a temp dir: a `contest.rbx.yml` with two `problems` (`A`, `B`)
+and minimal `problem.rbx.yml` files (one with `titles: {en: "Two Sum"}`).
+
+**Step 2: Run `rbx each` / `rbx on`**
+
+From the contest dir:
+```bash
+uv run rbx each   # or: uv run rbx on "*"
+```
+- Sidebar shows `A. <name>` by default.
+- Press `l`: cycles to `title` (shows the single title where present, name
+  otherwise), then `path`, then back to `name`. A toast shows the mode.
+- Quit (`q`), relaunch: the last-cycled mode persists (read from
+  `~/.config/rbx/setter_config.yml`).
+
+**Step 3: Confirm persistence on disk**
+
+Run: `uv run rbx config list` (or open the file) → `ui.problem_label` reflects
+the last cycled value.
+
+**Step 4: Reset for cleanliness (optional)**
+
+Set it back to `name` via `rbx config edit` or by editing the file, if you
+changed your personal config during testing.
+
+---
+
+## Done criteria
+
+- `ui.problem_label` exists in `SetterConfig`, defaults to `name`, documented in
+  both resource files; old configs without `ui:` still load.
+- `naming` exposes a pure formatter + `get_contest_problem_labels`;
+  `get_contest_problem_label` honors the configured mode.
+- Command app renders the configured label and cycles+persists with `l`
+  (documented in `HelpModal`).
+- All new + existing `test_naming.py` / `test_setter_config.py` tests pass;
+  ruff clean.
+- Manual `rbx each` smoke test confirms cycling + persistence.

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -368,6 +368,7 @@ def each(ctx: typer.Context) -> None:
             argv=argv,
             placeholder_prefix=placeholder_prefix,
             name=naming.get_contest_problem_label(problem),
+            labels=naming.get_contest_problem_labels(problem),
             cwd=str(problem.get_path()),
         )
         for problem in contest.problems
@@ -410,6 +411,7 @@ def on(
             argv=argv,
             placeholder_prefix=placeholder_prefix,
             name=naming.get_contest_problem_label(p),
+            labels=naming.get_contest_problem_labels(p),
             cwd=str(p.get_path()),
         )
         for p in problems_of_interest

--- a/rbx/box/naming.py
+++ b/rbx/box/naming.py
@@ -1,9 +1,9 @@
 import pathlib
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import typer
 
-from rbx.box import package
+from rbx.box import package, setter_config
 from rbx.box.contest import contest_package, contest_state
 from rbx.box.contest.contest_package import discover_contest_variants
 from rbx.box.contest.schema import Contest, ContestProblem, ContestStatement
@@ -174,17 +174,78 @@ def get_problem_name_with_contest_info() -> str:
     return f'{contest.name}-{short_name}-{problem.name}'
 
 
-def get_contest_problem_label(problem: ContestProblem) -> str:
-    """Human-readable label for a contest problem: '<short_name>. <name>'.
+def format_contest_problem_label(
+    short_name: str,
+    *,
+    name: Optional[str],
+    title: Optional[str],
+    path: Optional[pathlib.Path],
+    mode: setter_config.ProblemLabelMode,
+) -> str:
+    """Pure formatter: '<short_name>. <suffix>', or the bare short name.
 
-    Falls back to just the short name when the problem package cannot be
-    loaded (e.g. missing or broken problem.rbx.yml) or has no name, so
+    The suffix depends on `mode`. When the resolved suffix is empty (e.g. the
+    problem package could not be loaded), only the short name is returned, so
     callers keep working on a partially set-up contest.
     """
+    if mode is setter_config.ProblemLabelMode.PATH:
+        suffix = str(path) if path is not None else None
+    elif mode is setter_config.ProblemLabelMode.TITLE:
+        suffix = title or name
+    else:
+        suffix = name
+    if not suffix:
+        return short_name
+    return f'{short_name}. {suffix}'
+
+
+def _single_title(pkg: Package) -> Optional[str]:
+    """The problem's title when it has exactly one; otherwise None."""
+    if len(pkg.titles) == 1:
+        return next(iter(pkg.titles.values()))
+    return None
+
+
+def get_contest_problem_label(problem: ContestProblem) -> str:
+    """Human-readable label for a contest problem, honoring the configured mode.
+
+    See `setter_config.ProblemLabelMode`. Falls back to just the short name when
+    the problem package cannot be loaded (e.g. missing or broken
+    problem.rbx.yml) or the resolved suffix is empty.
+    """
+    mode = setter_config.get_setter_config().ui.problem_label
     pkg = package.find_problem_package(problem.get_path())
-    if pkg is not None and pkg.name:
-        return f'{problem.short_name}. {pkg.name}'
-    return problem.short_name
+    title = (
+        _single_title(pkg)
+        if pkg is not None and mode is setter_config.ProblemLabelMode.TITLE
+        else None
+    )
+    return format_contest_problem_label(
+        problem.short_name,
+        name=pkg.name if pkg is not None else None,
+        title=title,
+        path=problem.get_path(),
+        mode=mode,
+    )
+
+
+def get_contest_problem_labels(
+    problem: ContestProblem,
+) -> Dict[setter_config.ProblemLabelMode, str]:
+    """All label variants from a single package load, for the command-app UI."""
+    pkg = package.find_problem_package(problem.get_path())
+    name = pkg.name if pkg is not None else None
+    title = _single_title(pkg) if pkg is not None else None
+    return {
+        mode: format_contest_problem_label(
+            problem.short_name,
+            name=name,
+            title=title,
+            path=problem.get_path(),
+            mode=mode,
+        )
+        for mode in setter_config.ProblemLabelMode
+    }
 
 
 def get_problem_title(

--- a/rbx/box/setter_config.py
+++ b/rbx/box/setter_config.py
@@ -204,6 +204,19 @@ def save_setter_config(config: SetterConfig):
     get_setter_config.cache_clear()
 
 
+def set_problem_label(mode: ProblemLabelMode) -> None:
+    """Persist the command-app problem-label mode.
+
+    Reassigns the whole `ui` sub-model (instead of mutating
+    `cfg.ui.problem_label` in place) so the field is marked as set and survives
+    `model_to_yaml`'s `exclude_unset` — otherwise configs that predate the `ui`
+    field would silently drop the change.
+    """
+    cfg = get_setter_config()
+    cfg.ui = UIConfig(problem_label=mode)
+    save_setter_config(cfg)
+
+
 @app.command(help='Show the path to the setter config.')
 def path():
     print(get_setter_config_path())

--- a/rbx/box/setter_config.py
+++ b/rbx/box/setter_config.py
@@ -1,3 +1,4 @@
+import enum
 import functools
 import importlib.resources
 import pathlib
@@ -82,6 +83,27 @@ class JudgingConfig(BaseModel):
     )
 
 
+class ProblemLabelMode(str, enum.Enum):
+    """What to display after the short name in the contest command-app sidebar.
+
+    Iteration order defines the in-app cycle order.
+    """
+
+    NAME = 'name'
+    TITLE = 'title'
+    PATH = 'path'
+
+
+class UIConfig(BaseModel):
+    problem_label: ProblemLabelMode = Field(
+        default=ProblemLabelMode.NAME,
+        description='What to show after the short name in the `rbx on`/`rbx each` '
+        'sidebar: `name` (problem name), `title` (the single problem title, '
+        'falling back to the name), or `path` (problem path relative to the '
+        'contest). Press `l` in that UI to cycle this live.',
+    )
+
+
 class SetterConfig(BaseModel):
     sanitizers: SanitizersConfig = Field(
         default_factory=SanitizersConfig,
@@ -117,6 +139,10 @@ class SetterConfig(BaseModel):
     judging: JudgingConfig = Field(
         default_factory=JudgingConfig,
         description='Configuration for judging.',
+    )
+    ui: UIConfig = Field(
+        default_factory=UIConfig,
+        description='Configuration for the interactive UI.',
     )
 
     def substitute_command(self, command: str, sanitized: bool = False) -> str:

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -15,7 +15,7 @@ from textual.selection import Selection
 from textual.widget import Widget
 from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Select
 
-from rbx.box.setter_config import ProblemLabelMode
+from rbx.box.setter_config import ProblemLabelMode, get_setter_config
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
 from rbx.box.ui.main import rbxBaseApp
 from rbx.box.ui.screens.tab_selector import TabSelectorModal
@@ -363,6 +363,7 @@ class rbxCommandApp(rbxBaseApp):
         self.parallel = parallel
         self._tabs: List[TabState] = []
         self._active_tab: int = 0
+        self._label_mode: ProblemLabelMode = get_setter_config().ui.problem_label
         self._task_queue = TaskQueue(
             num_terminals=len(commands),
             parallel=parallel,
@@ -409,10 +410,15 @@ class rbxCommandApp(rbxBaseApp):
                         placeholder=self._get_input_placeholder(0),
                     )
 
+    def _entry_label(self, entry: CommandEntry) -> str:
+        if entry.labels:
+            return entry.labels.get(self._label_mode) or entry.display_name
+        return entry.display_name
+
     def _make_tab_label(self, index: int) -> str:
         tab = self._tabs[index]
         icon = _STATUS_MARKUP[tab.aggregate_status]
-        name = tab.entry.display_name
+        name = self._entry_label(tab.entry)
         return f'{icon} {name}'
 
     def _update_sidebar(self, index: int):

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -431,6 +431,18 @@ class rbxCommandApp(rbxBaseApp):
         label = item.query_one(Label)
         label.update(self._make_tab_label(index))
 
+    def _has_labels(self) -> bool:
+        return any(t.entry.labels for t in self._tabs)
+
+    def _sidebar_subtitle(self) -> str:
+        if self._has_labels():
+            return f'[b]l[/b] label: {self._label_mode.value}  [b]?[/b] help'
+        return _SIDEBAR_SUBTITLE
+
+    def _update_sidebar_subtitle(self) -> None:
+        sidebar = self.query_one('#command-list', ListView)
+        sidebar.border_subtitle = self._sidebar_subtitle()
+
     def _cycle_problem_label(self) -> None:
         modes = list(ProblemLabelMode)
         nxt = modes[(modes.index(self._label_mode) + 1) % len(modes)]
@@ -438,7 +450,7 @@ class rbxCommandApp(rbxBaseApp):
         set_problem_label(nxt)
         for i in range(len(self._tabs)):
             self._update_sidebar(i)
-        self.notify(f'Problem label: {nxt.value}')
+        self._update_sidebar_subtitle()
 
     def _get_select_options(self, tab_index: int) -> List[Tuple[str, int]]:
         return [
@@ -494,7 +506,7 @@ class rbxCommandApp(rbxBaseApp):
     def on_mount(self):
         sidebar = self.query_one('#command-list', ListView)
         sidebar.border_title = 'Commands'
-        sidebar.border_subtitle = _SIDEBAR_SUBTITLE
+        sidebar.border_subtitle = self._sidebar_subtitle()
 
         select = self.query_one('#command-select', Select)
         select.border_subtitle = _SELECT_SUBTITLE
@@ -636,7 +648,7 @@ class rbxCommandApp(rbxBaseApp):
             self._select_next_sub_command()
             return
 
-        if event.character == 'l' and any(t.entry.labels for t in self._tabs):
+        if event.character == 'l' and self._has_labels():
             event.stop()
             event.prevent_default()
             self._cycle_problem_label()

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -2,7 +2,7 @@ import dataclasses
 import enum
 import shlex
 from time import monotonic
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from textual import events, on
 from textual.app import ComposeResult
@@ -15,6 +15,7 @@ from textual.selection import Selection
 from textual.widget import Widget
 from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Select
 
+from rbx.box.setter_config import ProblemLabelMode
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
 from rbx.box.ui.main import rbxBaseApp
 from rbx.box.ui.screens.tab_selector import TabSelectorModal
@@ -204,6 +205,9 @@ class CommandEntry:
     cwd: Optional[str] = None
     prefix: Optional[str] = None
     placeholder_prefix: Optional[str] = None
+    # Precomputed sidebar labels per ProblemLabelMode, so the UI can swap them
+    # live without reloading problem packages. None for non-contest entries.
+    labels: Optional[Dict[ProblemLabelMode, str]] = None
 
     @property
     def display_name(self) -> str:

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -15,7 +15,11 @@ from textual.selection import Selection
 from textual.widget import Widget
 from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Select
 
-from rbx.box.setter_config import ProblemLabelMode, get_setter_config
+from rbx.box.setter_config import (
+    ProblemLabelMode,
+    get_setter_config,
+    save_setter_config,
+)
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
 from rbx.box.ui.main import rbxBaseApp
 from rbx.box.ui.screens.tab_selector import TabSelectorModal
@@ -153,6 +157,7 @@ class HelpModal(ModalScreen[None]):
                 '  [b]tab[/b]         Focus terminal\n'
                 '  [b]![/b]           Open shell input\n'
                 '  [b]\u2190 / \u2192[/b]       Previous / next sub-command\n'
+                '  [b]l[/b]           Cycle problem label (name/title/path)\n'
                 '  [b]?[/b]           Show this help\n'
                 '  [b]q[/b]           Quit',
                 markup=True,
@@ -426,6 +431,17 @@ class rbxCommandApp(rbxBaseApp):
         label = item.query_one(Label)
         label.update(self._make_tab_label(index))
 
+    def _cycle_problem_label(self) -> None:
+        modes = list(ProblemLabelMode)
+        nxt = modes[(modes.index(self._label_mode) + 1) % len(modes)]
+        self._label_mode = nxt
+        cfg = get_setter_config()
+        cfg.ui.problem_label = nxt
+        save_setter_config(cfg)
+        for i in range(len(self._tabs)):
+            self._update_sidebar(i)
+        self.notify(f'Problem label: {nxt.value}')
+
     def _get_select_options(self, tab_index: int) -> List[Tuple[str, int]]:
         return [
             (f'{_STATUS_ICON[sub.status]} {sub.name}', i)
@@ -620,6 +636,12 @@ class rbxCommandApp(rbxBaseApp):
             event.stop()
             event.prevent_default()
             self._select_next_sub_command()
+            return
+
+        if event.character == 'l' and any(t.entry.labels for t in self._tabs):
+            event.stop()
+            event.prevent_default()
+            self._cycle_problem_label()
             return
 
         if event.character == '?':

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -18,7 +18,7 @@ from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Se
 from rbx.box.setter_config import (
     ProblemLabelMode,
     get_setter_config,
-    save_setter_config,
+    set_problem_label,
 )
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
 from rbx.box.ui.main import rbxBaseApp
@@ -435,9 +435,7 @@ class rbxCommandApp(rbxBaseApp):
         modes = list(ProblemLabelMode)
         nxt = modes[(modes.index(self._label_mode) + 1) % len(modes)]
         self._label_mode = nxt
-        cfg = get_setter_config()
-        cfg.ui.problem_label = nxt
-        save_setter_config(cfg)
+        set_problem_label(nxt)
         for i in range(len(self._tabs)):
             self._update_sidebar(i)
         self.notify(f'Problem label: {nxt.value}')

--- a/rbx/resources/default_setter_config.mac.yml
+++ b/rbx/resources/default_setter_config.mac.yml
@@ -52,3 +52,12 @@ sanitizers:
   command_substitutions:
     g++: clang++
     gcc: clang
+
+# How problems are labeled in the `rbx on` / `rbx each` command-app sidebar.
+# Press `l` in that UI to cycle this setting live.
+#
+# name:  problem name from problem.rbx.yml (default)
+# title: the problem's title, if it has exactly one; otherwise the name
+# path:  problem path relative to the contest
+ui:
+  problem_label: name

--- a/rbx/resources/default_setter_config.yml
+++ b/rbx/resources/default_setter_config.yml
@@ -50,3 +50,12 @@ sanitizers:
   # This is useful when replacing compilers in OS such as Mac,
   # since GCC on Mac does not support sanitizers.
   command_substitutions: {}
+
+# How problems are labeled in the `rbx on` / `rbx each` command-app sidebar.
+# Press `l` in that UI to cycle this setting live.
+#
+# name:  problem name from problem.rbx.yml (default)
+# title: the problem's title, if it has exactly one; otherwise the name
+# path:  problem path relative to the contest
+ui:
+  problem_label: name

--- a/tests/rbx/box/test_naming.py
+++ b/tests/rbx/box/test_naming.py
@@ -14,6 +14,18 @@ from rbx.box.setter_config import ProblemLabelMode
 from rbx.box.statements.schema import Statement
 
 
+@pytest.fixture(autouse=True)
+def _default_label_mode():
+    # `mock_app_path` is session-scoped, so the persisted setter config leaks
+    # across tests. Pin the label mode to the default so these tests don't
+    # depend on whatever a prior test left behind.
+    with patch(
+        'rbx.box.naming.setter_config.get_setter_config',
+        return_value=setter_config.SetterConfig(),
+    ):
+        yield
+
+
 def _write_problem(folder: pathlib.Path, name: str) -> None:
     folder.mkdir(parents=True, exist_ok=True)
     (folder / 'problem.rbx.yml').write_text(f'name: {name}\n')

--- a/tests/rbx/box/test_naming.py
+++ b/tests/rbx/box/test_naming.py
@@ -5,11 +5,12 @@ from unittest.mock import Mock, patch
 import pytest
 import typer
 
-from rbx.box import naming
+from rbx.box import naming, setter_config
 from rbx.box.contest import contest_package as cp_module
 from rbx.box.contest.contest_state import selected_variant_id_var
 from rbx.box.contest.schema import ContestProblem
 from rbx.box.schema import Package
+from rbx.box.setter_config import ProblemLabelMode
 from rbx.box.statements.schema import Statement
 
 
@@ -280,6 +281,149 @@ class TestGetContestProblemLabel:
 
         with patch('rbx.box.naming.package.find_problem_package', return_value=pkg):
             assert naming.get_contest_problem_label(problem) == 'C'
+
+
+class TestFormatContestProblemLabel:
+    def test_name_mode(self):
+        assert (
+            naming.format_contest_problem_label(
+                'A',
+                name='Two Sum',
+                title='T',
+                path=pathlib.Path('A'),
+                mode=ProblemLabelMode.NAME,
+            )
+            == 'A. Two Sum'
+        )
+
+    def test_title_mode_uses_title(self):
+        assert (
+            naming.format_contest_problem_label(
+                'A',
+                name='two-sum',
+                title='Two Sum',
+                path=pathlib.Path('A'),
+                mode=ProblemLabelMode.TITLE,
+            )
+            == 'A. Two Sum'
+        )
+
+    def test_title_mode_falls_back_to_name(self):
+        assert (
+            naming.format_contest_problem_label(
+                'A',
+                name='two-sum',
+                title=None,
+                path=pathlib.Path('A'),
+                mode=ProblemLabelMode.TITLE,
+            )
+            == 'A. two-sum'
+        )
+
+    def test_path_mode(self):
+        assert (
+            naming.format_contest_problem_label(
+                'A',
+                name='two-sum',
+                title='Two Sum',
+                path=pathlib.Path('probs/two-sum'),
+                mode=ProblemLabelMode.PATH,
+            )
+            == 'A. probs/two-sum'
+        )
+
+    def test_empty_suffix_falls_back_to_short_name(self):
+        assert (
+            naming.format_contest_problem_label(
+                'B',
+                name=None,
+                title=None,
+                path=None,
+                mode=ProblemLabelMode.NAME,
+            )
+            == 'B'
+        )
+
+
+class TestGetContestProblemLabels:
+    def test_returns_all_three_variants(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('probs/two-sum'))
+        pkg = Package(
+            name='two-sum',
+            timeLimit=1000,
+            memoryLimit=256,
+            titles={'en': 'Two Sum'},
+        )
+        with patch('rbx.box.naming.package.find_problem_package', return_value=pkg):
+            labels = naming.get_contest_problem_labels(problem)
+        assert labels == {
+            ProblemLabelMode.NAME: 'A. two-sum',
+            ProblemLabelMode.TITLE: 'A. Two Sum',
+            ProblemLabelMode.PATH: 'A. probs/two-sum',
+        }
+
+    def test_missing_package_falls_back_to_short_name_for_name_and_title(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('probs/two-sum'))
+        with patch('rbx.box.naming.package.find_problem_package', return_value=None):
+            labels = naming.get_contest_problem_labels(problem)
+        assert labels == {
+            ProblemLabelMode.NAME: 'A',
+            ProblemLabelMode.TITLE: 'A',
+            ProblemLabelMode.PATH: 'A. probs/two-sum',
+        }
+
+
+class TestGetContestProblemLabelHonorsConfig:
+    def _patch_mode(self, mode):
+        cfg = setter_config.SetterConfig()
+        cfg.ui.problem_label = mode
+        return patch('rbx.box.naming.setter_config.get_setter_config', return_value=cfg)
+
+    def test_title_mode_single_title(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('a'))
+        pkg = Package(
+            name='two-sum',
+            timeLimit=1000,
+            memoryLimit=256,
+            titles={'en': 'Two Sum'},
+        )
+        with (
+            patch('rbx.box.naming.package.find_problem_package', return_value=pkg),
+            self._patch_mode(ProblemLabelMode.TITLE),
+        ):
+            assert naming.get_contest_problem_label(problem) == 'A. Two Sum'
+
+    def test_title_mode_multiple_titles_falls_back_to_name(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('a'))
+        pkg = Package(
+            name='two-sum',
+            timeLimit=1000,
+            memoryLimit=256,
+            titles={'en': 'Two Sum', 'pt': 'Dois Numeros'},
+        )
+        with (
+            patch('rbx.box.naming.package.find_problem_package', return_value=pkg),
+            self._patch_mode(ProblemLabelMode.TITLE),
+        ):
+            assert naming.get_contest_problem_label(problem) == 'A. two-sum'
+
+    def test_title_mode_no_titles_falls_back_to_name(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('a'))
+        pkg = Package(name='two-sum', timeLimit=1000, memoryLimit=256)
+        with (
+            patch('rbx.box.naming.package.find_problem_package', return_value=pkg),
+            self._patch_mode(ProblemLabelMode.TITLE),
+        ):
+            assert naming.get_contest_problem_label(problem) == 'A. two-sum'
+
+    def test_path_mode(self):
+        problem = ContestProblem(short_name='A', path=pathlib.Path('probs/a'))
+        pkg = Package(name='two-sum', timeLimit=1000, memoryLimit=256)
+        with (
+            patch('rbx.box.naming.package.find_problem_package', return_value=pkg),
+            self._patch_mode(ProblemLabelMode.PATH),
+        ):
+            assert naming.get_contest_problem_label(problem) == 'A. probs/a'
 
 
 class TestGetTitle:

--- a/tests/rbx/box/test_setter_config.py
+++ b/tests/rbx/box/test_setter_config.py
@@ -16,3 +16,27 @@ def test_ui_config_absent_key_defaults_to_name():
 def test_default_resource_setter_config_parses_with_ui():
     cfg = setter_config.get_default_setter_config()
     assert cfg.ui.problem_label is ProblemLabelMode.NAME
+
+
+def test_set_problem_label_persists_without_existing_ui_key(mock_app_path):
+    # Reproduce a user config that predates the `ui` field (no `ui:` key). The
+    # change must survive model_to_yaml's exclude_unset.
+    path = setter_config.get_setter_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('warnings:\n  enabled: true\n')
+    setter_config.get_setter_config.cache_clear()
+    try:
+        assert (
+            setter_config.get_setter_config().ui.problem_label is ProblemLabelMode.NAME
+        )
+
+        setter_config.set_problem_label(ProblemLabelMode.TITLE)
+
+        assert (
+            setter_config.get_setter_config().ui.problem_label is ProblemLabelMode.TITLE
+        )
+        assert 'problem_label: title' in path.read_text()
+    finally:
+        # `mock_app_path` is session-scoped; don't leak this config to other tests.
+        path.unlink(missing_ok=True)
+        setter_config.get_setter_config.cache_clear()

--- a/tests/rbx/box/test_setter_config.py
+++ b/tests/rbx/box/test_setter_config.py
@@ -1,0 +1,18 @@
+from rbx.box import setter_config
+from rbx.box.setter_config import ProblemLabelMode, SetterConfig
+
+
+def test_ui_problem_label_defaults_to_name():
+    cfg = SetterConfig()
+    assert cfg.ui.problem_label is ProblemLabelMode.NAME
+
+
+def test_ui_config_absent_key_defaults_to_name():
+    # Configs predating this change have no `ui:` key.
+    cfg = SetterConfig.model_validate({})
+    assert cfg.ui.problem_label is ProblemLabelMode.NAME
+
+
+def test_default_resource_setter_config_parses_with_ui():
+    cfg = setter_config.get_default_setter_config()
+    assert cfg.ui.problem_label is ProblemLabelMode.NAME

--- a/tests/rbx/box/ui/test_command_app.py
+++ b/tests/rbx/box/ui/test_command_app.py
@@ -1,0 +1,84 @@
+"""Tests for the rbx on / rbx each command app (rbx.box.ui.command_app)."""
+
+import pytest
+from textual.widgets import Label, ListItem
+
+from rbx.box import setter_config
+from rbx.box.setter_config import ProblemLabelMode
+from rbx.box.ui.command_app import CommandEntry, rbxCommandApp
+
+
+@pytest.fixture(autouse=True)
+def _reset_label_mode():
+    # `mock_app_path` is session-scoped, so the persisted setter config is shared
+    # across tests; pin it to the default before each test for isolation.
+    cfg = setter_config.get_setter_config()
+    cfg.ui.problem_label = ProblemLabelMode.NAME
+    setter_config.save_setter_config(cfg)
+    yield
+
+
+def _labeled_entry() -> CommandEntry:
+    return CommandEntry(
+        # Empty argv => no sub-command is enqueued, so no subprocess is spawned.
+        argv=[],
+        name='A. two-sum',
+        labels={
+            ProblemLabelMode.NAME: 'A. two-sum',
+            ProblemLabelMode.TITLE: 'A. Two Sum',
+            ProblemLabelMode.PATH: 'A. probs/a',
+        },
+    )
+
+
+def _sidebar_text(app, index: int) -> str:
+    label = app.query_one(f'#cmd-item-{index}', ListItem).query_one(Label)
+    return str(label.render())
+
+
+def _persisted_mode() -> ProblemLabelMode:
+    return setter_config.get_setter_config().ui.problem_label
+
+
+async def test_sidebar_uses_configured_label_mode():
+    app = rbxCommandApp([_labeled_entry()])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Default mode is `name`.
+        assert 'A. two-sum' in _sidebar_text(app, 0)
+
+
+async def test_l_cycles_and_persists_problem_label():
+    app = rbxCommandApp([_labeled_entry()])
+    async with app.run_test() as pilot:
+        # shift+tab deterministically focuses the sidebar (public key path).
+        await pilot.press('shift+tab')
+        await pilot.pause()
+
+        await pilot.press('l')
+        await pilot.pause()
+        assert _persisted_mode() is ProblemLabelMode.TITLE
+        assert 'A. Two Sum' in _sidebar_text(app, 0)
+
+        await pilot.press('l')
+        await pilot.pause()
+        assert _persisted_mode() is ProblemLabelMode.PATH
+        assert 'A. probs/a' in _sidebar_text(app, 0)
+
+        # Wraps back to name.
+        await pilot.press('l')
+        await pilot.pause()
+        assert _persisted_mode() is ProblemLabelMode.NAME
+        assert 'A. two-sum' in _sidebar_text(app, 0)
+
+
+async def test_l_is_inert_without_labels():
+    app = rbxCommandApp([CommandEntry(argv=[], name='echo')])
+    async with app.run_test() as pilot:
+        await pilot.press('shift+tab')
+        await pilot.pause()
+
+        await pilot.press('l')
+        await pilot.pause()
+        # No labels => the key falls through; the persisted config is unchanged.
+        assert _persisted_mode() is ProblemLabelMode.NAME

--- a/tests/rbx/box/ui/test_command_app.py
+++ b/tests/rbx/box/ui/test_command_app.py
@@ -1,7 +1,7 @@
 """Tests for the rbx on / rbx each command app (rbx.box.ui.command_app)."""
 
 import pytest
-from textual.widgets import Label, ListItem
+from textual.widgets import Label, ListItem, ListView
 
 from rbx.box import setter_config
 from rbx.box.setter_config import ProblemLabelMode
@@ -36,6 +36,10 @@ def _sidebar_text(app, index: int) -> str:
     return str(label.render())
 
 
+def _sidebar_subtitle(app) -> str:
+    return str(app.query_one('#command-list', ListView).border_subtitle)
+
+
 def _persisted_mode() -> ProblemLabelMode:
     return setter_config.get_setter_config().ui.problem_label
 
@@ -44,8 +48,9 @@ async def test_sidebar_uses_configured_label_mode():
     app = rbxCommandApp([_labeled_entry()])
     async with app.run_test() as pilot:
         await pilot.pause()
-        # Default mode is `name`.
+        # Default mode is `name`, shown both in the item and as a sidebar hint.
         assert 'A. two-sum' in _sidebar_text(app, 0)
+        assert 'label: name' in _sidebar_subtitle(app)
 
 
 async def test_l_cycles_and_persists_problem_label():
@@ -59,17 +64,20 @@ async def test_l_cycles_and_persists_problem_label():
         await pilot.pause()
         assert _persisted_mode() is ProblemLabelMode.TITLE
         assert 'A. Two Sum' in _sidebar_text(app, 0)
+        assert 'label: title' in _sidebar_subtitle(app)
 
         await pilot.press('l')
         await pilot.pause()
         assert _persisted_mode() is ProblemLabelMode.PATH
         assert 'A. probs/a' in _sidebar_text(app, 0)
+        assert 'label: path' in _sidebar_subtitle(app)
 
         # Wraps back to name.
         await pilot.press('l')
         await pilot.pause()
         assert _persisted_mode() is ProblemLabelMode.NAME
         assert 'A. two-sum' in _sidebar_text(app, 0)
+        assert 'label: name' in _sidebar_subtitle(app)
 
 
 async def test_l_is_inert_without_labels():
@@ -80,5 +88,7 @@ async def test_l_is_inert_without_labels():
 
         await pilot.press('l')
         await pilot.pause()
-        # No labels => the key falls through; the persisted config is unchanged.
+        # No labels => the key falls through; the persisted config is unchanged
+        # and the sidebar shows no label hint.
         assert _persisted_mode() is ProblemLabelMode.NAME
+        assert 'label:' not in _sidebar_subtitle(app)


### PR DESCRIPTION
Closes #582.

## What

Makes the problem label shown in the `rbx on` / `rbx each` command-app sidebar **configurable** and **persistent**, with an in-app key to cycle it live.

Three modes (default `name`):
- **name** — problem name from `problem.rbx.yml` (current behavior)
- **title** — the problem's title when it has exactly one, otherwise the name
- **path** — problem path relative to the contest

> Note: showing the problem *name* already landed in #467; this PR adds the configurability that #582 asked for.

## How

- **`SetterConfig.ui.problem_label`** (`~/.config/rbx/setter_config.yml`, editable via `rbx config edit`) — new `ProblemLabelMode` enum + `UIConfig`. Documented in the bundled `default_setter_config*.yml`.
- **`naming.py`** — `get_contest_problem_label` split into a pure `format_contest_problem_label` formatter plus a `get_contest_problem_labels` helper that loads the package once and returns all three variants for the UI.
- **Command app** — `CommandEntry` carries the precomputed variants; `rbxCommandApp` renders the configured mode and **`l`** cycles `name → title → path`, persisting the choice and refreshing the sidebar live (documented in the help modal). Inert when an entry has no labels.

## Notable fix found while testing

The in-app toggle originally mutated `cfg.ui.problem_label` in place, which `model_to_yaml`'s `exclude_unset` **dropped** for configs that predate the `ui` field — so the toggle silently failed to persist for existing users. Fixed with `setter_config.set_problem_label`, which reassigns the whole `ui` sub-model (the existing persist pattern), with a regression test.

## Tests

- Pure formatter across all modes + fallbacks; `get_contest_problem_labels`; config-honoring (`title` with 0/1/≥2 titles, `path`).
- Setter config defaults + the persistence regression test.
- Headless Textual pilot tests for the `l` cycle: cycles, persists, wraps, and is inert without labels.
- Verified end-to-end against the `multi-contest` fixture (real package loading + persistence), including a config that predates the `ui` field.

Default stays `name`, so existing behavior is unchanged.

Design + plan: `docs/plans/2026-06-10-configurable-contest-problem-label*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)