### PR TITLE
fix(solutions): surface the dropped soft-TLE double TL warning

### DIFF
--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -1447,29 +1447,32 @@ class SolutionOutcomeReport(BaseModel):
 
     def get_verdict_markup_with_warnings(self, subset: bool = False) -> str:
         res = self.get_verdict_markup(subset=subset)
+        # The two double-TL facts are independent, so each is its own sentence
+        # naming its own groups. A single layer either passed *within* 2x TL or
+        # finished within it with other (soft-TLE) verdicts, never both -- but
+        # both aggregate fields are unions over the pooled layer and every group,
+        # so two different groups can each contribute one fact. Reporting them
+        # together would have to attribute both to a single group list, and
+        # gating one on the other is how the second was lost entirely (#607).
         if self.runUnderDoubleTl:
-            # Both aggregate fields are unions over the pooled layer and every
-            # group, so each half of the sentence names its own groups: a single
-            # group either passed *within* 2x TL or had other soft-TLE verdicts,
-            # never both, and they need not be the same group.
-            passed_where = _on_groups_markup(
+            where = _on_groups_markup(
                 [
                     name
                     for name, group in self.perGroup.items()
                     if group.runUnderDoubleTl
                 ]
             )
-            failed_where = _on_groups_markup(
+            res += f'\n[warning]WARNING[/warning] The solution still passed in double TL{where}.'
+        if self.doubleTlVerdicts:
+            where = _on_groups_markup(
                 [
                     name
                     for name, group in self.perGroup.items()
                     if group.doubleTlVerdicts
                 ]
             )
-            if self.doubleTlVerdicts:
-                res += f'\n[warning]WARNING[/warning] The solution still passed in double TL{passed_where}, but failed with [item]{" ".join(v.name for v in self.doubleTlVerdicts)}[/item]{failed_where}.'
-            else:
-                res += f'\n[warning]WARNING[/warning] The solution still passed in double TL{passed_where}.'
+            verdicts = ' '.join(sorted(v.name for v in self.doubleTlVerdicts))
+            res += f'\n[warning]WARNING[/warning] The solution still finished in double TL, but failed with [item]{verdicts}[/item]{where}.'
         if self.sanitizerWarnings:
             res += '\n[warning]WARNING[/warning] The solution had sanitizer errors or warnings, marked with [item]*[/item]. See their stderr for more details.'
         return res

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -134,7 +134,31 @@ async def test_get_solution_outcome_report(pkg_from_testdata: pathlib.Path):
     assert tle_report.status == SolutionOutcomeStatus.OK
     assert tle_report.expectedOutcome == ExpectedOutcome.TIME_LIMIT_EXCEEDED
     # Should have double TL warning for soft TLE
-    assert tle_report.runUnderDoubleTl is True or len(tle_report.doubleTlVerdicts) > 0
+    assert tle_report.runUnderDoubleTl is True
+    assert (
+        'still passed in double TL'
+        in Text.from_markup(tle_report.get_verdict_markup_with_warnings()).plain
+    )
+
+    # Solution that is within double TL but is *also* wrong there: the warning
+    # must name the verdict instead of staying silent (#607).
+    tle_incorrect_solution = result.skeleton.solutions[4]
+    tle_incorrect_evals = res[4]['gen1']
+    tle_incorrect_report = get_solution_outcome_report(
+        tle_incorrect_solution,
+        result.skeleton,
+        tle_incorrect_evals,
+        VerificationLevel.FULL,
+    )
+    assert tle_incorrect_report.status == SolutionOutcomeStatus.OK
+    assert tle_incorrect_report.doubleTlVerdicts == {Outcome.WRONG_ANSWER}
+    warning = Text.from_markup(
+        tle_incorrect_report.get_verdict_markup_with_warnings()
+    ).plain
+    assert warning.splitlines()[-1] == (
+        'WARNING The solution still finished in double TL, '
+        'but failed with WRONG_ANSWER.'
+    )
 
 
 # Unit tests with custom inputs
@@ -549,6 +573,49 @@ def test_solution_outcome_report_tle_with_soft_tle_and_wa(
     # Should show double TL verdicts
     assert len(report.doubleTlVerdicts) > 0
     assert Outcome.WRONG_ANSWER in report.doubleTlVerdicts
+    # ...and must actually say so: this warning used to be computed and then
+    # dropped, since a report can never have both double TL flags set at the
+    # pooled layer alone (#607).
+    assert report.runUnderDoubleTl is False
+    assert report.get_verdict_markup_with_warnings() == (
+        '[success]OK[/success] \n'
+        '[warning]WARNING[/warning] The solution still finished in double TL, '
+        'but failed with [item]WRONG_ANSWER[/item].'
+    )
+
+
+def test_double_tl_warning_lists_every_verdict_in_a_stable_order(
+    tmp_path, mock_skeleton, mock_binary_scoring
+):
+    """Several soft-TLE verdicts are all named, sorted so the line does not
+    change between runs."""
+    solution = Solution(
+        path=tmp_path / 'tle.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED
+    )
+    skeleton = mock_skeleton([solution])
+    evals = [
+        make_evaluation(
+            Outcome.TIME_LIMIT_EXCEEDED,
+            time_ms=1500,
+            no_tle_outcome=Outcome.WRONG_ANSWER,
+        ),
+        make_evaluation(
+            Outcome.TIME_LIMIT_EXCEEDED,
+            time_ms=1600,
+            no_tle_outcome=Outcome.RUNTIME_ERROR,
+        ),
+    ]
+
+    report = get_solution_outcome_report(
+        solution, skeleton, evals, VerificationLevel.FULL
+    )
+
+    assert report.doubleTlVerdicts == {Outcome.WRONG_ANSWER, Outcome.RUNTIME_ERROR}
+    warning = Text.from_markup(report.get_verdict_markup_with_warnings()).plain
+    assert warning.splitlines()[-1] == (
+        'WARNING The solution still finished in double TL, '
+        'but failed with RUNTIME_ERROR WRONG_ANSWER.'
+    )
 
 
 def test_solution_outcome_report_sanitizer_warnings(
@@ -717,11 +784,12 @@ def test_per_group_double_tl_is_reported_and_merged(
     assert report.doubleTlVerdicts == {Outcome.WRONG_ANSWER}
 
 
-def test_double_tl_warning_attributes_each_half_to_its_own_group(
+def test_double_tl_warning_attributes_each_fact_to_its_own_group(
     tmp_path, mock_skeleton, mock_binary_scoring
 ):
-    """The two halves of the warning come from different groups, so each names
-    its own: group2 is what passed within 2x TL, group3 is what failed."""
+    """The two facts come from different groups, so each is its own sentence
+    naming its own group: group2 is what passed within 2x TL, group3 is what
+    failed."""
     solution = Solution(
         path=tmp_path / 'tle.cpp',
         outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED,
@@ -754,10 +822,11 @@ def test_double_tl_warning_attributes_each_half_to_its_own_group(
     )
 
     warning = Text.from_markup(report.get_verdict_markup_with_warnings()).plain
-    assert warning.splitlines()[-1] == (
-        'WARNING The solution still passed in double TL on group2, '
-        'but failed with WRONG_ANSWER on group3.'
-    )
+    assert warning.splitlines()[-2:] == [
+        'WARNING The solution still passed in double TL on group2.',
+        'WARNING The solution still finished in double TL, '
+        'but failed with WRONG_ANSWER on group3.',
+    ]
 
 
 def test_double_tl_warning_comma_joins_the_groups_it_names(


### PR DESCRIPTION
Fixes pre-existing bug 2 from #607.

## The bug

`get_verdict_markup_with_warnings` rendered the `but failed with <verdicts>` clause **inside** `if self.runUnderDoubleTl:`, but `_get_verdict_report` sets `run_under_double_tl` and `double_tl_verdicts` in mutually exclusive `if`/`elif` branches. At the pooled layer the two can therefore never both be set, so the clause was unreachable: a TLE-expected solution that finished within 2x TL *and* was also wrong there (soft TLE with a bad `no_tle_outcome`) reported a bare `OK` and the information was silently dropped.

The `box1` test package has shipped a fixture for exactly this case all along -- `tle-and-incorrect.sol.cpp` -- and it printed nothing.

## The fix

The two are independent facts, so each is now its own sentence naming its own groups:

```
WARNING The solution still passed in double TL{ on <groups>}.
WARNING The solution still finished in double TL, but failed with <verdicts>{ on <groups>}.
```

Merely relaxing the outer condition would not have been enough: both aggregate fields are unions over the pooled layer and every group, so two different groups can each contribute one fact, and a single sentence would have to attribute both halves to one group list -- claiming only `group2` "finished in double TL" when `group3` did too. Sibling `if`s keep every clause true and mean neither fact can gate the other again.

Verdicts are also sorted now, so the line does not change between runs.

## User-visible change

Packages with a TLE-expected solution that is wrong under double TL will start emitting this warning on `--verification=full`. That is the point of the fix -- the warning was always meant to be there -- but it is a new line on existing packages that currently report clean.

## Tests

- `test_solution_outcome_report_tle_with_soft_tle_and_wa` -- extended with the exact markup and `runUnderDoubleTl is False`, pinning the case that was dead.
- `test_double_tl_warning_lists_every_verdict_in_a_stable_order` -- new; two soft-TLE verdicts, sorted.
- `test_double_tl_warning_attributes_each_half_to_its_own_group` -> `..._each_fact_to_its_own_group`, now expecting the two lines.
- `test_get_solution_outcome_report` -- the weak `A or B` assertion split in two, and solution 4 (`tle-and-incorrect.sol.cpp`) now asserts the warning end-to-end.
- Unchanged and still green: the pure-pass case, the comma-joined group list, and the no-`outcomePerGroup` wording.

`solutions_test.py` (37 unit + the slow `box1` integration test), `test_timing.py`, and ruff all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)