### PR TITLE
perf(tests): cut the tests/rbx suite from 196s to 60s

### DIFF
--- a/docs/plans/2026-08-14-test-suite-speed-design.md
+++ b/docs/plans/2026-08-14-test-suite-speed-design.md
@@ -196,13 +196,60 @@ cache DB and an empty content-addressed store. Only the precompilation cache is
 session-scoped, which is exactly why Phase 1 moved the header precompiles from
 98x to 7x while ordinary program compiles kept repeating.
 
-**Actual fix: session-scope the problem dependency cache and storage in the test
+**Actual fix: a session-wide problem dependency cache and storage in the test
 fixtures**, mirroring what `precompilation_should_use_tmp_cache` already does.
 This is a test-only change and safe *because* Phase 1 made keys
-content-addressed rather than path-addressed. A `no_shared_cache` marker exists
-as an escape hatch for tests that need to observe a real compilation.
+content-addressed rather than path-addressed.
 
-Measured: full suite 101s -> 61s, `generators_test.py` 52.7s -> 18.9s.
+### Sharing is opt-in, not the default
+
+It was first built as the default, with an opt-out. That was rejected on review,
+and rightly: sharing a compile cache across problems by default weakens
+isolation everywhere, and a future bug in cache keying would mask itself across
+the whole suite rather than failing loudly in one place. Correctness defaults
+should be conservative; speed is the thing to opt into.
+
+So the default is a per-problem cache -- exactly the pre-existing behaviour --
+and a `shared_cache` marker opts specific modules in. It is applied only where
+the measured gain is large *and* the tests do not depend on a compile actually
+running:
+
+| File | Isolated | Shared | Marked |
+| --- | --- | --- | --- |
+| `solutions_test.py` | 83.8s | 41.8s | yes |
+| `unit_test.py` | 62.1s | 18.5s | yes |
+| `validators_test.py` | 61.2s | 28.4s | yes |
+| `generators_test.py` | 57.8s | 21.0s | yes, 1 test opts out |
+| `generator_outputs_test.py` | 32.1s | 13.1s | yes, 2 tests opt out |
+| `testcases/test_promote.py` | 23.1s | 8.8s | yes |
+| `test_header.py` | 30.8s | 28.4s | no -- compiles via raw `g++` |
+| `code_run_test.py` | 15.0s | 13.5s | no -- gain too small |
+| `checkers_test.py` | 8.5s | 6.7s | no -- see below |
+| `code_compile_integration_test.py` | 7.2s | 6.9s | no -- real-compile coverage |
+
+The three tests that opt back out individually are the ones asserting on
+compilation output or failure messages, which a warm cache would turn into
+silent hits.
+
+Cost of keeping isolation everywhere else: about 10s (roughly 60s -> 70s),
+against ~119s with no sharing at all.
+
+### A trap worth knowing about
+
+`maybe_shared_problem_cache` is function-scoped, so the shared cache is only
+installed for the duration of each test. A **module- or session-scoped fixture
+that compiles runs before it**, writing into the isolated per-problem storage;
+the marked tests then look for that digest in the shared storage and fail with
+an opaque `KeyError: 'File not found.'`.
+
+`checkers_test.py` is the live example -- marking it fails 14 of its 43 tests,
+because `pkg_with_compiled_checker` is `scope='module'`. This is a property of
+the opt-in mechanism, not evidence that sharing is unsafe for those tests: under
+the original session-scoped-autouse version they passed. It costs nothing here,
+since sharing was only worth 1.8s in that file. The constraint is documented on
+the marker and in the fixture docstring.
+
+Measured: `generators_test.py` 57.8s -> 21.0s on the marked path.
 
 ## Phases 3 and 4 -- descoped after re-measuring
 
@@ -293,11 +340,13 @@ unwanted.
 
 | Run | Before | After |
 | --- | --- | --- |
-| `tests/rbx -n 8`, fixed order | 196s | **59-62s** |
-| `tests/rbx -n 8`, random order | 238s | **73s** |
+| `tests/rbx -n 8`, fixed order | 196s | **69-78s** |
 | Suite CPU | 992s | 351s |
 | C++ compiles | 498 | 219 |
 | Tests over 3s | 108 | 22 |
