### PR TITLE
fix(schema): compare solution outcome against ExpectedOutcome

### DIFF
--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -1057,7 +1057,7 @@ that is correct and used as reference -- and should have the `accepted` outcome.
 
     @model_validator(mode='after')
     def check_first_solution_is_main_if_there_is_ac(self):
-        if all(sol.outcome != Outcome.ACCEPTED for sol in self.solutions):
+        if all(sol.outcome != ExpectedOutcome.ACCEPTED for sol in self.solutions):
             # No main solution.
             return self
         if self.solutions:

--- a/tests/rbx/box/test_schema.py
+++ b/tests/rbx/box/test_schema.py
@@ -503,14 +503,14 @@ class TestPackageOutcomePerGroupValidation:
                 ],
             )
 
-    def test_main_solution_is_the_accepted_one_not_the_first_one(self):
+    def test_accepted_solution_listed_after_another_one_is_rejected(self):
         from pydantic import ValidationError
 
         from rbx.box.schema import ExpectedOutcome, Package, Solution, TestcaseGroup
 
-        # `get_main_solution` picks the first ACCEPTED solution, so that is the one
-        # held to being accepted everywhere -- even when it is not listed first.
-        with pytest.raises(ValidationError, match='first accepted solution'):
+        # An ACCEPTED solution that is not listed first is rejected outright, so
+        # `get_main_solution` never has to look past the first solution.
+        with pytest.raises(ValidationError, match='must have the "ACCEPTED" outcome'):
             Package(
                 name='prob',
                 timeLimit=1000,
@@ -688,3 +688,53 @@ class TestPackageOutcomePerGroupValidation:
         assert package.solutions[1].outcomePerGroup['group2'] == (
             ExpectedOutcome.TIME_LIMIT_EXCEEDED
         )
+
+
+class TestFirstSolutionIsMain:
+    def _package(self, *outcomes):
+        from rbx.box.schema import Package, Solution, TestcaseGroup
+
+        return Package(
+            name='prob',
+            timeLimit=1000,
+            memoryLimit=256,
+            testcases=[TestcaseGroup(name='samples')],
+            solutions=[
+                Solution(path=f'sols/sol{i}.cpp', outcome=outcome)
+                for i, outcome in enumerate(outcomes)
+            ],
+        )
+
+    def test_accepted_solution_after_a_non_accepted_one_is_rejected(self):
+        from pydantic import ValidationError
+
+        from rbx.box.schema import ExpectedOutcome
+
+        # Regression: the guard used to compare the solution's `ExpectedOutcome`
+        # against the grading `Outcome` enum, which never matches, so this
+        # package was silently accepted.
+        with pytest.raises(ValidationError, match='must have the "ACCEPTED" outcome'):
+            self._package(
+                ExpectedOutcome.WRONG_ANSWER,
+                ExpectedOutcome.ACCEPTED,
+            )
+
+    def test_accepted_solution_coming_first_is_accepted(self):
+        from rbx.box.schema import ExpectedOutcome
+
+        package = self._package(
+            ExpectedOutcome.ACCEPTED,
+            ExpectedOutcome.WRONG_ANSWER,
+        )
+
+        assert package.solutions[0].outcome == ExpectedOutcome.ACCEPTED
+
+    def test_package_without_accepted_solutions_is_not_checked(self):
+        from rbx.box.schema import ExpectedOutcome
+
+        package = self._package(
+            ExpectedOutcome.WRONG_ANSWER,
+            ExpectedOutcome.TIME_LIMIT_EXCEEDED,
+        )
+
+        assert len(package.solutions) == 2


### PR DESCRIPTION
## Problem

`Package.check_first_solution_is_main_if_there_is_ac` guarded on:

```python
if all(sol.outcome != Outcome.ACCEPTED for sol in self.solutions):
    return self
```

`sol.outcome` is an `ExpectedOutcome`, but it was compared against the grading `Outcome` enum. Cross-enum comparison is never equal, so the guard was always true and the validator returned early for every package — the "first solution must be ACCEPTED" rule never fired.

## Fix

Compare against `ExpectedOutcome.ACCEPTED`, matching the check right below it and `package.get_main_solution`.

## Tests

- New `TestFirstSolutionIsMain` regression class in `tests/rbx/box/test_schema.py`: an ACCEPTED solution listed after a non-ACCEPTED one is now rejected; ACCEPTED-first and no-ACCEPTED packages still validate.
- `test_main_solution_is_the_accepted_one_not_the_first_one` built a package whose ACCEPTED solution was not listed first — an arrangement that was only constructible because of the bug. Renamed and repointed at the error that now (correctly) fires first.
- Verified: `tests/rbx/box/test_schema.py`, `test_yaml_validation.py`, `test_fields.py` — 89 passed. All 27 `problem*.rbx.yml` fixture packages in the repo still validate under the fixed model, so no existing package relied on the broken guard.

Note: broader `pytest -n auto` runs hung locally in this environment (hours elapsed, seconds of CPU) unrelated to this change; the same modules pass in ~0.3s when run individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)