### PR TITLE
fix(packaging): thread testcase entries through polygon upload (#591)

### DIFF
--- a/rbx/box/packaging/polygon/upload.py
+++ b/rbx/box/packaging/polygon/upload.py
@@ -133,6 +133,22 @@ def _get_validator_name() -> str:
     return validator.path.with_stem('validator').name
 
 
+def _extracted_entries(
+    entries: Optional[List['GenerationTestcaseEntry']],
+) -> List['GenerationTestcaseEntry']:
+    """Return ``entries`` if already extracted, else extract them synchronously.
+
+    The synchronous ``asyncio.run`` fallback only works OUTSIDE a running event
+    loop -- it exists for sync callers such as the namespace-builder unit tests.
+    The async ``upload_problem`` path runs inside the event loop driven by
+    ``syncer``, so it MUST extract once via ``await`` and thread the result down,
+    never reaching this fallback (#591).
+    """
+    if entries is not None:
+        return entries
+    return asyncio.run(extract_generation_testcases_from_groups())
+
+
 def _collect_generators(
     entries: Optional[List['GenerationTestcaseEntry']] = None,
 ) -> List[Generator]:
@@ -143,8 +159,7 @@ def _collect_generators(
     namespace and the actual generator uploads agree on the set of generators.
     Pass already-extracted ``entries`` to avoid re-walking the testcase groups.
     """
-    if entries is None:
-        entries = asyncio.run(extract_generation_testcases_from_groups())
+    entries = _extracted_entries(entries)
     generators: Dict[str, Generator] = {}
     for entry in entries:
         if not entry.metadata.generator_call:
@@ -156,7 +171,9 @@ def _collect_generators(
     return [generators[k] for k in sorted(generators)]
 
 
-def _build_upload_namespace() -> flattening.FlatNamespace:
+def _build_upload_namespace(
+    entries: Optional[List['GenerationTestcaseEntry']] = None,
+) -> flattening.FlatNamespace:
     """Build a single flat namespace spanning every uploaded source.
 
     The checker/interactor/validator keep their special Polygon names via
@@ -164,6 +181,10 @@ def _build_upload_namespace() -> flattening.FlatNamespace:
     same-basename sources in different directories no longer collide (#527).
     ``enforce_stem_unique`` is required because Polygon compiles each source to a
     program named after its stem.
+
+    Pass already-extracted ``entries`` to thread them into ``_collect_generators``
+    (the async ``upload_problem`` caller must, to avoid ``asyncio.run`` inside the
+    running loop -- #591).
     """
     pkg = package.find_problem_package_or_die()
     sources: List[CodeItem] = []
@@ -184,7 +205,7 @@ def _build_upload_namespace() -> flattening.FlatNamespace:
         reserved[package.get_relative_source_path(validator)] = _get_validator_name()
 
     sources.extend(package.get_solutions())
-    sources.extend(_collect_generators())
+    sources.extend(_collect_generators(entries))
 
     return flattening.build_flat_namespace(
         sources, reserved=reserved, enforce_stem_unique=True
@@ -391,8 +412,12 @@ def _upload_generator(
         raise typer.Exit(1) from None
 
 
-def _upload_testcases(problem: api.Problem, ns: flattening.FlatNamespace):
-    entries = asyncio.run(extract_generation_testcases_from_groups())
+def _upload_testcases(
+    problem: api.Problem,
+    ns: flattening.FlatNamespace,
+    entries: Optional[List['GenerationTestcaseEntry']] = None,
+):
+    entries = _extracted_entries(entries)
     generators = _collect_generators(entries)
 
     if generators:
@@ -468,8 +493,11 @@ def _upload_testcases(problem: api.Problem, ns: flattening.FlatNamespace):
         progress.update(task_id, completed=len(entries))
 
 
-def _upload_testcases_raw(problem: api.Problem):
-    entries = asyncio.run(extract_generation_testcases_from_groups())
+def _upload_testcases_raw(
+    problem: api.Problem,
+    entries: Optional[List['GenerationTestcaseEntry']] = None,
+):
+    entries = _extracted_entries(entries)
 
     errors = _validate_raw_tests(entries)
     if errors:
@@ -718,10 +746,19 @@ async def upload_problem(
     # aborted by the flattening guardrail. Dependency headers are shared
     # resources, so ship them whenever any source that may ``#include`` them
     # (generators, solutions, checker/validator/interactor) is uploaded.
+    uploads_sources = bool(which_upload & {'files', 'solutions', 'tests'})
+
+    # Walk the testcase groups once here, on the async path, and thread the
+    # result into the sync upload helpers. Those helpers must not call
+    # asyncio.run() themselves -- this function already runs inside the event
+    # loop driven by ``syncer`` (#591). The namespace builder needs the entries
+    # for ``_collect_generators``, so they are required whenever sources upload.
+    entries: Optional[List[GenerationTestcaseEntry]] = (
+        await extract_generation_testcases_from_groups() if uploads_sources else None
+    )
+
     ns: Optional[flattening.FlatNamespace] = (
-        _build_upload_namespace()
-        if which_upload & {'files', 'solutions', 'tests'}
-        else None
+        _build_upload_namespace(entries) if uploads_sources else None
     )
     if ns is not None:
         _upload_dep_files(problem, ns)
@@ -745,9 +782,9 @@ async def upload_problem(
 
         if 'tests' in which_upload:
             if raw_tests:
-                _upload_testcases_raw(problem)
+                _upload_testcases_raw(problem, entries)
             else:
-                _upload_testcases(problem, ns)
+                _upload_testcases(problem, ns, entries)
 
     if 'statements' in which_upload:
         await _upload_statement(

--- a/tests/e2e/testdata/polygon-default-preset/A/tests/testplan.txt
+++ b/tests/e2e/testdata/polygon-default-preset/A/tests/testplan.txt
@@ -1,3 +1,3 @@
 # Each line calls a generator to produce tests; uncomment to use.
 # tests/gen 1000000000
-# tests/gen 100
+tests/gen 100

--- a/tests/e2e/testdata/polygon-default-preset/e2e.rbx.yml
+++ b/tests/e2e/testdata/polygon-default-preset/e2e.rbx.yml
@@ -15,20 +15,26 @@ scenarios:
   - name: problem-polygon-upload
     markers: [pdflatex]
     description: >
-      The default preset's problem uploads its statement to Polygon successfully.
-      This used to fail out of the box (#589 finding #1): building the standalone
-      statement overlay merged the contest chrome (statements/) with the problem's
-      statement dir (statement/), both holding an `editorial.rbx.tex`, which the
-      statements-v2 overlay rejected as an asset-name collision before any upload.
-      Fixed by renaming the bundled contest editorial template to
+      The default preset's problem runs a FULL `package polygon -u` (every upload
+      category: files, solutions, tests/generators, statement) end-to-end against
+      the recording Polygon fake. This guards two regressions at once:
+
+      #589 finding #1 -- building the standalone statement overlay used to merge
+      the contest chrome (statements/) with the problem's statement dir
+      (statement/), both holding an `editorial.rbx.tex`, which the statements-v2
+      overlay rejected as an asset-name collision before any upload. Fixed by
+      renaming the bundled contest editorial template to
       `editorial-standalone.rbx.tex`. The notes assertion also covers #589 finding
-      #4: the separate-file sample explanation (statement/samples/000.rbx.tex) now
-      reaches the uploaded Polygon notes. Scoped to `--upload-only statements`
-      because the full generator-upload path hits an unrelated, pre-existing bug
-      (`_collect_generators` calls `asyncio.run()` inside the upload event loop in
-      polygon/upload.py), which is outside the #589 statement-overlay fix; see #591.
+      #4: the separate-file sample explanation reaches the uploaded Polygon notes.
+
+      #591 -- the full upload (with a generator in the testplan) reaches generator
+      collection, which crashed with `RuntimeError: asyncio.run() cannot be called
+      from a running event loop` because the sync upload helpers called
+      `asyncio.run()` from inside the upload event loop. Fixed by extracting the
+      testcase entries once on the async path and threading them down. Before the
+      fix the command exited 1 here and never printed "uploaded successfully".
     steps:
-      - cmd: package polygon -u --upload-as-english --upload-only statements
+      - cmd: package polygon -u --upload-as-english
         cwd: A
         expect:
           stdout_contains: "uploaded successfully"

--- a/tests/rbx/box/packaging/test_polygon_upload_event_loop.py
+++ b/tests/rbx/box/packaging/test_polygon_upload_event_loop.py
@@ -1,0 +1,69 @@
+"""Regression coverage for #591: ``rbx package polygon -u`` (a full upload)
+crashed during generator collection with ``RuntimeError: asyncio.run() cannot
+be called from a running event loop``.
+
+``upload_problem`` is async and runs inside the event loop driven by ``syncer``.
+It used to call the sync helpers ``_build_upload_namespace`` /
+``_collect_generators`` / ``_upload_testcases``, which each invoked
+``asyncio.run(extract_generation_testcases_from_groups())`` -- illegal from
+within an already-running loop. The fix extracts the testcase entries once on
+the async path and threads them down into the sync helpers.
+
+These tests drive ``upload_problem`` through a *real* running event loop (via
+``asyncio.run``), which is exactly the context the unit tests in
+``test_polygon_upload_flatten.py`` never exercise (they call the sync helpers
+directly, where ``asyncio.run`` is legal).
+"""
+
+import asyncio
+from unittest import mock
+
+from rbx.box.packaging.polygon import upload
+
+
+def _bare_checker(testing_pkg) -> None:
+    testing_pkg.add_file('check.cpp').write_text('#include "testlib.h"\nint main(){}\n')
+    testing_pkg.set_checker('check.cpp')
+
+
+def _mock_polygon_api():
+    """A ``_get_polygon_api`` replacement whose problem records nothing and
+    performs no network I/O. ``solutions()`` must be iterable (it is consumed by
+    ``_upload_solutions``)."""
+    problem = mock.Mock(name='RecordingProblem')
+    problem.solutions.return_value = []
+    api = mock.Mock(name='Polygon')
+    api.problems_list.return_value = []
+    api.problem_create.return_value = problem
+    return api, problem
+
+
+def test_full_upload_does_not_call_asyncio_run_inside_loop(testing_pkg):
+    # A package with a generator + a testgroup that calls it: the full upload
+    # path walks the testcase groups (the crash site in #591).
+    _bare_checker(testing_pkg)
+    testing_pkg.add_file('gen.cpp').write_text('int main(){}\n')
+    testing_pkg.add_generator('gen.cpp', alias='gen')
+    testing_pkg.add_testgroup_with_generators(
+        'main', generators=[{'name': 'gen', 'args': '1'}]
+    )
+    testing_pkg.save()
+
+    api, problem = _mock_polygon_api()
+    with mock.patch.object(upload, '_get_polygon_api', return_value=api):
+        # Before the #591 fix this raised
+        # "RuntimeError: asyncio.run() cannot be called from a running event
+        # loop" inside _collect_generators, driven from this running loop.
+        asyncio.run(
+            upload.upload_problem(
+                name='prob',
+                main_language=None,
+                upload_only={'tests'},
+            )
+        )
+
+    # The upload reached its commit step instead of crashing mid-way, and the
+    # generator source was shipped (proving generator collection ran).
+    assert problem.commit_changes.called
+    saved_names = {c.kwargs.get('name') for c in problem.save_file.call_args_list}
+    assert 'gen.cpp' in saved_names


### PR DESCRIPTION
## Summary

Fixes #591 — a full `rbx package polygon -u` (without `--upload-only statements`) crashed during generator collection with:

```
RuntimeError: asyncio.run() cannot be called from a running event loop
```

### Root cause

`upload_problem()` is `async` and runs inside the event loop driven by `syncer`. It called three sync helpers that each invoked `asyncio.run(extract_generation_testcases_from_groups())` — illegal from inside an already-running loop:

- `_collect_generators` (via `_build_upload_namespace`) — the site named in the issue
- `_upload_testcases`
- `_upload_testcases_raw`

A full upload builds the flat namespace first, so it hit `_collect_generators` and exited 1 before uploading anything. It escaped existing coverage because the e2e scenarios used `--upload-only statements` (which skips generator collection) and the flatten unit tests call `_build_upload_namespace()` from a *sync* context where `asyncio.run` is legal.

### Fix

Extract the testcase entries **once** on the async path (`await extract_generation_testcases_from_groups()`) in `upload_problem()` and thread them down into all three helpers. The lone remaining synchronous fallback is centralized in a new `_extracted_entries()` helper and documented as sync-callers-only (the namespace-builder unit tests) — it is never reached from the upload loop. This also dedupes the testcase-group walk (previously up to twice per full upload).

### Tests (TDD, both confirmed red → green)

- **New unit test** `tests/rbx/box/packaging/test_polygon_upload_event_loop.py`: drives `upload_problem(upload_only={'tests'})` through a real running loop with a generator. Reproduced the exact `RuntimeError` before the fix; passes after and asserts the generator source is shipped.
- **E2e regression**: widened `polygon-default-preset`'s `problem-polygon-upload` scenario to a full `package polygon -u` (activated a generator in the testplan), removing the `--upload-only statements` workaround and the `#591` caveat. Verified by reverting the fix that the scenario fails pre-fix (`exited 1` / the asyncio `RuntimeError`) and passes post-fix.

### Verification

- New unit + flatten tests: 11 passed
- Full packaging unit suite: 200 passed, 1 xfailed (3 BOCA *docker* errors are pre-existing — no `docker-compose` available locally)
- Polygon e2e scenarios + e2e harness tests: 50 passed, 1 xfailed (unrelated tikz xfail)
- `ruff check` + `ruff format`: clean; pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
