### PR TITLE
feat(run): add a --fail-fast/--ff flag to rbx run

### DIFF
--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -7,6 +7,7 @@ import tempfile
 from typing import Annotated, List, Optional, Union
 
 import rich
+import rich.console
 import rich.prompt
 import syncer
 import typer
@@ -478,7 +479,22 @@ async def run(
         VerificationLevel(verification),
         detailed=detailed,
         skip_printing_limits=sanitized,
+        # A solution that stopped at its first bad verdict was not timed on the
+        # testcases that never ran, so every extreme in the timing summary --
+        # and the time limit picked off it -- would rest on a lower bound.
+        timing=not fail_fast,
     )
+
+    def _print_fail_fast_warning(to: rich.console.Console) -> None:
+        to.print()
+        to.print(
+            '[warning]The [item]--fail-fast / --ff[/item] flag should only be used for quick experimentation, '
+            'and should not be trusted for full validation of the problem.[/warning]'
+        )
+        to.print(
+            '[warning]The timing summary was omitted: a solution that stopped early '
+            'is only timed on the testcases that ran.[/warning]'
+        )
 
     if share is not None:
         rec = sharing.recording_console()
@@ -488,15 +504,16 @@ async def run(
             VerificationLevel(verification),
             detailed=detailed,
             skip_printing_limits=sanitized,
+            timing=not fail_fast,
         )
+        # The shared report is the copy that leaves this machine, and whoever
+        # reads it never sees the warning printed below.
+        if fail_fast:
+            _print_fail_fast_warning(rec)
         sharing.capture_and_share(rec, fmt=share, title='rbx run report')
 
     if fail_fast:
