### PR TITLE
feat(release): confirm bumps and allow forcing the increment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ For complex modules, see the inner CLAUDE.md files:
 
 Releases are commitizen-driven and cut manually with `mise run release` (bump + push tags + PyPI + schemas). There is no release CI on `main` -- the tag-push trigger in `.github/workflows/release.yml` is deliberately disabled. Tags cut from older commits still carry the enabled trigger, which matters when backporting.
 
+The bump goes through [`scripts/release.py`](scripts/release.py), which prints `current -> next` and **asks for confirmation** before committing, tagging and pushing; declining aborts the whole release before anything is published. Pass `--minor` (or `--major` / `--patch` / `-i MINOR`) to override the increment commitizen derives from the commit log -- e.g. `mise run release --minor` ships a `feat!` as a minor bump, and the prompt says which version commitizen would have picked instead. `--yes` skips the prompt (required when there is no terminal), `--no-push` bumps locally only, and any other flag is forwarded to `cz bump`.
+
 To ship a fix to an already-released older version (e.g. patch `0.38.0` while `main` is at `1.0.0`), follow [`docs/internal/backporting.md`](docs/internal/backporting.md). The short version: **fix forward on `main` first, cherry-pick down to a `release/<major>.<minor>.x` branch cut from the old tag, never merge that branch back.**
 
 ## Architecture

--- a/docs/internal/backporting.md
+++ b/docs/internal/backporting.md
@@ -37,6 +37,11 @@ Read this before touching anything, because the mechanics decide what is safe.
   schemas), or its pieces: `mise run bump`, `mise run publish`,
   `mise run publish-schemas`. The tag-push trigger in
   `.github/workflows/release.yml` is deliberately commented out.
+- `mise run bump` / `mise run release` go through `scripts/release.py`, which
+  shows `current -> next` and asks before committing, tagging and pushing, and
+  accepts `--minor` / `--major` / `--patch` to override the increment
+  commitizen derived. Maintenance branches still bump with `cz bump` directly
+  (see below), so this front-end does not apply there.
 
 That last point is the trap, because **GitHub Actions runs the workflow files
 as they existed at the tagged commit**, not as they exist on `main`. Older tags

--- a/mise.toml
+++ b/mise.toml
@@ -51,12 +51,14 @@ description = "Run docker tests"
 run = "pytest -m 'docker' -v -s"
 
 [tasks.bump]
-description = "Commitizen bump + push tags"
-run = "cz bump && git push && git push --tags"
+description = "Commitizen bump (asks to confirm) + push tags"
+# Extra args go to scripts/release.py, and anything it doesn't know on to
+# `cz bump` -- e.g. `mise run bump --minor` to force a minor over a major.
+run = "python scripts/release.py {{arg(name='bump_args', var=true, required=false)}}"
 
 [tasks.bump-pre]
-description = "Commitizen bump pre-release + push tags"
-run = "cz bump --prerelease rc && git push && git push --tags"
+description = "Commitizen bump pre-release (asks to confirm) + push tags"
+run = "python scripts/release.py --prerelease rc {{arg(name='bump_args', var=true, required=false)}}"
 
 [tasks.build]
 description = "Clean build the package"
@@ -72,7 +74,13 @@ run = "python scripts/publish_schemas.py"
 
 [tasks.release]
 description = "Full release: bump + push tags, publish to PyPI, publish schemas"
-run = "mise run bump && mise run publish && mise run publish-schemas"
+# `mise run release --minor` forces a minor bump; the bump is confirmed
+# interactively, and declining it aborts before anything is published.
+run = [
+  "python scripts/release.py {{arg(name='bump_args', var=true, required=false)}}",
+  "mise run publish",
+  "mise run publish-schemas",
+]
 
 [tasks.bench-completion]
 description = "Benchmark shell completion latency"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,143 @@
