### PR TITLE
feat(schema): restrict outcomePerGroup to points-scored problems

### DIFF
--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -9,7 +9,7 @@ The central Pydantic model hierarchy defining `problem.rbx.yml`:
 ### Key Models
 
 - **`Package`** -- Root model. Contains: `name`, `timeLimit`, `memoryLimit`, `solutions`, `testcases`, `checker`, `validator`, `interactor`, `statements`, `vars`, `limitsProfiles`, `scoreType`
-- **`Solution`** -- `path`, `outcome` (ExpectedOutcome, matched against the whole testset pooled), `outcomePerGroup` (per-group expectations keyed by top-level group name, `'*'` = default applied to every group individually; an additive second layer, checked on top of `outcome`), `score`, `doubleTL`, `language`. Resolution helpers: `expected_outcome_for_group()`, `all_expected_outcomes()`
+- **`Solution`** -- `path`, `outcome` (ExpectedOutcome, matched against the whole testset pooled), `outcomePerGroup` (per-group expectations keyed by top-level group name, `'*'` = default applied to every group individually; an additive second layer, checked on top of `outcome`; **POINTS scoring only** -- a BINARY problem yields one pooled verdict for the whole testset, so `check_scoring_fields` rejects the field there and every consumer may assume the per-group layer implies POINTS), `score`, `doubleTL`, `language`. Resolution helpers: `expected_outcome_for_group()`, `all_expected_outcomes()`
 - **`TestcaseGroup`** (extends `TestcaseSubgroup`) -- `name`, `generator`, `generatorScript`, `testcases`, `subgroups`, `validator`, `score`, `deps`, `vars` (per-group overrides of the package `vars`; top-level groups only, since only the top-level group name reaches the validator)
 - **`TestcaseSubgroup`** -- `testcases` list, `generator` (GeneratorCall or CodeItem)
 - **`Testcase`** -- `inputPath`, `outputPath` (for manual test cases)

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -668,6 +668,11 @@ class Solution(CodeItem):
         description="""The expected outcome of this solution for each testcase group,
 keyed by group name.
 
+Only available for problems with `scoring: points`. A binary-scored problem is
+judged as a single pooled verdict over the whole testset, so its groups carry no
+independent judgement for an expectation to attach to; declaring this field there
+is an error.
+
 Keys must be top-level group names declared in `testcases`; subgroups are not
 addressable here.
 
@@ -682,6 +687,7 @@ entry here is matched against that group's tests alone. A solution fails if
 either layer fails.
 
 ```yaml
+scoring: points
 solutions:
   - path: 'sols/partial.cpp'
     outcome: incorrect  # fails somewhere in the testset
@@ -1179,6 +1185,18 @@ that is correct and used as reference -- and should have the `accepted` outcome.
                     raise PydanticCustomError(
                         'SCORE_NOT_ALLOWED',
                         'Expected score is not allowed for solutions of problems with scoring != POINTS.',
+                    )
+                # A BINARY problem judges the testset as one pooled verdict, so a
+                # per-group expectation has no scoring semantics to attach to.
+                # Rejecting it here lets every consumer downstream assume the
+                # per-group layer only ever exists under POINTS.
+                if solution.outcomePerGroup:
+                    raise PydanticCustomError(
+                        'OUTCOME_PER_GROUP_NOT_ALLOWED',
+                        'Per-group expected outcomes ("outcomePerGroup") are not allowed '
+                        'for solutions of problems with scoring != POINTS, since such '
+                        'problems are judged as a single pooled verdict over the whole '
+                        'testset. Use "outcome", or set "scoring: points".',
                     )
         return self
 

--- a/tests/e2e/testdata/outcome-per-group/e2e.rbx.yml
+++ b/tests/e2e/testdata/outcome-per-group/e2e.rbx.yml
@@ -2,7 +2,8 @@ scenarios:
   - name: per-group-outcomes
     description: |
       `outcomePerGroup` is checked per testgroup, on top of the pooled
-      `outcome`. `sols/partial.cpp` declares what it really does and passes;
+      `outcome`. It only applies to `scoring: points` problems, which is what
+      this package is. `sols/partial.cpp` declares what it really does and passes;
       `sols/mislabeled.cpp` is the same program claiming to time out
       everywhere, and is caught even though its pooled `incorrect` holds.
       The verdicts themselves are identical for both, which is the point:
@@ -14,9 +15,10 @@ scenarios:
         expect_exit: 1
         expect:
           stdout_contains:
-            # Both testgroups missed the expectation, so the verdict says
-            # FAILED once and lines the second one up under it.
-            - "FAILED small: expected TIME_LIMIT_EXCEEDED, got: ACCEPTED"
+            # Under POINTS the verdict leads with the score line, and both
+            # missed testgroups line up underneath that single FAILED.
+            - "FAILED Got [40/100 pts]"
+            - "       small: expected TIME_LIMIT_EXCEEDED, got: ACCEPTED"
             - "       big: expected TIME_LIMIT_EXCEEDED, got: WRONG_ANSWER"
           stdout_not_contains:
             # The correctly-declared solution is never named.

--- a/tests/e2e/testdata/outcome-per-group/problem.rbx.yml
+++ b/tests/e2e/testdata/outcome-per-group/problem.rbx.yml
@@ -2,6 +2,11 @@ name: outcome-per-group
 timeLimit: 1000
 memoryLimit: 256
 
+# `outcomePerGroup` only applies to points-scored problems: a binary problem is
+# judged as one pooled verdict, so its groups have no separate judgement for a
+# per-group expectation to attach to.
+scoring: points
+
 generators:
   - name: gen
     path: gens/gen.cpp
@@ -26,6 +31,7 @@ solutions:
 
 testcases:
   - name: small
+    score: 40
     subgroups:
       - name: gen
         generators:
@@ -34,6 +40,7 @@ testcases:
           - name: gen
             args: 3 4
   - name: big
+    score: 60
     subgroups:
       - name: gen
         generators:

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -266,6 +266,15 @@ def mock_binary_scoring():
         yield
 
 
+@pytest.fixture
+def mock_points_scoring():
+    # `outcomePerGroup` is only loadable under POINTS scoring (see
+    # `Package.check_scoring_fields`), so every per-group test must run here and
+    # not under `mock_binary_scoring`, which would be an impossible package.
+    with patch('rbx.box.solutions.package.get_scoring', return_value=ScoreType.POINTS):
+        yield
+
+
 @contextlib.contextmanager
 def fresh_issue_stack() -> Iterator[IssueAccumulator]:
     """Isolate the issue stack, so a test sees exactly the issues it caused."""
@@ -709,7 +718,7 @@ def test_no_outcome_per_group_leaves_the_report_untouched(
 
 
 def test_pooled_outcome_fails_while_every_group_passes(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     """The mirror case: relaxing a group's expectation without relaxing the
     pooled one still fails, and it fails on the pooled layer."""
@@ -737,7 +746,7 @@ def test_pooled_outcome_fails_while_every_group_passes(
 
 
 def test_per_group_double_tl_is_reported_and_merged(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     """Double TL is detected per group and merged into the aggregate, keeping
     "passed within 2x TL" distinguishable from "had other soft-TLE verdicts"."""
@@ -785,7 +794,7 @@ def test_per_group_double_tl_is_reported_and_merged(
 
 
 def test_double_tl_warning_attributes_each_fact_to_its_own_group(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     """The two facts come from different groups, so each is its own sentence
     naming its own group: group2 is what passed within 2x TL, group3 is what
