### PR TITLE
fix(stressing): support general paths in finder expressions

### DIFF
--- a/docs/setters/stress-testing.md
+++ b/docs/setters/stress-testing.md
@@ -110,6 +110,28 @@ sols/wa.cpp
 [$ ON 2:$] ~ INCORRECT
 ```
 
+#### Paths with unusual characters
+
+Solution and checker paths can be written directly, and may contain almost any
+character -- `sols/ac_nsqrtS+qsqrtn.cpp` and `sols/n^2/brute.cpp` are both fine.
+
+The only characters a bare path cannot contain are the ones the grammar itself
+uses: whitespace, `(`, `)`, `[`, `]`, `|`, `&`, `!`, `~`, `=`, `$`, `@`, `"` and
+`:`. To use those, wrap the path in double quotes:
+
+```py
+# A path with spaces and parentheses.
+["sols/wa (old attempt).cpp"] ~ INCORRECT
+
+# A Windows-style path, whose drive letter needs the ':'.
+["C:/sols/wa.cpp"] ~ INCORRECT
+```
+
+Inside quotes everything is taken literally, so `"$"` means a file actually
+named `$` rather than the main solution, and `"@foo/bar.cpp"` is a local path
+rather than a remote solution reference. Quoted paths may contain anything
+except a double quote itself.
+
 ## Running a stress test
 
 {{rbx}} exposes an `rbx stress` command that can be used to run a stress test. The syntax is pretty straightforward.

--- a/rbx/box/stressing/finder_parser.py
+++ b/rbx/box/stressing/finder_parser.py
@@ -56,10 +56,19 @@ _NOT: "!"
 WILDCARD: "$"
 
 // File name
-_filename: FILENAME | "\"" FILENAME "\""
+_filename: FILENAME | "\"" QUOTED_FILENAME "\""
 _solution_filename: _filename | AT _filename
 AT: "@"