-        console.console.print()
-        console.console.print(
-            '[warning]The [item]--fail-fast / --ff[/item] flag should only be used for quick experimentation, '
-            'and should not be trusted for full validation of the problem.[/warning]'
-        )
+        _print_fail_fast_warning(console.console)
 
     if not ok:
         raise typer.Exit(1)

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -44,6 +44,7 @@ from rbx.box.header import generate_header
 from rbx.box.packaging import main as packaging
 from rbx.box.schema import ExpectedOutcome, GeneratorScript, TestcaseGroup
 from rbx.box.solutions import (
+    fail_fast_abort_predicate,
     get_exact_matching_solutions,
     get_matching_solutions,
     pick_solutions,
@@ -382,6 +383,13 @@ async def run(
         help='Capture the run report and copy it to the clipboard. '
         'Pass a format: --share png or --share text.',
     ),
+    fail_fast: bool = typer.Option(
+        False,
+        '--fail-fast',
+        '--ff',
+        help='Whether to stop running a solution as soon as it gets a non-accepted verdict. '
+        'Only meant for quick experimentation, as the remaining tests are reported as failed.',
+    ),
 ):
     if share is not None and share not in ('png', 'text'):
         console.console.print(
@@ -459,6 +467,7 @@ async def run(
             check=check,
             verification=VerificationLevel(verification),
             sanitized=sanitized,
+            abort_on=fail_fast_abort_predicate if fail_fast else None,
         )
 
     console.console.print()
@@ -481,6 +490,13 @@ async def run(
             skip_printing_limits=sanitized,
         )
         sharing.capture_and_share(rec, fmt=share, title='rbx run report')
+
+    if fail_fast:
+        console.console.print()
+        console.console.print(
+            '[warning]The [item]--fail-fast / --ff[/item] flag should only be used for quick experimentation, '
+            'and should not be trusted for full validation of the problem.[/warning]'
+        )
 
     if not ok:
         raise typer.Exit(1)

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -209,6 +209,16 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': 'Whether to stop running a solution as soon as it gets a '
+                    'non-accepted verdict. Only meant for quick experimentation, as '
+                    'the remaining tests are reported as failed.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--fail-fast', '--ff'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,
@@ -1820,6 +1830,16 @@ SPEC = {
                                 'completer': 'verification_level',
                                 'kind': 'completer',
                             },
+                        },
+                        {
+                            'help': 'If set, will build the statement in the given '
+                            'language. Leave unset if you want to use the '
+                            'language of the topmost statement.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--language', '-l'],
+                            'takes_value': True,
+                            'value': {'completer': 'language', 'kind': 'completer'},
                         },
                         {
                             'help': 'Show this message and exit.',

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -1761,12 +1761,14 @@ def _get_verdict_report(
     verification: VerificationLevel,
 ) -> VerdictReport:
     has_plain_tle = False
+    has_skipped = False
     all_verdicts = set()
     bad_verdicts = set()
     no_tle_bad_verdicts = set()
     has_sanitizer_warnings = False
     for eval in evals:
         all_verdicts.add(eval.result.outcome)
+        has_skipped = has_skipped or eval.result.outcome == Outcome.SKIPPED
         if eval.result.outcome != Outcome.ACCEPTED:
             bad_verdicts.add(eval.result.outcome)
         if (
@@ -1814,6 +1816,12 @@ def _get_verdict_report(
         and expected_outcome_is_tle
         # Solution does not have a plain TLE.
         and not has_plain_tle
+        # Every testcase of the report actually ran. A skipped one leaves the
+        # measurement a lower bound over a prefix of the testset, and a testcase
+        # that never ran could well be the one that does not fit in double TL.
+        # SKIPPED also lands in `other_verdicts` below, which suppresses both
+        # messages anyway -- this states the reason instead of relying on it.
+        and not has_skipped
         # A TLE has happened.
         and Outcome.TIME_LIMIT_EXCEEDED in matched_bad_verdicts
         # The solution runs in double TL.
@@ -2025,7 +2033,17 @@ def get_solution_outcome_report(
             status = SolutionOutcomeStatus.UNEXPECTED_SCORE
 
     limits = skeleton.get_solution_limits(solution)
-    if report_issues and limits.profile is None and has_unmatched_slow_verdict:
+    # A truncated run is read the same way a partial one is (see the docstring):
+    # a solution expected to be slow that failed early for another reason never
+    # reaches the testcase that would have timed out, so it looks "too fast" only
+    # because the rest never ran. Blaming the limits for that is misleading.
+    has_skipped_eval = any(eval.result.outcome == Outcome.SKIPPED for eval in evals)
+    if (
+        report_issues
+        and not has_skipped_eval
+        and limits.profile is None
+        and has_unmatched_slow_verdict
+    ):
         issue_stack.add_issue(TimingIssue())
 
     return SolutionOutcomeReport(
@@ -2864,6 +2882,11 @@ async def print_run_report(
     Time limit inference uses it to run solutions that are *expected* to hit the
     cap without their timeouts aborting the estimate. ``None`` gates on all of
     them.
+
+    ``timing`` drops the timing summary, in both the detailed and the plain
+    report. Pass ``False`` when the run may stop early: every line of that
+    summary is an extreme over the solutions, and a solution that did not run to
+    the end only measures a lower bound.
     """
     if not skip_printing_limits:
         _print_limits(result.skeleton.limits)
@@ -2901,7 +2924,7 @@ async def print_run_report(
         if _gates_report(solution, gating_solutions):
             ok = ok and cur_ok
 
-    if not single_solution:
+    if not single_solution and timing:
         await _print_timing(
             console,
             result.skeleton,

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -126,6 +126,18 @@ class AbortContext:
 AbortPredicate = Callable[[AbortContext], bool]
 
 
+def fail_fast_abort_predicate(context: AbortContext) -> bool:
+    """Stops running a solution's group as soon as a testcase is not accepted.
+
+    This is a deliberately coarse predicate: a non-accepted verdict does not
+    necessarily doom the group (a solution expected to be WA is *supposed* to
+    fail some testcase), so the skipped testcases are reported as failed even
+    though they were never measured. It exists to cut the wall clock of a quick
+    experimental run, and its report must not be trusted to validate a problem.
+    """
+    return context.evaluation.result.outcome != Outcome.ACCEPTED
+
+
 class _AbortGate:
     """Tracks which groups of a single solution must no longer run.
 

--- a/tests/e2e/testdata/mixed-solutions/e2e.rbx.yml
+++ b/tests/e2e/testdata/mixed-solutions/e2e.rbx.yml
@@ -1,4 +1,50 @@
 scenarios:
+  - name: fail-fast
+    description: >
+      `rbx run --ff` stops each solution at its first non-accepted verdict, and
+      the report drops what a truncated run cannot support: the timing summary
+      goes, and the command says the flag is not to be trusted for validation.
+      `sols/wa.cpp` is wrong on the samples testcase, so this is also the shape
+      that makes the warning necessary -- it still reports OK, off one testcase.
+    steps:
+      - cmd: run --ff
+        expect:
+          stdout_contains:
+            - '--fail-fast / --ff'
+            - 'should not be trusted for full validation of the problem'
+            - 'The timing summary was omitted'
+          # Not a word about the slowest/fastest solutions: every line of that
+          # summary is an extreme, and a solution that stopped early is only
+          # timed on the testcases that ran.
+          stdout_not_contains:
+            - 'Timing summary:'
+            - 'Fastest'
+            - 'Slowest'
+          file_contains:
+            # `.rbx/runs/1` is the second declared solution, sols/wa.cpp: wrong
+            # on samples, so the `main` group never runs. Binary scoring, so the
+            # abort takes the whole testset, not just the failing group.
+            .rbx/runs/1/samples/1-gen-000.eval: 'outcome: wrong-answer'
+            .rbx/runs/1/main/1-gen-000.eval: 'outcome: skipped'
+            .rbx/runs/1/main/1-gen-001.eval: 'outcome: skipped'
+            # The accepted solution never trips its gate, so it runs in full.
+            .rbx/runs/0/main/1-gen-001.eval: 'outcome: accepted'
+
+  - name: fail-fast-off-by-default
+    description: >
+      Without the flag the run is complete, so the report keeps the timing
+      summary and says nothing about fail-fast.
+    steps:
+      - cmd: run
+        expect:
+          stdout_contains:
+            - 'Timing summary:'
+          stdout_not_contains:
+            - '--fail-fast / --ff'
+            - 'The timing summary was omitted'
+          file_contains:
+            .rbx/runs/1/main/1-gen-000.eval: 'outcome: wrong-answer'
+
   - name: verdict-matrix
     description: |
       Exercises the full solution matcher syntax: bare verdict, '*' with

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -26,6 +26,7 @@ from rbx.box.schema import (
     Testcase,
 )
 from rbx.box.solutions import (
+    AbortContext,
     EvaluationItem,
     FailedToCompileSolutionIssue,
     GroupOutcomeReport,
@@ -42,6 +43,7 @@ from rbx.box.solutions import (
     _print_timing,  # noqa: SLF001
     _render_detailed_group_table,  # noqa: SLF001
     convert_list_of_solution_evaluations_to_dict,
+    fail_fast_abort_predicate,
     get_full_outcome_markup_verdict,
     get_matching_solutions,
     get_outcome_markup_verdict,
@@ -49,6 +51,7 @@ from rbx.box.solutions import (
     get_solution_outcome_report,
     get_ui_friendly_outcome_style_verdict,
     is_fast,
+    print_run_report,
     run_solutions,
 )
 from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
@@ -1873,6 +1876,155 @@ async def test_abort_skips_dependent_groups_but_not_independent_ones(
     # The gate belongs to one solution: the next one is judged from scratch.
     for group in groups:
         assert outcomes(2, group) == [Outcome.ACCEPTED] * len(res[2][group])
+
+
+def _fail_fast_context(
+    outcome: Outcome,
+    expected_outcome: ExpectedOutcome = ExpectedOutcome.ACCEPTED,
+) -> AbortContext:
+    return AbortContext(
+        solution=Solution(path=pathlib.Path('sol.cpp'), outcome=expected_outcome),
+        group=_group('group1', []),
+        entry=TestcaseEntry(group='group1', index=0),
+        expected_outcome=expected_outcome,
+        group_expected_outcome=None,
+        evaluation=make_evaluation(outcome),
+    )
+
+
+def test_fail_fast_trips_on_every_verdict_but_accepted():
+    assert not fail_fast_abort_predicate(_fail_fast_context(Outcome.ACCEPTED))
+
+    for outcome in Outcome:
+        if outcome == Outcome.ACCEPTED:
+            continue
+        assert fail_fast_abort_predicate(_fail_fast_context(outcome)), outcome
+
+
+def test_fail_fast_trips_even_on_the_verdict_the_solution_declared():
+    """The coarseness is the point, and the reason the command warns about the
+    flag: a solution declared `wa` is *supposed* to fail somewhere, so its
+    remaining testcases are not doomed at all -- they are dropped anyway."""
+    context = _fail_fast_context(
+        Outcome.WRONG_ANSWER, expected_outcome=ExpectedOutcome.WRONG_ANSWER
+    )
+    assert context.expected_outcome.match(context.evaluation.result.outcome)
+    assert fail_fast_abort_predicate(context)
+
+
+def test_double_tl_is_not_claimed_off_a_truncated_run(
+    tmp_path, mock_skeleton, mock_binary_scoring
+):
+    """A run that stopped early only measures a prefix of the testset, and a
+    testcase that never ran could well be the one that does not fit in double
+    TL.
+
+    Two things suppress the claim today -- the explicit skipped check, and
+    SKIPPED landing among the other bad verdicts -- so this pins the behavior
+    rather than either mechanism.
+    """
+    solution = Solution(
+        path=tmp_path / 'tle.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED
+    )
+    skeleton = mock_skeleton([solution])
+    soft_tle = make_evaluation(
+        Outcome.TIME_LIMIT_EXCEEDED, time_ms=1500, no_tle_outcome=Outcome.ACCEPTED
+    )
+    skipped = make_evaluation(Outcome.SKIPPED, time_ms=None, memory_bytes=None)
+
+    complete = get_solution_outcome_report(
+        solution,
+        skeleton,
+        [soft_tle, make_evaluation(Outcome.ACCEPTED, time_ms=200)],
+        VerificationLevel.FULL,
+    )
+    assert complete.runUnderDoubleTl is True
+
+    truncated = get_solution_outcome_report(
+        solution, skeleton, [soft_tle, skipped], VerificationLevel.FULL
+    )
+    assert truncated.runUnderDoubleTl is False
+    assert 'double TL' not in truncated.get_verdict_markup_with_warnings()
+
+
+def test_double_tl_verdicts_are_not_claimed_off_a_truncated_run(
+    tmp_path, mock_skeleton, mock_binary_scoring
+):
+    solution = Solution(
+        path=tmp_path / 'tle.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED
+    )
+    skeleton = mock_skeleton([solution])
+    soft_tle_with_wa = make_evaluation(
+        Outcome.TIME_LIMIT_EXCEEDED, time_ms=1500, no_tle_outcome=Outcome.WRONG_ANSWER
+    )
+
+    complete = get_solution_outcome_report(
+        solution, skeleton, [soft_tle_with_wa], VerificationLevel.FULL
+    )
+    assert complete.doubleTlVerdicts == {Outcome.WRONG_ANSWER}
+
+    truncated = get_solution_outcome_report(
+        solution,
+        skeleton,
+        [soft_tle_with_wa, make_evaluation(Outcome.SKIPPED, time_ms=None)],
+        VerificationLevel.FULL,
+    )
+    assert truncated.doubleTlVerdicts == set()
+
+
+def test_timing_issues_are_not_raised_off_a_truncated_run(
+    tmp_path, mock_skeleton, mock_binary_scoring
+):
+    """A solution expected to be slow that fails early for another reason never
+    reaches the testcase that would have timed out, so it looks 'too fast' only
+    because the rest never ran. Blaming the limits for that is misleading --
+    same rule as the partial reports, which is why they pass
+    ``report_issues=False``."""
+    solution = Solution(
+        path=tmp_path / 'tle.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED
+    )
+    skeleton = mock_skeleton([solution])
+    wrong_answer = make_evaluation(Outcome.WRONG_ANSWER)
+
+    # Ran to the end and never timed out: the limits really may be untuned.
+    with fresh_issue_stack() as issues:
+        get_solution_outcome_report(
+            solution, skeleton, [wrong_answer], VerificationLevel.FULL
+        )
+    assert any(isinstance(issue, TimingIssue) for issue in issues.issues)
+
+    # Same verdicts, but the run stopped: the missing TLE says nothing.
+    with fresh_issue_stack() as issues:
+        get_solution_outcome_report(
+            solution,
+            skeleton,
+            [wrong_answer, make_evaluation(Outcome.SKIPPED, time_ms=None)],
+            VerificationLevel.FULL,
+        )
+    assert [issue for issue in issues.issues if isinstance(issue, TimingIssue)] == []
+
+
+async def test_plain_report_drops_the_timing_summary_when_timing_is_off(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """`rbx run --ff` turns `timing` off, since every line of that summary is an
+    extreme over the solutions and a solution that stopped early is only timed
+    on the testcases that ran. Only the detailed report used to honor the flag,
+    so the plain one kept printing the summary."""
+    solutions = [
+        Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED),
+        Solution(path=pathlib.Path('other.cpp'), outcome=ExpectedOutcome.ACCEPTED),
+    ]
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 1})
+    result = make_run_result(skeleton, {('group1', 0): Outcome.ACCEPTED})
+
+    console = recording_console()
+    await print_run_report(result, console, VerificationLevel.FULL, timing=True)
+    assert 'Timing summary' in console.export_text(clear=False)
+
+    console = recording_console()
+    await print_run_report(result, console, VerificationLevel.FULL, timing=False)
+    assert 'Timing summary' not in console.export_text(clear=False)
 
 
 @pytest.mark.test_pkg('problems/abort-groups')

--- a/tests/rbx/box/test_run_cli.py
+++ b/tests/rbx/box/test_run_cli.py
@@ -1,0 +1,156 @@
+"""What `rbx run --fail-fast` hands to the runner and to the report.
+
+The flag is three decisions taken in the command itself -- which predicate stops
+a solution, whether the timing summary may still be drawn, and who gets told the
+run was truncated -- so they are pinned here, where the wiring is, rather than
+through a full run.
+"""
+
+import asyncio
+from typing import Any, Dict, List, Tuple
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box import cli
+from rbx.box.solutions import fail_fast_abort_predicate
+from rbx.box.testing import testing_package
+
+FAIL_FAST_WARNING = 'should not be trusted for full validation of the problem'
+
+
+def _flat(text: str) -> str:
+    """Collapse the console's own wrapping, which lands mid-sentence."""
+    return ' '.join(text.split())
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _skip_preset_check():
+    # The root Typer callback checks the active preset's compatibility, which is
+    # unrelated to the wiring under test and fails for the bare testing package.
+    with mock.patch('rbx.box.presets.check_active_preset_compatibility'):
+        yield
+
+
+async def _build_ok(*args, **kwargs):
+    return True
+
+
+class _Invocation:
+    """The calls `run` made, once its heavy collaborators are stubbed out."""
+
+    def __init__(self):
+        self.run_solutions_kwargs: Dict[str, Any] = {}
+        self.reports: List[Tuple[Any, Dict[str, Any]]] = []
+        self.shared: List[Any] = []
+
+    @property
+    def shared_text(self) -> str:
+        assert len(self.shared) == 1
+        # The console wraps at its own width, so a warning long enough to be
+        # worth printing is long enough to be broken across lines.
+        return _flat(self.shared[0].export_text(clear=False))
+
+
+def _invoke_run(runner: CliRunner, *args: str) -> Tuple[Any, _Invocation]:
+    calls = _Invocation()
+
+    async def run_solutions(**kwargs):
+        calls.run_solutions_kwargs = kwargs
+        return mock.MagicMock()
+
+    async def print_run_report(result, console, verification, **kwargs):
+        calls.reports.append((console, kwargs))
+        return True
+
+    def capture_and_share(console, **kwargs):
+        calls.shared.append(console)
+
+    with (
+        mock.patch('rbx.box.builder.build', _build_ok),
+        mock.patch('rbx.box.cli.run_solutions', run_solutions),
+        mock.patch('rbx.box.cli.print_run_report', print_run_report),
+        mock.patch('rbx.box.sharing.capture_and_share', capture_and_share),
+    ):
+        result = runner.invoke(cli.app, ['run', *args])
+    return result, calls
+
+
+def test_fail_fast_hands_the_runner_its_predicate(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    result, calls = _invoke_run(runner, '--ff')
+
+    assert result.exit_code == 0, result.output
+    assert calls.run_solutions_kwargs['abort_on'] is fail_fast_abort_predicate
+
+
+def test_a_plain_run_stops_for_nothing(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    result, calls = _invoke_run(runner)
+
+    assert result.exit_code == 0, result.output
+    assert calls.run_solutions_kwargs['abort_on'] is None
+
+
+@pytest.mark.parametrize('flag', ['--fail-fast', '--ff'])
+def test_both_spellings_of_the_flag_warn_and_drop_the_timing_summary(
+    flag: str,
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    result, calls = _invoke_run(runner, flag)
+
+    assert result.exit_code == 0, result.output
+    assert FAIL_FAST_WARNING in _flat(result.output)
+    # Every line of that summary is an extreme over the solutions, and a
+    # solution that stopped early is only timed on the testcases that ran.
+    assert [kwargs['timing'] for _, kwargs in calls.reports] == [False]
+
+
+def test_a_plain_run_keeps_the_timing_summary_and_says_nothing(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    result, calls = _invoke_run(runner)
+
+    assert result.exit_code == 0, result.output
+    assert FAIL_FAST_WARNING not in _flat(result.output)
+    assert [kwargs['timing'] for _, kwargs in calls.reports] == [True]
+
+
+def test_the_shared_report_carries_the_warning(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    # The shared copy is the one that leaves this machine, and whoever reads it
+    # never sees the terminal warning.
+    result, calls = _invoke_run(runner, '--ff', '--share', 'text')
+
+    assert result.exit_code == 0, result.output
+    assert FAIL_FAST_WARNING in calls.shared_text
+    # ...and it is shared with the summary dropped, same as the printed one.
+    assert [kwargs['timing'] for _, kwargs in calls.reports] == [False, False]
+
+
+def test_the_shared_report_of_a_plain_run_is_unchanged(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    result, calls = _invoke_run(runner, '--share', 'text')
+
+    assert result.exit_code == 0, result.output
+    assert FAIL_FAST_WARNING not in calls.shared_text


### PR DESCRIPTION
## What

Adds `--fail-fast` / `--ff` to `rbx run`. When set, a solution stops running the rest of a testcase group as soon as it gets a non-accepted verdict, via the `abort_on` hook added in #647.

- `solutions.fail_fast_abort_predicate`: trips on any `outcome != ACCEPTED`.
- `rbx/box/cli.py`: new flag, wired into `run_solutions(abort_on=...)`, plus a warning printed at the end of the command:

  > The `--fail-fast / --ff` flag should only be used for quick experimentation, and should not be trusted for full validation of the problem.

- `rbx/box/completion/_spec.py`: regenerated with `mise run gen-completion-spec`. The `--language` hunk on `statements build` is pre-existing drift that the regeneration picked up (it fixes `completion/drift_test.py`, which fails on `main`).

## What a truncated run may no longer conclude

Second commit. A `--ff` run only measures a prefix of the testset, so the report must not draw conclusions that need the whole one. Each of these was checked against a live package, not just read.

**Timing summary — was wrong, now omitted.** Every line of it (`Slowest AC`, `Slowest AC or TLE`, `Fastest slow`) is an extreme over the solutions, and it exists to pick a time limit. A solution that stopped early is only timed on the testcases that ran, so each time is a lower bound. On a fixture whose `tle`-declared solution takes 1400ms on `samples` and 1900ms on `main`, `Fastest slow solution` reported **1902 ms** normally and **1345 ms** under `--ff`. Note the two directions of the error are both harmful: understating `Fastest slow` makes the limit look tighter than it is, while understating `Slowest AC or TLE` makes a too-tight limit look fine.

This reuses `print_run_report`'s existing `timing` flag, which the plain (non-`--detailed`) report was silently ignoring — that path now honors it, which changes nothing for the other callers since none of them pass it. Deliberately **not** done inside `_print_timing`: that would also change the inference report from #647, whose `test_timing_summary_ignores_skipped_testcases` pins the opposite behavior (keep the summary, drop the skipped evals). Happy to widen it if you'd rather that decision be uniform.

**Double TL — already safe, now explicitly so.** This was the suspicion that started the investigation, and it turns out the claim is never made on truncated evidence: `SKIPPED` is a bad verdict, so it lands in `other_verdicts` and disqualifies both branches. Verified — the same solution prints `WARNING The solution still passed in double TL.` on a full run and stays silent under `--ff`. But it held only incidentally, so `_get_verdict_report` now checks `not has_skipped` outright, with the reasoning written down.

**`TimingIssue`** ("limits might not be tuned, consider `rbx time`") is no longer pushed off a truncated run. A solution expected to be slow that fails early for another reason never reaches the testcase that would have timed out, so it looks "too fast" only because the rest never ran. This matches the existing `report_issues=False` rule for partial reports.

**`--share`** now carries the warning into the shared copy — that is the report that leaves the machine, and its reader never sees the terminal warning.

## Confirmed sound under `--ff` (no change needed)

- **POINTS scoring is exact.** The gate skips only the failing group and its dependents, which score 0 either way; independent groups still run in full. On `tests/e2e/testdata/outcome-per-group`, scores and per-group expectations are identical with and without `--ff` (`40/100` for `partial.cpp`, `mislabeled.cpp` still caught).

## Inherent to fail-fast — what the warning is for

- A truncated run can flip **FAILED → OK**. Verified: a solution declared `wa` that prints a wrong answer on `samples` but crashes on later tests reports `FAILED Expected: WRONG_ANSWER, got: RUNTIME_ERROR` normally, and `OK` under `--ff`.
- `SKIPPED` satisfies every expectation except `ac` (`ExpectedOutcome.match`), so per-group expectations on skipped groups are vacuous — and conversely, a group declared `ac` that gets skipped as a dependent falsely fails.

## Testing

Third commit. Rebased on `256c143e`.

**Unit** (`tests/rbx/box/solutions_test.py`) — the predicate trips on every verdict but `ACCEPTED`, including one the solution declared (the coarseness that makes the warning necessary); double TL and its per-verdict variant are not claimed off a truncated run; `TimingIssue` is not raised off one; and the plain report honors `timing`, which only the detailed one used to.

**CLI** (`tests/rbx/box/test_run_cli.py`, new) — the wiring the command owns, with the runner stubbed: both spellings of the flag hand `run_solutions` the predicate and turn `timing` off, a plain run does neither, and `--share` carries the warning into the shared copy.

**E2E** (`tests/e2e/testdata/mixed-solutions/e2e.rbx.yml`) — two scenarios over a real package: `run --ff` writes `outcome: skipped` for the testcases after the first bad verdict, prints the warning, and prints no timing summary; a plain `run` keeps the summary and says nothing.

Each test was checked against the unfixed code — reverting a guard fails the test that covers it. **One exception, stated plainly:** the two double-TL tests pass with or without my explicit `not has_skipped` check, because `SKIPPED` also lands in `other_verdicts` and disqualifies both branches. That check is therefore provably redundant today; it is there so the invariant is local and stated rather than incidental, and the tests pin the behavior, not the line. Drop it if you'd rather keep only the comment.

`tests/rbx --ignore=tests/rbx/box/cli`: 35 failures on this branch vs 36 on `256c143e`, same set except the completion drift test the branch fixes (the rest are local C++/sandbox failures). `mise run test-e2e`: the same 6 pre-existing g++ compilation failures as `main`, with both new scenarios passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
