### PR TITLE
fix(cli): exit non-zero when build, run or verification fails

### DIFF
--- a/docs/setters/verification/index.md
+++ b/docs/setters/verification/index.md
@@ -48,3 +48,28 @@ Setting a larger value is usually the recommended approach to ensure all your ex
 
 Setting a smaller value is usually useful when you want to run the commands faster, and you are sure that
 the checks you are running are not being violated.
+
+## Exit codes
+
+Verification is only useful in a pipeline if a failure actually fails the pipeline. The commands
+below exit with status `1` when a check they ran did not pass, and `0` otherwise:
+
+| Command                      | Exits `1` when                                                           |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `rbx build`                  | A validator rejects a generated test.                                     |
+| `rbx run`                    | The build fails, or a solution's verdict does not match its expected one. |
+| `rbx time`                   | The build fails.                                                          |
+| `rbx package build`          | The build or the verification of the testset fails.                       |
+| `rbx contest statements build` | Samples could not be built for some problem.                            |
+
+`rbx contest statements build` still builds every statement it can before failing, so the
+report tells you which problems are broken rather than stopping at the first one.
+
+!!! warning "Behavior change"
+
+    Up to and including `1.0.0`, `rbx build` and `rbx run` exited `0` even when they printed a
+    failing report. A CI job that is silently green today on a broken package will start failing
+    once you upgrade — which is the point, but it may surprise you.
+
+    Use a lower [verification level](#verification-level) (or `--no-validate`) if you deliberately
+    want a step that does not check the testset.

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -311,9 +311,10 @@ async def build(
 ):
     from rbx.box import builder
 
-    await builder.build(
+    if not await builder.build(
         verification=verification, validate=validate, visualize=visualize
-    )
+    ):
+        raise typer.Exit(1)
 
 
 @app.command(
@@ -424,7 +425,7 @@ async def run(
     if not await builder.build(
         verification=verification, output=check, validate=validate, is_run=True
     ):
-        return
+        raise typer.Exit(1)
 
     if verification <= VerificationLevel.VALIDATE.value:
         console.console.print(
@@ -461,7 +462,7 @@ async def run(
 
     console.console.print()
     console.console.rule('[status]Run report[/status]', style='status')
-    await print_run_report(
+    ok = await print_run_report(
         solution_result,
         console.console,
         VerificationLevel(verification),
@@ -479,6 +480,9 @@ async def run(
             skip_printing_limits=sanitized,
         )
         sharing.capture_and_share(rec, fmt=share, title='rbx run report')
+
+    if not ok:
+        raise typer.Exit(1)
 
 
 @app.command(
@@ -647,7 +651,7 @@ async def time(
     if not await builder.build(
         verification=verification, output=check, validate=validate, is_run=True
     ):
-        return None
+        raise typer.Exit(1)
 
     await timing.compute_time_limits(
         check, detailed, runs, formula=formula, profile=profile, auto=auto, share=share

--- a/rbx/box/contest/contest_package.py
+++ b/rbx/box/contest/contest_package.py
@@ -228,10 +228,14 @@ def within_contest(func):
             issue_level_token = issue_stack.issue_level_var.set(
                 issue_stack.IssueLevel.OVERVIEW
             )
-            ret = func(*args, **kwargs)
-            issue_stack.print_current_report()
-            issue_stack.issue_level_var.reset(issue_level_token)
-            return ret
+            try:
+                return func(*args, **kwargs)
+            finally:
+                # Print in a finally so a command that exits non-zero (e.g. a
+                # contest statement build that failed for some problem) still
+                # shows the report explaining why.
+                issue_stack.print_current_report()
+                issue_stack.issue_level_var.reset(issue_level_token)
 
     return wrapper
 

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -95,6 +95,7 @@ async def _execute_build(
 
     # At most run the validators, only in samples.
     problems_of_interest: Optional[List[ContestProblem]] = None
+    failed_problems: List[ContestProblem] = []
     if samples:
         from rbx.box.testcase_sample_utils import build_samples
 
@@ -109,10 +110,12 @@ async def _execute_build(
                 try:
                     if not await build_samples(verification, validate):
                         issue_stack.add_issue(StatementBuildIssue(problem))
+                        failed_problems.append(problem)
                     else:
                         problems_of_interest.append(problem)
                 except Exception:
                     issue_stack.add_issue(StatementBuildIssue(problem))
+                    failed_problems.append(problem)
 
     if profile is not None and problems_of_interest is None:
         problems_of_interest = eligible_problems
@@ -168,6 +171,15 @@ async def _execute_build(
         console.console.print(
             f'[item]{document.name} {document.language}[/item] (document) -> {href(built_path)}'
         )
+
+    if failed_problems:
+        # The statements that could be built were built, but samples are missing
+        # for some problem, so the command as a whole did not succeed.
+        console.console.print(
+            f'[error]Failed to build samples for [item]{len(failed_problems)}[/item] '
+            'problem(s), check the report above.[/error]'
+        )
+        raise typer.Exit(1)
 
 
 @app.command('build, b', help='Build statements.')

--- a/tests/e2e/testdata/failing-exit-codes/e2e.rbx.yml
+++ b/tests/e2e/testdata/failing-exit-codes/e2e.rbx.yml
@@ -1,0 +1,28 @@
+scenarios:
+  - name: build-succeeds-exits-zero
+    description: |
+      The control for `run-fails-exits-nonzero`: nothing is wrong with the
+      tests themselves, so `rbx build` still exits 0. Only the *solutions*
+      are inconsistent with the package, and `rbx build` does not run them.
+    steps:
+      - cmd: build
+        expect:
+          tests:
+            count: 2
+            groups:
+              samples: 1
+              main: 1
+
+  - name: run-fails-exits-nonzero
+    description: |
+      `sols/liar.cpp` is declared `ac` but answers `a * b`, so its verdict
+      never matches its expected outcome. Before #625 `rbx run` printed the
+      failing report and exited 0, which let CI go green on a broken package.
+      It must exit 1.
+    steps:
+      - cmd: run
+        expect_exit: 1
+        expect:
+          solutions:
+            sols/main.cpp: ac
+            sols/liar.cpp: wa

--- a/tests/e2e/testdata/failing-exit-codes/gens/gen.cpp
+++ b/tests/e2e/testdata/failing-exit-codes/gens/gen.cpp
@@ -1,0 +1,14 @@
+#include <cstdio>
+#include <cstdlib>
+
+// Minimal generator: takes two integers as args and prints them as the input.
+// Usage: gen <a> <b>
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        return 1;
+    }
+    int a = atoi(argv[1]);
+    int b = atoi(argv[2]);
+    printf("%d %d\n", a, b);
+    return 0;
+}

--- a/tests/e2e/testdata/failing-exit-codes/problem.rbx.yml
+++ b/tests/e2e/testdata/failing-exit-codes/problem.rbx.yml
@@ -1,0 +1,27 @@
+name: failing-exit-codes
+timeLimit: 1000
+memoryLimit: 256
+
+generators:
+  - name: gen
+    path: gens/gen.cpp
+
+solutions:
+  - path: sols/main.cpp
+    outcome: ac
+  - path: sols/liar.cpp
+    outcome: ac
+
+testcases:
+  - name: samples
+    subgroups:
+      - name: gen
+        generators:
+          - name: gen
+            args: 1 2
+  - name: main
+    subgroups:
+      - name: gen
+        generators:
+          - name: gen
+            args: 3 4

--- a/tests/e2e/testdata/failing-exit-codes/sols/liar.cpp
+++ b/tests/e2e/testdata/failing-exit-codes/sols/liar.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+using namespace std;
+
+// Declared `ac` in problem.rbx.yml, but prints the product instead of the sum.
+// That mismatch is what `rbx run` has to fail on.
+int main() {
+    int a, b;
+    cin >> a >> b;
+    cout << a * b << endl;
+    return 0;
+}

--- a/tests/e2e/testdata/failing-exit-codes/sols/main.cpp
+++ b/tests/e2e/testdata/failing-exit-codes/sols/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+using namespace std;
+
+int main() {
+    int a, b;
+    cin >> a >> b;
+    cout << a + b << endl;
+    return 0;
+}

--- a/tests/e2e/testdata/group-vars-violation/e2e.rbx.yml
+++ b/tests/e2e/testdata/group-vars-violation/e2e.rbx.yml
@@ -14,11 +14,12 @@ scenarios:
       names the offending group through the testcase path and quotes the
       group-resolved range `[0, 200]`, not the package-level `[-200, 200]`.
 
-      `rbx build` reports the failure and stops before generating outputs, but
-      still exits 0, so the assertions are on the report and on the absence of
-      `.out` files rather than on the exit code.
+      `rbx build` reports the failure, stops before generating outputs, and
+      exits 1 (#625), so the assertions cover the report, the absence of `.out`
+      files, and the exit code.
     steps:
       - cmd: build
+        expect_exit: 1
         expect:
           stdout_matches: "n\\s*o\\s*n\\s*n\\s*e\\s*g\\s*/\\s*0\\s*0\\s*1\\s*\\.\\s*i\\s*n[\\s\\S]*Gen\\.\\s+call:\\s+gen\\s+-5\\s+5[\\s\\S]*violates\\s+the\\s+range\\s+\\[0,\\s*200\\][\\s\\S]*Validation\\s+failed"
           stdout_not_contains:

--- a/tests/e2e/testdata/outcome-per-group/e2e.rbx.yml
+++ b/tests/e2e/testdata/outcome-per-group/e2e.rbx.yml
@@ -7,8 +7,11 @@ scenarios:
       everywhere, and is caught even though its pooled `incorrect` holds.
       The verdicts themselves are identical for both, which is the point:
       only the per-group expectations tell them apart.
+
+      `sols/mislabeled.cpp` misses its expectation, so `rbx run` exits 1 (#625).
     steps:
       - cmd: run
+        expect_exit: 1
         expect:
           stdout_contains:
             # Both testgroups missed the expectation, so the verdict says


### PR DESCRIPTION
Closes #625.

`rbx build` printed a failing validation report and exited **0**, so a CI job running it went green on a broken package. `builder.build()` already returned `False` — the CLI just dropped the result.

## What changed

| Command | Now exits 1 when |
| --- | --- |
| `rbx build` | a validator rejects a generated test |
| `rbx run` | the build fails, **or** a solution's verdict misses its expected outcome |
| `rbx time` | the build fails |
| `rbx contest statements build` | samples could not be built for some problem |

`rbx package build` already exited 1 and is unchanged.

The contest-level command is the same defect one layer up: a problem whose samples fail is recorded as an issue and reported, but the command still exited 0. It now builds every statement it can first, then exits 1, so the report still tells you which problems are broken. `within_contest` prints its issue report in a `finally` so that report still appears when the command exits non-zero.

## Compatibility

This is a **CLI-visible behaviour change**: a pipeline that is silently green on a broken package today will start failing. Documented under a warning in `docs/setters/verification/index.md`, along with an exit-code table.

## Tests

- New e2e fixture `failing-exit-codes` covering both directions: a healthy `rbx build` still exits 0, and `rbx run` exits 1 when `sols/liar.cpp` (declared `ac`, answers `a * b`) misses its expectation.
- `group-vars-violation` asserted on report text plus `files_absent` precisely *because* the exit code was useless (noted in its own description, from #619). It now asserts `expect_exit: 1`.
- `outcome-per-group` deliberately contains a mislabeled solution, so it correctly exits 1 now; updated to `expect_exit: 1`.

## Verification notes

Run locally against a checkout with pre-existing C++/sandbox breakage:

- e2e: 6 failures on a stashed baseline and the same 6 with this change (all from a local `wcmp.cpp` compile failure). The two fixtures above are the only behavioural deltas, both intended.
- unit: `unit_test.py` / `validators_test.py` / `generators_test.py` / `walltime_test.py` give an identical 29 failed / 65 passed with and without this change. Full-suite counts vary run-to-run on the same code (30 then 34), i.e. local flakiness, not regressions. All 92 contest tests pass.

### One risk worth a maintainer's call

Because `rbx run` now fails on *any* solution whose verdict misses its expectation, the `interactive` e2e fixture (24 solutions, several TLE-sensitive) becomes sensitive to timing flakiness across all of them rather than only the 5 it asserts on. It failed once under heavy parallel load during a full e2e run and passed twice in isolation. Worth watching on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
