### PR TITLE
refactor(solutions): drop the unreachable FullRunReporter

### DIFF
--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -92,8 +92,7 @@ Evaluations are **not truly parallel** -- they are deferred/lazy sequential. The
 ### Reporter Hierarchy
 
 - **`TraditionalRunReporter`** -- Base with start/finish lifecycle per solution/group/testcase
-- **`FullRunReporter`** -- Compact verdict marks (checkmarks/crosses) per testcase
-- **`LiveRunReporter`** -- Real-time `rich.live.Live` updates
+- **`LiveRunReporter`** -- One `rich.live.Live` line per group, with compact verdict marks (accepted testcases are omitted). Used whenever more than one solution runs, terminal or not: on a non-terminal console Live finalizes a single frame per group, which is what `--share`'s recorded consoles rely on.
 - **`SingleSolutionRunReporter`** -- Verbose per-testcase details (used when only 1 solution)
 
 ### Verdict Verification

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -2433,7 +2433,20 @@ class TraditionalRunReporter:
         pass
 
 
-class FullRunReporter(TraditionalRunReporter):
+class LiveRunReporter(TraditionalRunReporter):
+    """The reporter used whenever more than one solution is run.
+
+    Group lines are rendered through ``rich.live.Live``, which also covers the
+    non-terminal case: there, Live finalizes a single frame per group instead of
+    animating, which is what the recorded consoles behind ``--share`` rely on.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.live: Optional[rich.live.Live] = None
+        self.pre_evaluated = 0
+        self.post_evaluated = 0
+
     def render_solution(self, solution: Solution):
         solution_skeleton = self.result.skeleton.find_solution_skeleton(solution)
         assert solution_skeleton is not None
@@ -2453,49 +2466,6 @@ class FullRunReporter(TraditionalRunReporter):
         )
         self.console.print()
         return report.status.ok()
-
-    def render_group(self, group: GroupSkeleton):
-        self.console.print(
-            f'[bold][status]{group.name} ({len(group.testcases)})[/status][/bold]',
-            end='',
-        )
-
-    def render_group_end(self, group: GroupSkeleton):
-        bracketed = f'{get_capped_evals_formatted_time(self.get_current_limits(), self.current_group_evals, self.verification)}, {get_evals_formatted_memory(self.current_group_evals)}'
-        self.console.print(
-            f'[info]({bracketed})[/info]',
-            end='',
-        )
-        partial_report = self.get_partial_report(group)
-        if partial_report is not None:
-            got_score = partial_report.gotScorePerGroup.get(group.name, 0)
-            self.console.print(
-                f' {get_solution_score_markup(got_score, group.score, pts=True)}',
-                end='',
-            )
-        self.console.print()
-
-    def render_pre_evaluation(self, entry: GenerationTestcaseEntry):
-        self.console.print(f'[info]{entry.group_entry.index}/[/info]', end='')
-
-    def render_post_evaluation(
-        self, entry: GenerationTestcaseEntry, evaluation: Optional[Evaluation]
-    ):
-        if evaluation is None:
-            self.console.print('x ', end='')
-            return
-        self.console.print(get_testcase_markup_verdict(evaluation), end='')
-        if evaluation.result.sanitizer_warnings:
-            self.console.print('[warning]*[/warning]', end='')
-        self.console.print(' ', end='')
-
-
-class LiveRunReporter(FullRunReporter):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.live: Optional[rich.live.Live] = None
-        self.pre_evaluated = 0
-        self.post_evaluated = 0
 
     def _update_live(self, finished: bool = False):
         if self.live is None:

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -24,9 +24,9 @@ from rbx.box.schema import (
 from rbx.box.solutions import (
     EvaluationItem,
     FailedToCompileSolutionIssue,
-    FullRunReporter,
     GroupOutcomeReport,
     GroupSkeleton,
+    LiveRunReporter,
     RunSolutionResult,
     SolutionOutcomeStatus,
     SolutionReportSkeleton,
@@ -1167,16 +1167,17 @@ async def test_reporter_leaves_group_lines_alone_and_names_failures_once(
 
     with fresh_issue_stack():
         ok = await drive_reporter(
-            FullRunReporter(result, VerificationLevel.FULL, console), skeleton
+            LiveRunReporter(result, VerificationLevel.FULL, console), skeleton
         )
 
     assert not ok
     # No expectation markers here: the group lines are exactly what a package
-    # without `outcomePerGroup` renders.
+    # without `outcomePerGroup` renders. Accepted verdicts are left out of the
+    # line, as the live reporter always does, so group3 shows none at all.
     assert rendered_group_lines(console) == [
-        'group1 (2)0/✓ 1/✗ (100 ms, 1 KiB)',
-        'group2 (1)0/✗ (100 ms, 1 KiB)',
-        'group3 (1)0/✓ (100 ms, 1 KiB)',
+        'group1 (2) 1/✗ (100 ms, 1 KiB)',
+        'group2 (1) 0/✗ (100 ms, 1 KiB)',
+        'group3 (1) (100 ms, 1 KiB)',
     ]
     # The summary names every group that missed its expectation, and only those,
     # saying FAILED once and aligning the rest under it.
@@ -1213,15 +1214,15 @@ async def test_reporter_group_lines_carry_only_the_score(
         patch('rbx.box.solutions.package.get_scoring', return_value=ScoreType.POINTS),
     ):
         await drive_reporter(
-            FullRunReporter(result, VerificationLevel.FULL, console), skeleton
+            LiveRunReporter(result, VerificationLevel.FULL, console), skeleton
         )
 
     lines = rendered_lines(console)
     # group2 failed its tests, so it scores 0 of 60 -- while still meeting the
     # expectation that it fail, which the line says nothing about.
-    assert 'group2 (1)0/✗ (100 ms, 1 KiB) [0/60 pts]' in lines
+    assert 'group2 (1) 0/✗ (100 ms, 1 KiB) [0/60 pts]' in lines
     # `samples` has no score, so it gets no trailing mark at all.
-    assert 'samples (1)0/✓ (100 ms, 1 KiB)' in lines
+    assert 'samples (1) (100 ms, 1 KiB)' in lines
 
 
 async def test_partial_reports_do_not_add_timing_issues(
@@ -1257,7 +1258,7 @@ async def test_partial_reports_do_not_add_timing_issues(
         patch('rbx.box.solutions.package.get_scoring', return_value=ScoreType.POINTS),
     ):
         await drive_reporter(
-            FullRunReporter(result, VerificationLevel.FULL, recording_console()),
+            LiveRunReporter(result, VerificationLevel.FULL, recording_console()),
             skeleton,
         )
 


### PR DESCRIPTION
Closes the `FullRunReporter` item (#3) of #607.

## Assessment

The issue reports `FullRunReporter.render_group_end` as unreachable. It is worse than that: `LiveRunReporter` overrode **every** render method `FullRunReporter` defined except `render_solution` / `render_solution_end`, so the whole compact group/testcase renderer was dead. `print_run_report` only ever builds `LiveRunReporter` (multi-solution) or `SingleSolutionRunReporter` (single).

## Wire up or delete?

Wiring it up as a non-terminal fallback (CI logs, `--share` captures) was considered and rejected. That case is already deliberately served by `LiveRunReporter`: on a non-terminal console `rich.live.Live` finalizes one frame per group instead of animating, which is exactly what `sharing.recording_console()` is documented to rely on (`sharing.py:133`, and the matching newline handling in `solutions.py`). Introducing a second renderer there would change `rbx run --share` / `rbx time --share` output -- much taller reports for large groups -- for no gain.

So: deleted.

## Changes

- `LiveRunReporter` now extends `TraditionalRunReporter` directly and absorbs the two solution-level renderers it actually used; `FullRunReporter` is gone, with a docstring recording why Live also covers the non-terminal case.
- The three reporter tests move to `LiveRunReporter`, so they assert what production actually prints. Their expected group lines lose the accepted verdicts, which the live line omits by design (`group3 (1) (100 ms, 1 KiB)`).
- `rbx/box/CLAUDE.md` reporter hierarchy updated.

**No runtime behavior change** -- nothing that ran before stops running.

## Verification

- `uv run pytest tests/rbx/box/solutions_test.py` -- 39 passed
- `uv run pytest tests/rbx/box/test_timing.py` -- 19 passed
- `uv run ruff check .` / `ruff format --check .` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)