### PR TITLE
fix(statements): depend-on-template polygon TikZ externalization (#590)

### DIFF
--- a/docs/plans/2026-06-20-polygon-tikz-depend-on-template-design.md
+++ b/docs/plans/2026-06-20-polygon-tikz-depend-on-template-design.md
@@ -1,0 +1,163 @@
+# Design: depend-on-template TikZ externalization for Polygon (#590)
+
+Date: 2026-06-20
+
+Split out from #590 (itself #589 audit finding #2, High). When
+`rbx package polygon -u` exports a statement whose **sample explanation** contains
+a `\tikzpicture`, the uploaded `notes` reference an externalized figure
+(`\includegraphics{artifacts/tikz_figures/<sample>_<fig>}`) whose PDF may never be
+produced — Polygon renders a broken image.
+
+## Decision: reject template-independence; depend on the template
+
+Issue #590 proposes a **template-independent** fix: a dedicated externalization
+pass that compiles every staged explanation in an auxiliary document after the
+main render, so figures are produced regardless of the statement template. Its
+stated premise:
+
+> The Polygon export therefore **must not depend on the user's template happening
+> to render sample explanations**.
+
+**We reject that premise.** A template-independent externalization pass (reusing
+the preamble, re-driving `\tikzexternalize` in an overlay) carries real mechanism
+risk (preamble reuse / externalization-prefix interaction) for little gain. We
+instead make externalization **depend on the statement template**, with one
+guarantee:
+
+> **The bundled default/fallback preset template renders or `\subimport`s every
+> block and explanation that the Polygon upload references**, so the default and
+> fallback (no problem-level template) cases upload with zero dangling references.
+
+Custom standalone templates are the **author's responsibility**: a template that
+wants a block's or explanation's TikZ on Polygon must render/subimport it. A
+custom template that omits a subimport ships a dangling reference *by design* —
+there is **no runtime guard** (decided explicitly; the guard / hard-error
+alternatives were considered and dropped in favor of the smallest model).
+
+## What the check found (current behavior)
+
+The upload (`polygon/upload.py:_upload_statement.process_statement`) maps **only**
+these to Polygon fields:
+
+- `legend`, `input`, `output`, `interaction`, `notes` — from the **named** body
+  blocks (`blocks.blocks`).
+- sample explanations — from the **int-keyed** `blocks.explanations` dict,
+  appended into `notes`.
+
+In the bundled default body template (`presets/default/contest/statements/
+_problem-body.rbx.tex`):
+
+- legend / input / output / interaction / notes render **directly in the body**
+  (`\VAR{...}`), so their TikZ externalizes under `legend_0`, `input_0`, … →
+  the PDF is **always** produced, independent of any subimport. ✓
+- every sample explanation is `\subimport`-ed (line 49). An **inline**
+  `explanation_<i>` block is externalized (`engine.py`) and staged carrying its
+  `i_0` label, so the subimported figure produces `i_0.pdf`. ✓
+
+So for body blocks + inline explanations the default preset is already
+**referentially complete** — exactly the "preset problems happen to work" the
+issue admits. The #590 bug only manifests for a *custom* template that omits the
+explanation subimport, which under this design is the author's responsibility.
+
+### Gap 1 — separate-file explanations are staged unlabeled (real bug)
+
+A **separate-file** sample explanation (`samples/<idx>.rbx.tex`, #589 finding #4)
+breaks **even under the default preset**. The `i_0` externalization label is
+applied only to the upload-side copy (`engine.py` externalizes
+`file_latex_explanations`), but the file the template actually subimports is
+staged **unlabeled** (`sample_staging.py:_resolve_explanation` → `render_text`,
+no externalize). A separate-file explanation containing TikZ therefore produces a
+figure under an auto-name (`<jobname>-figureN.pdf`) while the upload references
+`i_0` → dangling, default preset notwithstanding. This must be fixed for the
+default-preset guarantee to be airtight. (Currently untested: the
+`polygon-default-preset` fixture's separate-file explanation has no TikZ.)
+
+### Gap 2 — dead-weight dual label (harmless under this design)
+
+`extract_blocks` (`render.py`) splits inline `explanation_<i>` blocks into the
+int-keyed `.explanations` dict **but leaves the same content in `.blocks` under
+the string key `explanation_<i>`**. When externalizing, that string-keyed copy is
+labeled `explanation_<i>_<fig>` → a PDF that is never produced (no body/subimport
+renders `blocks.explanation_<i>`) and never uploaded (the upload only reads the
+int-keyed dict). It is pure dead weight in `blocks.sub.yml`, not a dangling
+reference. Verified: no template or production path reads
+`problem.blocks.explanation_<i>`.
+
+## Changes
+
+### 1. Production fix — stage separate-file explanations with their label
+
+- `engine.py`: thread the already-externalized `file_latex_explanations` into
+  `sample_staging.stage_samples` (new `extra_explanations` param), scoped to
+  `externalize=True` builds.
+- `sample_staging.py`: `_resolve_explanation` returns `extra_explanations[index]`
+  when present (the externalized text), **before** the disk read. The index is
+  not in `explanation_blocks`, so the existing source-dir mirror still runs (so
+  static images in the explanation still resolve).
+- Effect: the staged `.samples/<i>/explanation.tex` and the uploaded explanation
+  now share one source of truth (`file_latex_explanations`), so the subimported
+  figure externalizes under `i_0` — the exact name the upload references. The
+  default preset becomes airtight for **both** inline and separate-file
+  explanations. The inline path is untouched (already correct).
+
+### 2. Hygiene — drop the dead-weight dual label
+
+- `render.py:extract_blocks`: remove the `explanation_<i>` keys from
+  `StatementBlocks.blocks` (they are already split into the int-keyed
+  `.explanations`). `blocks.sub.yml` no longer carries the never-produced,
+  never-uploaded `explanation_<i>_<fig>` reference — settling on the single
+  int-keyed label scheme the issue's secondary defect asks for. Guarded by the
+  verification that nothing reads the string-keyed block.
+
+### 3. Acceptance fixture — make it compliant
+
+The `polygon-tikz-assets` fixture is itself a custom-template-omits-subimport
+case (its `statements/problem-standalone.rbx.tex` renders only input/output in the
+sample loop). Under this design it is by-design broken, so the issue's
+"flip the xfail to xpass" criterion requires making the fixture's template
+compliant rather than changing production code:
+
+- `polygon-tikz-assets/statements/problem-standalone.rbx.tex`: add
+  `\explanation{\subimport{\VAR{sample.dir}}{\VAR{sample.explanation_file}}}` to
+  the sample loop. `0_0.pdf` is now produced (the inline `explanation_0` block is
+  already staged with its `0_0` label — **no production change needed** for this
+  fixture).
+- `polygon-upload-assets` (`e2e.rbx.yml`): flip assertions — `notes_contains`
+  references `\includegraphics{artifacts__tikz_figures__0_0.pdf}`;
+  `resources_present` gains `artifacts__tikz_figures__0_0.pdf`; drop the two
+  `0_0.pdf` entries from `resources_absent`.
+- `tests/e2e/conftest.py`: remove `polygon-upload-assets-referential-integrity`
+  from `_XFAIL_SCENARIOS` → it becomes a real **xpass**.
+
+### 4. Coverage for the production fix (§1)
+
+- Add a **separate-file** `samples/<idx>.rbx.tex` explanation containing a
+  `\tikzpicture` to a default-preset e2e scenario (`polygon-default-preset` or a
+  new sibling), asserting `resources_referenced_consistent: true` and the
+  produced `i_0.pdf` resource present. Without this the §1 fix is unexercised.
+
+### 5. Documentation
+
+- `rbx/box/statements/CLAUDE.md` + the statements docs: state the contract — for
+  a block's or explanation's TikZ (or static image) to externalize and upload to
+  Polygon, the statement template must render/subimport it; the bundled
+  default/fallback preset satisfies this for all blocks and explanations; a custom
+  standalone template that omits a subimport ships a dangling reference (author's
+  responsibility, no runtime guard).
+
+## Acceptance / verification
+
+- `polygon-upload-assets-referential-integrity` flips from xfail to **xpass**
+  (every `\includegraphics` resolves to an uploaded resource).
+- `polygon-upload-assets` green with the flipped assertions.
+- New separate-file-explanation-with-TikZ scenario green (guards §1).
+- Run: `mise run test-e2e-pdflatex` + the statements unit tests
+  (`uv run pytest tests/rbx/box/statements`).
+
+## Out of scope
+
+- Template-independent externalization (the issue's auxiliary-document pass) —
+  explicitly rejected above.
+- A runtime referential-integrity guard for non-compliant custom templates
+  (strip-and-warn / hard-error) — considered and dropped.
+- Offline Polygon `problem.zip`/`contest.zip` statement embedding (#583).

--- a/docs/plans/2026-06-20-polygon-tikz-depend-on-template.md
+++ b/docs/plans/2026-06-20-polygon-tikz-depend-on-template.md
@@ -1,0 +1,456 @@
+# Polygon TikZ depend-on-template Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `rbx package polygon -u` upload every sample-explanation TikZ figure without a dangling reference, by depending on the statement template and guaranteeing the bundled default/fallback preset renders/subimports everything — instead of #590's rejected template-independent externalization pass.
+
+**Architecture:** The Polygon upload references figures by the externalization label the engine assigns (`legend_0`, `i_0`, …). Body blocks always render in the document body, so their figures always externalize. Sample explanations only externalize if the template `\subimport`s them — which the default preset does. Two real fixes: (1) separate-file `samples/<idx>.rbx.tex` explanations are currently staged *unlabeled*, so their subimported figure is produced under the wrong name — thread the already-externalized text into staging so the staged file carries the `i_0` label; (2) drop the dead-weight string-keyed `explanation_<i>` block that produces an unused, never-uploaded label. Then make the acceptance fixture's custom template compliant so the xfail flips to xpass.
+
+**Tech Stack:** Python 3, Pydantic v2, pytest, the statements-v2 engine (`rbx/box/statements/`), the e2e YAML DSL (`tests/e2e/`), pdflatex-marked e2e runs (`mise run test-e2e-pdflatex`).
+
+**Design doc:** `docs/plans/2026-06-20-polygon-tikz-depend-on-template-design.md`
+
+**Commit convention:** This repo enforces commitizen conventional commits (see `.claude/skills/commit.md`). Use the `/commit` workflow for every commit; append the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer. Stage files by name (no `git add -A`).
+
+**Working dir:** the worktree `.claude/worktrees/issue-590-polygon-tikz-template` (already created). All paths below are repo-relative.
+
+---
+
+## Task 1: Drop the dead-weight string-keyed `explanation_<i>` block
+
+The `explanation_<i>` blocks are split into the int-keyed `StatementBlocks.explanations` but left **also** in `.blocks` under the string key. When externalizing, that copy is labeled `explanation_<i>_<fig>` → a PDF that is never produced and never uploaded (the upload only reads `.explanations`). Remove it.
+
+**Files:**
+- Modify: `rbx/box/statements/render.py:94-101` (`render_jinja_blocks`)
+- Test: `tests/rbx/box/statements/test_render.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/rbx/box/statements/test_render.py` (place it near the existing explanation test that asserts `0 in blocks.explanations`):
+
+```python
+def test_explanation_blocks_are_removed_from_named_blocks(tmp_path):
+    # An `explanation_<i>` block is split into `.explanations` and must NOT
+    # remain in `.blocks` under its string key (it would otherwise be labeled
+    # `explanation_0_0` on externalize -> a PDF never produced or uploaded).
+    content = (
+        b'%- block legend\nhi\n%- endblock\n'
+        b'%- block explanation_0\nwhy sample zero\n%- endblock\n'
+    )
+    blocks = render.render_jinja_blocks(tmp_path, content, mode='latex')
+    assert 0 in blocks.explanations
+    assert 'why sample zero' in blocks.explanations[0]
+    assert 'explanation_0' not in blocks.blocks
+    assert 'legend' in blocks.blocks
+```
+
+(Check the file's existing imports — it already imports `render`. Match the existing test's call signature; if the existing test constructs `ProblemRenderContext`/`ContestRenderContext` and calls `extract_blocks`, mirror that instead and assert the same three things.)
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/statements/test_render.py::test_explanation_blocks_are_removed_from_named_blocks -v`
+Expected: FAIL — `assert 'explanation_0' not in blocks.blocks` fails (the key is present).
+
+**Step 3: Write minimal implementation**
+
+In `rbx/box/statements/render.py`, `render_jinja_blocks`, change the tail (lines ~94-101) to pop the matched keys out of `result`:
+
+```python
+    pattern = re.compile(r'explanation_(\d+)')
+    explanation_keys = []
+    for key in result:
+        if match := pattern.match(key):
+            explanation_keys.append((key, int(match.group(1))))
+
+    # Split per-sample explanations into the int-keyed `explanations` map and
+    # remove them from the named `blocks` so they are not double-labeled on
+    # externalize (the upload only reads `.explanations`).
+    explanations = {value: result.pop(key) for key, value in explanation_keys}
+    return StatementBlocks(blocks=result, explanations=explanations)
+```
+
+(`pattern.match` anchors at the start; if a real block legitimately starts with `explanation_` but is not a sample explanation, that is already the existing behavior — no change. Keep `match` not `fullmatch` to preserve current semantics.)
+
+**Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/statements/test_render.py -v`
+Expected: PASS (new test + the existing explanation test still green).
+
+**Step 5: Run the broader statements + polygon-export unit suites**
+
+Run: `uv run pytest tests/rbx/box/statements/test_render.py tests/rbx/box/statements/test_engine.py tests/rbx/box/statements/test_engine_blocks.py tests/rbx/box/statements/test_polygon_export.py -v`
+Expected: PASS. If `test_polygon_export.py` asserts an `explanation_0` key inside `blocks.sub.yml`'s `blocks`, update that assertion to reflect the removed dead-weight label (the int-keyed `explanations` entry is the real one).
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/statements/render.py tests/rbx/box/statements/test_render.py
+# + tests/rbx/box/statements/test_polygon_export.py if it needed updating
+git commit  # via /commit -> refactor(statements): drop dead-weight string-keyed explanation block
+```
+
+---
+
+## Task 2: `stage_samples` honors `extra_explanations` (separate-file label fix, unit)
+
+Give `stage_samples` a new `extra_explanations: Dict[int, str]` map. For a sample whose explanation comes from a **file** (not an inline `explanation_<i>` block), if `extra_explanations[index]` is present, use that text for `explanation.tex` **while still mirroring the source dir** (so the explanation's own figures resolve). This lets the engine feed the already-externalized text so the staged figure externalizes under the label the upload references.
+
+**Files:**
+- Modify: `rbx/box/statements/sample_staging.py` (`_resolve_explanation` lines 61-85; `stage_samples` signature lines 88-128)
+- Test: `tests/rbx/box/statements/test_sample_staging.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/rbx/box/statements/test_sample_staging.py`, inside `class TestExplanations`:
+
+```python
+    def test_extra_explanation_overrides_file_text_and_still_mirrors_dir(
+        self, tmp_path
+    ):
+        # A separate-file explanation: the staged text comes from
+        # `extra_explanations` (the engine's externalized copy), but the source
+        # directory is STILL mirrored so the explanation's own figures resolve.
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        _write(src / '000.tex', 'raw \\includegraphics{diagram}')
+        _write(src / 'diagram.png', 'PNG')
+        source = SampleSource(
+            input_path=src / '000.in',
+            explanation_path=src / '000.tex',
+        )
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        handles = sample_staging.stage_samples(
+            problem_root=root,
+            root_prefix='',
+            sources=[source],
+            extra_explanations={0: 'labeled \\tikzsetnextfilename{0_0} text'},
+        )
+
+        explanation = root / '.samples' / '000' / 'explanation.tex'
+        assert explanation.read_text() == 'labeled \\tikzsetnextfilename{0_0} text'
+        # The source dir was still mirrored for the explanation's figures.
+        assert (root / '.samples' / '000' / 'diagram.png').read_text() == 'PNG'
+        assert handles[0].explanation_file == 'explanation'
+
+    def test_inline_block_still_wins_over_extra_explanation(self, tmp_path):
+        # An inline explanation_<i> block takes precedence over extra_explanations.
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        source = SampleSource(input_path=src / '000.in')
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        sample_staging.stage_samples(
+            problem_root=root,
+            root_prefix='',
+            sources=[source],
+            explanation_blocks={0: 'INLINE'},
+            extra_explanations={0: 'EXTRA'},
+        )
+        assert (root / '.samples' / '000' / 'explanation.tex').read_text() == 'INLINE'
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/statements/test_sample_staging.py -k extra_explanation -v`
+Expected: FAIL — `stage_samples() got an unexpected keyword argument 'extra_explanations'`.
+
+**Step 3: Implement**
+
+In `rbx/box/statements/sample_staging.py`:
+
+a) Extend `_resolve_explanation` to consult `extra_explanations` **after** inline blocks, **before** the disk read:
+
+```python
+def _resolve_explanation(
+    index: int,
+    source: SampleSource,
+    explanation_blocks: Dict[int, str],
+    extra_explanations: Dict[int, str],
+    render_text: Optional[RenderText],
+    render_blocks: Optional[RenderBlocks],
+    lang: str,
+    mode: str,
+) -> Optional[bytes]:
+    """Return the final explanation content for a sample, or None.
+
+    Inline ``explanation_<i>`` blocks take precedence over an authored file.
+    ``extra_explanations`` (the engine's already-externalized copy of a
+    separate-file explanation) overrides the on-disk text but does NOT suppress
+    the source-dir mirror, so the explanation's own figures still resolve.
+    """
+    if index in explanation_blocks:
+        return explanation_blocks[index].encode()
+    if index in extra_explanations:
+        return extra_explanations[index].encode()
+    if source.explanation_path is None or not source.explanation_path.is_file():
+        return None
+    raw = source.explanation_path.read_bytes()
+    if source.explanation_from_blocks and render_blocks is not None:
+        blocks = render_blocks(raw, mode)
+        selected = blocks.get(lang)
+        return selected.encode() if selected is not None else None
+    if render_text is not None:
+        return render_text(raw, mode)
+    return raw
+```
+
+b) Add the `extra_explanations` param to `stage_samples` (default `None`), normalize it, and pass it through. In `stage_samples`:
+
+```python
+def stage_samples(
+    problem_root: pathlib.Path,
+    root_prefix: str,
+    sources: List[SampleSource],
+    *,
+    explanation_blocks: Optional[Dict[int, str]] = None,
+    extra_explanations: Optional[Dict[int, str]] = None,
+    render_text: Optional[RenderText] = None,
+    render_explanation_text: Optional[RenderText] = None,
+    render_blocks: Optional[RenderBlocks] = None,
+    lang: str = 'en',
+    mode: str = 'latex',
+) -> List[SampleHandle]:
+```
+
+After `explanation_blocks = explanation_blocks or {}` add:
+
+```python
+    extra_explanations = extra_explanations or {}
+```
+
+Update the `_resolve_explanation(...)` call (around line 120) to pass `extra_explanations` positionally/keyword in the new slot.
+
+c) The dir-mirror guard (lines 134-140) keys off `index not in explanation_blocks` and `source.explanation_path.is_file()`. A separate-file explanation supplied via `extra_explanations` is **not** in `explanation_blocks` and **has** an `explanation_path`, so the mirror already fires — **no change needed there**. (Verify this by re-reading lines 134-140; do not add `extra_explanations` to that condition.)
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/statements/test_sample_staging.py -v`
+Expected: PASS (new tests + all existing staging tests green).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/statements/sample_staging.py tests/rbx/box/statements/test_sample_staging.py
+git commit  # via /commit -> feat(statements): stage separate-file explanations with externalized label
+```
+
+---
+
+## Task 3: Wire the externalized `file_latex_explanations` into staging (engine)
+
+Feed the engine's already-externalized separate-file explanations into `stage_samples` so the staged figure externalizes under the `i_0` label the upload references. Scope to `externalize=True` so the normal PDF build stays byte-identical.
+
+**Files:**
+- Modify: `rbx/box/statements/engine.py` (the `stage_samples(...)` call, ~lines 205-214)
+
+**Step 1: Make the change**
+
+In `rbx/box/statements/engine.py`, the `stage_samples` call currently passes `explanation_blocks=latex_explanations`. Add the externalized separate-file map, gated on `externalize`:
+
+```python
+        problem.samples = sample_staging.stage_samples(
+            problem_root,
+            root_prefix,
+            sources,
+            explanation_blocks=latex_explanations,
+            extra_explanations=file_latex_explanations if externalize else None,
+            render_text=render_text,
+            render_blocks=render_blocks,
+            lang=lang,
+            mode=mode,
+        )
+```
+
+Rationale: `file_latex_explanations` is externalized at line 180 only under `externalize`; passing it as `extra_explanations` makes the staged `.samples/<i>/explanation.tex` and the uploaded explanation share one source of truth, so the produced figure name (`i_0`) matches the uploaded `\includegraphics{artifacts/tikz_figures/i_0}`. Inline `explanation_<i>` explanations are unaffected (they take precedence in `_resolve_explanation` and were already correct).
+
+**Step 2: Run the engine + polygon-export unit suites (regression)**
+
+Run: `uv run pytest tests/rbx/box/statements/test_engine.py tests/rbx/box/statements/test_engine_blocks.py tests/rbx/box/statements/test_polygon_export.py -v`
+Expected: PASS (no behavior change for inline explanations or non-externalize builds). The new behavior is covered end-to-end in Task 5.
+
+**Step 3: Commit**
+
+```bash
+git add rbx/box/statements/engine.py
+git commit  # via /commit -> fix(statements): externalize separate-file sample explanations for polygon (#590)
+```
+
+---
+
+## Task 4: Make the acceptance fixture compliant and flip the xfail to xpass
+
+`polygon-tikz-assets` uses a custom standalone template that omits the explanation subimport — by-design broken under depend-on-template. Make its template compliant; the inline `explanation_0` block is already staged with its `0_0` label, so `0_0.pdf` is produced with **no production change**. Then flip the assertions and remove the xfail.
+
+**Files:**
+- Modify: `tests/e2e/testdata/polygon-tikz-assets/statements/problem-standalone.rbx.tex`
+- Modify: `tests/e2e/testdata/polygon-tikz-assets/e2e.rbx.yml` (`polygon-upload-assets` scenario)
+- Modify: `tests/e2e/conftest.py` (`_XFAIL_SCENARIOS`)
+
+**Step 1: Make the fixture template subimport explanations**
+
+In `tests/e2e/testdata/polygon-tikz-assets/statements/problem-standalone.rbx.tex`, the sample loop currently renders only `\example{...}{...}`. Add the explanation subimport inside the loop:
+
+```latex
+%- if problem.samples
+  \subsection*{Examples}
+  %- for sample in problem.samples
+    \example{\VAR{sample.input}}{\VAR{sample.output if sample.output is not none else ''}}
+    %- if sample.explanation_file is not none
+      \subimport{\VAR{sample.dir}}{\VAR{sample.explanation_file}}
+    %- endif
+  %- endfor
+%- endif
+```
+
+(The template has no `\explanation` macro defined, so `\subimport` is used directly — equivalent for figure production. Keep `\usepackage{import}`/`{tikz}`/`{graphicx}` which are already present.)
+
+**Step 2: Flip the `polygon-upload-assets` assertions**
+
+In `tests/e2e/testdata/polygon-tikz-assets/e2e.rbx.yml`, scenario `polygon-upload-assets`:
+
+- In `notes_contains`, replace the dangling line `"\\includegraphics{artifacts/tikz_figures/0_0}"` with `"\\includegraphics{artifacts__tikz_figures__0_0.pdf}"`.
+- In `resources_present`, add `"artifacts__tikz_figures__0_0.pdf"`.
+- In `resources_absent`, remove `"artifacts__tikz_figures__0_0.pdf"` and `"artifacts/tikz_figures/0_0.pdf"` (keep `"samples__000.in"`).
+- Update the scenario `description` so it no longer claims the explanation TikZ is un-externalized (it now is). Note the template now subimports the explanation.
+
+**Step 3: Remove the xfail registration**
+
+In `tests/e2e/conftest.py`, delete the `'polygon-upload-assets-referential-integrity'` entry from `_XFAIL_SCENARIOS` (lines ~89-…). The scenario `polygon-upload-assets-referential-integrity` now passes normally.
+
+**Step 4: Run the affected e2e scenarios with pdflatex**
+
+Run: `mise run test-e2e-pdflatex`
+Expected: `polygon-upload-assets` PASS with the flipped assertions; `polygon-upload-assets-referential-integrity` PASS (no longer xfail). If `mise run test-e2e-pdflatex` runs the whole pdflatex suite, confirm no other scenario regressed.
+
+(If a filter is supported, scope to the fixture, e.g. `mise run test-e2e-pdflatex -- -k polygon_tikz_assets` or the project's documented selector — check `tests/e2e/README.md`.)
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/testdata/polygon-tikz-assets/statements/problem-standalone.rbx.tex \
+        tests/e2e/testdata/polygon-tikz-assets/e2e.rbx.yml \
+        tests/e2e/conftest.py
+git commit  # via /commit -> test(e2e): make polygon-tikz-assets template compliant, flip referential-integrity to xpass
+```
+
+---
+
+## Task 5: Cover the separate-file explanation TikZ fix end-to-end (default preset)
+
+Guard the Task 2/3 fix: a **separate-file** `samples/<idx>.rbx.tex` explanation containing TikZ, built with the **default preset** chrome, must upload with a consistent reference. The `polygon-default-preset/A` fixture already has a no-TikZ separate-file explanation (`samples/000.rbx.tex`); add TikZ to it and assert referential consistency.
+
+**Files:**
+- Modify: `tests/e2e/testdata/polygon-default-preset/A/statement/samples/000.rbx.tex`
+- Modify: `tests/e2e/testdata/polygon-default-preset/e2e.rbx.yml` (`problem-polygon-upload` scenario)
+
+**Step 1: Add TikZ to the separate-file explanation**
+
+In `tests/e2e/testdata/polygon-default-preset/A/statement/samples/000.rbx.tex`, append a TikZ picture inside the `en` block:
+
+```latex
+%- block en
+In the first sample, $A = 3$ and $B = 7$, so the answer is $A + B = 10$.
+
+\begin{tikzpicture}
+  \draw (0,0) -- (1,1) -- (2,0) -- cycle;
+\end{tikzpicture}
+%- endblock
+```
+
+**Step 2: Assert referential consistency + the produced figure**
+
+In `tests/e2e/testdata/polygon-default-preset/e2e.rbx.yml`, scenario `problem-polygon-upload`, extend the `polygon_upload` expectation:
+
+```yaml
+          polygon_upload:
+            statements:
+              english:
+                legend_contains: ["A", "B"]
+                notes_contains: "In the first sample"
+            resources_present:
+              - "artifacts__tikz_figures__0_0.pdf"
+            resources_referenced_consistent: true
+```
+
+(Match the existing YAML shape for `resources_present`/`resources_referenced_consistent` used by `polygon-tikz-assets`. The separate-file explanation is sample index 0 → label `0_0`.)
+
+**Step 3: Run the scenario with pdflatex (the TDD red→green for the integration)**
+
+Run: `mise run test-e2e-pdflatex`
+Expected: `problem-polygon-upload` PASS. To prove the guard bites, temporarily revert Task 3's engine change and confirm this scenario goes RED (`0_0.pdf` produced under an auto-name; reference dangling) — then restore.
+
+**Step 4: Commit**
+
+```bash
+git add tests/e2e/testdata/polygon-default-preset/A/statement/samples/000.rbx.tex \
+        tests/e2e/testdata/polygon-default-preset/e2e.rbx.yml
+git commit  # via /commit -> test(e2e): cover separate-file explanation tikz under default preset (#590)
+```
+
+---
+
+## Task 6: Document the template contract
+
+**Files:**
+- Modify: `rbx/box/statements/CLAUDE.md` (Polygon export section)
+- Modify: the user-facing statements docs (find under `docs/`; check `mkdocs.yml` nav for the statements/Polygon page)
+
+**Step 1: Update the module CLAUDE.md**
+
+In `rbx/box/statements/CLAUDE.md`, under "## Polygon export (S12, #568)", add a short paragraph:
+
+> **Template contract (#590):** TikZ externalization depends on the statement
+> template. A block's or explanation's TikZ (or static image) is uploaded to
+> Polygon only if the template renders/subimports it. Body blocks
+> (legend/input/output/interaction/notes) render directly, so their figures
+> always externalize; sample explanations externalize only when the template
+> `\subimport`s them. The bundled default/fallback preset
+> (`_problem-body.rbx.tex`) renders all blocks and subimports every explanation,
+> so default and contest-less-fallback uploads are referentially complete.
+> Custom standalone templates that omit an explanation subimport ship a dangling
+> reference by design — there is no runtime guard. Separate-file
+> (`samples/<idx>.rbx.tex`) and inline (`explanation_<i>`) explanations are both
+> staged carrying their `i_0` externalization label, so either source produces
+> the figure the upload references.
+
+**Step 2: Update the user-facing docs**
+
+Locate the statements / Polygon-packaging docs page (grep `docs/` for "subimport", "explanation", or "Polygon"). Add a note in the author-facing voice: to get a sample-explanation figure onto Polygon with a custom standalone template, the template must `\subimport` the explanation (as the default preset does); the bundled preset already does this.
+
+**Step 3: Verify docs build**
+
+Run the project's docs build (non-strict, per repo convention — strict has ~9 pre-existing unrelated warnings). Check `mkdocs.yml` / `mise` tasks for the command (e.g. `uv run mkdocs build`).
+Expected: builds; the new page content renders. Ignore the known pre-existing strict warnings.
+
+**Step 4: Commit**
+
+```bash
+git add rbx/box/statements/CLAUDE.md docs/  # + the specific docs file
+git commit  # via /commit -> docs(statements): document polygon tikz template contract (#590)
+```
+
+---
+
+## Final verification
+
+Run the full relevant suites and confirm green:
+
+```bash
+uv run pytest tests/rbx/box/statements -v
+mise run test-e2e-pdflatex
+```
+
+Expected:
+- All statements unit tests pass.
+- `polygon-upload-assets` passes with flipped assertions; `polygon-upload-assets-referential-integrity` passes (no longer xfail); `problem-polygon-upload` (default preset) passes with the new TikZ explanation referenced consistently.
+
+Then finish the branch per superpowers:finishing-a-development-branch (PR referencing #590; note the design doc and that #590's template-independent approach was deliberately rejected).
+
+## Notes / gotchas
+
+- The pdflatex e2e runs are slow and need a real `pdflatex` on PATH; the fast TDD loop is the unit tests in Tasks 1–2. Tasks 4–5 are integration guards run once.
+- Do NOT add a runtime referential-integrity guard for non-compliant custom templates — that was explicitly rejected (design "Out of scope").
+- Per repo memory: some C++ checker/validator/sandbox/docker tests fail pre-existingly on this machine and are unrelated; don't chase them.

--- a/docs/setters/statements/formats/rbxtex.md
+++ b/docs/setters/statements/formats/rbxtex.md
@@ -167,9 +167,9 @@ the same sample):
     statement template must `\subimport` that explanation — the figure is only
     uploaded when the template actually renders it. The bundled default (and
     fallback) preset already subimports every explanation, so it works out of the
-    box. If you use a **custom** standalone template that omits the explanation
-    subimport, the figure won't be uploaded and the explanation will show a broken
-    image on Polygon.
+    box. If you use a **custom** template that omits the explanation subimport,
+    the figure won't be uploaded and the explanation will show a broken image on
+    Polygon.
 
 ## Example
 

--- a/docs/setters/statements/formats/rbxtex.md
+++ b/docs/setters/statements/formats/rbxtex.md
@@ -161,6 +161,16 @@ the same sample):
     file has no block for the statement's language, no explanation is shown for
     that sample in that language (and {{rbx}} warns you).
 
+!!! note "Sample-explanation figures on {{polygon}}"
+    If a sample explanation contains a figure (TikZ or an image) and you want it
+    to show up when uploading to {{polygon}} (`rbx package polygon -u`), your
+    statement template must `\subimport` that explanation — the figure is only
+    uploaded when the template actually renders it. The bundled default (and
+    fallback) preset already subimports every explanation, so it works out of the
+    box. If you use a **custom** standalone template that omits the explanation
+    subimport, the figure won't be uploaded and the explanation will show a broken
+    image on Polygon.
+
 ## Example
 
 Here is a barebones example of a problem statement written in rbxTeX.

--- a/rbx/box/statements/CLAUDE.md
+++ b/rbx/box/statements/CLAUDE.md
@@ -158,6 +158,20 @@ consumes the v2 overlay directly. The standalone overlay root
   and converts to Polygon TeX (`polygon_utils.py`). No per-builder subdirs, no
   absolute/temp paths.
 
+**Template contract (#590):** TikZ externalization depends on the statement
+template. A block's or explanation's TikZ (or static image) is uploaded to
+Polygon only if the template renders/`\subimport`s it. Body blocks
+(legend/input/output/interaction/notes) render directly into the body, so their
+figures always externalize; sample explanations externalize only when the
+template `\subimport`s them. The bundled default/fallback preset
+(`_problem-body.rbx.tex`) renders all blocks and subimports every explanation, so
+default and contest-less-fallback uploads are referentially complete. Custom
+standalone templates that omit an explanation subimport ship a dangling reference
+by design — there is no runtime guard. Both separate-file
+(`samples/<idx>.rbx.tex`) and inline (`explanation_<i>`) explanations are staged
+carrying their `i_0` externalization label, so either source produces the figure
+the upload references.
+
 The **offline** Polygon packager (embedding PDFs in `problem.zip` /
 `contest.zip`) is a separate follow-up (#583).
 

--- a/rbx/box/statements/engine.py
+++ b/rbx/box/statements/engine.py
@@ -207,6 +207,12 @@ def render_problem_tex(
             root_prefix,
             sources,
             explanation_blocks=latex_explanations,
+            # Only on the externalize path do we feed the already-externalized
+            # separate-file explanations through staging, so the staged figure
+            # carries the same label the Polygon upload references. The normal
+            # PDF build (externalize=False) keeps resolving these from disk and
+            # stays byte-identical.
+            extra_explanations=file_latex_explanations if externalize else None,
             render_text=render_text,
             render_blocks=render_blocks,
             lang=lang,

--- a/rbx/box/statements/render.py
+++ b/rbx/box/statements/render.py
@@ -97,7 +97,10 @@ def render_jinja_blocks(
         if match := pattern.match(key):
             explanation_keys.append((key, int(match.group(1))))
 
-    explanations = {value: result[key] for key, value in explanation_keys}
+    # Split per-sample explanations into the int-keyed `explanations` map and
+    # remove them from the named `blocks` so they are not double-labeled on
+    # externalize (the upload only reads `.explanations`).
+    explanations = {value: result.pop(key) for key, value in explanation_keys}
     return StatementBlocks(blocks=result, explanations=explanations)
 
 

--- a/rbx/box/statements/sample_staging.py
+++ b/rbx/box/statements/sample_staging.py
@@ -62,6 +62,7 @@ def _resolve_explanation(
     index: int,
     source: SampleSource,
     explanation_blocks: Dict[int, str],
+    extra_explanations: Dict[int, str],
     render_text: Optional[RenderText],
     render_blocks: Optional[RenderBlocks],
     lang: str,
@@ -69,10 +70,16 @@ def _resolve_explanation(
 ) -> Optional[bytes]:
     """Return the final explanation content for a sample, or None.
 
-    Inline ``explanation_<i>`` blocks take precedence over an authored file.
+    Precedence: inline ``explanation_<i>`` blocks → ``extra_explanations`` →
+    the authored file on disk. ``extra_explanations`` only overrides the staged
+    *text* of a separate-file explanation (e.g. the engine's already-externalized
+    copy); it does NOT suppress the source-dir mirror, so the explanation's own
+    figures still resolve (the caller's mirror guard is left untouched).
     """
     if index in explanation_blocks:
         return explanation_blocks[index].encode()
+    if index in extra_explanations:
+        return extra_explanations[index].encode()
     if source.explanation_path is None or not source.explanation_path.is_file():
         return None
     raw = source.explanation_path.read_bytes()
@@ -91,6 +98,7 @@ def stage_samples(
     sources: List[SampleSource],
     *,
     explanation_blocks: Optional[Dict[int, str]] = None,
+    extra_explanations: Optional[Dict[int, str]] = None,
     render_text: Optional[RenderText] = None,
     render_explanation_text: Optional[RenderText] = None,
     render_blocks: Optional[RenderBlocks] = None,
@@ -107,6 +115,7 @@ def stage_samples(
     Jinja before it is written into the sample folder.
     """
     explanation_blocks = explanation_blocks or {}
+    extra_explanations = extra_explanations or {}
     render_text = render_text or render_explanation_text
     samples_root = problem_root / SAMPLES_DIRNAME
 
@@ -121,6 +130,7 @@ def stage_samples(
             index,
             source,
             explanation_blocks,
+            extra_explanations,
             render_text,
             render_blocks,
             lang,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -85,13 +85,7 @@ def pytest_collect_file(parent, file_path):
 # (non-strict) so the suite stays green while documenting a known bug, and flips
 # to xpass the moment the bug is fixed. Keyed by scenario name. See
 # docs/plans/2026-06-10-polygon-statement-upload-audit.md.
-_XFAIL_SCENARIOS = {
-    'polygon-upload-assets-referential-integrity': (
-        'sample-explanation TikZ is not externalized/uploaded; the notes '
-        'reference a non-existent artifacts/tikz_figures/0_0 PDF (#586 audit, '
-        'tracked by #590).'
-    ),
-}
+_XFAIL_SCENARIOS = {}
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -85,6 +85,8 @@ def pytest_collect_file(parent, file_path):
 # (non-strict) so the suite stays green while documenting a known bug, and flips
 # to xpass the moment the bug is fixed. Keyed by scenario name. See
 # docs/plans/2026-06-10-polygon-statement-upload-audit.md.
+# Intentionally empty right now (the #590 referential-integrity scenario was
+# fixed and now passes normally); keep the hook for the next documented bug.
 _XFAIL_SCENARIOS = {}
 
 

--- a/tests/e2e/testdata/polygon-default-preset/A/statement/samples/000.rbx.tex
+++ b/tests/e2e/testdata/polygon-default-preset/A/statement/samples/000.rbx.tex
@@ -1,3 +1,7 @@
 %- block en
 In the first sample, $A = 3$ and $B = 7$, so the answer is $A + B = 10$.
+
+\begin{tikzpicture}
+  \draw (0,0) -- (1,1) -- (2,0) -- cycle;
+\end{tikzpicture}
 %- endblock

--- a/tests/e2e/testdata/polygon-default-preset/e2e.rbx.yml
+++ b/tests/e2e/testdata/polygon-default-preset/e2e.rbx.yml
@@ -17,7 +17,7 @@ scenarios:
     description: >
       The default preset's problem runs a FULL `package polygon -u` (every upload
       category: files, solutions, tests/generators, statement) end-to-end against
-      the recording Polygon fake. This guards two regressions at once:
+      the recording Polygon fake. This guards three regressions at once:
 
       #589 finding #1 -- building the standalone statement overlay used to merge
       the contest chrome (statements/) with the problem's statement dir
@@ -33,6 +33,12 @@ scenarios:
       `asyncio.run()` from inside the upload event loop. Fixed by extracting the
       testcase entries once on the async path and threading them down. Before the
       fix the command exited 1 here and never printed "uploaded successfully".
+
+      #590 -- the separate-file sample explanation contains TikZ; the standalone
+      template subimports it so the figure externalizes to the `0_0` label the
+      uploaded notes reference (resources_present + resources_referenced_consistent
+      assert it resolves). Before the fix the figure was staged unlabeled and
+      produced under an auto-name, leaving a dangling reference.
     steps:
       - cmd: package polygon -u --upload-as-english
         cwd: A

--- a/tests/e2e/testdata/polygon-default-preset/e2e.rbx.yml
+++ b/tests/e2e/testdata/polygon-default-preset/e2e.rbx.yml
@@ -43,3 +43,9 @@ scenarios:
               english:
                 legend_contains: ["A", "B"]
                 notes_contains: "In the first sample"
+            resources_present:
+              # #590: the separate-file sample explanation contains TikZ, so the
+              # standalone template subimports it and externalizes the figure to
+              # the 0_0 label the uploaded notes reference.
+              - "artifacts__tikz_figures__0_0.pdf"
+            resources_referenced_consistent: true

--- a/tests/e2e/testdata/polygon-tikz-assets/e2e.rbx.yml
+++ b/tests/e2e/testdata/polygon-tikz-assets/e2e.rbx.yml
@@ -5,12 +5,12 @@ scenarios:
       Grills the Polygon upload of statement assets: a TikZ picture and two
       static images (root-level + nested) in the legend, plus a sample
       explanation (inline explanation_0 block) that itself contains a TikZ
-      picture and a nested image. Encodes the CURRENT behavior (so the suite is
-      green and documents reality): the legend TikZ is externalized and
-      uploaded; both legend images upload (subdir remapped to __, root kept
-      as-is); the explanation merges into notes and its image is remapped and
-      uploaded -- BUT the explanation's TikZ is NOT externalized (notes reference
-      an artifacts/tikz_figures/0_0 PDF that is never produced or uploaded). See
+      picture and a nested image. The legend TikZ is externalized and uploaded;
+      both legend images upload (subdir remapped to __, root kept as-is); the
+      explanation merges into notes and its image is remapped and uploaded. The
+      template now subimports the explanation, so its TikZ externalizes to
+      artifacts__tikz_figures__0_0.pdf, which is uploaded and referenced
+      consistently from the notes. See
       docs/plans/2026-06-10-polygon-statement-upload-audit.md.
     steps:
       - cmd: build
@@ -38,18 +38,16 @@ scenarios:
                 notes_contains:
                   - "Explanation for example 1"
                   - "\\includegraphics{figs__expl.png}"
-                  # BUG: the explanation TikZ references a PDF that is never
-                  # produced or uploaded (it is not externalized).
-                  - "\\includegraphics{artifacts/tikz_figures/0_0}"
+                  # The template now subimports the explanation, so its TikZ is
+                  # externalized and the notes reference the uploaded PDF.
+                  - "\\includegraphics{artifacts__tikz_figures__0_0.pdf}"
             resources_present:
               - "artifacts__tikz_figures__legend_0.pdf"
               - "img__diagram.png"
               - "pic.png"
               - "figs__expl.png"
-            resources_absent:
-              # BUG: the explanation TikZ was never externalized to a PDF.
               - "artifacts__tikz_figures__0_0.pdf"
-              - "artifacts/tikz_figures/0_0.pdf"
+            resources_absent:
               # #595: sample I/O sources are no longer shipped as statement
               # resources (audit finding #5).
               - "samples__000.in"

--- a/tests/e2e/testdata/polygon-tikz-assets/e2e.rbx.yml
+++ b/tests/e2e/testdata/polygon-tikz-assets/e2e.rbx.yml
@@ -55,11 +55,11 @@ scenarios:
   - name: polygon-upload-assets-referential-integrity
     markers: [pdflatex]
     description: >
-      The DESIRED end state: every \includegraphics in the uploaded statement
-      resolves to an uploaded resource. Currently xfails (registered in
-      tests/e2e/conftest.py) because the sample explanation's TikZ is not
-      externalized/uploaded -- the notes reference an artifacts/tikz_figures/0_0
-      PDF that does not exist. Flips to xpass when that bug is fixed.
+      Acceptance assertion for #590: every \includegraphics in the uploaded
+      statement resolves to an uploaded resource, including the sample
+      explanation's externalized TikZ. The standalone template subimports the
+      explanation, so its TikZ externalizes to artifacts__tikz_figures__0_0.pdf,
+      which is uploaded and referenced consistently. Passes as a normal scenario.
     steps:
       - cmd: package polygon -u --upload-as-english --upload-only statements
         cwd: A

--- a/tests/e2e/testdata/polygon-tikz-assets/statements/problem-standalone.rbx.tex
+++ b/tests/e2e/testdata/polygon-tikz-assets/statements/problem-standalone.rbx.tex
@@ -24,6 +24,9 @@
   \subsection*{Examples}
   %- for sample in problem.samples
     \example{\VAR{sample.input}}{\VAR{sample.output if sample.output is not none else ''}}
+    %- if sample.explanation_file is not none
+      \subimport{\VAR{sample.dir}}{\VAR{sample.explanation_file}}
+    %- endif
   %- endfor
 %- endif
 

--- a/tests/rbx/box/statements/test_render.py
+++ b/tests/rbx/box/statements/test_render.py
@@ -41,6 +41,21 @@ class TestExtractBlocks:
         assert 'why sample zero' in blocks.explanations[0]
 
 
+def test_explanation_blocks_are_removed_from_named_blocks(tmp_path):
+    # An `explanation_<i>` block is split into `.explanations` and must NOT
+    # remain in `.blocks` under its string key (it would otherwise be labeled
+    # `explanation_0_0` on externalize -> a PDF never produced or uploaded).
+    content = (
+        b'%- block legend\nhi\n%- endblock\n'
+        b'%- block explanation_0\nwhy sample zero\n%- endblock\n'
+    )
+    blocks = render.render_jinja_blocks(tmp_path, content, mode='latex')
+    assert 0 in blocks.explanations
+    assert 'why sample zero' in blocks.explanations[0]
+    assert 'explanation_0' not in blocks.blocks
+    assert 'legend' in blocks.blocks
+
+
 class TestRenderProblemDocument:
     def test_fills_template_with_blocks_and_namespaces(self, tmp_path):
         # Template lives in the overlay root (staged by the stager).

--- a/tests/rbx/box/statements/test_sample_staging.py
+++ b/tests/rbx/box/statements/test_sample_staging.py
@@ -155,6 +155,53 @@ class TestExplanations:
         assert (root / '.samples' / '000' / 'explanation.tex').is_file()
         assert handles[0].explanation_file == 'explanation'
 
+    def test_extra_explanation_overrides_file_text_and_still_mirrors_dir(
+        self, tmp_path
+    ):
+        # A separate-file explanation: the staged text comes from
+        # `extra_explanations` (the engine's externalized copy), but the source
+        # directory is STILL mirrored so the explanation's own figures resolve.
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        _write(src / '000.tex', 'raw \\includegraphics{diagram}')
+        _write(src / 'diagram.png', 'PNG')
+        source = SampleSource(
+            input_path=src / '000.in',
+            explanation_path=src / '000.tex',
+        )
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        handles = sample_staging.stage_samples(
+            problem_root=root,
+            root_prefix='',
+            sources=[source],
+            extra_explanations={0: 'labeled \\tikzsetnextfilename{0_0} text'},
+        )
+
+        explanation = root / '.samples' / '000' / 'explanation.tex'
+        assert explanation.read_text() == 'labeled \\tikzsetnextfilename{0_0} text'
+        # The source dir was still mirrored for the explanation's figures.
+        assert (root / '.samples' / '000' / 'diagram.png').read_text() == 'PNG'
+        assert handles[0].explanation_file == 'explanation'
+
+    def test_inline_block_still_wins_over_extra_explanation(self, tmp_path):
+        # An inline explanation_<i> block takes precedence over extra_explanations.
+        src = tmp_path / 'src'
+        _write(src / '000.in')
+        source = SampleSource(input_path=src / '000.in')
+
+        root = tmp_path / 'overlay'
+        root.mkdir()
+        sample_staging.stage_samples(
+            problem_root=root,
+            root_prefix='',
+            sources=[source],
+            explanation_blocks={0: 'INLINE'},
+            extra_explanations={0: 'EXTRA'},
+        )
+        assert (root / '.samples' / '000' / 'explanation.tex').read_text() == 'INLINE'
+
     def test_inline_block_takes_precedence_over_file(self, tmp_path):
         src = tmp_path / 'src'
         _write(src / '000.in')


### PR DESCRIPTION
## Summary

Resolves #590. The issue proposed a **template-independent** externalization pass (an auxiliary document compiling every explanation after the main render). This PR deliberately **rejects** that in favor of **depending on the statement template**, with one guarantee: the bundled default/fallback preset renders/`\subimport`s every block and explanation the Polygon upload references, so default and contest-less-fallback uploads are referentially complete. Custom templates that omit an explanation subimport ship a dangling reference by design — no runtime guard (an explicit decision).

### Production changes
- **`engine.py` / `sample_staging.py`**: separate-file sample explanations (`samples/<idx>.rbx.tex`) are now staged carrying their `i_0` TikZ externalization label on the Polygon export path (new `extra_explanations` channel, gated on `externalize`), so the subimported figure is produced under the exact name the uploaded notes reference. Previously they were staged unlabeled → the figure was produced under an auto-name (`statement-figureN.pdf`) → dangling reference, **even under the default preset**. The non-externalize PDF build is byte-identical.
- **`render.py`**: drop the dead-weight string-keyed `explanation_<i>` block (already split into the int-keyed `.explanations`); it was being double-labeled `explanation_<i>_<fig>` on externalize → a PDF never produced or uploaded. Settles on the single int-keyed label scheme (#590 secondary defect).

### Tests & docs
- Make the `polygon-tikz-assets` acceptance fixture's custom template compliant (`\subimport` the explanation); flip `polygon-upload-assets` assertions and remove the `polygon-upload-assets-referential-integrity` xfail → it now passes normally.
- Add **separate-file explanation + TikZ** coverage under the default preset (`polygon-default-preset`), asserting `resources_referenced_consistent`. Guard-bites verified: reverting the engine wiring makes it fail (figure → `statement-figure0.pdf`, dangling `0_0` reference).
- Document the template contract in `rbx/box/statements/CLAUDE.md` and the author-facing `docs/setters/statements/formats/rbxtex.md`.

Design & plan: `docs/plans/2026-06-20-polygon-tikz-depend-on-template-design.md`, `docs/plans/2026-06-20-polygon-tikz-depend-on-template.md`.

## Test Plan
- [x] `uv run pytest tests/rbx/box/statements` → 251 passed
- [x] `mise run test-e2e-pdflatex` (`pytest -m 'e2e and pdflatex and not docker'`) → 5 passed, incl. `polygon-upload-assets-referential-integrity` (now a normal pass) and the new default-preset separate-file-tikz guard
- [x] guard-bites: temporarily reverting the `engine.py` wiring fails the new e2e (dangling reference), confirming the test bites

🤖 Generated with [Claude Code](https://claude.com/claude-code)