@@ -830,7 +839,7 @@ def test_double_tl_warning_attributes_each_fact_to_its_own_group(
 
 
 def test_double_tl_warning_comma_joins_the_groups_it_names(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     """Several groups are listed with separators, not space-joined into one
     unreadable run of names."""
@@ -889,7 +898,7 @@ def test_double_tl_warning_is_unchanged_without_outcome_per_group(
 
 
 def test_per_group_outcome_fails_while_pooled_outcome_passes(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     """group2 is expected to TLE but is fully accepted: the solution fails even
     though the pooled INCORRECT expectation is satisfied by group1's WA."""
@@ -923,7 +932,7 @@ def test_per_group_outcome_fails_while_pooled_outcome_passes(
     )
 
 
-def test_per_group_outcome_all_satisfied(tmp_path, mock_skeleton, mock_binary_scoring):
+def test_per_group_outcome_all_satisfied(tmp_path, mock_skeleton, mock_points_scoring):
     solution = Solution(
         path=tmp_path / 'partial.cpp',
         outcome=ExpectedOutcome.INCORRECT,
@@ -954,7 +963,7 @@ def test_per_group_outcome_all_satisfied(tmp_path, mock_skeleton, mock_binary_sc
 
 
 def test_wildcard_expectation_is_checked_per_group(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     """'*': wa demands a WA in EVERY group; group1 being clean is a failure."""
     solution = Solution(
@@ -979,7 +988,7 @@ def test_wildcard_expectation_is_checked_per_group(
 
 
 def test_groups_without_evaluations_are_not_checked(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     """Mid-run, later groups have no evals yet. A bad expectation on them must
     not fail the report, or the live reporters would flash spurious failures."""
@@ -1001,7 +1010,7 @@ def test_groups_without_evaluations_are_not_checked(
 
 
 def test_groups_outside_the_testset_are_not_checked(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     """`rbx irun` evaluates a synthetic `interactive` group that is not part of
     the testset, and builds its skeleton with no groups at all. A `'*'` default
@@ -1030,14 +1039,18 @@ def test_groups_outside_the_testset_are_not_checked(
 
 
 def test_verdict_markup_attributes_failure_to_the_group(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     solution = Solution(
         path=tmp_path / 'partial.cpp',
         outcome=ExpectedOutcome.INCORRECT,
         outcomePerGroup={'group2': ExpectedOutcome.TIME_LIMIT_EXCEEDED},
     )
-    skeleton = mock_skeleton([solution], entries_per_group={'group1': 1, 'group2': 1})
+    skeleton = mock_skeleton(
+        [solution],
+        entries_per_group={'group1': 1, 'group2': 1},
+        scores_per_group={'group1': 40, 'group2': 60},
+    )
     evals = [make_evaluation(Outcome.WRONG_ANSWER), make_evaluation(Outcome.ACCEPTED)]
 
     report = get_solution_outcome_report(
@@ -1051,15 +1064,16 @@ def test_verdict_markup_attributes_failure_to_the_group(
     assert 'ACCEPTED' in markup
     # The pooled layer passed, so it must not be reported as the culprit.
     assert 'Expected: INCORRECT' not in markup
-    # Rendering also asserts the markup is well-formed.
-    assert (
-        Text.from_markup(markup).plain
-        == 'FAILED group2: expected TIME_LIMIT_EXCEEDED, got: ACCEPTED'
+    # Rendering also asserts the markup is well-formed. POINTS scoring leads with
+    # the score line, and the group attribution lines up underneath it.
+    assert Text.from_markup(markup).plain == (
+        'FAILED Got [60/100 pts]\n'
+        '       group2: expected TIME_LIMIT_EXCEEDED, got: ACCEPTED'
     )
 
 
 def test_verdict_markup_lists_every_failed_group(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     solution = Solution(
         path=tmp_path / 'partial.cpp',
@@ -1069,7 +1083,11 @@ def test_verdict_markup_lists_every_failed_group(
             'group2': ExpectedOutcome.WRONG_ANSWER,
         },
     )
-    skeleton = mock_skeleton([solution], entries_per_group={'group1': 1, 'group2': 1})
+    skeleton = mock_skeleton(
+        [solution],
+        entries_per_group={'group1': 1, 'group2': 1},
+        scores_per_group={'group1': 40, 'group2': 60},
+    )
     # group1 was supposed to be clean, group2 was supposed to fail.
     evals = [make_evaluation(Outcome.WRONG_ANSWER), make_evaluation(Outcome.ACCEPTED)]
 
@@ -1078,17 +1096,18 @@ def test_verdict_markup_lists_every_failed_group(
     )
     markup = report.get_verdict_markup()
 
-    # FAILED is said once; the remaining groups line up underneath it.
+    # FAILED is said once; the remaining lines line up underneath it.
     assert markup.count('FAILED') == 1
     assert 'group1' in markup and 'group2' in markup
     assert Text.from_markup(markup).plain == (
-        'FAILED group1: expected ACCEPTED, got: WRONG_ANSWER\n'
+        'FAILED Got [60/100 pts]\n'
+        '       group1: expected ACCEPTED, got: WRONG_ANSWER\n'
         '       group2: expected WRONG_ANSWER, got: ACCEPTED'
     )
 
 
 def test_verdict_markup_hides_group_lines_when_incomplete(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     solution = Solution(
         path=tmp_path / 'partial.cpp',
@@ -1106,7 +1125,7 @@ def test_verdict_markup_hides_group_lines_when_incomplete(
 
 
 def test_passing_subset_group_reports_all_of_its_verdicts(
-    tmp_path, mock_skeleton, mock_binary_scoring
+    tmp_path, mock_skeleton, mock_points_scoring
 ):
     """In `subset` mode a *passing* group reports all of its verdicts rather than
     an empty set, so pass/fail must be read off `status`, never off

--- a/tests/rbx/box/test_schema.py
+++ b/tests/rbx/box/test_schema.py
@@ -8,6 +8,7 @@ from rbx.box.schema import (
     RESERVED_VAR_NAMES,
     LimitModifiers,
     LimitsProfile,
+    ScoreType,
 )
 
 
@@ -435,6 +436,7 @@ class TestPackageOutcomePerGroupValidation:
             name='prob',
             timeLimit=1000,
             memoryLimit=256,
+            scoring=ScoreType.POINTS,
             testcases=[
                 TestcaseGroup(name='samples'),
                 TestcaseGroup(name='group1'),
@@ -498,6 +500,7 @@ class TestPackageOutcomePerGroupValidation:
                 name='prob',
                 timeLimit=1000,
                 memoryLimit=256,
+                scoring=ScoreType.POINTS,
                 testcases=[TestcaseGroup(name='samples'), TestcaseGroup(name='group1')],
                 solutions=[
                     Solution(
@@ -520,6 +523,7 @@ class TestPackageOutcomePerGroupValidation:
                 name='prob',
                 timeLimit=1000,
                 memoryLimit=256,
+                scoring=ScoreType.POINTS,
                 testcases=[TestcaseGroup(name='samples'), TestcaseGroup(name='group1')],
                 solutions=[
                     Solution(path='sols/wa.cpp', outcome=ExpectedOutcome.INCORRECT),
@@ -541,6 +545,7 @@ class TestPackageOutcomePerGroupValidation:
                 name='prob',
                 timeLimit=1000,
                 memoryLimit=256,
+                scoring=ScoreType.POINTS,
                 testcases=[TestcaseGroup(name='samples'), TestcaseGroup(name='group1')],
                 solutions=[
                     Solution(
@@ -562,6 +567,7 @@ class TestPackageOutcomePerGroupValidation:
             name='prob',
             timeLimit=1000,
             memoryLimit=256,
+            scoring=ScoreType.POINTS,
             testcases=[TestcaseGroup(name='samples'), TestcaseGroup(name='group1')],
             solutions=[
                 Solution(
@@ -583,6 +589,7 @@ class TestPackageOutcomePerGroupValidation:
             name='prob',
             timeLimit=1000,
             memoryLimit=256,
+            scoring=ScoreType.POINTS,
             testcases=[TestcaseGroup(name='samples'), TestcaseGroup(name='group1')],
             solutions=[
                 Solution(
@@ -652,6 +659,7 @@ class TestPackageOutcomePerGroupValidation:
             name='prob',
             timeLimit=1000,
             memoryLimit=256,
+            scoring=ScoreType.POINTS,
             solutions=[
                 Solution(
                     path='sols/wa.cpp',
@@ -693,6 +701,118 @@ class TestPackageOutcomePerGroupValidation:
         assert package.solutions[1].outcomePerGroup['group2'] == (
             ExpectedOutcome.TIME_LIMIT_EXCEEDED
         )
+
+
+class TestOutcomePerGroupRequiresPointsScoring:
+    """`outcomePerGroup` is only meaningful under POINTS scoring.
+
+    A BINARY problem is judged as one pooled verdict over the whole testset, so
+    its groups carry no independent judgement for a per-group expectation to
+    attach to. Rejecting the field at load time is what lets every consumer
+    downstream assume the per-group layer only ever exists under POINTS.
+    """
+
+    def _package(self, scoring: ScoreType, **solution_kwargs):
+        from rbx.box.schema import ExpectedOutcome, Package, Solution, TestcaseGroup
+
+        return Package(
+            name='prob',
+            timeLimit=1000,
+            memoryLimit=256,
+            scoring=scoring,
+            testcases=[TestcaseGroup(name='samples'), TestcaseGroup(name='group1')],
+            solutions=[
+                Solution(path='sols/main.cpp', outcome=ExpectedOutcome.ACCEPTED),
+                Solution(path='sols/other.cpp', **solution_kwargs),
+            ],
+        )
+
+    def test_binary_scoring_rejects_per_group_outcomes(self):
+        from rbx.box.schema import ExpectedOutcome
+
+        with pytest.raises(ValidationError, match='outcomePerGroup') as excinfo:
+            self._package(
+                ScoreType.BINARY,
+                outcome=ExpectedOutcome.INCORRECT,
+                outcomePerGroup={'group1': ExpectedOutcome.WRONG_ANSWER},
+            )
+
+        # The error has no `loc`, so the message alone has to say how to fix it.
+        assert 'scoring: points' in str(excinfo.value)
+
+    def test_binary_scoring_rejects_the_wildcard_too(self):
+        from rbx.box.schema import ExpectedOutcome
+
+        with pytest.raises(ValidationError, match='outcomePerGroup'):
+            self._package(
+                ScoreType.BINARY,
+                outcome=ExpectedOutcome.INCORRECT,
+                outcomePerGroup={'*': ExpectedOutcome.ACCEPTED},
+            )
+
+    def test_binary_scoring_is_the_default(self):
+        from rbx.box.schema import Package
+
+        # A package that says nothing about scoring is BINARY, so the field is
+        # rejected there without the setter ever mentioning `scoring`.
+        with pytest.raises(ValidationError, match='outcomePerGroup'):
+            Package.model_validate(
+                {
+                    'name': 'prob',
+                    'timeLimit': 1000,
+                    'memoryLimit': 256,
+                    'testcases': [{'name': 'samples'}, {'name': 'group1'}],
+                    'solutions': [
+                        {'path': 'sols/main.cpp', 'outcome': 'ac'},
+                        {
+                            'path': 'sols/other.cpp',
+                            'outcome': 'incorrect',
+                            'outcomePerGroup': {'group1': 'wa'},
+                        },
+                    ],
+                }
+            )
+
+    def test_binary_scoring_still_allows_an_empty_map(self):
+        from rbx.box.schema import ExpectedOutcome
+
+        # The default `{}` must stay loadable: the gate keys off a *declared*
+        # expectation, not off the field being present.
+        package = self._package(
+            ScoreType.BINARY,
+            outcome=ExpectedOutcome.INCORRECT,
+            outcomePerGroup={},
+        )
+
+        assert package.solutions[1].outcomePerGroup == {}
+
+    def test_points_scoring_allows_per_group_outcomes(self):
+        from rbx.box.schema import ExpectedOutcome
+
+        package = self._package(
+            ScoreType.POINTS,
+            outcome=ExpectedOutcome.INCORRECT,
+            outcomePerGroup={'group1': ExpectedOutcome.WRONG_ANSWER},
+        )
+
+        assert package.solutions[1].outcomePerGroup == {
+            'group1': ExpectedOutcome.WRONG_ANSWER
+        }
+
+    def test_scoring_gate_precedes_the_per_group_diagnostics(self):
+        from rbx.box.schema import ExpectedOutcome
+
+        # The key is both unknown and disallowed by scoring. Telling the setter
+        # the field does not apply at all is more actionable than nitpicking a
+        # group name they should not be naming in the first place.
+        with pytest.raises(ValidationError, match='outcomePerGroup') as excinfo:
+            self._package(
+                ScoreType.BINARY,
+                outcome=ExpectedOutcome.INCORRECT,
+                outcomePerGroup={'typo': ExpectedOutcome.WRONG_ANSWER},
+            )
+
+        assert 'not a testcase group' not in str(excinfo.value)
 
 
 class TestPackageVarsPerGroup:


### PR DESCRIPTION
## What

Rejects `outcomePerGroup` on solutions of problems whose `scoring` is not `points`.

A binary-scored problem is judged as a single pooled verdict over the whole testset, so its testgroups carry no independent judgement for a per-group expectation to attach to. Declaring `outcomePerGroup` there expressed an authoring assertion with no scoring semantics behind it.

The check lives in `Package.check_scoring_fields`, next to the existing `deps` and `score` gates, and is declared ahead of the three `outcomePerGroup` validators — so a binary package is told the field does not apply, rather than being nitpicked about a group name it should not be naming in the first place.

## Why this is safe to assume downstream

No runtime change was needed in `solutions.py`. With the field unloadable under `BINARY`, `expected_outcome_for_group` already returns `None` for every group, so `per_group_expectation_reports` is empty there. The assumption now holds by construction rather than by convention.

`outcomePerGroup` (#608) is in no release tag, so no shipped version is affected.

## Worth a look during review

Gating to points **changed the observable output** of the e2e fixture. Under `scoring: points` the failure verdict leads with a score line, so it went from

```
FAILED small: expected TIME_LIMIT_EXCEEDED, got: ACCEPTED
```

to

```
FAILED Got [40/100 pts]
       small: expected TIME_LIMIT_EXCEEDED, got: ACCEPTED
       big: expected TIME_LIMIT_EXCEEDED, got: WRONG_ANSWER
```

Two unit tests in `solutions_test.py` needed the same fix. Nothing is wrong with it, but the per-group report and the score report now always render together — a presentation coupling that did not exist before.

## Changes

- `rbx/box/schema.py` — the gate (`OUTCOME_PER_GROUP_NOT_ALLOWED`), plus field docs.
- `tests/rbx/box/test_schema.py` — new `TestOutcomePerGroupRequiresPointsScoring` (6 tests); existing per-group package tests moved to `scoring=POINTS`.
- `tests/rbx/box/solutions_test.py` — new `mock_points_scoring`; all 13 per-group report tests moved onto it, since they were asserting against a package shape that is now unloadable.
- `tests/e2e/testdata/outcome-per-group/` — fixture is now `scoring: points` (`small: 40` / `big: 60`).
- `rbx/box/CLAUDE.md` — records the constraint.

## Verification

`pytest -n auto -m 'not (e2e or slow or docker)'` → **4197 passed, 42 failed**. The 42 were checked against a baseline rather than assumed:

- Reverted `rbx/box/schema.py` to HEAD, re-ran the same 42 → 31 still failed (the known local C++/sandbox set, plus the two on record: `drift_test::test_committed_spec_matches_generated` and `walltime_test::test_compute_walltime_uses_active_environment`).
- The 11 that differed were re-run **with** the change in subset mode → 10 passed (all 8 `test_promote`, both `TestRunUnitTests`); their full-suite failures are suite-context, not this diff.
- The last, `package_digest_cache_test::test_get_digest_as_string_safe_across_concurrent_event_loops`, fails **at HEAD** 3 times in 6 runs — a pre-existing symlink race in `FileCacher._load` (`rbx/grading/judge/cacher.py:162`).

Also green: `test_schema.py` 69/69, `solutions_test.py` 39/39, `tests/rbx/grading` 389, root+casts 217, the `outcome-per-group` e2e scenario, `ruff check` and `ruff format --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
