### PR TITLE
fix(solutions): use a valid rich color for the OLE verdict

### DIFF
--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -1101,7 +1101,7 @@ def get_outcome_style_verdict(outcome: Outcome) -> str:
     if outcome == Outcome.MEMORY_LIMIT_EXCEEDED:
         return 'yellow'
     if outcome == Outcome.OUTPUT_LIMIT_EXCEEDED:
-        return 'orange'
+        return 'orange1'
     if outcome == Outcome.COMPILATION_ERROR:
         return 'blue'
     return 'magenta'

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 import rich.console
+import rich.style
 from rich.text import Text
 
 from rbx.box.deferred import Deferred
@@ -34,8 +35,11 @@ from rbx.box.solutions import (
     TimingIssue,
     TraditionalRunReporter,
     convert_list_of_solution_evaluations_to_dict,
+    get_full_outcome_markup_verdict,
     get_matching_solutions,
+    get_outcome_style_verdict,
     get_solution_outcome_report,
+    get_ui_friendly_outcome_style_verdict,
     is_fast,
     run_solutions,
 )
@@ -1647,3 +1651,15 @@ def test_failed_to_compile_issue_generic_message_without_reason():
     msg = issue.get_detailed_message()
     assert 'could not be compiled and was skipped' in msg
     assert 'sols/wa.py' in msg
+
+
+@pytest.mark.parametrize('outcome', list(Outcome))
+def test_outcome_styles_are_valid_rich_styles(outcome: Outcome):
+    # Rich has no plain 'orange' color, and an invalid style blows up at render
+    # time (e.g. in the UI's test list), so every outcome must map to a
+    # parseable style.
+    rich.style.Style.parse(get_outcome_style_verdict(outcome))
+    rich.style.Style.parse(get_ui_friendly_outcome_style_verdict(outcome))
+    Text.from_markup(get_full_outcome_markup_verdict(outcome)).render(
+        rich.console.Console()
+    )


### PR DESCRIPTION
Rich has no color named `orange` (only `orange1`/`orange3`/`dark_orange`), so `get_outcome_style_verdict(Outcome.OUTPUT_LIMIT_EXCEEDED)` produced an unparseable style. Any render of an OLE verdict raised `MissingStyle: Failed to get style 'orange'` — reported as a crash of the test list in `rbx ui` on 0.38.x.

Switches to `orange1` and adds a regression test asserting every `Outcome` maps to a style Rich can parse and render.

To be cherry-picked onto `release/0.38.x` for a 0.38.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)