### PR TITLE
feat(testset): problem-level generatorScript default (#599)

### DIFF
--- a/docs/plans/2026-06-20-problem-level-generator-script-design.md
+++ b/docs/plans/2026-06-20-problem-level-generator-script-design.md
@@ -1,0 +1,77 @@
+# Problem-level `generatorScript` default (issue #599)
+
+## Goal
+
+Add a problem-level `generatorScript` field to `problem.rbx.yml`. When set, any test
+group **or subgroup** that does not specify its own test parameters
+(`testcases`, `testcaseGlob`, `generators`, `generatorScript`) inherits this script as a
+default. This removes the need to repeat `generatorScript` on every group when a single
+shared script (typically partitioned with `@testgroup` blocks) drives all generation.
+
+## Decisions
+
+- **Inheritance scope:** all groups *and* subgroups with zero test parameters inherit the
+  package default (uniform rule in the extractor).
+- **Validation:** keep the current permissive behavior. `_check_oneof` already allows zero
+  test parameters per (sub)group; the package default does not conflict, so no new
+  hard-error validation is added. A group with no source and no package default remains a
+  silent no-op, as today.
+
+## Design
+
+### 1. Schema (`rbx/box/schema.py`, `Package`)
+
+Add an optional field, mirroring the existing problem-level defaults (`validator`,
+`visualizer`):
+
+```python
+generatorScript: Optional[GeneratorScript] = Field(
+    default=None,
+    description='A generator script used as the default for any test group or subgroup '
+    'that does not specify its own test parameters.',
+)
+```
+
+No change to `_check_oneof` (it only forbids setting more than one source on a single
+(sub)group; the package default is orthogonal).
+
+### 2. Inheritance (`rbx/box/testcase_extractors.py`)
+
+In `run_testcase_visitor._explore_subgroup`, resolve an *effective* script before the
+existing generator-script block:
+
+```python
+effective_gs = subgroup.generatorScript
+if effective_gs is None and not (
+    subgroup.testcases or subgroup.testcaseGlob
+    or subgroup.generators or subgroup.generatorScript
+):
+    effective_gs = pkg.generatorScript  # closure over pkg; may be None
+```
+
+The existing block then uses `effective_gs` instead of `subgroup.generatorScript`.
+`run_generator_script` is refactored to accept a `GeneratorScript` entry plus a name (its
+only caller is internal). The `@testgroup` filter key stays `group_path` (unchanged).
+
+This follows the existing precedent in the same function, where `pkg.validator` and
+`pkg.visualizer` are inherited into groups.
+
+### 3. Known limitations (tracked as follow-ups)
+
+- **#600** — `@testgroup` cannot target subgroups (parser uses a flat group name; extractor
+  filters subgroup runs by the parent group name). Sibling subgroups inheriting a shared
+  script therefore receive identical filtered lines.
+- **#601** — `rbx add-tests` and promotion operate on explicit per-group scripts only, not
+  inherited ones.
+
+## Testing
+
+- `tests/rbx/box/testcase_extractors_test.py`: group inherits the package script; subgroup
+  inherits; group/subgroup with its own params overrides (no inheritance); no package
+  script means no inheritance (silent).
+- Schema round-trip test for the new field.
+
+## Out of scope
+
+Subgroup-targeted `@testgroup` filtering (#600) and edit/promotion of inherited scripts
+(#601).

--- a/docs/setters/testset/index.md
+++ b/docs/setters/testset/index.md
@@ -209,6 +209,28 @@ random 5
 }
 ```
 
+##### A shared, problem-level generator script
+
+When a single testplan -- usually partitioned with `@testgroup` blocks like above --
+drives generation for every group, you don't have to repeat the `generatorScript` field on
+each one. Set it once at the **problem level**, and any test group (or subgroup) that does
+not define its own test parameters (`testcases`, `testcaseGlob`, `generators`,
+`generatorScript`) and has no subgroups of its own will inherit it as a default.
+
+```yaml
+# problem.rbx.yml
+generatorScript:
+  path: "testplan/main.txt"
+
+testcases:
+  - name: "subtask1"   # inherits the problem-level generatorScript
+  - name: "subtask2"   # inherits the problem-level generatorScript
+  - name: "manual"
+    testcaseGlob: "tests/*.in"   # has its own parameters, so it does NOT inherit
+```
+
+A group that sets any of its own test parameters always overrides the default.
+
 ### What about the outputs?
 
 Until now, we've just generated the inputs of our testcases. What about the outputs? Where they come from?

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -946,6 +946,18 @@ A list of output validators to use to validate the output of the testcases of th
         default=[], description='Generators for this problem.'
     )
 
+    generatorScript: Optional[GeneratorScript] = Field(
+        default=None,
+        description="""
+A generator script used as the default for any test group or subgroup that does
+not specify its own test parameters (testcases, testcaseGlob, generators,
+generatorScript) and has no subgroups of its own.
+
+Useful when a single script -- usually partitioned with `@testgroup` blocks --
+drives generation for every group, so it does not need to be repeated on each one.
+""",
+    )
+
     solutions: List[Solution] = Field(
         default=[],
         description="""

--- a/rbx/box/testcase_extractors.py
+++ b/rbx/box/testcase_extractors.py
@@ -47,43 +47,37 @@ def _get_group_output(
     return group_path / f'{subgroup_prefix}{i:03d}.out'
 
 
-async def run_generator_script(testcase: TestcaseSubgroup) -> str:
-    assert testcase.generatorScript is not None
-
+async def run_generator_script(script_entry: GeneratorScript, name: str) -> str:
     cacher = package.get_file_cacher()
 
-    if not testcase.generatorScript.path.is_file():
+    if not script_entry.path.is_file():
         console.console.print(
-            f'[error]Generator script not found: [item]{testcase.generatorScript.href()}[/item][/error]'
+            f'[error]Generator script not found: [item]{script_entry.href()}[/item][/error]'
         )
         raise typer.Exit(1)
 
     script_digest = DigestHolder()
-    if testcase.generatorScript.path.suffix == '.txt':
-        script_digest.value = await cacher.put_file_from_path(
-            testcase.generatorScript.path
-        )
+    if script_entry.path.suffix == '.txt':
+        script_digest.value = await cacher.put_file_from_path(script_entry.path)
     else:
         try:
-            compiled_digest = await compile_item(testcase.generatorScript)
+            compiled_digest = await compile_item(script_entry)
         except:
             console.console.print(
-                f'[error]Failed compiling generator script for group [item]{testcase.name}[/item].[/error]'
+                f'[error]Failed compiling generator script for group [item]{name}[/item].[/error]'
             )
             raise
 
         run_stderr = DigestHolder()
         run_log = await run_item(
-            testcase.generatorScript,
+            script_entry,
             DigestOrSource.create(compiled_digest),
             stdout=DigestOrDest.create(script_digest),
             stderr=DigestOrDest.create(run_stderr),
         )
 
         if run_log is None or run_log.exitcode != 0:
-            console.console.print(
-                f'Could not run generator script for group {testcase.name}'
-            )
+            console.console.print(f'Could not run generator script for group {name}')
             if run_log is not None:
                 console.console.print(
                     f'[error]Summary:[/error] {run_log.get_summary()}'
@@ -291,13 +285,26 @@ async def run_testcase_visitor(visitor: TestcaseVisitor):
         if not visitor.should_visit_generator_scripts(group_path, subgroup_path):
             return
 
+        # A group or subgroup that does not define any test parameters of its own
+        # (and has no subgroups) inherits the problem-level generatorScript, if set.
+        effective_generator_script = subgroup.generatorScript
+        if effective_generator_script is None and not (
+            subgroup.testcases
+            or subgroup.testcaseGlob
+            or subgroup.generators
+            or getattr(subgroup, 'subgroups', None)
+        ):
+            effective_generator_script = pkg.generatorScript
+
         # Run generator script.
-        if subgroup.generatorScript is not None:
-            script = await run_generator_script(subgroup)
+        if effective_generator_script is not None:
+            script = await run_generator_script(
+                effective_generator_script, subgroup.name
+            )
 
             # Run each line from generator script.
             for generation_input in _extract_script_lines(
-                script, subgroup.generatorScript, group_path
+                script, effective_generator_script, group_path
             ):
                 if generation_input.copied_from is not None:
                     metadata = GenerationMetadata(
@@ -311,7 +318,7 @@ async def run_testcase_visitor(visitor: TestcaseVisitor):
                     call = GeneratorCall(
                         name=_resolve_generator_name(
                             generation_input.generator_call.name,
-                            subgroup.generatorScript,
+                            effective_generator_script,
                         ),
                         args=generation_input.generator_call.args,
                     )

--- a/tests/rbx/box/testcase_extractors_test.py
+++ b/tests/rbx/box/testcase_extractors_test.py
@@ -8,7 +8,11 @@ from rbx.box.generation_schema import (
     GeneratorScriptEntry,
     TestcaseOrScriptEntry,
 )
-from rbx.box.schema import CodeItem, GeneratorScript, TestcaseGroup
+from rbx.box.schema import (
+    CodeItem,
+    GeneratorScript,
+    TestcaseGroup,
+)
 from rbx.box.testcase_extractors import (
     TestcaseGroupVisitor,
     TestcaseVisitor,
@@ -189,6 +193,120 @@ class TestRunTestcaseVisitor:
         assert visited_entries[1].metadata.generator_call.args == '456'
         assert visited_entries[0].metadata.generator_script is not None
         assert visited_entries[1].metadata.generator_script is not None
+
+    async def test_group_inherits_problem_level_generator_script(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        """A group with no test parameters inherits the problem-level generatorScript."""
+        testing_pkg.add_generator('gen1', src='generators/gen-id.cpp')
+        plan_path = testing_pkg.add_testplan('shared')
+        plan_path.write_text('gen1 123\ngen1 456')
+        testing_pkg.yml.generatorScript = GeneratorScript(path=plan_path)
+        testing_pkg.yml.testcases = testing_pkg.yml.testcases + [
+            TestcaseGroup(name='inherits')
+        ]
+        testing_pkg.save()
+
+        visited_entries = []
+
+        class CollectingVisitor(TestcaseVisitor):
+            async def visit(self, entry):
+                visited_entries.append(entry)
+
+        await run_testcase_visitor(CollectingVisitor())
+
+        assert len(visited_entries) == 2
+        assert all(e.group_entry.group == 'inherits' for e in visited_entries)
+        assert visited_entries[0].metadata.generator_call.name == 'gen1'
+        assert visited_entries[0].metadata.generator_call.args == '123'
+        assert visited_entries[1].metadata.generator_call.args == '456'
+        assert visited_entries[0].metadata.generator_script is not None
+
+    async def test_group_with_own_params_overrides_problem_level_generator_script(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        """A group with its own test parameters ignores the problem-level default."""
+        testing_pkg.add_generator('gen1', src='generators/gen-id.cpp')
+        plan_path = testing_pkg.add_testplan('shared')
+        plan_path.write_text('gen1 111\ngen1 222\ngen1 333')
+        testing_pkg.yml.generatorScript = GeneratorScript(path=plan_path)
+        testing_pkg.save()
+
+        testing_pkg.add_testgroup_with_generators(
+            'own', [{'name': 'gen1', 'args': 'explicit'}]
+        )
+
+        visited_entries = []
+
+        class CollectingVisitor(TestcaseVisitor):
+            async def visit(self, entry):
+                visited_entries.append(entry)
+
+        await run_testcase_visitor(CollectingVisitor())
+
+        assert len(visited_entries) == 1
+        assert visited_entries[0].metadata.generator_call.args == 'explicit'
+        assert visited_entries[0].metadata.generator_script is None
+
+    async def test_subgroup_inherits_problem_level_generator_script(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        """An empty subgroup inherits the default; a group with subgroups does not.
+
+        The parent group itself has subgroups, so it does not generate from the
+        inherited script at its own root (which would duplicate its subgroups).
+        The empty subgroup inherits, while the subgroup with its own generator does not.
+        """
+        testing_pkg.add_generator('gen1', src='generators/gen-id.cpp')
+        plan_path = testing_pkg.add_testplan('shared')
+        plan_path.write_text('gen1 a\ngen1 b')
+        testing_pkg.yml.generatorScript = GeneratorScript(path=plan_path)
+        testing_pkg.add_testgroup_with_subgroups(
+            'main',
+            [
+                {'name': 'sub1', 'generators': [{'name': 'gen1', 'args': 'own'}]},
+                {'name': 'sub2'},
+            ],
+        )
+
+        visited_entries = []
+
+        class CollectingVisitor(TestcaseVisitor):
+            async def visit(self, entry):
+                visited_entries.append(entry)
+
+        await run_testcase_visitor(CollectingVisitor())
+
+        sub1 = [e for e in visited_entries if e.subgroup_entry.group == 'main/sub1']
+        sub2 = [e for e in visited_entries if e.subgroup_entry.group == 'main/sub2']
+
+        assert len(visited_entries) == 3
+        assert len(sub1) == 1
+        assert sub1[0].metadata.generator_call.args == 'own'
+        assert sub1[0].metadata.generator_script is None
+
+        assert len(sub2) == 2
+        assert [e.metadata.generator_call.args for e in sub2] == ['a', 'b']
+        assert all(e.metadata.generator_script is not None for e in sub2)
+
+    async def test_empty_group_without_problem_level_generator_script_is_silent(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        """Without a problem-level default, an empty group produces no testcases."""
+        testing_pkg.yml.testcases = testing_pkg.yml.testcases + [
+            TestcaseGroup(name='empty')
+        ]
+        testing_pkg.save()
+
+        visited_entries = []
+
+        class CollectingVisitor(TestcaseVisitor):
+            async def visit(self, entry):
+                visited_entries.append(entry)
+
+        await run_testcase_visitor(CollectingVisitor())
+
+        assert len(visited_entries) == 0
 
     async def test_run_testcase_visitor_with_subgroups(
         self, testing_pkg: testing_package.TestingPackage


### PR DESCRIPTION
## Summary

Adds a problem-level `generatorScript` field to `problem.rbx.yml`. When set, any test group **or subgroup** that does not define its own test parameters (`testcases`, `testcaseGlob`, `generators`, `generatorScript`) and has no subgroups of its own inherits it as a default. This lets a single shared script — typically partitioned with `@testgroup` blocks — drive generation for every group without repeating the field on each one.

Closes #599.

## Behavior

- A group/subgroup with its own test parameters always **overrides** the default.
- A group that itself has subgroups does not generate from the inherited script at its own root (that would duplicate its subgroups); its empty subgroups inherit instead.
- Validation stays **permissive**: an empty group with no problem-level default remains a silent no-op, as before (no new hard error).

## Changes

- `rbx/box/schema.py` — new `Package.generatorScript: Optional[GeneratorScript]` (default `None`).
- `rbx/box/testcase_extractors.py` — resolve an *effective* generator script in `run_testcase_visitor` (following the existing `pkg.validator`/`pkg.visualizer` inheritance precedent); `run_generator_script` refactored to take the resolved `GeneratorScript` entry.
- `docs/setters/testset/index.md` — documents the shared problem-level script next to `@testgroup`.
- `docs/plans/2026-06-20-problem-level-generator-script-design.md` — design doc.

## Testing

- New TDD tests in `tests/rbx/box/testcase_extractors_test.py`: group inherits, subgroup inherits, own-params overrides, empty-without-default is silent.
- `testcase_extractors_test.py` passes fully (53/53). The remaining failures in a broad box-module sweep were confirmed pre-existing on `main` (C++ checker/validator/sandbox compilation + the stale walltime test) and unrelated to this change.

## Follow-ups

`@testgroup` cannot target subgroups today (flat group-name token; the extractor filters subgroup runs by the parent group name), so sibling subgroups inheriting a shared script currently receive identical filtered lines. Tracked separately:

- #600 — Support subgroup-level `@testgroup` filtering.
- #601 — `add-tests`/promotion support for inherited problem-level scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
