### PR TITLE
fix(presets): bump default min_version to 1.0.0

### DIFF
--- a/rbx/box/presets/schema.py
+++ b/rbx/box/presets/schema.py
@@ -126,7 +126,7 @@ class Preset(BaseModel):
     uri: str
 
     # Minimum version of rbx.cp required to use this preset.
-    min_version: str = '0.14.0'
+    min_version: str = '1.0.0'
 
     # Path to the environment file that will be installed with this preset.
     # When copied to the box environment, the environment will be named `name`.

--- a/tests/e2e/testdata/multi-contest/.local.rbx/preset.rbx.yml
+++ b/tests/e2e/testdata/multi-contest/.local.rbx/preset.rbx.yml
@@ -1,6 +1,6 @@
 ---
 name: "e2e-preset"
 uri: "test/e2e-preset"
-min_version: "0.14.0"
+min_version: "1.0.0"
 contest: "contest"
 env: "env.rbx.yml"

--- a/tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/preset.rbx.yml
+++ b/tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/preset.rbx.yml
@@ -1,5 +1,5 @@
 ---
 name: "e2e-boca-min-running-time"
 uri: "test/e2e-boca-min-running-time"
-min_version: "0.14.0"
+min_version: "1.0.0"
 env: "env.rbx.yml"

--- a/tests/rbx/box/presets/test_presets.py
+++ b/tests/rbx/box/presets/test_presets.py
@@ -23,6 +23,25 @@ from rbx.box.testing.testing_preset import TestingPreset
 from rbx.config import CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME
 
 
+def test_preset_default_min_version_is_compatible_with_installed_version():
+    """The default `min_version` must accept the rbx version being shipped.
+
+    Presets that don't declare a floor inherit this default, so if it lags
+    behind a major bump every such preset (including the ones built by the
+    test fixtures) is rejected as a breaking change. Bump the default
+    deliberately whenever the major version changes.
+    """
+    from rbx import utils
+    from rbx.box.presets.schema import Preset
+
+    default_min_version = Preset.model_fields['min_version'].default
+
+    assert (
+        utils.check_version_compatibility(default_min_version)
+        == utils.SemVerCompatibility.COMPATIBLE
+    )
+
+
 def test_preset_parses_libraries_block():
     from rbx.box.presets.schema import Preset
 


### PR DESCRIPTION
## Problem

The `1.0.0` bump left the preset schema default at `0.14.0`, so the compatibility guard classified **every** preset that doesn't declare a floor as a `BREAKING_CHANGE` and hard-exited:

```
AssertionError: Preset test-preset requires rbx at version 0.14.0, but the current version is 1.0.0.
```

Because `TestingPreset` constructs `Preset(...)` without a `min_version`, it inherits the schema default — which is why hundreds of tests failed on every PR regardless of what the PR touched.

## Changes

1. `rbx/box/presets/schema.py` — schema default `'0.14.0'` → `'1.0.0'`.
2. The two e2e fixtures still pinning the old value:
   - `tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/preset.rbx.yml`
   - `tests/e2e/testdata/multi-contest/.local.rbx/preset.rbx.yml`
3. A regression test asserting the schema default is compatible with the installed version.

## On suggestion (3) — commitizen `version_files`

I did **not** add `min_version` to `[tool.commitizen] version_files`, following the issue's own caveat: coupling the preset floor to every release would invalidate users' existing presets on each major bump. The regression test gives the same protection without that coupling — the next major bump fails one fast, clearly-named unit test with an explicit docstring, instead of silently red-lining the whole suite.

## Verification

Baseline on unmodified `main`, `tests/rbx/box/unit_test.py`: **22 failed, 8 passed** — every failure `click.exceptions.Exit: 1` (the preset guard exiting).

With this change, the same file's remaining failures are `assert 'OK Unit test #1' in ...` — the known local C++/sandbox toolchain issue on this machine, unrelated to presets. The `Exit: 1` failure mode is gone entirely.

- `tests/rbx/box/presets/` — **56 passed**, including the new regression test (confirmed failing before the fix with `BREAKING_CHANGE != COMPATIBLE`).
- Broader run (`presets/`, `testcase_extractors_test.py`, `unit_test.py`, `testcases/test_promote.py`): 248 passed; **zero** `min_version` errors anywhere in the output.

CI on a clean runner is the real verifier for the C++-dependent tests.

Fixes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)