+"""Interactive front-end for `cz bump`, used by `mise run bump` / `mise run release`.
+
+Adds two things on top of a bare `cz bump`:
+
+- **Increment override**: `--minor` (or `--major` / `--patch` / `-i MINOR`)
+  forces the bump size when commitizen's own reading of the commit log would
+  pick something else -- e.g. shipping a `feat!` as a minor release instead of
+  the major that `BREAKING CHANGE` implies.
+- **Confirmation**: shows current -> next (and what commitizen would have
+  chosen on its own) and asks before touching the repo, since the bump commits,
+  tags and pushes.
+
+Any argument this script does not recognize is forwarded to `cz bump` verbatim.
+"""
+
+import argparse
+import subprocess
+import sys
+from typing import List, Optional
+
+INCREMENTS = ['MAJOR', 'MINOR', 'PATCH']
+
+
+def _cz(args: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ['cz', *args], capture_output=True, text=True, encoding='utf-8'
+    )
+
+
+def _current_version() -> str:
+    res = _cz(['version', '-p'])
+    if res.returncode != 0:
+        print(res.stderr.strip() or res.stdout.strip(), file=sys.stderr)
+        sys.exit(res.returncode)
+    return res.stdout.strip()
+
+
+def _next_version(bump_args: List[str]) -> Optional[str]:
+    """Ask commitizen what it would bump to, without touching the repo.
+
+    Returns None when commitizen refuses (most often: no bumpable commits since
+    the last tag).
+    """
+    res = _cz(['bump', '--get-next', *bump_args])
+    if res.returncode != 0:
+        return None
+    return res.stdout.strip().splitlines()[-1].strip() if res.stdout.strip() else None
+
+
+def _confirm(prompt: str) -> bool:
+    try:
+        answer = input(f'{prompt} [y/N] ').strip().lower()
+    except EOFError:
+        return False
+    return answer in ('y', 'yes')
+
+
+def _run(cmd: List[str]) -> None:
+    print(f'$ {" ".join(cmd)}')
+    res = subprocess.run(cmd)
+    if res.returncode != 0:
+        sys.exit(res.returncode)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Bump the version (with confirmation) and push the tag.',
+        epilog='Unrecognized arguments are forwarded to `cz bump`.',
+    )
+    increment = parser.add_mutually_exclusive_group()
+    increment.add_argument(
+        '-i',
+        '--increment',
+        choices=INCREMENTS,
+        help='force the increment instead of deriving it from the commit log',
+    )
+    for level in INCREMENTS:
+        increment.add_argument(
+            f'--{level.lower()}',
+            dest='increment',
+            action='store_const',
+            const=level,
+            help=f'shorthand for --increment {level}',
+        )
+    parser.add_argument(
+        '-y',
+        '--yes',
+        action='store_true',
+        help='skip the confirmation prompt',
+    )
+    parser.add_argument(
+        '--no-push',
+        action='store_true',
+        help='bump locally but do not push the commit and tag',
+    )
+    args, extra = parser.parse_known_args()
+
+    bump_args = list(extra)
+    if args.increment:
+        bump_args = ['--increment', args.increment, *bump_args]
+
+    current = _current_version()
+    next_version = _next_version(bump_args)
+    if next_version is None:
+        print(
+            'Commitizen found nothing to bump (no new commits since the last tag?).',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f'Current version: {current}')
+    print(f'Next version:    {next_version}', flush=True)
+
+    if args.increment:
+        # Show what we are overriding, so a forced --minor over a major bump is
+        # a deliberate choice rather than a silent one.
+        auto = _next_version(list(extra))
+        if auto is not None and auto != next_version:
+            print(
+                f'(commitizen would have bumped to {auto}; forcing {args.increment})',
+                flush=True,
+            )
+
+    if not args.yes:
+        if not sys.stdin.isatty():
+            print(
+                'Refusing to bump without a terminal to confirm on; pass --yes.',
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        action = 'Bump' if args.no_push else 'Bump, tag and push'
+        if not _confirm(f'{action} {current} -> {next_version}?'):
+            print('Aborted.')
+            sys.exit(1)
+
+    _run(['cz', 'bump', *bump_args])
+    if not args.no_push:
+        _run(['git', 'push'])
+        _run(['git', 'push', '--tags'])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Two changes to how a release is cut, both requested for the upcoming bump.

## Confirmation before the bump

`mise run bump` / `mise run release` now go through a new `scripts/release.py`, which prints `current -> next` and asks `[y/N]` before committing, tagging and pushing:

```
Current version: 1.0.0
Next version:    1.1.0
(commitizen would have bumped to 2.0.0; forcing MINOR)
Bump, tag and push 1.0.0 -> 1.1.0? [y/N]
```

`release` runs it as step 1 of its 3-step chain, so declining aborts before anything reaches PyPI or the schemas repo. Without a terminal the script refuses outright rather than bumping unattended -- pass `--yes` for that case.

## Forcing the increment

`--minor` (also `--major`, `--patch`, `-i MINOR`) overrides the increment commitizen derives from the commit log, for shipping e.g. a `feat!` as a minor release:

```
mise run release --minor
```

When the increment is overridden, the prompt names the version commitizen *would* have picked, so the override is a visible decision rather than a silent one.

`--no-push` bumps locally only; any other flag is forwarded to `cz bump` verbatim (`bump-pre` still works, it just passes `--prerelease rc` through).

## Verification

Ran a real `cz bump` end-to-end in a throwaway repo whose HEAD was a `feat!` commit:

- `--minor` produced `1.1.0` instead of the `2.0.0` commitizen wanted, with the override notice shown;
- answering `n` aborted with the repo untouched;
- flag forwarding checked through `mise run bump`, `mise run bump-pre` and `mise run release`, and declining stops the chain before `publish`;
- `mise run check` (ruff lint + format) passes.

Docs updated in `CLAUDE.md` and `docs/internal/backporting.md` (noting maintenance branches still bump with `cz bump` directly, so this front-end does not apply there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