-FILENAME: /[\/A-Za-z0-9\-_\.]/+
+
+// A bare path may use any character that is not whitespace and does not carry
+// meaning in this grammar. The reserved set is exactly the operators above:
+// ( ) [ ] | & ! ~ = $ @ " and the ':' of `2:checker` / `:nil`. Everything else
+// -- '+', ',', '#', '%', '^', '*', '{', '}', "'", ... -- is just a path char.
+FILENAME: /[^\s()\[\]|&!~=$@":]/+
+// Inside quotes nothing is ambiguous, so any path can be spelled out verbatim,
+// including one using the reserved characters above. Quoting is literal: no
+// wildcard ('$') or remote ('@') expansion happens inside it.
+QUOTED_FILENAME: /[^"\r\n]/+
 
 // Names (Variables)
 LCASE_LETTER: "a".."z"
@@ -158,12 +167,11 @@ def _get_default_checker_for_finder() -> Optional[FinderChecker]:
 
 
 def _get_solution_from_token(token: lark.Token) -> str:
-    path = str(token)
-    if path == '$':
+    if token.type == 'WILDCARD':
         main_path = _get_main_solution()
         assert main_path is not None
         return main_path
-    return path
+    return str(token)
 
 
 def _get_solution_from_node(node: lark.ParseTree) -> str:
@@ -175,12 +183,11 @@ def _get_solution_from_node(node: lark.ParseTree) -> str:
 
 
 def _get_checker_from_token(token: lark.Token) -> str:
-    path = str(token)
-    if path == '$':
+    if token.type == 'WILDCARD':
         main_path = _get_main_checker()
         assert main_path is not None
         return main_path
-    return path
+    return str(token)
 
 
 def _get_eval_checker(eval: lark.ParseTree) -> Optional[FinderChecker]:

--- a/tests/rbx/box/stressing/test_finder_parser.py
+++ b/tests/rbx/box/stressing/test_finder_parser.py
@@ -1,3 +1,6 @@
+import typing
+from typing import List
+
 import lark
 import pytest
 import typer
@@ -6,6 +9,7 @@ from rbx.box.schema import ExpectedOutcome, Solution
 from rbx.box.stressing.finder_parser import (
     LARK_PARSER,
     FinderSolutionResolver,
+    _get_solution_from_node,
     get_all_checker_items,
     get_all_checkers,
     get_all_solution_items,
@@ -241,6 +245,29 @@ class TestParseFunction:
         assert len(solutions) > 0
         assert any(str(s.path) == 'sol-file.cpp' for s in solutions)
 
+    @pytest.mark.parametrize(
+        'expression',
+        [
+            'ac_nsqrtS+qsqrtn_reference.cpp',
+            '"ac_nsqrtS+qsqrtn_reference.cpp"',
+        ],
+    )
+    def test_parse_solution_whose_name_has_a_plus(
+        self, expression: str, testing_pkg: testing_package.TestingPackage
+    ):
+        """Regression: '+' in a path used to be a syntax error (#622)."""
+        testing_pkg.add_solution(
+            'ac_nsqrtS+qsqrtn_reference.cpp', outcome=ExpectedOutcome.ACCEPTED
+        ).write_text('#include <iostream>\nint main() { return 0; }')
+        testing_pkg.set_checker('checker.cpp', src='checkers/checker.cpp')
+        testing_pkg.save()
+
+        reference = Solution(path='ac_nsqrtS+qsqrtn_reference.cpp')
+        tree = parse(expression, reference_solution=reference)
+
+        solutions = get_all_solution_items(tree, reference_solution=reference)
+        assert [str(s.path) for s in solutions] == ['ac_nsqrtS+qsqrtn_reference.cpp']
+
     def test_parse_validation_fails_for_missing_solution(
         self, testing_pkg: testing_package.TestingPackage
     ):
@@ -374,6 +401,99 @@ class TestParseFunction:
         for expr in expressions:
             tree = parse(expr, reference_solution=reference)
             assert tree is not None, f'Failed to parse expression: {expr}'
+
+
+def _parsed_solution_paths(expression: str) -> List[str]:
+    """Parse an expression at the grammar level and return its solution paths."""
+    tree = LARK_PARSER.parse(expression)
+    return [
+        _get_solution_from_node(typing.cast(lark.Tree, node))
+        for node in tree.find_data('solution')
+    ]
+
+
+class TestFilenameGrammar:
+    """Grammar-level tests for how paths are spelled in finder expressions.
+
+    These do not need a package on disk -- they only exercise the tokenizer,
+    which is where path support is decided.
+    """
+
+    @pytest.mark.parametrize(
+        'path',
+        [
+            'sol.cpp',
+            'solutions/good/sol.cpp',
+            './solutions/sol.cpp',
+            '../shared/sol.cpp',
+            # Characters that carry no meaning in the finder grammar, so they
+            # are safe to spell out unquoted.
+            'solutions/good/ac_nsqrtS+qsqrtn_reference_bruno.cpp',
+            'solutions/n^2/sol.cpp',
+            'solutions/a,b/sol.cpp',
+            'solutions/50%/sol.cpp',
+            'solutions/sol#2.cpp',
+            "solutions/bruno's/sol.cpp",
+            'solutions/{alt}/sol.cpp',
+            'solutions/*.cpp',
+        ],
+    )
+    def test_bare_path_is_parsed_verbatim(self, path: str):
+        assert _parsed_solution_paths(path) == [path]
+
+    @pytest.mark.parametrize(
+        'path',
+        [
+            'sol.cpp',
+            'solutions/good/ac_nsqrtS+qsqrtn_reference_bruno.cpp',
+            # Only quoting can express these -- every one of them is a grammar
+            # operator when spelled bare.
+            'solutions/my sol.cpp',
+            'solutions/(old)/sol.cpp',
+            'solutions/[wip]/sol.cpp',
+            'solutions/a&b/sol.cpp',
+            'solutions/a|b/sol.cpp',
+            'solutions/sol!.cpp',
+            'solutions/~backup/sol.cpp',
+            'solutions/x=y/sol.cpp',
+            'C:/solutions/sol.cpp',
+            'solutions/@remote/sol.cpp',
+            # Quoting is literal: no wildcard or remote expansion inside it.
+            '$',
+            '@sol.cpp',
+        ],
+    )
+    def test_quoted_path_is_parsed_verbatim(self, path: str):
+        assert _parsed_solution_paths(f'"{path}"') == [path]
+
+    def test_bare_dollar_is_the_wildcard(self):
+        tree = LARK_PARSER.parse('$')
+        (solution,) = tree.find_data('solution')
+        (token,) = solution.children
+        assert typing.cast(lark.Token, token).type == 'WILDCARD'
+
+    def test_at_prefix_is_preserved_for_bare_and_quoted_paths(self):
+        assert _parsed_solution_paths('@rbx/sol.cpp') == ['@rbx/sol.cpp']
+        assert _parsed_solution_paths('"@rbx/my sol.cpp"') == ['@rbx/my sol.cpp']
+
+    def test_paths_with_operators_still_parse_as_expressions(self):
+        """Widening the path charset must not swallow the operators."""
+        assert _parsed_solution_paths('a+b.cpp && c+d.cpp') == ['a+b.cpp', 'c+d.cpp']
+        assert _parsed_solution_paths('a+b.cpp || c+d.cpp') == ['a+b.cpp', 'c+d.cpp']
+        assert _parsed_solution_paths('!(a+b.cpp)') == ['a+b.cpp']
+        assert _parsed_solution_paths('a+b.cpp == c+d.cpp') == ['a+b.cpp', 'c+d.cpp']
+        assert _parsed_solution_paths('a+b.cpp ~ WRONG_ANSWER') == ['a+b.cpp']
+        assert _parsed_solution_paths('[a+b.cpp on 2:c+d.cpp]') == ['a+b.cpp']
+
+    def test_quoted_path_may_contain_a_checking_keyword(self):
+        assert _parsed_solution_paths('["sols/on my own.cpp" on chk.cpp]') == [
+            'sols/on my own.cpp'
+        ]
+
+    @pytest.mark.parametrize('expression', ['"sol.cpp', 'sol.cpp"', '""'])
+    def test_unterminated_or_empty_quotes_are_rejected(self, expression: str):
+        with pytest.raises(lark.exceptions.LarkError):
+            LARK_PARSER.parse(expression)
 
 
 class TestParseTreeMethods:


### PR DESCRIPTION
## Problem

A finder expression could not name a solution whose path contained a `+`:

```
rbx stress ... -f 'solutions/good/ac_nsqrtS+qsqrtn_reference_bruno.cpp'
UnexpectedCharacters: No terminal matches '+' in the current parser context, at line 1 col 25
```

The `FILENAME` terminal was `/[\/A-Za-z0-9\-_\.]/+` -- a charset far narrower
than what a filesystem allows. And quoting was not an escape hatch, because the
quoted alternative reused the *same* terminal:

```lark
_filename: FILENAME | "\"" FILENAME "\""
```

so `"a+b.cpp"` failed exactly like `a+b.cpp`.

## Fix

Split the two cases and give each the widest charset it can safely have.

- **Bare paths** now accept everything that is not whitespace and does not carry
  meaning in the grammar. The reserved set is exactly the operators:
  `(` `)` `[` `]` `|` `&` `!` `~` `=` `$` `@` `"` and the `:` of `2:checker` /
  `:nil`. So `+`, `,`, `#`, `%`, `^`, `*`, `{`, `}`, `'` are now ordinary path
  characters.
- **Quoted paths** get their own terminal accepting anything but a double quote,
  which makes quoting a real escape hatch for spaces, parentheses, `~`, and
  Windows drive letters.

`:` is the one interesting exclusion from bare paths: allowing it would make
`[sol on 2:chk.cpp]` genuinely ambiguous between `mode=2, checker=chk.cpp` and
`checker=2:chk.cpp`. Quoting resolves it.

Quoting is now literal, so `"$"` is a file named `$` rather than the main
solution, and `"@x/y.cpp"` is a local path rather than a remote reference. The
wildcard is resolved off the token *type* instead of the token *text* to make
that work.

## Verification

- New `TestFilenameGrammar` covers bare/quoted paths, that operators are still
  tokenized correctly around widened paths, and that unterminated/empty quotes
  are rejected.
- Parsing every realistic expression under `ambiguity='explicit'` yields zero
  `_ambig` nodes, so no new grammar ambiguity was introduced.
- `uv run pytest tests/rbx/box/stressing` -- 230 passed.

Backport to `0.38.1` follows via `release/0.38.x` per `docs/internal/backporting.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