+
+(An earlier revision shared the cache globally and reached ~60s. Restoring
+per-problem isolation by default costs ~10s of that, deliberately.)
 
 Failure count did not increase: 37 failed / 4512 passed before, 36 failed /
 4520 passed after in fixed order (37 in random order, matching its own

--- a/docs/plans/2026-08-14-test-suite-speed-design.md
+++ b/docs/plans/2026-08-14-test-suite-speed-design.md
@@ -1,0 +1,247 @@
+# Speeding up the `tests/rbx` suite
+
+Date: 2026-08-14
+
+## Summary
+
+The `tests/rbx` suite spends **76% of its time compiling C++**, and **89% of
+those compiles rebuild a source that was already compiled earlier in the same
+run**. The redundancy is caused by a cache key that embeds absolute file paths,
+so the content-addressed global compilation cache can never hit across tests
+(each test runs in a fresh temporary package directory).
+
+Fixing the cache key is a five-line change to production code. Measured on the
+full suite it cuts wall time by 41% and introduces no regressions.
+
+This document records the measurements, the root cause, and a five-phase plan.
+
+## Baseline measurements
+
+All numbers from one machine: 8 cores, macOS 14.6, Apple clang 15.0.0,
+`uv run pytest`, `-p no:randomly` unless noted.
+
+| Command | Wall time |
+| --- | --- |
+| `pytest tests/rbx -n 8` (fixed order) | 3m15s |
+| `pytest tests/rbx -n 8` (default random order) | 3m57s |
+| `mise run test` (`-n auto`, whole tree) | 3m35s |
+| `mise run test-cov` (serial + coverage, the CI command) | 10m13s |
+
+`mise run test-cov` passes no `-n`, so CI runs single-threaded. That is the only
+path above ten minutes. A reported 25-minute figure could not be reproduced on
+this machine for any parallel invocation; the design targets the parallel path.
+
+### Where the time goes
+
+Total CPU across `tests/rbx` is 992s (wall 196s on 8 workers). Every subprocess
+the sandbox spawns was instrumented by wrapping `Program.wait`:
+
+| Kind | Time | n | Share of suite |
+| --- | --- | --- | --- |
+| C++ compilation | 756s | 498 | 76% |
+| Program execution (all languages) | 99s | 512 | 10% |
+| Python / pytest overhead | ~135s | -- | 14% |
+
+Actually *running* programs -- including the deliberately slow and TLE ones --
+is 10% of the suite. Compilation dominates.
+
+### Concentration
+
+123 tests (2.7% of 4553) account for 86% of runtime. The remaining 4430 tests
+cost ~140s combined.
+
+| Slice | Time | Share |
+| --- | --- | --- |
+| top 10 tests | 182s | 18.4% |
+| top 25 tests | 331s | 33.4% |
+| top 50 tests | 541s | 54.5% |
+| top 100 tests | 822s | 82.9% |
+
+Two tests alone are 8.5%: `test_get_solution_outcome_report` (44s) and
+`test_solutions` (41s). Ideal wall time at perfect balance would be 992/8 =
+124s; actual is 196s. The gap is the xdist tail -- one worker still running a
+40s test while seven idle.
+
+### Compilation cost primitives
+
+| Program | Compile time |
+| --- | --- |
+| trivial `int main(){}` | 0.07s |
+| `#include <iostream>` a+b | 0.34s |
+| testlib.h generator, `-O2` | 2.61s |
+| testlib.h generator, `-O0` | 1.45s |
+| testlib.h generator, `-O2`, with PCH | 2.07s |
+| equivalent Python program (no compile) | 0.02s |
+
+testlib's cost is template instantiation and codegen, not preprocessing
+(`-E` alone is 0.13s). That is why a precompiled header saves only ~0.5s of
+2.6s, and why `-O0` is the more effective lever.
+
+## Root cause
+
+Of 498 C++ compiles, only **56 are distinct source blobs**. 442 compiles (89%)
+rebuild a blob already compiled elsewhere in the run, worth ~614s -- 62% of the
+suite's total CPU.
+
+The three most-recompiled blobs are compiled **98 times each**: they are
+`testlib.h` (207KB), `jngen.h` (183KB) and `tgen.h` (170KB), built as
+precompiled headers by `_precompile_header` in `rbx/box/code.py`. That is ~350s,
+**35% of the whole suite**, spent re-precompiling three headers.
+
+A global, content-addressed PCH cache exists (`rbx/box/global_package.py`) and
+is correctly session-scoped in tests (`clear_all_functools_cache` deliberately
+excludes `global_package`). It never hits. Diffing the cache key input between
+two consecutive tests in the same process:
+
+```
+-  "src": ".../cleandir0/pkg/.rbx/.preprocessed/.local.rbx/libs/testlib/testlib.h",
++  "src": ".../cleandir1/pkg/.rbx/.preprocessed/.local.rbx/libs/jngen/jngen.h",
+   "digest": null,
+```
+
+`_build_cache_input` (`rbx/grading/caching.py:234-241`) replaces a source path
+with its content digest **only when the file is a symlink into cacher storage**
+(`cacher.digest_from_symlink`). The preprocessed headers are real copies, so the
+absolute path stays in the key. Each test uses a fresh temporary package
+directory, so the key differs every time.
+
+Measured on three consecutive tests: 5, 4 and 4 compiles respectively,
+`cache hit=2 miss=17`.
+
+Two factors compound it. `testing_package._declare_standard_libraries` declares
+testlib **and** jngen **and** tgen for every test package, so a test whose
+generator only uses testlib still pays to precompile all three.
+
+This is a production defect, not only a test-speed one: a path-keyed "global"
+cache misses for real users whenever the package path changes.
+
+## Phase 1 -- Content-address the compile cache key
+
+In `_build_cache_input`, fall back to hashing file contents when
+`digest_from_symlink` yields nothing:
+
+```python
+inferred_digest = await cacher.digest_from_symlink(input.src)
+if inferred_digest is None and input.src.is_file():
+    inferred_digest = digester.digest_file(input.src)
+if inferred_digest is not None:
+    input.digest = DigestHolder(value=inferred_digest)
+    input.src = None
+```
+
+Keying on `(dest, content digest)` is strictly more precise than
+`(dest, source path)`: the compiler command references `dest`, which is
+preserved, so two identical files under different paths are genuinely
+interchangeable.
+
+Requires a `CACHE_STEP_VERSION` bump (`rbx/box/global_package.py`) to invalidate
+existing user caches.
+
+### Validated result
+
+Prototyped and measured on the full suite:
+
+| Metric | Before | After |
+| --- | --- | --- |
+| Wall (`-n 8`) | 196s | **116s** (-41%) |
+| CPU | 992s | 578s (-42%) |
+| C++ compiles | 498 | 219 (-56%) |
+| Compile time | 756s | 363s (-52%) |
+| testlib/jngen/tgen precompiles | 98x each | 7x each |
+| Worst file (`generators_test`) | 107.4s | 56.6s (-47%) |
+| Failures | 37 | **36** |
+
+The three headers now compile roughly once per xdist worker, which is the
+correct floor for 8 independent worker processes. Failures went *down* by one:
+a previously failing test now passes. No new failures.
+
+## Phase 2 -- Recover the remaining 163 redundant compiles
+
+After Phase 1, 219 compiles remain over 56 distinct blobs -- still 163
+redundant, ~200s of CPU. The remaining offenders are the small testlib
+generators and validators in `rbx/testdata/` (one 167-byte generator is compiled
+36 times, costing 98s).
+
+The cache *keys* already match: two consecutive tests were verified to produce
+byte-identical cache inputs. The miss happens later, in
+`_build_output_fingerprint_list` (`rbx/grading/caching.py:164-177`). It digests
+each non-hash, non-intermediate output at its `dest` path. In a fresh package
+the compiled binary does not exist yet, so it fingerprints as `''`, mismatches
+the stored fingerprint, and `find_in_cache` **evicts the entry** rather than
+materializing the artifact from storage.
+
+Fix: when the only discrepancy is that an output is absent, materialize it from
+content-addressed storage instead of evicting.
+
+This is the subtlest change in the plan -- it modifies the invariant that
+guarantees on-disk artifacts are current. Land it isolated, with its own tests
+covering: output absent (materialize), output present and matching (hit),
+output present but modified (evict, as today).
+
+## Phase 3 -- Stop declaring libraries tests do not use
+
+`testing_package._declare_standard_libraries` declares testlib, jngen and tgen
+for every test package. Almost every test uses only testlib. Make jngen and tgen
+opt-in via an argument to `TestingPackage`.
+
+Independent of Phases 1-2, and removes two-thirds of header precompilation even
+if those phases regress.
+
+## Phase 4 -- Python program helpers, and convert the obvious tests
+
+The contracts rbx enforces are protocol-only, so Python equivalents are exact
+substitutes rather than approximations:
+
+- **Checker**: exit code in `{0,1,2,3}` plus the last line of stderr.
+  `_is_checker_exitcode` and `process_checker_run_log`
+  (`rbx/box/checkers.py:210,255`). 0 = AC, 1/2 = WA, 3 = judge failed.
+- **Validator**: exit code plus stderr (`rbx/box/validators.py:155,170`). An
+  optional `validator.log` carries the bounds overview, needed only by tests
+  that assert on bounds coverage.
+- **Generator**: writes to stdout.
+
+Cost per program: 2.6s to compile a testlib C++ program versus 0.02s to run a
+Python one, which skips compilation entirely (`fileMapping.executable` maps to
+the source).
+
+Add helpers to `TestingPackage` so converted tests stay one-liners rather than
+growing inline source blobs:
+
+- `add_python_generator(path, *, echoes_argv=...)`
+- `add_python_validator(path, *, verdict=..., message=...)`
+- `add_python_checker(path, *, verdict=..., message=...)`
+
+Convert tests that only exercise orchestration (does the generator get invoked,
+is the verdict routed correctly, is the group wired up). **Deliberately retain a
+tagged set of real-C++ full-flow tests** so the compiler path, testlib
+integration, and the C++ toolchain stay covered. The goal is a handful of real
+end-to-end tests, not a hundred.
+
+Correcting the ~36 pre-existing failures is explicitly out of scope.
+
+## Phase 5 -- Two cheap wins
+
+**`-O0` in the test environment.** Test packages copy the shipped preset
+`env.rbx.yml` verbatim (`TestingPreset.initialize` copies
+`presets/default/env.rbx.yml`), inheriting `-O2`. Overriding the C and C++
+compilation commands to `-O0` in the test preset measured 21% faster on
+`generators_test` before the cache fix. Test-only; tests that assert on program
+performance must opt out.
+
+**Split the two mega-tests.** `test_get_solution_outcome_report` (44s) and
+`test_solutions` (41s) are the xdist tail. The suite cannot finish faster than
+its longest single test, so splitting them is what closes the 196s-versus-124s
+gap.
+
+## Out of scope
+
+- Adding `-n auto` to `mise run test-cov`. Considered and declined.
+- Fixing the 36-37 pre-existing test failures.
+- The `tests/e2e`, `tests/casts` and `tests/docker` suites.
+
+## Expected outcome
+
+Phase 1 alone is validated at 196s -> 116s. With Phases 2-5, compilation should
+stop being the dominant cost and wall time should land well under 90s on 8
+cores, with the tail-latency fix mattering proportionally more as total CPU
+falls.

--- a/docs/plans/2026-08-14-test-suite-speed-design.md
+++ b/docs/plans/2026-08-14-test-suite-speed-design.md
@@ -163,31 +163,72 @@ generators and validators in `rbx/testdata/` (one 167-byte generator is compiled
 36 times, costing 98s).
 
 The cache *keys* already match: two consecutive tests were verified to produce
-byte-identical cache inputs. The miss happens later, in
-`_build_output_fingerprint_list` (`rbx/grading/caching.py:164-177`). It digests
-each non-hash, non-intermediate output at its `dest` path. In a fresh package
-the compiled binary does not exist yet, so it fingerprints as `''`, mismatches
-the stored fingerprint, and `find_in_cache` **evicts the entry** rather than
-materializing the artifact from storage.
+byte-identical cache inputs.
 
-Fix: when the only discrepancy is that an output is absent, materialize it from
-content-addressed storage instead of evicting.
+**This section originally blamed `_build_output_fingerprint_list` and proposed
+relaxing its eviction rule. That diagnosis was wrong, and the proposed fix would
+have been a no-op that deleted a dormant safety check.** It is recorded here
+because the correction is the useful part.
 
-This is the subtlest change in the plan -- it modifies the invariant that
-guarantees on-disk artifacts are current. Land it isolated, with its own tests
-covering: output absent (materialize), output present and matching (hit),
-output present but modified (evict, as today).
+`_build_output_fingerprint_list` skips every output that is `hash`,
+`intermediate`, or has no `dest`. `GradingFileOutput.hash` defaults to `True`
+(`rbx/grading/steps.py:193`) and nothing in `rbx/` ever sets it `False` on an
+output -- the single `hash=False` in the tree (`rbx/box/code.py:602`) is on a
+`GradingFileInput`. The list is therefore structurally always empty, so
+`_output_fingerprints_match` is always trivially true and evicts nothing.
 
-## Phase 3 -- Stop declaring libraries tests do not use
+Instrumenting every miss branch of `find_in_cache` over a real compile-heavy run
+settled it:
+
+```
+key_lookup: 175   key_HIT: 109   key_MISS: 66
+input_fingerprint_MISMATCH: 0
+output_fingerprint_MISMATCH: 0
+artifacts_NOT_OK: 0
+```
+
+No entry is evicted by any post-key validation. All 66 misses are **cold** --
+the key is simply absent from the database. The cause is fixture layout, not
+cache correctness: `cleandir` mints a fresh `tmp_path` per test, and the
+problem-level `DependencyCache` and `FilesystemStorage` live under
+`<problem>/.rbx` (`rbx/box/package.py`), so every test starts with an empty
+cache DB and an empty content-addressed store. Only the precompilation cache is
+session-scoped, which is exactly why Phase 1 moved the header precompiles from
+98x to 7x while ordinary program compiles kept repeating.
+
+**Actual fix: session-scope the problem dependency cache and storage in the test
+fixtures**, mirroring what `precompilation_should_use_tmp_cache` already does.
+This is a test-only change and safe *because* Phase 1 made keys
+content-addressed rather than path-addressed. A `no_shared_cache` marker exists
+as an escape hatch for tests that need to observe a real compilation.
+
+Measured: full suite 101s -> 61s, `generators_test.py` 52.7s -> 18.9s.
+
+## Phases 3 and 4 -- descoped after re-measuring
+
+**Not implemented.** Phases 1 and 2 changed the profile they were sized against,
+so they were re-measured and dropped rather than executed on stale numbers.
+
+After Phases 1-2, suite CPU fell from 992s to 351s and the number of tests over
+3s fell from 108 to 22. Compilation is no longer the dominant cost, because
+almost every compile is now a cache hit:
+
+- **Phase 3** (jngen/tgen opt-in) targeted header precompiles that Phase 1
+  already took from 98x to 7x each. Remaining value ~2s of wall time.
+- **Phase 4** (Python programs for orchestration tests) targeted a 2.6s C++
+  compile per program that is now a cache hit. It would have touched ~100 tests
+  and traded away real-compiler coverage for a few seconds.
+
+Both remain reasonable ideas if the profile shifts again; neither earns its
+churn today. The analysis is kept below for that case.
+
+### Phase 3 (not implemented) -- stop declaring libraries tests do not use
 
 `testing_package._declare_standard_libraries` declares testlib, jngen and tgen
 for every test package. Almost every test uses only testlib. Make jngen and tgen
 opt-in via an argument to `TestingPackage`.
 
-Independent of Phases 1-2, and removes two-thirds of header precompilation even
-if those phases regress.
-
-## Phase 4 -- Python program helpers, and convert the obvious tests
+### Phase 4 (not implemented) -- Python program helpers
 
 The contracts rbx enforces are protocol-only, so Python equivalents are exact
 substitutes rather than approximations:
@@ -219,19 +260,28 @@ end-to-end tests, not a hundred.
 
 Correcting the ~36 pre-existing failures is explicitly out of scope.
 
-## Phase 5 -- Two cheap wins
+## Phase 5 -- the tail split
 
-**`-O0` in the test environment.** Test packages copy the shipped preset
-`env.rbx.yml` verbatim (`TestingPreset.initialize` copies
-`presets/default/env.rbx.yml`), inheriting `-O2`. Overriding the C and C++
-compilation commands to `-O0` in the test preset measured 21% faster on
-`generators_test` before the cache fix. Test-only; tests that assert on program
-performance must opt out.
+**`-O0` in the test environment: not implemented.** It measured 21% faster on
+`generators_test` before the cache fixes, but compiles are cache hits now, so
+there is little compilation left to make cheaper.
 
-**Split the two mega-tests.** `test_get_solution_outcome_report` (44s) and
-`test_solutions` (41s) are the xdist tail. The suite cannot finish faster than
-its longest single test, so splitting them is what closes the 196s-versus-124s
-gap.
+**Split the mega-tests: implemented, with a caveat.** `test_solutions` and
+`test_get_solution_outcome_report` each ran all seven `problems/box1` solutions
+in one shot; they are now seven tests, one per solution, sharing setup through a
+fixture. All 22 original assertions were mapped 1:1 onto the new tests.
+
+The caveat is honest: this was predicted to be worth ~15s of wall time and
+delivered ~3s, inside this machine's run-to-run noise. At 8 workers the suite is
+CPU-bound, not tail-bound -- 351s of CPU over 8 workers plus per-worker startup
+and collection already puts the floor near 55s, so removing the 30s test mostly
+removed slack. It costs ~3s of extra CPU (~1%) because shared setup now runs
+seven times instead of two.
+
+It was kept for structure rather than speed: seven tests named for the outcome
+they check beat two grab-bags, and it removes a serialisation point that would
+bite on more workers or faster hardware. Revert it cleanly if that trade is
+unwanted.
 
 ## Out of scope
 
@@ -239,9 +289,19 @@ gap.
 - Fixing the 36-37 pre-existing test failures.
 - The `tests/e2e`, `tests/casts` and `tests/docker` suites.
 
-## Expected outcome
+## Outcome
 
-Phase 1 alone is validated at 196s -> 116s. With Phases 2-5, compilation should
-stop being the dominant cost and wall time should land well under 90s on 8
-cores, with the tail-latency fix mattering proportionally more as total CPU
-falls.
+| Run | Before | After |
+| --- | --- | --- |
+| `tests/rbx -n 8`, fixed order | 196s | **59-62s** |
+| `tests/rbx -n 8`, random order | 238s | **73s** |
+| Suite CPU | 992s | 351s |
+| C++ compiles | 498 | 219 |
+| Tests over 3s | 108 | 22 |
+
+Failure count did not increase: 37 failed / 4512 passed before, 36 failed /
+4520 passed after in fixed order (37 in random order, matching its own
+baseline). The extra passes are the new cache tests and the solution split.
+
+Two commits produced essentially all of the gain, and both are production
+caching fixes that benefit real users, not just the test suite.

--- a/docs/plans/2026-08-14-test-suite-speed-plan.md
+++ b/docs/plans/2026-08-14-test-suite-speed-plan.md
@@ -1,0 +1,844 @@
+# tests/rbx Suite Speedup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Cut `tests/rbx` wall time on 8 cores from ~3m15s to well under 1m30s by
+eliminating redundant C++ compilation, without losing real-compiler coverage.
+
+**Architecture:** The suite spends 76% of its time compiling C++, and 89% of
+those compiles rebuild a source already built in the same run. The compile cache
+key embeds absolute file paths, and every test runs in a fresh temporary package
+directory, so the content-addressed global cache never hits. Phases 1-2 fix the
+caching layer (production code, benefiting real users too); phases 3-5 remove
+work the tests never needed.
+
+**Tech Stack:** Python 3.14, pytest + pytest-xdist + pytest-asyncio (auto mode),
+Pydantic v2, `uv` for dependency management, ruff for lint/format, commitizen for
+commit messages.
+
+**Background reading before starting:**
+- `docs/plans/2026-08-14-test-suite-speed-design.md` -- the design and all
+  measurements this plan implements.
+- `rbx/grading/CLAUDE.md` -- how the grading engine, sandbox and caches fit
+  together.
+- `.claude/skills/commit.md` -- **required** commit message format. The
+  pre-commit hook rejects non-compliant messages.
+
+**Conventions you must follow:**
+- Single quotes for strings (ruff enforces this).
+- Absolute imports only; relative imports are banned (`TID` rule).
+- Every commit message must be a conventional commit. Use the `/commit` skill.
+- If the pre-commit hook rejects a commit, fix and make a NEW commit. Never amend.
+- ruff auto-fixes import ordering on commit. If a commit fails with "files were
+  modified by this hook", just `git add` the file again and re-commit.
+
+**Important context about the current branch state:**
+
+Commit `3306b98f` on this branch is an **unreviewed measurement spike** that
+already contains the Phase 1 production change, but without a test or the
+required cache-version bump. Task 1 reverts it so the work can be done
+test-first. Do not skip that revert.
+
+**How to measure:**
+
+```bash
+# Wall time for the whole suite (the number this plan optimises).
+time uv run pytest tests/rbx -p no:randomly -n 8 -q
+```
+
+Baseline before any work: **196s wall, 992s CPU, 37 failed / 4512 passed.**
+
+**There are ~36-37 pre-existing failures on this branch. They are out of scope.**
+Never "fix" them. Only ever check that your change does not *increase* the
+failure count. Record the count before and after each phase.
+
+---
+
+## Task 1: Revert the spike so Phase 1 can be done test-first
+
+**Files:**
+- Modify: `rbx/grading/caching.py`
+
+**Step 1: Revert the spike commit**
+
+```bash
+git revert --no-edit 3306b98f
+```
+
+**Step 2: Verify the revert is clean**
+
+Run: `git diff HEAD~1 HEAD --stat`
+Expected: only `rbx/grading/caching.py` changed, 4 deletions.
+
+Run: `grep -n 'digester.digest_file' rbx/grading/caching.py`
+Expected: no output (the spike is gone).
+
+---
+
+## Task 2: Phase 1 -- content-address the compile cache key
+
+The bug: `_build_cache_input` in `rbx/grading/caching.py:234-241` swaps a source
+path for its content digest **only** when the file is a symlink into cacher
+storage (`cacher.digest_from_symlink`). For any real file the absolute path
+stays in the cache key, so two byte-identical files at different paths get
+different keys.
+
+**Files:**
+- Modify: `rbx/grading/caching.py` (imports, and `_build_cache_input`)
+- Test: `tests/rbx/grading/caching_test.py` (create)
+
+**Step 1: Write the failing test**
+
+Create `tests/rbx/grading/caching_test.py`. The fixtures `cleandir`,
+`dependency_cache`, `file_cacher` and `sandbox` already exist in
+`tests/rbx/grading/conftest.py` -- reuse them, do not write new ones.
+
+```python
+import pathlib
+
+from rbx.grading import steps_with_caching
+from rbx.grading.caching import DependencyCache
+from rbx.grading.judge.cacher import FileCacher
+from rbx.grading.judge.sandbox import SandboxBase, SandboxParams
+from rbx.grading.steps import (
+    GradingArtifacts,
+    GradingFileInput,
+    GradingFileOutput,
+    RunLogMetadata,
+)
+
+
+async def _run_from(
+    src: pathlib.Path,
+    out: pathlib.Path,
+    sandbox: SandboxBase,
+    dependency_cache: DependencyCache,
+) -> GradingArtifacts:
+    artifacts = GradingArtifacts()
+    artifacts.inputs.append(
+        GradingFileInput(src=src, dest=pathlib.Path('executable.py'))
+    )
+    artifacts.outputs.append(
+        GradingFileOutput(src=pathlib.Path('box-out.txt'), dest=out)
+    )
+    await steps_with_caching.run(
+        'python3 executable.py',
+        params=SandboxParams(stdout_file=pathlib.Path('box-out.txt')),
+        sandbox=sandbox,
+        artifacts=artifacts,
+        dependency_cache=dependency_cache,
+        metadata=RunLogMetadata(),
+    )
+    return artifacts
+
+
+async def test_cache_hits_for_identical_content_at_a_different_path(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    # Same bytes, two different absolute paths -- as happens when every test
+    # copies its package into a fresh temporary directory.
+    first = cleandir / 'a' / 'executable.py'
+    second = cleandir / 'b' / 'executable.py'
+    for path in (first, second):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('print(7)')
+
+    await _run_from(first, pathlib.Path('out-a.txt'), sandbox, dependency_cache)
+    artifacts = await _run_from(
+        second, pathlib.Path('out-b.txt'), sandbox, dependency_cache
+    )
+
+    assert (cleandir / 'out-b.txt').read_text().strip() == '7'
+    assert artifacts.logs is not None
+    assert artifacts.logs.cached
+
+
+async def test_cache_misses_when_content_differs(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    first = cleandir / 'a' / 'executable.py'
+    second = cleandir / 'b' / 'executable.py'
+    first.parent.mkdir(parents=True, exist_ok=True)
+    second.parent.mkdir(parents=True, exist_ok=True)
+    first.write_text('print(7)')
+    second.write_text('print(8)')
+
+    await _run_from(first, pathlib.Path('out-a.txt'), sandbox, dependency_cache)
+    artifacts = await _run_from(
+        second, pathlib.Path('out-b.txt'), sandbox, dependency_cache
+    )
+
+    assert (cleandir / 'out-b.txt').read_text().strip() == '8'
+    assert artifacts.logs is not None
+    assert not artifacts.logs.cached
+```
+
+**Step 2: Run the tests to verify the first one fails**
+
+Run:
+```bash
+uv run pytest tests/rbx/grading/caching_test.py -p no:randomly -v
+```
+Expected: `test_cache_hits_for_identical_content_at_a_different_path` FAILS on
+`assert artifacts.logs.cached` (the cache misses because the paths differ).
+`test_cache_misses_when_content_differs` PASSES already -- it is the guard rail
+proving the fix does not over-cache.
+
+**Step 3: Write the minimal implementation**
+
+In `rbx/grading/caching.py`, add the import next to the existing digester import:
+
+```python
+from rbx.grading.judge import digester
+```
+
+Then in `_build_cache_input`, change the input loop body:
+
+```python
+            inferred_digest = await cacher.digest_from_symlink(input.src)
+            if inferred_digest is None and input.src.is_file():
+                # Key on content, not on the absolute path. Two byte-identical
+                # files are interchangeable: the compiler command references
+                # `dest`, which stays in the key, so nothing is lost.
+                inferred_digest = digester.digest_file(input.src)
+            if inferred_digest is not None:
+                # Consume cache from digest instead of file.
+                input.digest = DigestHolder(value=inferred_digest)
+                input.src = None
+```
+
+**Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/grading/caching_test.py -p no:randomly -v`
+Expected: both PASS.
+
+**Step 5: Bump the cache version**
+
+Existing on-disk caches were built with path-based keys and must be invalidated.
+In `rbx/box/global_package.py:14`:
+
+```python
+CACHE_STEP_VERSION = 5
+```
+
+**Step 6: Run the full suite and compare against baseline**
+
+Run: `time uv run pytest tests/rbx -p no:randomly -n 8 -q`
+
+Expected: roughly **116s wall** (down from 196s), and **36 failed / 4513
+passed** -- one *fewer* failure than baseline, because a previously failing test
+starts passing. If the failure count is above 37, stop and investigate; you have
+introduced a regression.
+
+**Step 7: Commit**
+
+```bash
+git add rbx/grading/caching.py rbx/box/global_package.py tests/rbx/grading/caching_test.py
+git commit -m "$(cat <<'EOF'
+perf(grading): key the compile cache on content instead of path
+
+The cache key embedded the absolute source path, so byte-identical files
+at different paths never shared a cache entry. Every test runs in a fresh
+temporary package directory, which meant the global compilation cache
+could not hit even once across the suite.
+
+Cuts tests/rbx from 196s to 116s on 8 workers and C++ compiles from 498
+to 219. Bumps CACHE_STEP_VERSION to invalidate path-keyed entries.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Phase 2 -- materialize absent outputs instead of evicting
+
+After Task 2, cache *keys* match across tests but 163 compiles are still
+redundant (~200s CPU). The miss now happens in `_build_output_fingerprint_list`
+(`rbx/grading/caching.py:164-177`): it digests each non-hash, non-intermediate
+output at its `dest` path. In a fresh package that file does not exist yet, so
+it fingerprints as `''`, `_output_fingerprints_match` fails, and `find_in_cache`
+**evicts** the entry rather than restoring the artifact from storage.
+
+**This task changes a cache-correctness invariant. Land it alone, and do not
+combine it with any other task.** The behaviour that must be preserved: an
+output that exists on disk but has been *modified* still evicts.
+
+**Files:**
+- Modify: `rbx/grading/caching.py` (`_output_fingerprints_match` / `find_in_cache`)
+- Test: `tests/rbx/grading/caching_test.py` (extend)
+
+**Step 1: Write the three failing/guard tests**
+
+Append to `tests/rbx/grading/caching_test.py`. These cover the full matrix:
+
+```python
+async def test_cache_hits_when_output_is_absent(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    # An absent output means "not materialized yet", not "stale". It should be
+    # restored from storage rather than forcing a rerun.
+    src = cleandir / 'executable.py'
+    src.write_text('print(11)')
+
+    await _run_from(src, pathlib.Path('out.txt'), sandbox, dependency_cache)
+    (cleandir / 'out.txt').unlink()
+
+    artifacts = await _run_from(
+        src, pathlib.Path('out.txt'), sandbox, dependency_cache
+    )
+
+    assert artifacts.logs is not None
+    assert artifacts.logs.cached
+    assert (cleandir / 'out.txt').read_text().strip() == '11'
+
+
+async def test_cache_hits_when_output_is_present_and_matching(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    src = cleandir / 'executable.py'
+    src.write_text('print(12)')
+
+    await _run_from(src, pathlib.Path('out.txt'), sandbox, dependency_cache)
+    artifacts = await _run_from(
+        src, pathlib.Path('out.txt'), sandbox, dependency_cache
+    )
+
+    assert artifacts.logs is not None
+    assert artifacts.logs.cached
+
+
+async def test_cache_evicts_when_output_was_tampered_with(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    # This is the invariant Task 3 must NOT break.
+    src = cleandir / 'executable.py'
+    src.write_text('print(13)')
+
+    await _run_from(src, pathlib.Path('out.txt'), sandbox, dependency_cache)
+    (cleandir / 'out.txt').write_text('tampered\n')
+
+    artifacts = await _run_from(
+        src, pathlib.Path('out.txt'), sandbox, dependency_cache
+    )
+
+    assert artifacts.logs is not None
+    assert not artifacts.logs.cached
+    assert (cleandir / 'out.txt').read_text().strip() == '13'
+```
+
+**Step 2: Run them**
+
+Run: `uv run pytest tests/rbx/grading/caching_test.py -p no:randomly -v`
+Expected: `test_cache_hits_when_output_is_absent` FAILS on
+`assert artifacts.logs.cached`. The other two PASS.
+
+**Step 3: Implement**
+
+Change the output-fingerprint comparison so an absent output (`''`) on the
+*reference* side is treated as "materialize from storage", while a present but
+differing fingerprint still evicts. Concretely, in `find_in_cache`, distinguish
+the two cases rather than calling one `_output_fingerprints_match`:
+
+```python
+def _output_fingerprints_match(
+    fingerprint: CacheFingerprint, reference: CacheFingerprint
+) -> bool:
+    """Compare stored and on-disk output fingerprints.
+
+    An empty reference fingerprint means the output is simply not on disk yet
+    -- the artifact is restored from content-addressed storage further down, so
+    it must not evict. A non-empty fingerprint that differs means the file was
+    modified behind our back, which must still evict.
+    """
+    lhs, rhs = fingerprint.output_fingerprints, reference.output_fingerprints
+    if len(lhs) != len(rhs):
+        return False
+    return all(right == '' or left == right for left, right in zip(lhs, rhs))
+```
+
+Then confirm the existing `_copy_hashed_files` / `are_artifacts_ok` path
+actually writes the missing file. If it does not cover non-hash outputs, extend
+it to restore them from storage; the digests needed are already in
+`fingerprint.digests`.
+
+**Step 4: Run the tests**
+
+Run: `uv run pytest tests/rbx/grading/caching_test.py -p no:randomly -v`
+Expected: all five PASS.
+
+**Step 5: Run the caching-adjacent suites**
+
+Run:
+```bash
+uv run pytest tests/rbx/grading tests/rbx/box/code_compile_test.py \
+  tests/rbx/box/code_compile_integration_test.py -p no:randomly -q
+```
+Expected: no *new* failures versus the pre-existing set.
+
+**Step 6: Run the full suite**
+
+Run: `time uv run pytest tests/rbx -p no:randomly -n 8 -q`
+Expected: faster than Task 2's 116s; failure count no higher than 36.
+
+**Step 7: Commit**
+
+```bash
+git add rbx/grading/caching.py tests/rbx/grading/caching_test.py
+git commit -m "$(cat <<'EOF'
+perf(grading): restore absent cached outputs instead of evicting
+
+An output missing from disk means it has not been materialized yet, not
+that the entry is stale, but the fingerprint check treated the two the
+same and evicted. Every fresh package therefore recompiled sources whose
+cache keys already matched. A present-but-modified output still evicts.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Phase 3 -- make jngen and tgen opt-in for test packages
+
+`TestingPackage._declare_standard_libraries`
+(`rbx/box/testing/testing_package.py:76-118`) declares testlib, jngen **and**
+tgen as `always_include` libraries for every test package. Almost every test
+only uses testlib, but all three headers get precompiled.
+
+**Files:**
+- Modify: `rbx/box/testing/testing_package.py:76-118`
+- Modify: `tests/rbx/box/conftest.py` (only if a fixture needs the extra libs)
+
+**Step 1: Find which tests actually need jngen or tgen**
+
+Run:
+```bash
+grep -rln 'jngen\|tgen' tests/rbx
+```
+Note the list. `tests/rbx/box/test_header.py` and
+`tests/rbx/box/test_libraries.py` are the likely users -- confirm rather than
+assume.
+
+**Step 2: Make the library set a parameter**
+
+Change `TestingPackage.__init__` to accept `libraries: Sequence[str] = ('testlib',)`
+and pass it through to `_declare_standard_libraries`, which filters `specs` to
+the requested names. Keep the existing docstring -- especially the note that
+`rbx/resources/predownloaded/{testlib,jngen,tgen}.h` must stay bundled as test
+fixtures.
+
+**Step 3: Give the tests that need them a way to ask**
+
+Add a method so a test can opt in after construction:
+
+```python
+    def declare_library(self, name: str) -> None:
+        """Declare an extra bundled header (jngen, tgen) for this package.
+
+        Not declared by default: precompiling a ~180KB header costs ~1s, and
+        almost every test only uses testlib.
+        """
+        self._declare_standard_libraries(self.preset, names=[name])
+```
+
+**Step 4: Run the tests that use jngen/tgen**
+
+Run: `uv run pytest tests/rbx/box/test_header.py tests/rbx/box/test_libraries.py -p no:randomly -q`
+Expected: they fail with a missing-header compile error until you add the
+`declare_library` calls, then pass.
+
+**Step 5: Run the full suite**
+
+Run: `time uv run pytest tests/rbx -p no:randomly -n 8 -q`
+Expected: faster still; failure count no higher than 36.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/testing/testing_package.py tests/rbx
+git commit -m "$(cat <<'EOF'
+test(box): declare only testlib by default in test packages
+
+Every test package declared testlib, jngen and tgen as always-include
+libraries, so all three ~180KB headers were precompiled even though
+almost every test uses only testlib.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Phase 4a -- add Python program helpers
+
+The contracts rbx enforces are protocol-only, so a Python program is an exact
+substitute for a testlib C++ one, not an approximation:
+
+- **Checker** (`rbx/box/checkers.py:210,255`): exit code in `{0,1,2,3}` plus the
+  last line of stderr. 0 = accepted, 1/2 = wrong answer, 3 = judge failed.
+- **Validator** (`rbx/box/validators.py:155,170`): exit code plus stderr. An
+  optional `validator.log` carries the bounds overview, needed only by tests
+  asserting on bounds coverage.
+- **Generator**: writes to stdout.
+
+Cost: compiling a testlib C++ program is 2.6s; running the Python equivalent is
+0.02s and skips compilation entirely (`fileMapping.executable` maps to the
+source, so `py` files are never compiled).
+
+**Files:**
+- Modify: `rbx/box/testing/testing_package.py`
+- Test: `tests/rbx/box/testing/test_python_helpers.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+from rbx.box.schema import ExpectedOutcome
+from rbx.box.testing import testing_package
+
+
+async def test_python_generator_echoes_its_argument(
+    testing_pkg: testing_package.TestingPackage,
+):
+    testing_pkg.add_python_generator('gens/gen.py')
+    testing_pkg.add_testgroup_from_plan('main', 'gens/gen.py 123\n')
+
+    from rbx.box.generators import generate_testcases
+
+    await generate_testcases()
+
+    assert (
+        testing_pkg.get_build_testgroup_path('main') / '000.in'
+    ).read_text() == '123\n'
+```
+
+Add equivalent tests for `add_python_validator` (accepting and rejecting) and
+`add_python_checker` (each of accepted / wrong answer / judge failed).
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/testing/test_python_helpers.py -p no:randomly -v`
+Expected: FAIL with `AttributeError: 'TestingPackage' object has no attribute
+'add_python_generator'`.
+
+**Step 3: Implement the helpers**
+
+Add to `TestingPackage`, mirroring the existing `add_generator` /
+`add_solution` signatures so converted tests stay one-liners:
+
+```python
+    _PY_GENERATOR = """import sys
+
+print(sys.argv[1])
+"""
+
+    _PY_VALIDATOR = """import sys
+
+sys.stderr.write({message!r})
+sys.exit({exit_code!r})
+"""
+
+    _PY_CHECKER = """import sys
+
+sys.stderr.write({message!r})
+sys.exit({exit_code!r})
+"""
+
+    def add_python_generator(self, path: PathOrStr) -> pathlib.Path:
+        """A generator that echoes its first argument. Costs ~0.02s to run,
+        versus ~2.6s to compile the testlib C++ equivalent."""
+        ...
+
+    def add_python_validator(
+        self, path: PathOrStr, *, valid: bool = True, message: str = ''
+    ) -> pathlib.Path:
+        ...
+
+    def add_python_checker(
+        self,
+        path: PathOrStr,
+        *,
+        outcome: Outcome = Outcome.ACCEPTED,
+        message: str = 'ok',
+    ) -> pathlib.Path:
+        """Maps outcome to the testlib exit codes rbx parses: ACCEPTED -> 0,
+        WRONG_ANSWER -> 1, JUDGE_FAILED -> 3."""
+        ...
+```
+
+Write the source through the existing `self.add_file(path, ...)` machinery and
+register the program in `self.yml` exactly as the C++ variants do.
+
+**Step 4: Run the tests**
+
+Run: `uv run pytest tests/rbx/box/testing/test_python_helpers.py -p no:randomly -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/testing/testing_package.py tests/rbx/box/testing/test_python_helpers.py
+git commit -m "$(cat <<'EOF'
+test(box): add Python generator, validator and checker helpers
+
+rbx's checker and validator contracts are exit code plus stderr, so a
+Python program is an exact substitute for a testlib C++ one. Running one
+costs 0.02s against 2.6s to compile the C++ equivalent.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Phase 4b -- convert orchestration-only tests
+
+Convert tests that only check *orchestration* -- was the generator invoked, was
+the verdict routed, is the group wired up -- to the Python helpers. **Keep a
+tagged set of real-C++ full-flow tests**: the compiler path, testlib integration
+and the C++ toolchain must stay covered. The goal is a handful of genuine
+end-to-end tests, not a hundred.
+
+Work through these files in order of measured cost, **one file per commit**:
+
+| File | Time | n | avg |
+| --- | --- | --- | --- |
+| `tests/rbx/box/generators_test.py` | 163.6s | 28 | 5.84s |
+| `tests/rbx/box/validators_test.py` | 111.1s | 20 | 5.55s |
+| `tests/rbx/box/solutions_test.py` | 106.2s | 64 | 1.66s |
+| `tests/rbx/box/generator_outputs_test.py` | 89.6s | 11 | 8.15s |
+| `tests/rbx/box/testcases/test_promote.py` | 71.7s | 22 | 3.26s |
+| `tests/rbx/box/unit_test.py` | 145.6s | 20 | 7.28s |
+
+**For each file:**
+
+**Step 1: Time it before**
+
+Run: `time uv run pytest <file> -p no:randomly -q`
+Record the wall time and the failure count.
+
+**Step 2: Identify the keepers**
+
+Read the file. A test must **keep** real C++ when it asserts on any of:
+compilation output or warnings, compilation failure messages, testlib-specific
+behaviour (`registerGen`, `readInt` bounds, `quitf` formatting), sanitizers, or
+language-specific timing. Everything else is a conversion candidate.
+
+**Step 3: Convert one test, run it, then convert the rest**
+
+Convert a single test first and run it. If the assertions still hold, convert
+the remaining candidates in the file.
+
+**Step 4: Run the file**
+
+Run: `time uv run pytest <file> -p no:randomly -q`
+Expected: substantially faster, and the failure count no higher than in Step 1.
+
+**Step 5: Commit**
+
+```bash
+git add <file>
+git commit -m "$(cat <<'EOF'
+test(box): use Python programs for orchestration-only <area> tests
+
+Keeps the tests that exercise the real compiler and testlib; the rest
+only checked wiring and did not need a 2.6s C++ compile each.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Phase 5a -- compile test packages with -O0
+
+Test packages copy the shipped preset verbatim (`TestingPreset.initialize`
+copies `rbx/resources/presets/default/env.rbx.yml`), inheriting `-O2`. Measured
+21% faster on `generators_test` before the cache fix.
+
+**Files:**
+- Modify: `rbx/box/testing/testing_preset.py` (`initialize`)
+
+**Step 1: Override the optimisation level after copying the env**
+
+Do **not** edit `rbx/resources/presets/default/env.rbx.yml` -- that is the file
+shipped to users. Instead, in `TestingPreset.initialize`, after
+`add_from_resources` copies the env, rewrite the C and C++ compilation commands
+to use `-O0`:
+
+```python
+            # Tests do not measure generated-code quality, and -O0 roughly
+            # halves the cost of compiling testlib-based programs.
+            self._set_optimization_level('-O0')
+```
+
+Implement `_set_optimization_level` by loading the copied `env.rbx.yml`,
+replacing `-O2` with the given flag in `languages[].compilation.commands` for
+the `c` and `cpp` languages only, and writing it back. Leave the `boca`, `moj`
+and `polygon` extension flags untouched -- packaging tests assert on those
+exact strings.
+
+**Step 2: Verify the packaging assertions still hold**
+
+Run:
+```bash
+uv run pytest tests/rbx/box/packaging -p no:randomly -q
+```
+Expected: no new failures. If a packaging test now fails, you rewrote a flag
+outside `languages[].compilation.commands`.
+
+**Step 3: Add an opt-out for timing tests**
+
+Any test that asserts on program performance must keep `-O2`. Check:
+
+```bash
+uv run pytest tests/rbx/box/test_timing_estimation.py \
+  tests/rbx/box/test_timing_inference_run.py tests/rbx/box/walltime_test.py \
+  -p no:randomly -q
+```
+If any fail, expose the level as a `TestingPreset` argument and have those tests
+request `-O2`.
+
+**Step 4: Run the full suite**
+
+Run: `time uv run pytest tests/rbx -p no:randomly -n 8 -q`
+Expected: faster; failure count no higher than 36.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/testing/testing_preset.py tests/rbx
+git commit -m "$(cat <<'EOF'
+test(box): compile test packages with -O0
+
+Test packages inherited -O2 from the shipped preset. Tests do not measure
+generated-code quality, and -O0 roughly halves compile cost for
+testlib-based programs.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Phase 5b -- split the two tail tests
+
+`test_get_solution_outcome_report` (44s) and `test_solutions` (41s) are 8.5% of
+the suite on their own, and they are the xdist tail: the suite cannot finish
+faster than its longest single test. At baseline, ideal wall time was 992/8 =
+124s but actual was 196s, and this gap is why.
+
+**Files:**
+- Modify: `tests/rbx/box/solutions_test.py`
+
+**Step 1: Confirm they are still the tail**
+
+Run:
+```bash
+uv run pytest tests/rbx -p no:randomly -n 8 -q --durations=15
+```
+Note the current slowest tests. After Tasks 2-7 the ranking may have changed --
+split whatever is actually longest now, not what this plan predicted.
+
+**Step 2: Read the tests and find the seams**
+
+These are broad tests asserting on many solutions at once. Split by the
+independent thing each assertion covers (one test per outcome class, or per
+solution group), sharing setup through a fixture so the split does not multiply
+the compilation work.
+
+**Step 3: Verify the split covers the same ground**
+
+Run: `uv run pytest tests/rbx/box/solutions_test.py -p no:randomly -q`
+Expected: the same assertions still run; failure count no higher than before.
+
+**Step 4: Confirm the tail shrank**
+
+Run: `uv run pytest tests/rbx -p no:randomly -n 8 -q --durations=15`
+Expected: no single test dominates; wall time closer to CPU/8.
+
+**Step 5: Commit**
+
+```bash
+git add tests/rbx/box/solutions_test.py
+git commit -m "$(cat <<'EOF'
+test(box): split the two longest solution tests
+
+At 44s and 41s they were the xdist tail: the suite could not finish
+faster than its longest single test, leaving seven workers idle.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Final verification and reporting
+
+**Step 1: Full suite, fixed order**
+
+Run: `time uv run pytest tests/rbx -p no:randomly -n 8 -q`
+Record wall time and failure count.
+
+**Step 2: Full suite, default random order**
+
+Run: `time uv run pytest tests/rbx -n 8 -q`
+Random ordering costs ~20% (measured 3m57s versus 3m15s at baseline). Confirm
+no test depends on ordering after the caching changes -- the failure count must
+match Step 1.
+
+**Step 3: The canonical developer command**
+
+Run: `time uv run mise run test`
+
+**Step 4: Lint and format**
+
+Run:
+```bash
+uv run ruff check .
+uv run ruff format --check .
+```
+Expected: clean.
+
+**Step 5: Report**
+
+State the before/after wall time, CPU time and failure count, and confirm the
+failure count did not increase from the 37-failure baseline. Name explicitly any
+phase that was skipped or only partly landed.
+
+---
+
+## Summary of expected gains
+
+| Phase | Change | Expected |
+| --- | --- | --- |
+| 1 | Content-address the cache key | 196s -> 116s (measured) |
+| 2 | Restore absent outputs | ~200s CPU recovered |
+| 3 | Drop jngen/tgen by default | 2 of 3 header precompiles gone |
+| 4 | Python programs for orchestration tests | 2.6s -> 0.02s per program |
+| 5 | `-O0` plus tail split | ~21% on compile; closes the CPU/8 gap |
+
+Target end state: comfortably under 90s wall on 8 cores, with compilation no
+longer the dominant cost.

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,6 @@ markers =
     slow: mark test as slow (deselect with '-m "not slow"')
     docker: mark test as requiring docker
     pdflatex: mark test as requiring a real pdflatex (with TikZ) install
-    shared_cache: back the problem-level dependency cache with a session-wide one shared by every marked test, so compiled artifacts are reused across problems. Opt-in: apply only where it measurably cuts wall time and the test does not assert that a compilation actually runs (compilation output, warnings or failures), since a warm cache turns that compilation into a silent hit. A single test inside a module that opts in can opt back out with '@pytest.mark.shared_cache(False)'.
+    shared_cache: back the problem-level dependency cache with a session-wide one shared by every marked test, so compiled artifacts are reused across problems. Opt-in: apply only where it measurably cuts wall time, the test does not assert that a compilation actually runs (compilation output, warnings or failures) since a warm cache turns that into a silent hit, and the module's package fixture is function-scoped (a module- or session-scoped one compiles before the marker takes effect and fails with KeyError: 'File not found.'). A single test inside a module that opts in can opt back out with '@pytest.mark.shared_cache(False)'.
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,6 @@ markers =
     slow: mark test as slow (deselect with '-m "not slow"')
     docker: mark test as requiring docker
     pdflatex: mark test as requiring a real pdflatex (with TikZ) install
-    no_shared_cache: give the test its own problem-level dependency cache (use when asserting that a compilation actually runs)
+    shared_cache: back the problem-level dependency cache with a session-wide one shared by every marked test, so compiled artifacts are reused across problems. Opt-in: apply only where it measurably cuts wall time and the test does not assert that a compilation actually runs (compilation output, warnings or failures), since a warm cache turns that compilation into a silent hit. A single test inside a module that opts in can opt back out with '@pytest.mark.shared_cache(False)'.
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,5 +9,6 @@ markers =
     slow: mark test as slow (deselect with '-m "not slow"')
     docker: mark test as requiring docker
     pdflatex: mark test as requiring a real pdflatex (with TikZ) install
+    no_shared_cache: give the test its own problem-level dependency cache (use when asserting that a compilation actually runs)
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function

--- a/rbx/box/global_package.py
+++ b/rbx/box/global_package.py
@@ -11,7 +11,7 @@ from rbx.grading.judge.sandbox import SandboxBase
 from rbx.grading.judge.sandboxes.stupid_sandbox import StupidSandbox
 from rbx.grading.judge.storage import FilesystemStorage, Storage
 
-CACHE_STEP_VERSION = 4
+CACHE_STEP_VERSION = 5
 
 
 def get_cache_fingerprint() -> str:

--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -13,7 +13,6 @@ from sqlitedict import SqliteDict
 
 from rbx import console
 from rbx.grading import grading_context
-from rbx.grading.judge import digester
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.judge.digester import digest_cooperatively
 from rbx.grading.judge.lock import make_async_file_lock
@@ -236,9 +235,6 @@ async def _build_cache_input(
             if input.src is None:
                 continue
             inferred_digest = await cacher.digest_from_symlink(input.src)
-            if inferred_digest is None and input.src.is_file():
-                # SPIKE: key on content instead of the absolute path.
-                inferred_digest = digester.digest_file(input.src)
             if inferred_digest is not None:
                 # Consume cache from digest instead of file.
                 input.digest = DigestHolder(value=inferred_digest)

--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -13,6 +13,7 @@ from sqlitedict import SqliteDict
 
 from rbx import console
 from rbx.grading import grading_context
+from rbx.grading.judge import digester
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.judge.digester import digest_cooperatively
 from rbx.grading.judge.lock import make_async_file_lock
@@ -235,6 +236,11 @@ async def _build_cache_input(
             if input.src is None:
                 continue
             inferred_digest = await cacher.digest_from_symlink(input.src)
+            if inferred_digest is None and input.src.is_file():
+                # Key on content, not on the absolute path. Two byte-identical
+                # files are interchangeable: the compiler command references
+                # `dest`, which stays in the key, so nothing is lost.
+                inferred_digest = digester.digest_file(input.src)
             if inferred_digest is not None:
                 # Consume cache from digest instead of file.
                 input.digest = DigestHolder(value=inferred_digest)

--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -13,6 +13,7 @@ from sqlitedict import SqliteDict
 
 from rbx import console
 from rbx.grading import grading_context
+from rbx.grading.judge import digester
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.judge.digester import digest_cooperatively
 from rbx.grading.judge.lock import make_async_file_lock
@@ -235,6 +236,9 @@ async def _build_cache_input(
             if input.src is None:
                 continue
             inferred_digest = await cacher.digest_from_symlink(input.src)
+            if inferred_digest is None and input.src.is_file():
+                # SPIKE: key on content instead of the absolute path.
+                inferred_digest = digester.digest_file(input.src)
             if inferred_digest is not None:
                 # Consume cache from digest instead of file.
                 input.digest = DigestHolder(value=inferred_digest)

--- a/tests/rbx/box/conftest.py
+++ b/tests/rbx/box/conftest.py
@@ -157,6 +157,18 @@ def maybe_shared_problem_cache(request):
     requesting `monkeypatch` from an autouse conftest fixture would make it be
     set up before the test's own autouse fixtures, flipping the teardown order
     of any `monkeypatch.setattr` a test stacks on top of a `mock.patch`.
+
+    LIMITATION -- this fixture is function-scoped, so the shared cache is only
+    installed for the duration of each test. A module- or session-scoped
+    fixture that compiles something runs BEFORE this one and therefore writes
+    into the isolated per-problem storage; the marked tests then look for that
+    digest in the shared storage and do not find it. The failure surfaces as an
+    opaque `KeyError: 'File not found.'`.
+
+    So do NOT mark a module whose package fixture is module- or session-scoped.
+    `checkers_test.py` is the live example: marking it fails 14 tests because
+    its `pkg_with_compiled_checker` is `scope='module'`. It is left unmarked --
+    which costs nothing, since sharing was only worth 1.8s there anyway.
     """
     marker = request.node.get_closest_marker('shared_cache')
     if marker is None or marker.args == (False,):

--- a/tests/rbx/box/conftest.py
+++ b/tests/rbx/box/conftest.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import subprocess
 from collections.abc import Iterator
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import pytest
 
@@ -11,6 +11,9 @@ from rbx.box import package, setter_config
 from rbx.box.statements.latex import LatexResult
 from rbx.box.testing import testing_package
 from rbx.config import CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME
+from rbx.grading.caching import DependencyCache
+from rbx.grading.judge import storage as storage_module
+from rbx.grading.judge.cacher import FileCacher
 from rbx.utils import copytree_honoring_gitignore
 
 
@@ -110,6 +113,64 @@ def precompilation_should_use_tmp_cache(monkeysession, tmp_path_factory):
         'rbx.box.global_package.get_global_cache_dir_path',
         lambda: cache_dir / CACHE_DIR_NAME,
     )
+
+
+@pytest.fixture(autouse=True, scope='session')
+def shared_problem_cache(monkeysession, tmp_path_factory) -> Dict[str, Any]:
+    """Back the problem-level dependency cache with a session-wide directory.
+
+    Every test gets a fresh problem directory, and the problem cache lives
+    inside it (`<problem>/.rbx`), so each test would otherwise start with an
+    empty cache DB and recompile the same handful of sources from scratch.
+    Cache keys are content-addressed, so one cache shared across problems is
+    still correct -- it just turns those recompilations into hits.
+
+    Returns the original accessors so `no_shared_cache` can restore them.
+    """
+    cache_dir = tmp_path_factory.mktemp('problem_cache')
+    storage = storage_module.FilesystemStorage(cache_dir / '.storage', compress=False)
+    cacher = FileCacher(storage)
+    dependency_cache = DependencyCache(cache_dir, cacher)
+
+    originals = {
+        name: getattr(package, name)
+        for name in ('get_cache_storage', 'get_file_cacher', 'get_dependency_cache')
+    }
+    monkeysession.setattr(package, 'get_cache_storage', lambda *a, **k: storage)
+    monkeysession.setattr(package, 'get_file_cacher', lambda *a, **k: cacher)
+    monkeysession.setattr(
+        package, 'get_dependency_cache', lambda *a, **k: dependency_cache
+    )
+    return originals
+
+
+@pytest.fixture(autouse=True)
+def no_shared_cache(request, shared_problem_cache: Dict[str, Any]):
+    """Restore the per-problem cache for tests marked `no_shared_cache`.
+
+    Tests that assert a compilation actually happened (compilation output,
+    warnings, failures) must opt out, since a warm shared cache would turn the
+    compilation they are checking for into a silent cache hit.
+
+    Patching is done by hand rather than through the `monkeypatch` fixture:
+    requesting `monkeypatch` from an autouse conftest fixture would make it be
+    set up before the test's own autouse fixtures, flipping the teardown order
+    of any `monkeypatch.setattr` a test stacks on top of a `mock.patch`.
+    """
+    if request.node.get_closest_marker('no_shared_cache') is None:
+        yield
+        return
+    shared = {name: getattr(package, name) for name in shared_problem_cache}
+    for name, original in shared_problem_cache.items():
+        original.cache_clear()
+        setattr(package, name, original)
+    try:
+        yield
+    finally:
+        for name, patched in shared.items():
+            setattr(package, name, patched)
+        for original in shared_problem_cache.values():
+            original.cache_clear()
 
 
 @pytest.fixture(autouse=True, scope='session')

--- a/tests/rbx/box/conftest.py
+++ b/tests/rbx/box/conftest.py
@@ -115,61 +115,63 @@ def precompilation_should_use_tmp_cache(monkeysession, tmp_path_factory):
     )
 
 
-@pytest.fixture(autouse=True, scope='session')
-def shared_problem_cache(monkeysession, tmp_path_factory) -> Dict[str, Any]:
-    """Back the problem-level dependency cache with a session-wide directory.
+@pytest.fixture(scope='session')
+def shared_problem_cache(tmp_path_factory) -> Dict[str, Any]:
+    """Build the session-wide problem cache accessors, one set per worker.
 
     Every test gets a fresh problem directory, and the problem cache lives
-    inside it (`<problem>/.rbx`), so each test would otherwise start with an
-    empty cache DB and recompile the same handful of sources from scratch.
-    Cache keys are content-addressed, so one cache shared across problems is
-    still correct -- it just turns those recompilations into hits.
+    inside it (`<problem>/.rbx`), so each test starts with an empty cache DB
+    and recompiles the same handful of sources from scratch. Cache keys are
+    content-addressed, so a cache shared across problems is still correct -- it
+    just turns those recompilations into hits.
 
-    Returns the original accessors so `no_shared_cache` can restore them.
+    Sharing is opt-in, so this fixture is not autouse: it is only instantiated
+    the first time a test carrying the `shared_cache` marker runs.
     """
     cache_dir = tmp_path_factory.mktemp('problem_cache')
     storage = storage_module.FilesystemStorage(cache_dir / '.storage', compress=False)
     cacher = FileCacher(storage)
     dependency_cache = DependencyCache(cache_dir, cacher)
 
-    originals = {
-        name: getattr(package, name)
-        for name in ('get_cache_storage', 'get_file_cacher', 'get_dependency_cache')
+    return {
+        'get_cache_storage': lambda *a, **k: storage,
+        'get_file_cacher': lambda *a, **k: cacher,
+        'get_dependency_cache': lambda *a, **k: dependency_cache,
     }
-    monkeysession.setattr(package, 'get_cache_storage', lambda *a, **k: storage)
-    monkeysession.setattr(package, 'get_file_cacher', lambda *a, **k: cacher)
-    monkeysession.setattr(
-        package, 'get_dependency_cache', lambda *a, **k: dependency_cache
-    )
-    return originals
 
 
 @pytest.fixture(autouse=True)
-def no_shared_cache(request, shared_problem_cache: Dict[str, Any]):
-    """Restore the per-problem cache for tests marked `no_shared_cache`.
+def maybe_shared_problem_cache(request):
+    """Install the session-wide problem cache for tests marked `shared_cache`.
 
-    Tests that assert a compilation actually happened (compilation output,
-    warnings, failures) must opt out, since a warm shared cache would turn the
-    compilation they are checking for into a silent cache hit.
+    Unmarked tests are left completely untouched: `package.get_cache_storage`,
+    `get_file_cacher` and `get_dependency_cache` keep pointing at the problem
+    directory, so each test gets its own isolated cache. A single test inside a
+    module that opts in can opt back out with `@pytest.mark.shared_cache(False)`.
+
+    The accessors are `functools.cache`d, so their caches have to be cleared
+    both when installing and when restoring -- otherwise a cache object built
+    for one side leaks across the boundary.
 
     Patching is done by hand rather than through the `monkeypatch` fixture:
     requesting `monkeypatch` from an autouse conftest fixture would make it be
     set up before the test's own autouse fixtures, flipping the teardown order
     of any `monkeypatch.setattr` a test stacks on top of a `mock.patch`.
     """
-    if request.node.get_closest_marker('no_shared_cache') is None:
+    marker = request.node.get_closest_marker('shared_cache')
+    if marker is None or marker.args == (False,):
         yield
         return
-    shared = {name: getattr(package, name) for name in shared_problem_cache}
-    for name, original in shared_problem_cache.items():
-        original.cache_clear()
-        setattr(package, name, original)
+    shared = request.getfixturevalue('shared_problem_cache')
+    originals = {name: getattr(package, name) for name in shared}
+    for name, patched in shared.items():
+        originals[name].cache_clear()
+        setattr(package, name, patched)
     try:
         yield
     finally:
-        for name, patched in shared.items():
-            setattr(package, name, patched)
-        for original in shared_problem_cache.values():
+        for name, original in originals.items():
+            setattr(package, name, original)
             original.cache_clear()
 
 

--- a/tests/rbx/box/generator_outputs_test.py
+++ b/tests/rbx/box/generator_outputs_test.py
@@ -7,6 +7,11 @@ from rbx.box.testcase_schema import TestcaseEntry
 from rbx.box.testing import testing_package
 from rbx.grading import steps
 
+# Sharing the problem cache across these tests takes the file from 32s to 13s:
+# they all rebuild the same generator and solutions. The two tests that assert
+# on a compilation failure message opt back out below.
+pytestmark = pytest.mark.shared_cache
+
 _SOL_DOUBLE_NUMBER = """
 #include <iostream>
 
@@ -115,6 +120,8 @@ async def test_generator_outputs_no_main_solution_and_does_not_need_output(
     ).read_bytes() == b'246\n'
 
 
+# Asserts on a compilation failure message, so it needs a cold cache.
+@pytest.mark.shared_cache(False)
 async def test_generator_outputs_main_solution_does_not_compile_and_needs_output(
     testing_pkg: testing_package.TestingPackage,
     capsys: pytest.CaptureFixture[str],
@@ -248,6 +255,8 @@ async def test_generator_outputs_with_multiple_model_solutions(
     ).read_bytes() == b'912\n'
 
 
+# Asserts on a compilation failure message, so it needs a cold cache.
+@pytest.mark.shared_cache(False)
 async def test_generator_outputs_model_solution_compilation_failure(
     testing_pkg: testing_package.TestingPackage,
     capsys: pytest.CaptureFixture[str],

--- a/tests/rbx/box/generators_test.py
+++ b/tests/rbx/box/generators_test.py
@@ -19,6 +19,12 @@ from rbx.box.testcase_extractors import (
 from rbx.box.testing import testing_package
 from rbx.grading import steps
 
+# These tests recompile the same handful of generators and validators in every
+# fresh problem directory; sharing the problem cache across them takes the file
+# from 58s to 21s. They only care about the generated testcases, not about a
+# compilation actually running -- the one test that does opts back out below.
+pytestmark = pytest.mark.shared_cache
+
 
 async def test_generator_in_testplan(
     testing_pkg: testing_package.TestingPackage,
@@ -282,6 +288,8 @@ async def test_generator_non_existent(
     )
 
 
+# Asserts on the compilation output itself, so it needs a cold cache.
+@pytest.mark.shared_cache(False)
 async def test_generator_not_compile(
     testing_pkg: testing_package.TestingPackage,
     capsys: pytest.CaptureFixture[str],

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -63,6 +63,13 @@ from rbx.grading.steps import (
     TestcaseLog,
 )
 
+# The heaviest file in the suite: every test re-runs the same `box1` solutions
+# in a fresh problem directory. Sharing the problem cache takes it from 84s to
+# 42s. Compilation is a means here, never the assertion -- the two compilation
+# tests in this file exercise `FailedToCompileSolutionIssue` messages built by
+# hand, without compiling anything.
+pytestmark = pytest.mark.shared_cache
+
 
 class Box1Run(NamedTuple):
     """One solution of `problems/box1`, run over the whole testset."""

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -1,6 +1,6 @@
 import contextlib
 import pathlib
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, NamedTuple, Optional, Set, Tuple
 from unittest.mock import patch
 
 import pytest
@@ -64,113 +64,132 @@ from rbx.grading.steps import (
 )
 
 
-@pytest.mark.test_pkg('problems/box1')
-async def test_solutions(pkg_from_testdata: pathlib.Path):
+class Box1Run(NamedTuple):
+    """One solution of `problems/box1`, run over the whole testset."""
+
+    skeleton: SolutionReportSkeleton
+    solution: SolutionSkeleton
+    evals: List[Evaluation]
+
+    def report(self):
+        return get_solution_outcome_report(
+            self.solution, self.skeleton, self.evals, VerificationLevel.FULL
+        )
+
+
+@pytest.fixture
+async def run_box1_solution(pkg_from_testdata: pathlib.Path):
+    """Build `box1`'s testset once, then run one solution at a time.
+
+    Every solution of this package is checked, but each in its own test: running
+    them all in a single test made it by far the longest test in the suite, and
+    `tracked_solutions` keeps each test's cost to the solution it is about.
+    """
     await generate_testcases()
     entries = [
         entry.group_entry for entry in await extract_generation_testcases_from_groups()
     ]
     await generate_outputs_for_testcases(entries)
 
-    result = await run_solutions(verification=VerificationLevel.FULL)
-    res = await convert_list_of_solution_evaluations_to_dict(
-        result.skeleton, result.items
-    )
+    async def _run(path: str) -> Box1Run:
+        result = await run_solutions(
+            verification=VerificationLevel.FULL, tracked_solutions=[path]
+        )
+        res = await convert_list_of_solution_evaluations_to_dict(
+            result.skeleton, result.items
+        )
+        return Box1Run(result.skeleton, result.skeleton.solutions[0], res[0]['gen1'])
 
-    # First solution should pass all tests.
-    assert all(chk.result.outcome == Outcome.ACCEPTED for chk in res[0]['gen1'])
-    # 25 test should be WA for the second solution.
-    assert res[1]['gen1'][3].result.outcome == Outcome.WRONG_ANSWER
-    # Runtime error for third solution.
-    assert all(chk.result.outcome == Outcome.RUNTIME_ERROR for chk in res[2]['gen1'])
-    # 1e9 test should be TLE for the fourth solution (soft TLE)
-    assert res[3]['gen1'][4].result.outcome == Outcome.TIME_LIMIT_EXCEEDED
-    # no TLE outcome should be WA (soft TLE)
-    assert res[4]['gen1'][4].result.no_tle_outcome == Outcome.WRONG_ANSWER
-    # hard TLE
-    assert res[5]['gen1'][4].result.outcome == Outcome.TIME_LIMIT_EXCEEDED
-    assert res[5]['gen1'][4].result.no_tle_outcome is None
-    # OLE
-    assert all(
-        chk.result.outcome == Outcome.OUTPUT_LIMIT_EXCEEDED for chk in res[6]['gen1']
-    )
+    return _run
 
 
 @pytest.mark.test_pkg('problems/box1')
-async def test_get_solution_outcome_report(pkg_from_testdata: pathlib.Path):
-    await generate_testcases()
-    entries = [
-        entry.group_entry for entry in await extract_generation_testcases_from_groups()
-    ]
-    await generate_outputs_for_testcases(entries)
+async def test_accepted_solution_passes_every_testcase(run_box1_solution):
+    run = await run_box1_solution('sol.cpp')
 
-    result = await run_solutions(verification=VerificationLevel.FULL)
-    res = await convert_list_of_solution_evaluations_to_dict(
-        result.skeleton, result.items
-    )
+    assert all(chk.result.outcome == Outcome.ACCEPTED for chk in run.evals)
 
-    # Test AC solution (expected AC, got AC)
-    ac_solution = result.skeleton.solutions[0]
-    ac_evals = res[0]['gen1']
-    ac_report = get_solution_outcome_report(
-        ac_solution, result.skeleton, ac_evals, VerificationLevel.FULL
-    )
-    assert ac_report.status == SolutionOutcomeStatus.OK
-    assert ac_report.expectedOutcome == ExpectedOutcome.ACCEPTED
-    assert ac_report.gotVerdicts == set()
+    report = run.report()
+    assert report.status == SolutionOutcomeStatus.OK
+    assert report.expectedOutcome == ExpectedOutcome.ACCEPTED
+    assert report.gotVerdicts == set()
 
-    # Test WA solution (expected fail, got WA) - should pass since it matches expectation
-    wa_solution = result.skeleton.solutions[1]
-    wa_evals = res[1]['gen1']
-    wa_report = get_solution_outcome_report(
-        wa_solution, result.skeleton, wa_evals, VerificationLevel.FULL
-    )
-    assert wa_report.status == SolutionOutcomeStatus.OK
-    assert wa_report.expectedOutcome == ExpectedOutcome.INCORRECT
 
-    # Test RTE solution (expected RTE, got RTE)
-    rte_solution = result.skeleton.solutions[2]
-    rte_evals = res[2]['gen1']
-    rte_report = get_solution_outcome_report(
-        rte_solution, result.skeleton, rte_evals, VerificationLevel.FULL
-    )
-    assert rte_report.status == SolutionOutcomeStatus.OK
-    assert rte_report.expectedOutcome == ExpectedOutcome.RUNTIME_ERROR
+@pytest.mark.test_pkg('problems/box1')
+async def test_incorrect_solution_is_wrong_on_the_big_testcase(run_box1_solution):
+    run = await run_box1_solution('wa.sol.cpp')
 
-    # Test TLE solution with double TL warning
-    tle_solution = result.skeleton.solutions[3]
-    tle_evals = res[3]['gen1']
-    tle_report = get_solution_outcome_report(
-        tle_solution, result.skeleton, tle_evals, VerificationLevel.FULL
-    )
-    assert tle_report.status == SolutionOutcomeStatus.OK
-    assert tle_report.expectedOutcome == ExpectedOutcome.TIME_LIMIT_EXCEEDED
-    # Should have double TL warning for soft TLE
-    assert tle_report.runUnderDoubleTl is True
+    # The 25 test is the one it gets wrong.
+    assert run.evals[3].result.outcome == Outcome.WRONG_ANSWER
+
+    # Expected to fail, and it does: that matches the expectation.
+    report = run.report()
+    assert report.status == SolutionOutcomeStatus.OK
+    assert report.expectedOutcome == ExpectedOutcome.INCORRECT
+
+
+@pytest.mark.test_pkg('problems/box1')
+async def test_runtime_error_solution_fails_every_testcase(run_box1_solution):
+    run = await run_box1_solution('re.sol.cpp')
+
+    assert all(chk.result.outcome == Outcome.RUNTIME_ERROR for chk in run.evals)
+
+    report = run.report()
+    assert report.status == SolutionOutcomeStatus.OK
+    assert report.expectedOutcome == ExpectedOutcome.RUNTIME_ERROR
+
+
+@pytest.mark.test_pkg('problems/box1')
+async def test_soft_tle_solution_warns_it_still_passed_in_double_tl(run_box1_solution):
+    run = await run_box1_solution('tle.sol.cpp')
+
+    # The 1e9 test times out, but only softly.
+    assert run.evals[4].result.outcome == Outcome.TIME_LIMIT_EXCEEDED
+
+    report = run.report()
+    assert report.status == SolutionOutcomeStatus.OK
+    assert report.expectedOutcome == ExpectedOutcome.TIME_LIMIT_EXCEEDED
+    assert report.runUnderDoubleTl is True
     assert (
         'still passed in double TL'
-        in Text.from_markup(tle_report.get_verdict_markup_with_warnings()).plain
+        in Text.from_markup(report.get_verdict_markup_with_warnings()).plain
     )
 
-    # Solution that is within double TL but is *also* wrong there: the warning
-    # must name the verdict instead of staying silent (#607).
-    tle_incorrect_solution = result.skeleton.solutions[4]
-    tle_incorrect_evals = res[4]['gen1']
-    tle_incorrect_report = get_solution_outcome_report(
-        tle_incorrect_solution,
-        result.skeleton,
-        tle_incorrect_evals,
-        VerificationLevel.FULL,
-    )
-    assert tle_incorrect_report.status == SolutionOutcomeStatus.OK
-    assert tle_incorrect_report.doubleTlVerdicts == {Outcome.WRONG_ANSWER}
-    warning = Text.from_markup(
-        tle_incorrect_report.get_verdict_markup_with_warnings()
-    ).plain
+
+@pytest.mark.test_pkg('problems/box1')
+async def test_soft_tle_solution_that_is_also_wrong_names_the_verdict(
+    run_box1_solution,
+):
+    """A solution that is within double TL but is *also* wrong there: the warning
+    must name the verdict instead of staying silent (#607)."""
+    run = await run_box1_solution('tle-and-incorrect.sol.cpp')
+
+    assert run.evals[4].result.no_tle_outcome == Outcome.WRONG_ANSWER
+
+    report = run.report()
+    assert report.status == SolutionOutcomeStatus.OK
+    assert report.doubleTlVerdicts == {Outcome.WRONG_ANSWER}
+    warning = Text.from_markup(report.get_verdict_markup_with_warnings()).plain
     assert warning.splitlines()[-1] == (
         'WARNING The solution still finished in double TL, '
         'but failed with WRONG_ANSWER.'
     )
+
+
+@pytest.mark.test_pkg('problems/box1')
+async def test_hard_tle_solution_has_no_outcome_within_double_tl(run_box1_solution):
+    run = await run_box1_solution('hard-tle.sol.cpp')
+
+    assert run.evals[4].result.outcome == Outcome.TIME_LIMIT_EXCEEDED
+    # It never finished, not even in double TL, so there is nothing to report.
+    assert run.evals[4].result.no_tle_outcome is None
+
+
+@pytest.mark.test_pkg('problems/box1')
+async def test_output_limit_exceeded_solution_fails_every_testcase(run_box1_solution):
+    run = await run_box1_solution('ole.cpp')
+
+    assert all(chk.result.outcome == Outcome.OUTPUT_LIMIT_EXCEEDED for chk in run.evals)
 
 
 # Unit tests with custom inputs

--- a/tests/rbx/box/testcases/test_promote.py
+++ b/tests/rbx/box/testcases/test_promote.py
@@ -7,6 +7,11 @@ from typer.testing import CliRunner
 from rbx.box.testcases import main as testcases_main
 from rbx.box.testing import testing_package
 
+# Promotion rebuilds the same generators and solutions in every test; sharing
+# the problem cache takes the file from 23s to 9s. The assertions are about the
+# promoted testcases and the prompts, never about a compilation running.
+pytestmark = pytest.mark.shared_cache
+
 
 def _scripted_prompt(*values):
     """Build a mock questionary prompt factory.

--- a/tests/rbx/box/unit_test.py
+++ b/tests/rbx/box/unit_test.py
@@ -9,6 +9,12 @@ from rbx.box.schema import CodeItem, ExpectedOutcome, ValidatorOutcome
 from rbx.box.testing import testing_package
 from rbx.utils import StatusProgress
 
+# Every unit test here compiles the same validators and checkers from scratch in
+# a fresh problem directory; sharing the problem cache takes the file from 62s to
+# 19s. The assertions are all about unit-test outcomes, never about a
+# compilation running.
+pytestmark = pytest.mark.shared_cache
+
 
 @pytest.fixture
 def mock_progress():

--- a/tests/rbx/box/validators_test.py
+++ b/tests/rbx/box/validators_test.py
@@ -16,6 +16,11 @@ from rbx.box.validators import (
     validate_testcases,
 )
 
+# Every test here rebuilds the same generators and validators from scratch in a
+# fresh problem directory; sharing the problem cache takes the file from 61s to
+# 28s. No test here asserts on a compilation actually running.
+pytestmark = pytest.mark.shared_cache
+
 
 async def test_no_validator_does_not_validate(
     testing_pkg: testing_package.TestingPackage,

--- a/tests/rbx/grading/caching_test.py
+++ b/tests/rbx/grading/caching_test.py
@@ -1,0 +1,84 @@
+import pathlib
+import sys
+
+from rbx.grading import steps_with_caching
+from rbx.grading.caching import DependencyCache
+from rbx.grading.judge.cacher import FileCacher
+from rbx.grading.judge.sandbox import SandboxBase, SandboxParams
+from rbx.grading.steps import (
+    GradingArtifacts,
+    GradingFileInput,
+    GradingFileOutput,
+    RunLogMetadata,
+)
+
+
+async def _run_from(
+    src: pathlib.Path,
+    out: pathlib.Path,
+    sandbox: SandboxBase,
+    dependency_cache: DependencyCache,
+) -> GradingArtifacts:
+    artifacts = GradingArtifacts()
+    artifacts.inputs.append(
+        GradingFileInput(src=src, dest=pathlib.Path('executable.py'))
+    )
+    artifacts.outputs.append(
+        GradingFileOutput(src=pathlib.Path('box-out.txt'), dest=out)
+    )
+    await steps_with_caching.run(
+        f'{sys.executable} executable.py',
+        params=SandboxParams(stdout_file=pathlib.Path('box-out.txt')),
+        sandbox=sandbox,
+        artifacts=artifacts,
+        dependency_cache=dependency_cache,
+        metadata=RunLogMetadata(),
+    )
+    return artifacts
+
+
+async def test_cache_hits_for_identical_content_at_a_different_path(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    # Same bytes, two different absolute paths -- as happens when every test
+    # copies its package into a fresh temporary directory.
+    first = cleandir / 'a' / 'executable.py'
+    second = cleandir / 'b' / 'executable.py'
+    for path in (first, second):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('print(7)')
+
+    await _run_from(first, pathlib.Path('out-a.txt'), sandbox, dependency_cache)
+    artifacts = await _run_from(
+        second, pathlib.Path('out-b.txt'), sandbox, dependency_cache
+    )
+
+    assert (cleandir / 'out-b.txt').read_text().strip() == '7'
+    assert artifacts.logs is not None
+    assert artifacts.logs.cached
+
+
+async def test_cache_misses_when_content_differs(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    first = cleandir / 'a' / 'executable.py'
+    second = cleandir / 'b' / 'executable.py'
+    first.parent.mkdir(parents=True, exist_ok=True)
+    second.parent.mkdir(parents=True, exist_ok=True)
+    first.write_text('print(7)')
+    second.write_text('print(8)')
+
+    await _run_from(first, pathlib.Path('out-a.txt'), sandbox, dependency_cache)
+    artifacts = await _run_from(
+        second, pathlib.Path('out-b.txt'), sandbox, dependency_cache
+    )
+
+    assert (cleandir / 'out-b.txt').read_text().strip() == '8'
+    assert artifacts.logs is not None
+    assert not artifacts.logs.cached


### PR DESCRIPTION
Cuts `tests/rbx` from **196s to ~70s** on 8 workers. Two production caching fixes produce most of the gain, and both benefit real users, not only the test suite.

## What was wrong

Profiling the suite (wrapping every subprocess the sandbox spawns) showed **76% of runtime was C++ compilation** — and of 498 compiles, only **56 were distinct sources**. 89% were rebuilding something the same run had already built. Actually *running* programs, including the deliberately slow and TLE ones, was only 10%.

Two independent causes, both about caches that could never hit:

**1. The compile cache key embedded absolute file paths.** `_build_cache_input` swapped a source path for its content digest only when the file was a symlink into cacher storage; for any real file the absolute path stayed in the key. Every test runs in a fresh temporary package directory, so byte-identical sources never shared an entry. Diffing the key between two consecutive tests showed only the path differing, with `"digest": null`.

**2. The problem-level cache lived inside the per-test directory.** `DependencyCache` and `FilesystemStorage` resolve to `<problem>/.rbx`, and `cleandir` mints a fresh `tmp_path` per test, so every test began with an empty cache DB. Instrumenting `find_in_cache` confirmed no entry was ever evicted by validation — all 66 misses were simply cold.

## Changes

| Commit | Change |
| --- | --- |
| `e143b250` | Key the compile cache on content instead of path (+ `CACHE_STEP_VERSION` bump) |
| `315a3fca`, `43a03b70`, `a1524d95` | Session-wide problem cache, **opt-in** via a `shared_cache` marker |
| `01a3f96e` | Split the box1 solution run into one test per solution |
| `b31a1a03`, `446de64e`, `7dcccdf1` | Design doc, implementation plan, corrections |

Only `e143b250` touches production code. The rest are test fixtures and docs.

## Cache sharing is opt-in, by design

It was first built as the default with an opt-out. That was rejected on review, and rightly: sharing a compile cache across problems by default weakens isolation everywhere, and a future bug in cache keying would mask itself across the whole suite instead of failing loudly in one place.

The default is now the pre-existing per-problem cache, and a `shared_cache` marker opts specific modules in — applied only where the measured gain is large *and* the tests do not depend on a compile actually running:

| File | Isolated | Shared | Marked |
| --- | --- | --- | --- |
| `solutions_test.py` | 83.8s | 41.8s | yes |
| `unit_test.py` | 62.1s | 18.5s | yes |
| `validators_test.py` | 61.2s | 28.4s | yes |
| `generators_test.py` | 57.8s | 21.0s | yes, 1 test opts out |
| `generator_outputs_test.py` | 32.1s | 13.1s | yes, 2 tests opt out |
| `testcases/test_promote.py` | 23.1s | 8.8s | yes |
| `test_header.py` | 30.8s | 28.4s | no — compiles via raw `g++` |
| `code_run_test.py` | 15.0s | 13.5s | no — gain too small |
| `checkers_test.py` | 8.5s | 6.7s | no — see the trap below |
| `code_compile_integration_test.py` | 7.2s | 6.9s | no — real-compile coverage |

The three individually-opted-out tests are the ones asserting on compilation output or failure messages, which a warm cache would turn into silent hits.

Keeping isolation everywhere else costs about 10s (~60s → ~70s), against ~119s with no sharing at all. That is the intended trade.

## Results

| Metric | Before | After |
| --- | --- | --- |
| `tests/rbx -n 8`, fixed order | 196s | **69–78s** |
| Suite CPU | 992s | 351s |
| C++ compiles | 498 | 219 |
| `testlib.h`/`jngen.h`/`tgen.h` precompiles | 98× each | 7× each (once per worker) |
| Tests over 3s | 108 | 22 |
| `generators_test.py` | 107s | 21s |

**Failure count did not increase.** 37 failed / 4512 passed before → 36 failed / 4520 passed after. The ~36 pre-existing failures on `main` are untouched and out of scope; the extra passes are the new cache regression tests plus the solution split. One test (`steps_with_caching_run_test.py::test_run_coordinated_evicts_when_retry_index_changes`) is flaky and intermittently makes it 37.

`ruff check` and `ruff format --check` are clean.

## Things a reviewer should push on

- **`CACHE_STEP_VERSION` 4 → 5** invalidates existing user caches. Intentional — old entries are path-keyed — but the first run after upgrading recompiles.
- **`digest_file` is a synchronous read on the cache-lookup path.** Every lookup now hashes the source. Trivial next to a C++ compile, and measured time went down, but it is a real cost if a caller passes very large inputs that were previously keyed by path alone.
- **The `shared_cache` marker has a scope trap.** `maybe_shared_problem_cache` is function-scoped, so a module- or session-scoped fixture that compiles runs *before* it and writes into the isolated store; marked tests then fail looking for that digest with an opaque `KeyError: 'File not found.'`. `checkers_test.py` is the live example — marking it fails 14 of 43 tests because `pkg_with_compiled_checker` is `scope='module'`. This is a property of the opt-in mechanism, not evidence that sharing is unsafe there. Documented on the marker and in the fixture docstring.
- **The tail split under-delivered.** Predicted ~15s, delivered ~3s, inside run-to-run noise — at 8 workers the suite is CPU-bound, not tail-bound. It costs ~1% extra CPU because shared setup now runs seven times instead of two. Kept for structure (seven tests named for the outcome they check, versus two grab-bags), and `01a3f96e` reverts cleanly on its own if that trade is unwanted.

## Descoped after re-measuring

The original plan had five phases. Phases 1–2 changed the profile the rest were sized against, so phases 3–4 were re-measured and dropped rather than executed on stale numbers: jngen/tgen opt-in now saves ~2s, and converting ~100 tests to Python programs would trade real-compiler coverage for a few seconds now that compiles are cache hits. `-O0` in the test env was dropped for the same reason. The analysis is retained in the design doc in case the profile shifts again.

One correction is recorded in `7dcccdf1`: the design doc originally blamed output-fingerprint eviction for the second cause. That was wrong — `_build_output_fingerprint_list` is structurally always empty, so the proposed fix would have been a no-op that deleted a dormant safety check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
