### PR TITLE
feat(vscode): summarize run tree nodes, and move the verdict logic into rbx (#25)

### DIFF
--- a/docs/plans/2026-08-11-vscode-extension-design.md
+++ b/docs/plans/2026-08-11-vscode-extension-design.md
@@ -64,6 +64,22 @@ The escape hatch remains: if the extension ever needs something genuinely not
 derivable from disk, rbx persists it — as D6 does — rather than growing a query
 command.
 
+> **Superseded in part (2026-08-16).** The third objection held; the first two
+> did not. Verdicts, expectation matching and dependency-gated scoring *are*
+> derivable from disk, but only by re-implementing
+> `get_solution_outcome_report` in TypeScript — 888 lines of `vscode/src/rbx/`
+> mirroring Python with no test comparing them. rbx now publishes
+> `.rbx/runs/report.yml` per solution, and the extension reads it instead of
+> deciding anything. Live progress is preserved where it matters (per-testcase
+> rows still come from `.eval`); a solution still running shows a progress
+> counter and no verdict, which is the accepted cost. See
+> [the report artifact design](2026-08-16-run-report-artifact-design.md).
+>
+> D2's rationale also understated itself: `rbx/box/cli.py:198-207` `rmtree`s
+> `build/` and `.rbx/` when the cache fingerprint does not match the installed
+> version, so an extension shelling out to a version-skewed rbx would destroy
+> the user's cache — not merely race it.
+
 ## Architecture
 
 ```

--- a/docs/plans/2026-08-16-run-report-artifact-design.md
+++ b/docs/plans/2026-08-16-run-report-artifact-design.md
@@ -1,0 +1,154 @@
+# A run report artifact, so verdict logic lives only in Python
+
+The VS Code extension re-derives from raw artifacts what rbx has already
+decided. Of the extension's 1797 lines, 888 sit in `vscode/src/rbx/` mirroring
+Python: the outcome ordering, `Outcome.short_name()`, `Outcome.worst_outcome()`,
+`ExpectedOutcome.match()`, the skeleton and evaluation models, and — added most
+recently — an aggregation that decides a solution's verdict and score.
+
+Nothing verifies any of it. No Python test references `vscode/`; nothing fails
+if `Outcome` gains a member or `ExpectedOutcome.match()` changes.
+
+The duplication that matters is the *logic*, not the models. Mirroring a
+Pydantic model's field names is cheap and fails loudly. Re-implementing "which
+verdict wins" is neither.
+
+## D1. rbx already computes this and discards it
+
+`get_solution_outcome_report()` (`rbx/box/solutions.py:1877-2032`, ~156 lines)
+produces a `SolutionOutcomeReport` (`solutions.py:1549-1716`) holding the
+pooled verdict, the per-group verdict reports, `gotScore` / `maxScore` /
+`gotScorePerGroup` — with `_check_deps` dependency propagation — the
+expected-score range check, and an aggregate status.
+
+It is a Pydantic v2 model. It serializes cleanly today. It is never written to
+disk, which is the only reason the extension had to re-derive any of it.
+
+So the fix is not to port less. It is to stop throwing the answer away.
+
+## D2. Why not just invoke rbx
+
+The extension is a pure reader and never spawns rbx (v1 design, D2). That
+decision turns out to be underjustified by its own comment. `rbx/box/cli.py:198-207`:
+when the cache fingerprint does not match the installed version, the root Typer
+callback `shutil.rmtree`s `build/` and the whole `.rbx/` directory. An extension
+that shelled out to a version-skewed rbx would silently destroy the user's
+cache mid-session.
+
+Beyond that: `rbx/grading/caching.py:385` and `rbx/grading/judge/cacher.py:93`
+take real `flock`s, so a second process serializes against an in-flight run
+rather than corrupting it — safe, but it would stall the tree. And Python
+startup with pydantic, typer and rich is far too slow for a watcher debounced
+at 200ms.
+
+A file on disk costs nothing to read, races nothing, and needs no rbx on
+`PATH`.
+
+## D3. A lean export model, not the internal one
+
+`SolutionOutcomeReport` embeds `solution: Solution`, `limits: Limits` and
+`evals: List[Evaluation]`; its JSON schema is 23 KB. Writing it verbatim would
+duplicate every evaluation already on disk in `.eval` files and pin an internal
+shape as an external contract.
+
+Instead a small model built *from* it, in `rbx/box/run_report.py`:
+
+```python
+class RunGroupReport(BaseModel):
+    name: str
+    outcome: Optional[Outcome]          # worst verdict in the group
+    expectedOutcome: Optional[ExpectedOutcome]
+    matchesExpectation: bool
+    score: int
+    maxScore: int
+    maxTime: Optional[float]            # seconds
+    maxMemory: Optional[int]            # bytes
+
+class RunSolutionReport(BaseModel):
+    path: str
+    index: int                          # directory name under .rbx/runs
+    expectedOutcome: ExpectedOutcome
+    outcome: Optional[Outcome]
+    status: SolutionOutcomeStatus
+    matchesExpectation: bool
+    score: int
+    maxScore: int
+    maxTime: Optional[float]
+    maxMemory: Optional[int]
+    failedGroups: List[str]
+    groups: List[RunGroupReport]
+
+class RunReport(BaseModel):
+    version: int = 1
+    solutions: List[RunSolutionReport]
+```
+
+Structured data only: enum values, seconds, bytes, integers. No `AC`, no
+`120 ms`, no `[70/100 pts]`. Rendering stays in the client, where a different
+client may reasonably render it differently.
+
+`version` is the stability hedge. A reader that finds a version it does not
+know shows the tree without aggregates rather than guessing.
+
+## D4. Written once per solution
+
+`TraditionalRunReporter.finish_solution()` (`solutions.py:2610`) is the single
+hook both `LiveRunReporter` and `SingleSolutionRunReporter` route through,
+exactly once per solution. The report is computed there — once, and handed to
+`render_solution_end` rather than computed a second time by it — and
+`.rbx/runs/report.yml` is rewritten with the solutions finished so far.
+
+Per solution, not per group or per testcase. A group-granular write would need
+`get_partial_report()` and would buy only a slightly earlier aggregate; a
+testcase-granular one would recompute a 156-line report N times per solution.
+
+The consequence is deliberate and visible: **while a solution is running, its
+row and its group rows show a progress counter and nothing else.** No
+worst-so-far verdict, no max time. Those appear when the solution finishes.
+That is the price of having no aggregation in the client, and it is the right
+price — a client-side "worst so far" is exactly the logic this document exists
+to delete.
+
+Per-testcase rows are unaffected: they read their own `.eval` directly, which
+is field access, not logic, and is what keeps live progress working.
+
+`--detailed` bypasses both reporters (`solutions.py:2874`), so it must write the
+report on its own path or explicitly not at all; whichever, `rbx run -d` must
+not leave a stale report from a previous run.
+
+## D5. What stays in TypeScript
+
+Three things, none of them logic:
+
+- **Structure and paths** — `skeleton.yml` for which testcases exist and their
+  artifact stems. Field access.
+- **Per-testcase facts** — each `.eval` for verdict, time, memory, message.
+  Field access, and the source of live progress.
+- **Display** — `accepted` → `AC`, `0.12` → `120 ms`, `[70/100 pts]`. About 60
+  lines of formatting and short-name tables.
+
+Deleted: `worstOutcome`, `matches`/`ExpectedOutcome.match()`, `isSlow`, the
+`OUTCOMES` ranking, and all of `summary.ts`'s aggregation and scoring.
+`outcome.ts` drops from 178 lines to roughly 40 of display mapping.
+
+This also removes a divergence shipped only days ago: the extension awards a
+group's score all-or-nothing *without* rbx's `_check_deps` gate, over-reporting
+on problems with group dependencies. Reading `gotScorePerGroup` makes the bug
+cease to exist rather than remain documented.
+
+## D6. Guarding the seam
+
+The remaining TS tables are display mappings, and unknown values already
+degrade safely (`shortName` renders `XX`, an unknown expectation matches). The
+`version` field guards the report shape.
+
+What is worth adding is the check that does not exist today: a test asserting
+the export model covers every `Outcome` and every `ExpectedOutcome` member, in
+the spirit of `tests/rbx/box/completion/enum_consistency_test.py`, so adding an
+enum member fails a Python test rather than silently rendering `XX` in an
+editor nobody is testing.
+
+Publishing JSON schemas for these models is deliberately out of scope. Worth
+noting for later: `utils.model_to_yaml` (`rbx/utils.py:365-368`) already stamps
+every `skeleton.yml` with `$schema=.../schemas/SolutionReportSkeleton.json`, a
+file that is never generated — a dangling URL in shipped fixtures today.

--- a/docs/plans/2026-08-16-run-report-artifact.md
+++ b/docs/plans/2026-08-16-run-report-artifact.md
@@ -1,0 +1,537 @@
+# Run Report Artifact Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `rbx run` persist the verdict/score aggregation it already computes, so the VS Code extension can read it instead of re-implementing it in TypeScript.
+
+**Architecture:** A new `rbx/box/run_report.py` defines a small, structured, versioned export model built *from* the existing `SolutionOutcomeReport`. `TraditionalRunReporter.finish_solution` persists it to `.rbx/runs/report.yml` once per solution as each one completes. The extension reads that file for all aggregates and deletes its own — keeping only artifact-path resolution, per-`.eval` field reads, and display formatting.
+
+**Tech Stack:** Python 3 / Pydantic v2 / pytest on the rbx side; TypeScript / esbuild / `node --test` on the extension side.
+
+**Design:** [`2026-08-16-run-report-artifact-design.md`](2026-08-16-run-report-artifact-design.md)
+
+**Background:** the extension currently mirrors ~888 lines of Python in `vscode/src/rbx/`. This plan deletes the *logic* half of that. Models staying mirrored is fine and deliberate (D5).
+
+---
+
+## Key facts to know before starting
+
+- `Outcome` (`rbx/grading/steps.py:38`) serializes as its lowercase-kebab **value** (`wrong-answer`). `ExpectedOutcome` (`rbx/box/schema.py:140`) serializes as its upper-snake **member name** (`WRONG_ANSWER`). They are different vocabularies; never conflate them. The extension already encodes this in `vscode/src/rbx/outcome.ts`.
+- `SolutionOutcomeReport.perGroup` holds **only** groups that carry an expectation AND were evaluated. It is not a complete group list — get the full list from `skeleton.groups`.
+- `_get_evals_per_group(evals, skeleton)` (`rbx/box/solutions.py:1837`) buckets evaluations by group, assuming `evals` is a gapless prefix of `skeleton.entries`. That holds for our caller.
+- A solution's index is its position in `skeleton.solutions`, which is also its directory name under `.rbx/runs/`. The extension depends on this.
+- Do **not** serialize `SolutionOutcomeReport` directly: it embeds `solution`, `limits` and `evals` (23 KB JSON schema, and it would duplicate every `.eval` on disk).
+
+---
+
+## Task 1: The export model
+
+**Files:**
+- Create: `rbx/box/run_report.py`
+- Test: `tests/rbx/box/run_report_test.py`
+
+**Step 1: Write the failing test**
+
+```python
+from rbx.box import run_report
+
+
+def test_report_model_round_trips_through_yaml():
+    report = run_report.RunReport(
+        solutions=[
+            run_report.RunSolutionReport(
+                path='sols/main.cpp',
+                index=0,
+                expectedOutcome='ACCEPTED',
+                outcome='accepted',
+                status='OK',
+                matchesExpectation=True,
+                score=100,
+                maxScore=100,
+                maxTime=0.008,
+                maxMemory=10485760,
+                failedGroups=[],
+                groups=[
+                    run_report.RunGroupReport(
+                        name='main',
+                        outcome='accepted',
+                        expectedOutcome=None,
+                        matchesExpectation=True,
+                        score=100,
+                        maxScore=100,
+                        maxTime=0.008,
+                        maxMemory=10485760,
+                    )
+                ],
+            )
+        ],
+    )
+    assert report.version == 1
+    reloaded = run_report.RunReport.model_validate(report.model_dump())
+    assert reloaded == report
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/run_report_test.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'rbx.box.run_report'`
+
+**Step 3: Write the minimal implementation**
+
+```python
+"""The run summary rbx publishes for other tools to read.
+
+`rbx run` already decides every solution's verdict and score in
+`solutions.get_solution_outcome_report`, then throws the answer away. This
+module is the on-disk form of that answer, so a client -- the VS Code
+extension today -- can render a run without re-deriving any of it.
+
+Deliberately *structured*, not rendered: enum values, seconds, bytes and
+integers. Turning `accepted` into `AC` and `0.008` into `8 ms` is the client's
+business, and a different client may reasonably differ.
+
+Deliberately *lean*: `SolutionOutcomeReport` embeds the solution, its limits
+and every evaluation. Those either live elsewhere on disk already (`.eval`
+files) or are internal shape that must not become an external contract.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from rbx.box.schema import ExpectedOutcome
+from rbx.grading.steps import Outcome
+
+# Bump when a change would make an older reader misread the file. Readers must
+# ignore a report whose version they do not know rather than guess at it.
+REPORT_VERSION = 1
+
+
+class RunGroupReport(BaseModel):
+    """How one testcase group fared, for one solution."""
+
+    name: str
+    # Worst verdict in the group; absent when nothing in it was evaluated.
+    outcome: Optional[Outcome] = None
+    # Only set when the solution declares an `outcomePerGroup` for this group.
+    expectedOutcome: Optional[ExpectedOutcome] = None
+    matchesExpectation: bool = True
+    score: int = 0
+    maxScore: int = 0
+    # Max, not sum: the slowest testcase is the one judged against the limit.
+    maxTime: Optional[float] = None  # seconds
+    maxMemory: Optional[int] = None  # bytes
+
+
+class RunSolutionReport(BaseModel):
+    path: str
+    # Position in `skeleton.solutions`, which is also the directory name under
+    # `.rbx/runs/`. Clients resolve artifact paths with it.
+    index: int
+    expectedOutcome: ExpectedOutcome
+    outcome: Optional[Outcome] = None
+    status: str
+    # `status == OK`, hoisted out so a client need not know the status values.
+    matchesExpectation: bool = True
+    score: int = 0
+    maxScore: int = 0
+    maxTime: Optional[float] = None
+    maxMemory: Optional[int] = None
+    failedGroups: List[str] = []
+    groups: List[RunGroupReport] = []
+
+
+class RunReport(BaseModel):
+    version: int = REPORT_VERSION
+    solutions: List[RunSolutionReport] = []
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/run_report_test.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/run_report.py tests/rbx/box/run_report_test.py
+git commit -m "feat(run): add the structured run report model (#25)"
+```
+
+---
+
+## Task 2: Build a report entry from a SolutionOutcomeReport
+
+**Files:**
+- Modify: `rbx/box/run_report.py`
+- Test: `tests/rbx/box/run_report_test.py`
+
+The builder needs `(solution_index, solution_path, skeleton, outcome_report)` and derives everything else. Import `_get_evals_per_group` and `Outcome.worst_outcome` rather than reimplementing bucketing or ranking.
+
+**Step 1: Write the failing test**
+
+Use the real pipeline rather than hand-built models — build a package and run it, then assert on the produced entry. Reuse `pkg_from_testdata` / `cleandir_with_testdata` from `tests/rbx/box/conftest.py`, and the scored fixture `tests/e2e/testdata/outcome-per-group` (groups `small`=40, `big`=60; `sols/main.cpp` all-AC, `sols/partial.cpp` WA on `big` only).
+
+```python
+@pytest.mark.test_pkg('outcome-per-group')
+async def test_report_entry_matches_what_rbx_decided(pkg_from_testdata):
+    # ... run the package through the normal run path, then:
+    entry = report.solutions[1]  # sols/partial.cpp
+    assert entry.path == 'sols/partial.cpp'
+    assert entry.index == 1
+    assert entry.outcome == Outcome.WRONG_ANSWER
+    assert entry.score == 40
+    assert entry.maxScore == 100
+    assert [g.name for g in entry.groups] == ['small', 'big']
+    assert entry.groups[0].outcome == Outcome.ACCEPTED
+    assert entry.groups[0].score == 40
+    assert entry.groups[1].outcome == Outcome.WRONG_ANSWER
+    assert entry.groups[1].score == 0
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/run_report_test.py -v`
+Expected: FAIL — the builder does not exist.
+
+**Step 3: Write the implementation**
+
+```python
+def _max_of(values: Iterable[Optional[float]]) -> Optional[float]:
+    present = [v for v in values if v is not None]
+    return max(present) if present else None
+
+
+def build_solution_report(
+    index: int,
+    skeleton: 'SolutionReportSkeleton',
+    report: 'SolutionOutcomeReport',
+) -> RunSolutionReport:
+    """Project the internal outcome report onto the published shape.
+
+    Every decision here is read off `report`, never recomputed: the worst
+    verdict comes from `Outcome.worst_outcome`, the scores from
+    `gotScorePerGroup` -- which already applies the `_check_deps` dependency
+    gate -- and the expectation results from `perGroup`. Recomputing any of it
+    would reintroduce exactly the divergence this module exists to remove.
+    """
+    evals_per_group = _get_evals_per_group(report.evals, skeleton)
+
+    groups = []
+    for group in skeleton.groups:
+        group_evals = evals_per_group.get(group.name, [])
+        per_group = report.perGroup.get(group.name)
+        groups.append(
+            RunGroupReport(
+                name=group.name,
+                outcome=Outcome.worst_outcome(e.result.outcome for e in group_evals)
+                if group_evals
+                else None,
+                expectedOutcome=per_group.expectedOutcome if per_group else None,
+                matchesExpectation=per_group.status.ok() if per_group else True,
+                score=report.gotScorePerGroup.get(group.name, 0),
+                maxScore=group.score,
+                maxTime=_max_of(e.log.time for e in group_evals),
+                maxMemory=_max_of(e.log.memory for e in group_evals),
+            )
+        )
+
+    return RunSolutionReport(
+        path=str(report.solution.path),
+        index=index,
+        expectedOutcome=report.expectedOutcome,
+        outcome=Outcome.worst_outcome(report.gotVerdicts) if report.gotVerdicts else None,
+        status=report.status.value,
+        matchesExpectation=report.status.ok(),
+        score=report.gotScore,
+        maxScore=report.maxScore,
+        maxTime=_max_of(e.log.time for e in report.evals),
+        maxMemory=_max_of(e.log.memory for e in report.evals),
+        failedGroups=report.failedGroups,
+        groups=groups,
+    )
+```
+
+Verify the real signatures before writing: `Outcome.worst_outcome` (`rbx/grading/steps.py:55`) — confirm whether it is a `staticmethod` taking an iterable and what it returns for an empty one. Confirm `Evaluation.log.time` / `.memory` are the right attribute paths (`rbx/grading/steps.py:301` `TestcaseLog`). Import `_get_evals_per_group` from `rbx.box.solutions`; if that creates a circular import, move the helper into `run_report.py` and have `solutions.py` import it from there.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/run_report_test.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/run_report.py tests/rbx/box/run_report_test.py
+git commit -m "feat(run): project the outcome report onto the published shape (#25)"
+```
+
+---
+
+## Task 3: Persist the report, once per solution
+
+**Files:**
+- Modify: `rbx/box/run_report.py` (writer)
+- Modify: `rbx/box/solutions.py` (`finish_solution`, both `render_solution_end`s, skeleton write site)
+- Test: `tests/rbx/box/run_report_test.py`
+
+**Step 1: Write the failing test**
+
+```python
+@pytest.mark.test_pkg('outcome-per-group')
+async def test_run_writes_report_yml(pkg_from_testdata):
+    # run the package, then:
+    path = pkg_from_testdata / '.rbx' / 'runs' / 'report.yml'
+    assert path.is_file()
+    loaded = run_report.RunReport.model_validate(yaml.safe_load(path.read_text()))
+    assert loaded.version == 1
+    assert [s.path for s in loaded.solutions] == [
+        'sols/main.cpp', 'sols/partial.cpp', 'sols/mislabeled.cpp',
+    ]
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/run_report_test.py -v`
+Expected: FAIL — no `report.yml`.
+
+**Step 3: Implement**
+
+Add to `run_report.py`:
+
+```python
+REPORT_FILENAME = 'report.yml'
+
+
+def report_path(runs_dir: pathlib.Path) -> pathlib.Path:
+    return runs_dir / REPORT_FILENAME
+
+
+def clear_report(runs_dir: pathlib.Path) -> None:
+    """Drop a previous run's report.
+
+    Called when a new skeleton is written. Without this an interrupted run
+    would leave the last run's verdicts on disk, and a client cannot tell a
+    stale report from a current one.
+    """
+    report_path(runs_dir).unlink(missing_ok=True)
+
+
+class RunReportWriter:
+    """Accumulates solution reports and rewrites the file as each one lands.
+
+    Rewritten whole rather than appended: the file is a few KB, and a whole
+    rewrite is atomic enough for a reader that tolerates a missing or
+    half-written file by treating it as "no aggregates yet".
+    """
+
+    def __init__(self, runs_dir: pathlib.Path):
+        self._path = report_path(runs_dir)
+        self._report = RunReport()
+
+    def add(self, entry: RunSolutionReport) -> None:
+        self._report.solutions.append(entry)
+        self.flush()
+
+    def flush(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(utils.model_to_yaml(self._report))
+```
+
+In `solutions.py`:
+
+1. At the skeleton write site (`solutions.py:704-705`), call `run_report.clear_report(runs_dir)` right after writing `skeleton.yml`. A new skeleton means a new run.
+2. Change `TraditionalRunReporter.render_solution_end` (base, `:2615`) to return `Optional[SolutionOutcomeReport]` instead of `bool`; both overrides (`:2681` `LiveRunReporter`, `:2787` `SingleSolutionRunReporter`) already hold the `report` from `_print_solution_outcome` — return it instead of `report.status.ok()`.
+3. In `finish_solution` (`:2608`), capture that report, persist it, and derive the boolean:
+
+```python
+def finish_solution(self) -> bool:
+    assert self.current_solution is not None
+    report = self.render_solution_end(self.current_solution)
+    if report is not None:
+        self.report_writer.add(
+            run_report.build_solution_report(
+                self.result.skeleton.solutions.index(...), self.result.skeleton, report
+            )
+        )
+    self.current_solution = None
+    self.current_solution_evals = []
+    return report is None or report.status.ok()
+```
+
+Construct `self.report_writer` in `TraditionalRunReporter.__init__` from `package.get_problem_runs_dir()`.
+
+**Critical:** do not call `get_solution_outcome_report` a second time to get the report. It runs with `report_issues=True` and calling it twice would double-push issues onto the issue stack. Thread the existing instance through.
+
+Resolve the solution index by position in `skeleton.solutions` — match on identity or `str(path)`, and assert it was found rather than defaulting to 0.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/run_report_test.py -v`
+Expected: PASS
+
+Then check nothing else broke: `uv run pytest tests/rbx/box/solutions_test.py -v` (and any test asserting on `finish_solution`'s return).
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/run_report.py rbx/box/solutions.py tests/rbx/box/run_report_test.py
+git commit -m "feat(run): persist the run report to .rbx/runs/report.yml (#25)"
+```
+
+---
+
+## Task 4: Cover the detailed path
+
+**Files:**
+- Modify: `rbx/box/solutions.py` (`_print_detailed_run_report`, around `:2472`)
+- Test: `tests/rbx/box/run_report_test.py`
+
+`print_run_report` returns early into `_print_detailed_run_report` when `detailed=True` (`solutions.py:2861`), bypassing the reporters entirely — so `rbx run -d` would write no report. That path already computes `report = _print_solution_outcome(...)` at `:2472`.
+
+**Step 1: Write the failing test** — same as Task 3's but running with `detailed=True`; assert `report.yml` exists and lists every solution.
+
+**Step 2: Run it** — Expected: FAIL, no file.
+
+**Step 3: Implement** — build a `RunReportWriter` in `_print_detailed_run_report` and `add()` each report as it is computed.
+
+**Step 4: Run tests** — both detailed and non-detailed report tests pass.
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(run): write the run report from the detailed path too (#25)"
+```
+
+---
+
+## Task 5: Guard the enum seam
+
+**Files:**
+- Test: `tests/rbx/box/run_report_test.py`
+
+Nothing today fails when `Outcome` gains a member, even though clients switch on its values. Mirror `tests/rbx/box/completion/enum_consistency_test.py`.
+
+**Step 1: Write the test**
+
+```python
+def test_every_outcome_is_publishable():
+    """A new Outcome must be a conscious decision, not a silent XX in a client."""
+    for outcome in Outcome:
+        entry = run_report.RunGroupReport(name='g', outcome=outcome)
+        assert run_report.RunGroupReport.model_validate(entry.model_dump()).outcome is outcome
+
+
+def test_every_expected_outcome_is_publishable():
+    for expected in ExpectedOutcome:
+        entry = run_report.RunSolutionReport(
+            path='s.cpp', index=0, expectedOutcome=expected, status='OK'
+        )
+        assert run_report.RunSolutionReport.model_validate(entry.model_dump()).expectedOutcome is expected
+```
+
+**Step 2-4:** Run; these should pass immediately. If one fails, the serialization of that member is the bug — fix it rather than weakening the test.
+
+**Step 5: Commit**
+
+```bash
+git commit -m "test(run): assert every outcome survives the published report (#25)"
+```
+
+---
+
+## Task 6: Extension reads the report
+
+**Files:**
+- Create: `vscode/src/rbx/report.ts`
+- Test: `vscode/src/rbx/report.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+test('a report of an unknown version is ignored rather than guessed at', () => {
+  assert.strictEqual(parseReport({ version: 99, solutions: [] }), undefined);
+});
+
+test('a solution report parses its aggregates', () => {
+  const report = parseReport({
+    version: 1,
+    solutions: [{
+      path: 'sols/main.cpp', index: 0, expectedOutcome: 'ACCEPTED',
+      outcome: 'accepted', status: 'OK', matchesExpectation: true,
+      score: 100, maxScore: 100, maxTime: 0.008, maxMemory: 10485760,
+      failedGroups: [], groups: [],
+    }],
+  });
+  assert.strictEqual(report?.solutions[0].score, 100);
+});
+```
+
+**Step 2: Run** — `cd vscode && npm test`. Expected: FAIL, module missing.
+
+**Step 3: Implement** `parseReport` using the existing tolerant helpers in `vscode/src/rbx/wire.ts` (`asRecord`, `asArray`, `asNumber`, `asString`, `field`). Return `undefined` for a missing file, an unparseable one, or `version !== 1` — all of which mean "render without aggregates".
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+---
+
+## Task 7: Delete the duplicated logic from the extension
+
+**Files:**
+- Modify: `vscode/src/rbx/store.ts`, `vscode/src/rbx/summary.ts`, `vscode/src/rbx/outcome.ts`, `vscode/src/runTree.ts`
+- Modify: `vscode/src/rbx/summary.test.ts`
+
+**Delete from `outcome.ts`:** `OUTCOMES`, `outcomeRank`, `worstOutcome`, `isSlow`, `matches`, and the `ExpectedOutcome` union. **Keep:** `SHORT_NAMES`/`shortName`, `expectedShortName`, `isAccepted` — display mappings, not ranking.
+
+**Delete from `summary.ts`:** `summarizeGroup`/`summarizeSolution`'s outcome and score derivation, `groupPassed`, `failingGroups`. **Keep:** `formatTime`, `formatMemory`, `formatScore`, and the `done`/`total` progress count (a count of `.eval` files present is not logic).
+
+`formatCounts` currently orders by `outcomeRank`. That ordering *is* the worst-outcome ranking — replace it with descending count, then name, so no ordering knowledge remains in TS.
+
+**`store.ts`:** load `report.yml` alongside `skeleton.yml`; hang the matching `RunSolutionReport` off `SolutionRun` and `RunGroupReport` off `GroupRun`, matched by index and group name. Both optional — absent while a run is in flight.
+
+**`runTree.ts`:** when a node has a report, render verdict/score/time/memory from it; when it does not, render only the progress counter. Per D4 this is the visible behaviour change: **mid-run, solution and group rows show `12/40` and nothing more.** Update the tooltip the same way. Testcase rows are unchanged — they read their own `.eval`.
+
+Rewrite `summary.test.ts` accordingly: drop the tests asserting worst-outcome and score derivation (that logic now lives in Python and is tested there), keep and extend the formatting and description tests.
+
+**Verify:** `cd vscode && npm run typecheck && npm test && npm run compile`.
+
+**Commit** once green.
+
+---
+
+## Task 8: End-to-end check against a real run
+
+Not a unit test — do this by hand before opening the PR, the way the previous change was verified.
+
+```bash
+mkdir -p /tmp/rbx-check && cp -r tests/e2e/testdata/outcome-per-group/. /tmp/rbx-check/
+cd /tmp/rbx-check && uv run --project <repo> rbx run
+cat .rbx/runs/report.yml
+```
+
+Assert by eye that `report.yml` agrees with what `rbx run` printed — `sols/main.cpp` at 100/100, `sols/partial.cpp` at 40/100 with `big` scoring 0, `sols/mislabeled.cpp` FAILED via its per-group expectations.
+
+Then build a temporary harness (as in the previous round) that renders the tree through `store.ts` + `summary.ts` and confirm it matches. **Specifically confirm the `_check_deps` fix**: find or construct a package with group dependencies where the old TypeScript over-reported, and check the tree now agrees with rbx.
+
+Also confirm `rbx run -d` writes the report, and that `rbx clean` followed by a fresh run leaves no stale one.
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `vscode/README.md` — the "What it reads" table gains `report.yml`; the run-tree section notes that aggregates appear when a solution finishes.
+- Modify: `rbx/box/CLAUDE.md` — a line on `run_report.py` being the published contract, and that it must stay structured, versioned, and free of rendered strings.
+- Modify: `docs/plans/2026-08-11-vscode-extension-design.md` — note that D2's rationale is now backed by `cli.py:198-207` (a version-skewed rbx rmtree's the cache), and that D3 is superseded by the report artifact.
+
+**Commit**, then open the PR.
+
+---
+
+## Out of scope
+
+- Publishing JSON schemas for these models (`schema_export.py` `MODELS`). Noted in the design as a follow-up; it would incidentally fix the dangling `$schema=.../SolutionReportSkeleton.json` URL that `utils.model_to_yaml` stamps into every `skeleton.yml`.
+- The `irun` variant (`.rbx/runs/.irun/`), which the extension does not read.
+- Per-group or per-testcase write granularity (explicitly rejected in D4).

--- a/docs/plans/2026-08-16-vscode-run-summaries-design.md
+++ b/docs/plans/2026-08-16-vscode-run-summaries-design.md
@@ -1,0 +1,98 @@
+# VS Code run tree: solo expansion and node summaries
+
+Follow-up to the M1 extension skeleton (#25, PR #650). Two defects in the Run
+view as shipped:
+
+1. Every solution is expanded on load. With a dozen solutions the tree opens as
+   a wall of testcases and the user has to collapse each one by hand.
+2. A solution or group node carries almost no information — just a verdict
+   short name, and a `done/total` counter while the run is in flight. The
+   aggregate facts a setter actually looks for (how slow was the worst test,
+   did this group score) are only visible by expanding to the testcases and
+   reading them off one at a time.
+
+## D1. Expand only a solo solution
+
+`rbx` already draws this exact distinction. `print_run_report` picks its
+reporter with `len(result.skeleton.solutions) == 1`
+(`rbx/box/solutions.py:2870`), and only the resulting `SingleSolutionRunReporter`
+prints a line per testcase; `LiveRunReporter` collapses each group to one line.
+The tree adopts the same condition, so the two surfaces agree on what "focused
+on one solution" means.
+
+- A package whose report has exactly one solution renders that solution
+  `Expanded`.
+- Otherwise every solution renders `Collapsed`.
+- Group nodes stay `Expanded` regardless. Collapsing them too would cost a
+  second click to reach any testcase, and the group breakdown is the reason to
+  open a solution at all.
+- The rule is evaluated per package, so in a multi-package workspace a package
+  with a single solution still opens.
+
+VS Code persists expansion state per `TreeItem.id`, and the ids here are stable
+(`<root>::<index>`). The collapsible state is therefore a *default*: once the
+user expands a solution it stays expanded across refreshes, which is the
+behaviour we want.
+
+## D2. Aggregate summaries on solution and group nodes
+
+A new `summary.ts` computes one `RunSummary` per solution and per group from
+the testcases already loaded:
+
+- `outcome` — worst outcome seen so far (existing `worstOutcome`).
+- `time` / `memory` — **max** across evaluated testcases. Max, not sum or mean:
+  the number that matters is the worst test, because that is what the time
+  limit is judged against. This mirrors `get_capped_evals_formatted_time`
+  (`solutions.py:1408`) and `get_evals_formatted_memory` (`solutions.py:1442`).
+- `done` / `total` — evaluated vs. expected testcases.
+- `counts` — testcases per outcome, for the tooltip.
+- `score` / `maxScore` — see D3.
+
+Formatting follows rbx rather than the extension's previous ad-hoc units:
+`120 ms` with a space, and memory on rbx's `B` / `KiB` / `MiB` ladder
+(`rbx/box/formatting.py:43`) instead of the old always-`MB` division. Two
+surfaces reporting the same run should not disagree on units.
+
+Descriptions, ` · `-separated:
+
+| node | in progress | complete |
+| --- | --- | --- |
+| solution, as declared | `12/40 · WA · 340 ms` | `AC · 120 ms · 32 MiB` |
+| solution, mismatched | — | `expected AC, got WA · 340 ms · 32 MiB` |
+| group | `3/8 · AC · 90 ms` | `WA · 340 ms · 12 MiB` |
+
+The mismatch spelling is kept from M1: an unexpected verdict is the headline
+finding of a run and outranks the raw verdict in the description.
+
+Tooltips carry what does not fit: expected outcome, verdict, max time and
+memory, the per-outcome counts (`14 AC, 2 WA`), and for a solution the groups
+that failed — the same detail `_group_failure_lines` (`solutions.py:1594`)
+prints.
+
+## D3. Scores, without dependency gating
+
+Under POINTS scoring rbx awards a group its full `score` all-or-nothing, gated
+on `_check_deps` (`solutions.py:1996`): a group scores zero if any group it
+depends on failed. The skeleton the extension reads carries `group.score` but
+not the dependency graph.
+
+The tree awards `group.score` whenever the group's worst outcome passes, and
+sums those for the solution, rendered rbx-style as `[70/100 pts]`. On a problem
+with group dependencies this **over-reports** — a group that rbx would zero out
+for a failed dependency still shows its points here. That is a deliberate
+trade: dependencies would mean parsing `problem.rbx.yml`, and the extension is
+otherwise a pure reader of `.rbx/runs` artifacts. The divergence only appears
+on a run that already has a failing group, where the tree is showing red
+anyway.
+
+Scores are omitted entirely when the package's groups declare no points
+(`maxScore == 0`), which is every BINARY-scored problem.
+
+## D4. Tests
+
+`vscode/` had no test setup. Everything in D2 and D3 is pure — outcomes in,
+strings out — so it is covered by `node --test` over the TypeScript sources
+compiled by esbuild, with no VS Code host. Run with `npm test` from `vscode/`.
+
+The tree provider itself is not tested; it needs the `vscode` module, and the
+logic worth protecting has been moved out of it into `summary.ts`.

--- a/mise.toml
+++ b/mise.toml
@@ -118,6 +118,11 @@ description = "Typecheck the VS Code extension"
 dir = "vscode"
 run = "npm run typecheck"
 
+[tasks."vscode:test"]
+description = "Run the VS Code extension's unit tests"
+dir = "vscode"
+run = "npm test"
+
 [tasks."vscode:package"]
 description = "Build the VS Code extension for publishing"
 dir = "vscode"

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -114,6 +114,34 @@ Solutions expecting TLE run with 2x time limit. Warns if a "TLE" solution passes
 - **`StructuredEvaluation`** -- 3D dict: `solution_path -> group_name -> [Deferred[Evaluation]]`
 - **`SolutionOutcomeReport`** -- Status (OK/UNEXPECTED_SCORE/UNEXPECTED_VERDICTS), expected/actual, scoring
 
+### The published run report (`run_report.py`)
+
+`SolutionOutcomeReport` used to be rendered and discarded, so anything outside
+Python that wanted to show a run had to re-derive verdicts from the raw `.eval`
+files -- outcome ranking, `ExpectedOutcome.match()` and dependency-gated scoring
+all re-implemented, with nothing catching the copies drifting. `run_report.py`
+is the on-disk form of that answer, written to `.rbx/runs/report.yml` once per
+solution as it finishes (from `TraditionalRunReporter.finish_solution`, the hook
+both reporters share, and from the `--detailed` path separately). Writing a new
+skeleton clears it, so its absence means "nothing has finished", never "stale".
+
+It is a **published contract**, so three rules hold:
+
+- **Structured, never rendered.** Enum values, seconds, bytes, integers. No
+  `AC`, no `120 ms`, no `[70/100 pts]` -- formatting is the client's business.
+- **Read off, never recomputed.** Every field comes from the existing
+  `SolutionOutcomeReport`; the scores come from `gotScorePerGroup`, which has
+  already applied the `_check_deps` gate. Recomputing anything defeats the point.
+  Note `gotVerdicts` holds only the verdicts that *offended* the expectation, so
+  the published `outcome` is the worst over `evals` instead.
+- **Versioned.** Bump `REPORT_VERSION` when a change would make an older reader
+  misread the file. Readers ignore versions they do not know.
+
+Lean on purpose: `SolutionOutcomeReport` embeds the solution, its limits and
+every evaluation, which either live on disk already or are internal shape that
+must not harden into a contract. Consumed by `vscode/src/rbx/report.ts`; see
+`docs/plans/2026-08-16-run-report-artifact-design.md`.
+
 ## Test Generation (`generators.py`, `generation_schema.py`, `stressing/generator_script_parser.py`)
 
 ### Generator Types

--- a/rbx/box/run_report.py
+++ b/rbx/box/run_report.py
@@ -1,0 +1,207 @@
+"""The run summary rbx publishes for other tools to read.
+
+`rbx run` already decides every solution's verdict and score, in
+`solutions.get_solution_outcome_report`, and then throws the answer away: the
+report is rendered to the console and never persisted. Anything else that wants
+to show a run -- the VS Code extension today -- has had to re-derive all of it
+from the raw `.eval` artifacts, which means re-implementing outcome ranking,
+expectation matching and dependency-gated scoring in another language, with
+nothing to catch the two copies drifting apart.
+
+This module is the on-disk form of that answer. See
+docs/plans/2026-08-16-run-report-artifact-design.md.
+
+Two deliberate constraints:
+
+- **Structured, not rendered.** Enum values, seconds, bytes, integers. Turning
+  `accepted` into `AC` or `0.008` into `8 ms` is the client's business, and a
+  client with a different surface may reasonably render it differently.
+- **Lean.** `SolutionOutcomeReport` embeds the solution, its limits and every
+  evaluation. Those either already live on disk (`.eval` files) or are internal
+  shape that must not harden into an external contract.
+"""
+
+import pathlib
+from typing import Dict, Iterable, List, Optional, TypeVar
+
+import yaml
+from pydantic import BaseModel
+
+from rbx.box.schema import ExpectedOutcome
+from rbx.grading.steps import Evaluation, Outcome
+
+# Bump when a change would make an older reader misread the file. A reader that
+# meets a version it does not know must ignore the report rather than guess --
+# showing a run without aggregates is recoverable, showing wrong verdicts is not.
+REPORT_VERSION = 1
+
+REPORT_FILENAME = 'report.yml'
+
+_T = TypeVar('_T', float, int)
+
+
+class RunGroupReport(BaseModel):
+    """How one testcase group fared, for one solution."""
+
+    name: str
+    # Worst verdict in the group. Absent when nothing in it has been evaluated,
+    # which is what an in-flight or interrupted run looks like.
+    outcome: Optional[Outcome] = None
+    # Only set when the solution declares an `outcomePerGroup` covering it.
+    expectedOutcome: Optional[ExpectedOutcome] = None
+    matchesExpectation: bool = True
+    score: int = 0
+    maxScore: int = 0
+    # Max, not sum or mean: the slowest testcase is the one judged against the
+    # time limit, and the only one worth a glance.
+    maxTime: Optional[float] = None  # seconds
+    maxMemory: Optional[int] = None  # bytes
+
+
+class RunSolutionReport(BaseModel):
+    path: str
+    # Position in `skeleton.solutions`, which is also the directory name under
+    # `.rbx/runs/`. Clients resolve artifact paths with it.
+    index: int
+    expectedOutcome: ExpectedOutcome
+    outcome: Optional[Outcome] = None
+    # `SolutionOutcomeStatus`, as its value.
+    status: str
+    # `status == OK`, hoisted out so a client need not learn the status values
+    # to answer the only question most of them ask.
+    matchesExpectation: bool = True
+    score: int = 0
+    maxScore: int = 0
+    maxTime: Optional[float] = None
+    maxMemory: Optional[int] = None
+    failedGroups: List[str] = []
+    groups: List[RunGroupReport] = []
+
+
+class RunReport(BaseModel):
+    version: int = REPORT_VERSION
+    solutions: List[RunSolutionReport] = []
+
+
+def _max_of(values: Iterable[Optional[_T]]) -> Optional[_T]:
+    present = [value for value in values if value is not None]
+    return max(present) if present else None
+
+
+def _worst_outcome(evals: List[Evaluation]) -> Optional[Outcome]:
+    # `Outcome.worst_outcome` is a `max`, so it raises on an empty iterable.
+    if not evals:
+        return None
+    return Outcome.worst_outcome(eval.result.outcome for eval in evals)
+
+
+def _evals_per_group(evals: List[Evaluation], skeleton) -> Dict[str, List[Evaluation]]:
+    # Imported here rather than at module scope: `solutions` is a heavy module
+    # and imports this one, so a top-level import would be circular.
+    from rbx.box.solutions import _get_evals_per_group  # noqa: SLF001
+
+    return _get_evals_per_group(evals, skeleton)
+
+
+def build_solution_report(
+    index: int,
+    skeleton,
+    report,
+) -> RunSolutionReport:
+    """Project the internal outcome report onto the published shape.
+
+    Every decision here is *read off* `report`, never recomputed. The scores
+    come from `gotScorePerGroup`, which has already applied the `_check_deps`
+    dependency gate; the expectation results come from `perGroup`. Recomputing
+    any of it would reintroduce exactly the divergence this module exists to
+    remove.
+
+    `report.perGroup` holds only the groups that carry an expectation *and*
+    were evaluated, so the group list is driven by the skeleton instead -- a
+    client needs a row per group either way.
+    """
+    evals_per_group = _evals_per_group(report.evals, skeleton)
+
+    groups = []
+    for group in skeleton.groups:
+        group_evals = evals_per_group.get(group.name, [])
+        per_group = report.perGroup.get(group.name)
+        groups.append(
+            RunGroupReport(
+                name=group.name,
+                outcome=_worst_outcome(group_evals),
+                expectedOutcome=per_group.expectedOutcome if per_group else None,
+                matchesExpectation=per_group.status.ok() if per_group else True,
+                score=report.gotScorePerGroup.get(group.name, 0),
+                maxScore=group.score,
+                maxTime=_max_of(eval.log.time for eval in group_evals),
+                maxMemory=_max_of(eval.log.memory for eval in group_evals),
+            )
+        )
+
+    return RunSolutionReport(
+        path=str(report.solution.path),
+        index=index,
+        expectedOutcome=report.expectedOutcome,
+        # Worst verdict observed, not `report.gotVerdicts`: that set holds only
+        # the verdicts that *offended* the expectation, so it is empty on a
+        # solution that behaved exactly as declared.
+        outcome=_worst_outcome(report.evals),
+        status=report.status.value,
+        matchesExpectation=report.status.ok(),
+        score=report.gotScore,
+        maxScore=report.maxScore,
+        maxTime=_max_of(eval.log.time for eval in report.evals),
+        maxMemory=_max_of(eval.log.memory for eval in report.evals),
+        failedGroups=report.failedGroups,
+        groups=groups,
+    )
+
+
+def report_path(runs_dir: pathlib.Path) -> pathlib.Path:
+    return runs_dir / REPORT_FILENAME
+
+
+def write_report(path: pathlib.Path, report: RunReport) -> None:
+    """Write the report as plain YAML.
+
+    Not `utils.model_to_yaml`: that stamps a `$schema` header pointing at a
+    published schema, and no schema is published for this model. It also drops
+    unset fields, which would make a client's parsing depend on which defaults
+    happened to be explicit at the call site.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            report.model_dump(mode='json', exclude_none=True),
+            sort_keys=False,
+            allow_unicode=True,
+        )
+    )
+
+
+def clear_report(runs_dir: pathlib.Path) -> None:
+    """Drop a previous run's report.
+
+    Called when a new skeleton is written, which is what marks a new run.
+    Without this, an interrupted run would leave the last run's verdicts on
+    disk and a client could not tell a stale report from a current one.
+    """
+    report_path(runs_dir).unlink(missing_ok=True)
+
+
+class RunReportWriter:
+    """Accumulates solution reports, rewriting the file as each one lands.
+
+    Rewritten whole rather than appended: the file is a few KB, and a reader
+    that treats a missing or unparseable file as "no aggregates yet" tolerates
+    being caught mid-write.
+    """
+
+    def __init__(self, runs_dir: pathlib.Path):
+        self._path = report_path(runs_dir)
+        self._report = RunReport()
+
+    def add(self, entry: RunSolutionReport) -> None:
+        self._report.solutions.append(entry)
+        write_report(self._path, self._report)

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -25,6 +25,7 @@ from rbx.box import (
     limits_info,
     package,
     remote,
+    run_report,
     setter_config,
     visualizers,
 )
@@ -703,6 +704,10 @@ async def _get_report_skeleton(
 
     skeleton_file = runs_dir / 'skeleton.yml'
     skeleton_file.write_text(utils.model_to_yaml(skeleton))
+    # A new skeleton is what marks a new run. Drop the previous run's report so
+    # an interrupted run cannot leave stale verdicts that a reader would take
+    # for current ones.
+    run_report.clear_report(runs_dir)
 
     return skeleton
 
@@ -2461,7 +2466,10 @@ async def _print_detailed_run_report(
         )
 
     ok = True
-    for solution in result.skeleton.solutions:
+    # `--detailed` bypasses the reporters entirely, so it has to publish the
+    # report itself or `rbx run -d` would leave none behind.
+    report_writer = run_report.RunReportWriter(package.get_problem_runs_dir())
+    for index, solution in enumerate(result.skeleton.solutions):
         all_evals = []
         for evals in structured_evaluations[str(solution.path)].values():
             all_evals.extend(evals)
@@ -2476,6 +2484,9 @@ async def _print_detailed_run_report(
             console,
             verification=verification,
             print_scoring=True,
+        )
+        report_writer.add(
+            run_report.build_solution_report(index, result.skeleton, report)
         )
         if _gates_report(solution, gating_solutions):
             ok = ok and report.status.ok()
@@ -2552,6 +2563,7 @@ class TraditionalRunReporter:
         self.current_solution_evals = []
         self.current_group_evals = []
         self.current_group_evals_per_index = {}
+        self.report_writer = run_report.RunReportWriter(package.get_problem_runs_dir())
 
     def get_limits(self, solution: Solution) -> Limits:
         return self.limits_per_solution[str(solution.path)]
@@ -2607,13 +2619,41 @@ class TraditionalRunReporter:
 
     def finish_solution(self) -> bool:
         assert self.current_solution is not None
-        ok = self.render_solution_end(self.current_solution)
+        report = self.render_solution_end(self.current_solution)
+        if report is not None:
+            self.report_writer.add(
+                run_report.build_solution_report(
+                    self.solution_index(self.current_solution),
+                    self.result.skeleton,
+                    report,
+                )
+            )
         self.current_solution = None
         self.current_solution_evals = []
-        return ok
+        return report is None or report.status.ok()
 
-    def render_solution_end(self, solution: Solution) -> bool:
-        return True
+    def render_solution_end(
+        self, solution: Solution
+    ) -> Optional[SolutionOutcomeReport]:
+        """Render the solution's verdict, and hand back the report it rendered.
+
+        The report is returned rather than reduced to a boolean because
+        ``finish_solution`` publishes it (see ``run_report``). Recomputing it
+        there instead would push every issue onto the stack a second time --
+        ``get_solution_outcome_report`` reports issues unless told not to.
+        """
+        return None
+
+    def solution_index(self, solution: Solution) -> int:
+        """Position in the skeleton, which is also the runs directory name.
+
+        Clients resolve artifact paths from it, so a wrong index would point at
+        another solution's output -- hence the assert rather than a default.
+        """
+        for index, candidate in enumerate(self.result.skeleton.solutions):
+            if str(candidate.path) == str(solution.path):
+                return index
+        raise ValueError(f'Solution {solution.path} is not in the skeleton')
 
     def start_group(self, group: GroupSkeleton):
         self.current_group = group
@@ -2678,7 +2718,9 @@ class LiveRunReporter(TraditionalRunReporter):
             self.console,
         )
 
-    def render_solution_end(self, solution: Solution) -> bool:
+    def render_solution_end(
+        self, solution: Solution
+    ) -> Optional[SolutionOutcomeReport]:
         report = _print_solution_outcome(
             solution,
             self.result.skeleton,
@@ -2688,7 +2730,7 @@ class LiveRunReporter(TraditionalRunReporter):
             print_message=True,
         )
         self.console.print()
-        return report.status.ok()
+        return report
 
     def _update_live(self, finished: bool = False):
         if self.live is None:
@@ -2783,7 +2825,9 @@ class SingleSolutionRunReporter(TraditionalRunReporter):
         _print_solution_header(solution_skeleton, self.console)
         self.console.print()
 
-    def render_solution_end(self, solution: Solution) -> bool:
+    def render_solution_end(
+        self, solution: Solution
+    ) -> Optional[SolutionOutcomeReport]:
         report = _print_solution_outcome(
             solution,
             self.result.skeleton,
@@ -2793,7 +2837,7 @@ class SingleSolutionRunReporter(TraditionalRunReporter):
             print_message=False,
         )
         self.console.print()
-        return report.status.ok()
+        return report
 
     def render_group_end(self, group: GroupSkeleton):
         self.console.print(f'  [status]{group.name}[/status]', end=' ')

--- a/tests/rbx/box/conftest.py
+++ b/tests/rbx/box/conftest.py
@@ -2,15 +2,33 @@ import os
 import pathlib
 import subprocess
 from collections.abc import Iterator
-from typing import Optional
+from typing import Dict, List, Optional
+from unittest.mock import patch
 
 import pytest
 
 from rbx import testing_utils
 from rbx.box import package, setter_config
+from rbx.box.environment import VerificationLevel
+from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
+from rbx.box.schema import ScoreType, Solution, Testcase
+from rbx.box.solutions import (
+    GroupSkeleton,
+    SolutionReportSkeleton,
+    SolutionSkeleton,
+)
 from rbx.box.statements.latex import LatexResult
+from rbx.box.testcase_schema import TestcaseEntry
 from rbx.box.testing import testing_package
 from rbx.config import CACHE_DIR_NAME, LEGACY_CACHE_DIR_NAME
+from rbx.grading.limits import Limits
+from rbx.grading.steps import (
+    CheckerResult,
+    Evaluation,
+    Outcome,
+    TestcaseIO,
+    TestcaseLog,
+)
 from rbx.utils import copytree_honoring_gitignore
 
 
@@ -117,6 +135,124 @@ def mock_setter_config(mock_app_path):
     cfg = setter_config.get_setter_config()
     cfg.judging = setter_config.JudgingConfig(check_stack=False)
     setter_config.save_setter_config(cfg)
+
+
+# Synthetic run skeletons and evaluations.
+#
+# Shared by every test that needs to feed `get_solution_outcome_report` (and
+# whatever is built on top of it) without running a real package: building one
+# in-memory is instant, deterministic, and does not need a compiler.
+
+
+@pytest.fixture
+def mock_limits():
+    """Create mock limits for testing."""
+    return Limits(time=1000, memory=256, profile=None, isDoubleTL=False)
+
+
+def make_generation_entry(
+    group: str, index: int, tmp_path: pathlib.Path
+) -> GenerationTestcaseEntry:
+    """Create a minimal GenerationTestcaseEntry for testing."""
+    entry = TestcaseEntry(group=group, index=index)
+    return GenerationTestcaseEntry(
+        group_entry=entry,
+        subgroup_entry=entry,
+        metadata=GenerationMetadata(
+            copied_to=Testcase(inputPath=tmp_path / f'{group}_{index}.in'),
+        ),
+    )
+
+
+@pytest.fixture
+def mock_skeleton(tmp_path, mock_limits):
+    """Create a minimal skeleton for testing.
+
+    Groups default to ``score=0``, so a POINTS-scoring test must pass
+    ``scores_per_group`` or it will assert against ``maxScore == 0`` vacuously.
+    """
+
+    def _create_skeleton(
+        solutions: List[Solution],
+        num_entries: int = 5,
+        entries_per_group: Optional[Dict[str, int]] = None,
+        scores_per_group: Optional[Dict[str, int]] = None,
+    ) -> SolutionReportSkeleton:
+        if entries_per_group is None:
+            entries_per_group = {'test': num_entries}
+        entries = [
+            make_generation_entry(group, i, tmp_path)
+            for group, count in entries_per_group.items()
+            for i in range(count)
+        ]
+        groups = [
+            GroupSkeleton(
+                name=group,
+                score=(scores_per_group or {}).get(group, 0),
+                deps=[],
+                testcases=[
+                    entry.metadata.copied_to
+                    for entry in entries
+                    if entry.group_entry.group == group
+                ],
+            )
+            for group in entries_per_group
+        ]
+        return SolutionReportSkeleton(
+            solutions=[
+                SolutionSkeleton(**sol.model_dump(), runs_dir=tmp_path / f'run_{i}')
+                for i, sol in enumerate(solutions)
+            ],
+            entries=entries,
+            groups=groups,
+            limits={'cpp': mock_limits},
+            compiled_solutions={
+                str(sol.path): f'digest_{i}' for i, sol in enumerate(solutions)
+            },
+            verification=VerificationLevel.FULL,
+        )
+
+    return _create_skeleton
+
+
+def make_evaluation(
+    outcome: Outcome,
+    time_ms: Optional[int] = 100,
+    memory_bytes: Optional[int] = 1024,
+    message: str = '',
+    no_tle_outcome: Optional[Outcome] = None,
+    sanitizer_warnings: bool = False,
+    testcase_index: int = 0,
+) -> Evaluation:
+    """Helper to create evaluation objects."""
+    return Evaluation(
+        result=CheckerResult(
+            outcome=outcome,
+            message=message,
+            no_tle_outcome=no_tle_outcome,
+            sanitizer_warnings=sanitizer_warnings,
+        ),
+        log=TestcaseLog(
+            time=time_ms / 1000.0 if time_ms is not None else None,
+            memory=memory_bytes,
+        ),
+        testcase=TestcaseIO(index=testcase_index),
+    )
+
+
+@pytest.fixture
+def mock_binary_scoring():
+    with patch('rbx.box.solutions.package.get_scoring', return_value=ScoreType.BINARY):
+        yield
+
+
+@pytest.fixture
+def mock_points_scoring():
+    # `outcomePerGroup` is only loadable under POINTS scoring (see
+    # `Package.check_scoring_fields`), so every per-group test must run here and
+    # not under `mock_binary_scoring`, which would be an impossible package.
+    with patch('rbx.box.solutions.package.get_scoring', return_value=ScoreType.POINTS):
+        yield
 
 
 @pytest.fixture(autouse=True, scope='session')

--- a/tests/rbx/box/run_report_test.py
+++ b/tests/rbx/box/run_report_test.py
@@ -1,0 +1,192 @@
+import pathlib
+
+import pytest
+import yaml
+
+from rbx.box import run_report
+from rbx.box.environment import VerificationLevel
+from rbx.box.schema import ExpectedOutcome, Solution
+from rbx.box.solutions import get_solution_outcome_report
+from rbx.grading.steps import Outcome
+from tests.rbx.box.conftest import make_evaluation
+
+
+def build(solution, skeleton, evals):
+    """The projection under test, fed by the real outcome report."""
+    report = get_solution_outcome_report(
+        solution, skeleton, evals, VerificationLevel.FULL
+    )
+    return run_report.build_solution_report(0, skeleton, report)
+
+
+def test_report_round_trips_through_yaml(tmp_path: pathlib.Path):
+    report = run_report.RunReport(
+        version=run_report.REPORT_VERSION,
+        solutions=[
+            run_report.RunSolutionReport(
+                path='sols/main.cpp',
+                index=0,
+                expectedOutcome=ExpectedOutcome.ACCEPTED,
+                outcome=Outcome.ACCEPTED,
+                status='OK',
+                matchesExpectation=True,
+                score=100,
+                maxScore=100,
+                maxTime=0.008,
+                maxMemory=10485760,
+            )
+        ],
+    )
+    path = tmp_path / 'report.yml'
+    run_report.write_report(path, report)
+
+    reloaded = run_report.RunReport.model_validate(yaml.safe_load(path.read_text()))
+    assert reloaded == report
+
+
+def test_projects_the_verdict_and_the_score_rbx_decided(
+    tmp_path, mock_skeleton, mock_points_scoring
+):
+    solution = Solution(
+        path=tmp_path / 'partial.cpp', outcome=ExpectedOutcome.INCORRECT
+    )
+    skeleton = mock_skeleton(
+        [solution],
+        entries_per_group={'small': 2, 'big': 2},
+        scores_per_group={'small': 40, 'big': 60},
+    )
+    evals = [
+        make_evaluation(Outcome.ACCEPTED, time_ms=19),
+        make_evaluation(Outcome.ACCEPTED, time_ms=8),
+        make_evaluation(Outcome.WRONG_ANSWER, time_ms=7),
+        make_evaluation(Outcome.WRONG_ANSWER, time_ms=7),
+    ]
+
+    entry = build(solution, skeleton, evals)
+
+    assert entry.path == str(tmp_path / 'partial.cpp')
+    assert entry.index == 0
+    assert entry.outcome == Outcome.WRONG_ANSWER
+    assert entry.score == 40
+    assert entry.maxScore == 100
+    # Max across the whole solution, not per group and not a sum.
+    assert entry.maxTime == pytest.approx(0.019)
+
+    assert [group.name for group in entry.groups] == ['small', 'big']
+    assert entry.groups[0].outcome == Outcome.ACCEPTED
+    assert entry.groups[0].score == 40
+    assert entry.groups[0].maxScore == 40
+    assert entry.groups[0].maxTime == pytest.approx(0.019)
+    assert entry.groups[1].outcome == Outcome.WRONG_ANSWER
+    assert entry.groups[1].score == 0
+    assert entry.groups[1].maxScore == 60
+    assert entry.groups[1].maxTime == pytest.approx(0.007)
+
+
+def test_score_honours_group_dependencies(tmp_path, mock_skeleton, mock_points_scoring):
+    """The reason this projection exists rather than a client-side one.
+
+    `big` passes on its own, but depends on `small`, which failed. rbx zeroes
+    it; a naive "did this group pass?" would award all 60 points.
+    """
+    solution = Solution(
+        path=tmp_path / 'partial.cpp', outcome=ExpectedOutcome.INCORRECT
+    )
+    skeleton = mock_skeleton(
+        [solution],
+        entries_per_group={'small': 1, 'big': 1},
+        scores_per_group={'small': 40, 'big': 60},
+    )
+    for group in skeleton.groups:
+        if group.name == 'big':
+            group.deps = ['small']
+    evals = [
+        make_evaluation(Outcome.WRONG_ANSWER),
+        make_evaluation(Outcome.ACCEPTED),
+    ]
+
+    entry = build(solution, skeleton, evals)
+
+    assert entry.groups[1].outcome == Outcome.ACCEPTED
+    assert entry.groups[1].score == 0
+    assert entry.score == 0
+
+
+def test_group_with_no_evaluations_has_no_outcome(
+    tmp_path, mock_skeleton, mock_binary_scoring
+):
+    solution = Solution(path=tmp_path / 'main.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'small': 1, 'big': 1})
+    # Only the first group ran -- an interrupted or in-flight run.
+    evals = [make_evaluation(Outcome.ACCEPTED)]
+
+    entry = build(solution, skeleton, evals)
+
+    assert entry.groups[0].outcome == Outcome.ACCEPTED
+    assert entry.groups[1].outcome is None
+    assert entry.groups[1].maxTime is None
+    assert entry.groups[1].maxMemory is None
+
+
+def test_unmeasured_evaluations_leave_time_and_memory_absent(
+    tmp_path, mock_skeleton, mock_binary_scoring
+):
+    solution = Solution(path=tmp_path / 'main.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'small': 1})
+    evals = [
+        make_evaluation(Outcome.COMPILATION_ERROR, time_ms=None, memory_bytes=None)
+    ]
+
+    entry = build(solution, skeleton, evals)
+
+    assert entry.maxTime is None
+    assert entry.maxMemory is None
+
+
+def test_per_group_expectations_are_carried_through(
+    tmp_path, mock_skeleton, mock_points_scoring
+):
+    solution = Solution(
+        path=tmp_path / 'mislabeled.cpp',
+        outcome=ExpectedOutcome.INCORRECT,
+        outcomePerGroup={'*': ExpectedOutcome.TIME_LIMIT_EXCEEDED},
+    )
+    skeleton = mock_skeleton(
+        [solution],
+        entries_per_group={'small': 1, 'big': 1},
+        scores_per_group={'small': 40, 'big': 60},
+    )
+    evals = [
+        make_evaluation(Outcome.ACCEPTED),
+        make_evaluation(Outcome.WRONG_ANSWER),
+    ]
+
+    entry = build(solution, skeleton, evals)
+
+    # The pooled `incorrect` holds -- it does fail somewhere -- so only the
+    # per-group layer catches this solution.
+    assert entry.matchesExpectation is False
+    assert entry.failedGroups == ['small', 'big']
+    assert entry.groups[0].expectedOutcome == ExpectedOutcome.TIME_LIMIT_EXCEEDED
+    assert entry.groups[0].matchesExpectation is False
+
+
+def test_every_outcome_survives_the_published_report():
+    """A new Outcome must be a deliberate choice, not a silent XX in a client."""
+    for outcome in Outcome:
+        entry = run_report.RunGroupReport(name='g', outcome=outcome)
+        reloaded = run_report.RunGroupReport.model_validate(
+            yaml.safe_load(yaml.safe_dump(entry.model_dump(mode='json')))
+        )
+        assert reloaded.outcome is outcome
+
+
+def test_every_expected_outcome_survives_the_published_report():
+    for expected in ExpectedOutcome:
+        entry = run_report.RunSolutionReport(
+            path='s.cpp', index=0, expectedOutcome=expected, status='OK'
+        )
+        reloaded = run_report.RunSolutionReport.model_validate(
+            yaml.safe_load(yaml.safe_dump(entry.model_dump(mode='json')))
+        )
+        assert reloaded.expectedOutcome == expected

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -55,13 +55,14 @@ from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
 from rbx.box.testcase_schema import TestcaseEntry
 from rbx.grading.limits import Limits
 from rbx.grading.steps import (
-    CheckerResult,
     CompilationError,
     Evaluation,
     Outcome,
-    TestcaseIO,
-    TestcaseLog,
 )
+
+# The synthetic skeleton/evaluation builders live in conftest so that other run
+# tests can share them; the fixtures come in automatically, these two do not.
+from tests.rbx.box.conftest import make_evaluation, make_generation_entry
 
 
 @pytest.mark.test_pkg('problems/box1')
@@ -174,117 +175,6 @@ async def test_get_solution_outcome_report(pkg_from_testdata: pathlib.Path):
 
 
 # Unit tests with custom inputs
-
-
-@pytest.fixture
-def mock_limits():
-    """Create mock limits for testing."""
-    return Limits(time=1000, memory=256, profile=None, isDoubleTL=False)
-
-
-def make_generation_entry(
-    group: str, index: int, tmp_path: pathlib.Path
-) -> GenerationTestcaseEntry:
-    """Create a minimal GenerationTestcaseEntry for testing."""
-    entry = TestcaseEntry(group=group, index=index)
-    return GenerationTestcaseEntry(
-        group_entry=entry,
-        subgroup_entry=entry,
-        metadata=GenerationMetadata(
-            copied_to=Testcase(inputPath=tmp_path / f'{group}_{index}.in'),
-        ),
-    )
-
-
-@pytest.fixture
-def mock_skeleton(tmp_path, mock_limits):
-    """Create a minimal skeleton for testing.
-
-    Groups default to ``score=0``, so a POINTS-scoring test must pass
-    ``scores_per_group`` or it will assert against ``maxScore == 0`` vacuously.
-    """
-
-    def _create_skeleton(
-        solutions: List[Solution],
-        num_entries: int = 5,
-        entries_per_group: Optional[Dict[str, int]] = None,
-        scores_per_group: Optional[Dict[str, int]] = None,
-    ) -> SolutionReportSkeleton:
-        if entries_per_group is None:
-            entries_per_group = {'test': num_entries}
-        entries = [
-            make_generation_entry(group, i, tmp_path)
-            for group, count in entries_per_group.items()
-            for i in range(count)
-        ]
-        groups = [
-            GroupSkeleton(
-                name=group,
-                score=(scores_per_group or {}).get(group, 0),
-                deps=[],
-                testcases=[
-                    entry.metadata.copied_to
-                    for entry in entries
-                    if entry.group_entry.group == group
-                ],
-            )
-            for group in entries_per_group
-        ]
-        return SolutionReportSkeleton(
-            solutions=[
-                SolutionSkeleton(**sol.model_dump(), runs_dir=tmp_path / f'run_{i}')
-                for i, sol in enumerate(solutions)
-            ],
-            entries=entries,
-            groups=groups,
-            limits={'cpp': mock_limits},
-            compiled_solutions={
-                str(sol.path): f'digest_{i}' for i, sol in enumerate(solutions)
-            },
-            verification=VerificationLevel.FULL,
-        )
-
-    return _create_skeleton
-
-
-def make_evaluation(
-    outcome: Outcome,
-    time_ms: Optional[int] = 100,
-    memory_bytes: Optional[int] = 1024,
-    message: str = '',
-    no_tle_outcome: Optional[Outcome] = None,
-    sanitizer_warnings: bool = False,
-    testcase_index: int = 0,
-) -> Evaluation:
-    """Helper to create evaluation objects."""
-    return Evaluation(
-        result=CheckerResult(
-            outcome=outcome,
-            message=message,
-            no_tle_outcome=no_tle_outcome,
-            sanitizer_warnings=sanitizer_warnings,
-        ),
-        log=TestcaseLog(
-            time=time_ms / 1000.0 if time_ms is not None else None,
-            memory=memory_bytes,
-        ),
-        testcase=TestcaseIO(index=testcase_index),
-    )
-
-
-@pytest.fixture
-def mock_binary_scoring():
-    with patch('rbx.box.solutions.package.get_scoring', return_value=ScoreType.BINARY):
-        yield
-
-
-@pytest.fixture
-def mock_points_scoring():
-    # `outcomePerGroup` is only loadable under POINTS scoring (see
-    # `Package.check_scoring_fields`), so every per-group test must run here and
-    # not under `mock_binary_scoring`, which would be an impossible package.
-    with patch('rbx.box.solutions.package.get_scoring', return_value=ScoreType.POINTS):
-        yield
 
 
 @contextlib.contextmanager

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
 out/
+out-test/
 *.vsix

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -11,10 +11,20 @@ run already in flight.
 
 ## The run tree
 
-Every solution and every group carries its own summary: the worst verdict
-underneath it, the points it earned, and the **max** time and memory across its
-testcases -- the slowest test being the one the time limit is judged against.
-Units and wording follow `rbx run` itself, so the two never disagree.
+Every solution and every group carries its own summary: the verdict underneath
+it, the points it earned, and the **max** time and memory across its testcases
+-- the slowest test being the one the time limit is judged against.
+
+**None of that is computed here.** rbx decides it and publishes it to
+`.rbx/runs/report.yml`; the extension reads it and renders it. That is
+deliberate: outcome ranking, expectation matching and dependency-gated scoring
+are subtle, they live in `rbx/box/run_report.py`, and a second implementation in
+TypeScript is a second implementation to keep in step. See
+[the design](../docs/plans/2026-08-16-run-report-artifact-design.md).
+
+The visible consequence is that rbx writes the report as each solution
+*finishes*, so a solution still running shows how far it has got (`12/40`) and
+no verdict. Individual testcase rows fill in live, from their own `.eval` files.
 
 A run of a single solution opens expanded, the way `rbx run` prints per-testcase
 lines only when there is one solution to print them for. A run of several opens
@@ -65,6 +75,7 @@ Everything comes from files rbx already writes. The layout is a contract, and
 | Path | Contents |
 |---|---|
 | `<pkg>/.rbx/runs/skeleton.yml` | solutions, groups, testcase entries with provenance |
+| `<pkg>/.rbx/runs/report.yml` | **every aggregate**: verdicts, scores, max time/memory, per-group expectation results |
 | `<pkg>/.rbx/runs/<i>/<group>/<stem>.eval` | verdict, time, memory, checker message |
 | `<pkg>/.rbx/runs/<i>/<group>/<stem>.out` | solution stdout |
 | `<pkg>/.rbx/runs/<i>/<group>/<stem>.err` | solution stderr (`.sol.err` for communication tasks) |
@@ -79,3 +90,7 @@ Two things are easy to get wrong here:
   real rbx bug once (#418 / #429).
 - A missing `.eval` means *pending*, not *failed*. That is what gives the tree
   live progress during a run for free.
+- A missing `report.yml` means *no solution has finished yet*, never *stale*:
+  rbx deletes it when it writes a new skeleton. A `version` it does not
+  recognise is ignored outright, because rendering a run without aggregates is
+  recoverable and rendering the wrong verdict is not.

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -9,6 +9,17 @@ Execution stays in the terminal. You type `rbx run`; the extension watches
 every `rbx` invocation has side effects on the package cache and could race a
 run already in flight.
 
+## The run tree
+
+Every solution and every group carries its own summary: the worst verdict
+underneath it, the points it earned, and the **max** time and memory across its
+testcases -- the slowest test being the one the time limit is judged against.
+Units and wording follow `rbx run` itself, so the two never disagree.
+
+A run of a single solution opens expanded, the way `rbx run` prints per-testcase
+lines only when there is one solution to print them for. A run of several opens
+with the solutions collapsed; expanding one reveals its groups already open.
+
 ## Status
 
 Milestone 1 of the [v1 design](../docs/plans/2026-08-11-vscode-extension-design.md):
@@ -29,14 +40,20 @@ folder containing a `problem.rbx.yml`.
 
 ```bash
 npm run typecheck  # tsc --noEmit
+npm test           # node --test, over esbuild-compiled sources
 npm run package    # production bundle
 ```
+
+The tests cover the pure logic only -- summarising a run, formatting a verdict
+-- which is why it lives in modules that never import `vscode` (`src/rbx/`).
+Anything touching the extension host is left to the F5 development host.
 
 From the repository root, the same via mise:
 
 ```bash
 mise run vscode:build
 mise run vscode:typecheck
+mise run vscode:test
 mise run vscode:package
 ```
 

--- a/vscode/esbuild.test.mjs
+++ b/vscode/esbuild.test.mjs
@@ -1,0 +1,34 @@
+/**
+ * Compile the `*.test.ts` files (and what they import) so `node --test` can run
+ * them.
+ *
+ * Separate from esbuild.mjs because the extension bundle has a single entry
+ * point and externalizes `vscode`; the tests have one entry point per file and
+ * must never reach the `vscode` module at all -- which is the point of keeping
+ * the logic they cover in plain modules.
+ */
+import { readdirSync } from 'node:fs';
+
+import * as esbuild from 'esbuild';
+
+// `readdirSync({recursive})` rather than `fs.globSync`, which only exists from
+// Node 22 and this repo does not pin a Node that new.
+const entryPoints = readdirSync('src', { recursive: true })
+  .map(String)
+  .filter((name) => name.endsWith('.test.ts'))
+  .map((name) => `src/${name}`);
+if (entryPoints.length === 0) {
+  throw new Error('No test files found under src/.');
+}
+
+await esbuild.build({
+  entryPoints,
+  bundle: true,
+  format: 'cjs',
+  platform: 'node',
+  target: 'node18',
+  outdir: 'out-test',
+  outbase: 'src',
+  sourcemap: 'inline',
+  logLevel: 'info',
+});

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -158,6 +158,8 @@
     "watch": "node esbuild.mjs --watch",
     "package": "node esbuild.mjs --production",
     "typecheck": "tsc --noEmit",
+    "pretest": "node esbuild.test.mjs",
+    "test": "node --test \"out-test/**/*.test.js\"",
     "lint": "eslint src",
     "vscode:prepublish": "npm run package"
   },

--- a/vscode/src/rbx/layout.ts
+++ b/vscode/src/rbx/layout.ts
@@ -68,6 +68,16 @@ export function skeletonPath(pkg: PackageLayout): string {
   return path.join(runsDir(pkg), 'skeleton.yml');
 }
 
+/**
+ * The aggregates rbx publishes for the last run (`rbx.box.run_report`).
+ *
+ * Written once per solution as it finishes, and removed when a new skeleton is
+ * written -- so its absence means "no solution has finished yet", never "stale".
+ */
+export function reportPath(pkg: PackageLayout): string {
+  return path.join(runsDir(pkg), 'report.yml');
+}
+
 export function testsDir(pkg: PackageLayout): string {
   return path.join(pkg.root, BUILD_DIR, 'tests');
 }

--- a/vscode/src/rbx/outcome.ts
+++ b/vscode/src/rbx/outcome.ts
@@ -1,7 +1,15 @@
 /**
- * The two outcome vocabularies rbx serializes, and the matching rule between them.
+ * How rbx's two outcome vocabularies are *displayed*. Nothing here decides
+ * anything.
  *
- * They are genuinely different types and must not be conflated:
+ * This file used to be a port: the outcome ranking, `Outcome.worst_outcome()`
+ * and `ExpectedOutcome.match()`, all re-implemented from Python with nothing
+ * checking the copies against each other. Those answers now arrive already
+ * decided in `.rbx/runs/report.yml` (see report.ts), and what is left is the
+ * mapping from a value to the two-or-three letters shown in the tree.
+ *
+ * The two vocabularies are still genuinely different types and must not be
+ * conflated:
  *
  *   - `Outcome` (rbx.grading.steps.Outcome) is what a run *produced*. It is a
  *     plain Enum, so it serializes as its lowercase kebab value: `wrong-answer`.
@@ -9,28 +17,7 @@
  *     *declared*. It is an AutoEnum whose __str__ is the member name, so it
  *     serializes upper snake-case: `WRONG_ANSWER` -- not the `wa` alias the user
  *     typed, and not the `Outcome` spelling either.
- *
- * An expectation can cover several outcomes (`ACCEPTED_OR_TLE`, `INCORRECT`),
- * so "did this solution behave as declared?" is a real predicate, ported here
- * from `ExpectedOutcome.match()`.
  */
-
-/** Serialized `Outcome` values, best to worst -- the declaration order rbx ranks by. */
-export const OUTCOMES = [
-  'accepted',
-  'skipped',
-  'wrong-answer',
-  'memory-limit-exceeded',
-  'time-limit-exceeded',
-  'idleness-limit-exceeded',
-  'runtime-error',
-  'output-limit-exceeded',
-  'judge-failed',
-  'internal-error',
-  'compilation-error',
-] as const;
-
-export type Outcome = (typeof OUTCOMES)[number];
 
 /** Mirrors `Outcome.short_name()`; unknown values render `XX`, as rbx does. */
 const SHORT_NAMES: Record<string, string> = {
@@ -58,57 +45,9 @@ export function isAccepted(outcome: string | undefined): boolean {
   return outcome === 'accepted';
 }
 
-/** Mirrors `Outcome.is_slow()`. */
-export function isSlow(outcome: string): boolean {
-  return outcome === 'time-limit-exceeded' || outcome === 'idleness-limit-exceeded';
+export function isSkipped(outcome: string | undefined): boolean {
+  return outcome === 'skipped';
 }
-
-/**
- * How bad an outcome is, by the declaration index rbx ranks with.
- *
- * Outcomes this extension does not know come from a newer rbx and rank worst,
- * so they surface instead of hiding behind a green group.
- */
-export function outcomeRank(outcome: string): number {
-  const known = OUTCOMES.indexOf(outcome as Outcome);
-  return known === -1 ? OUTCOMES.length : known;
-}
-
-/**
- * Worst of a set of outcomes, mirroring `Outcome.worst_outcome()` -- which ranks
- * by declaration index, so SKIPPED is worse than ACCEPTED but better than any
- * real failure.
- */
-export function worstOutcome(outcomes: Iterable<string | undefined>): string | undefined {
-  let worst: string | undefined;
-  let worstRank = -1;
-  for (const outcome of outcomes) {
-    if (outcome === undefined) {
-      continue;
-    }
-    const rank = outcomeRank(outcome);
-    if (rank > worstRank) {
-      worstRank = rank;
-      worst = outcome;
-    }
-  }
-  return worst;
-}
-
-/** Serialized `ExpectedOutcome` member names. */
-export type ExpectedOutcome =
-  | 'ANY'
-  | 'ACCEPTED'
-  | 'ACCEPTED_OR_TLE'
-  | 'WRONG_ANSWER'
-  | 'INCORRECT'
-  | 'RUNTIME_ERROR'
-  | 'TIME_LIMIT_EXCEEDED'
-  | 'MEMORY_LIMIT_EXCEEDED'
-  | 'OUTPUT_LIMIT_EXCEEDED'
-  | 'TLE_OR_RTE'
-  | 'JUDGE_FAILED'
-  | 'COMPILATION_ERROR';
 
 /** Display form of an expectation, e.g. `ACCEPTED_OR_TLE` -> `AC or TLE`. */
 export function expectedShortName(expected: string | undefined): string {
@@ -125,54 +64,5 @@ export function expectedShortName(expected: string | undefined): string {
       return 'INCORRECT';
     default:
       return shortName(expected.toLowerCase().replace(/_/g, '-'));
-  }
-}
-
-/**
- * Does `outcome` satisfy `expected`? A faithful port of `ExpectedOutcome.match()`.
- *
- * An unrecognized expectation returns `true`: it comes from a newer rbx, and
- * claiming a mismatch we cannot actually judge would be worse than staying quiet.
- */
-export function matches(expected: string | undefined, outcome: string): boolean {
-  if (expected === undefined || expected === 'ANY') {
-    return true;
-  }
-  // A skipped testcase was not awarded, so it satisfies any expectation that
-  // does not demand success.
-  if (outcome === 'skipped') {
-    return expected !== 'ACCEPTED';
-  }
-  switch (expected) {
-    case 'COMPILATION_ERROR':
-      return outcome === 'compilation-error';
-    case 'ACCEPTED':
-      return outcome === 'accepted';
-    case 'ACCEPTED_OR_TLE':
-      return outcome === 'accepted' || isSlow(outcome);
-    case 'WRONG_ANSWER':
-      return outcome === 'wrong-answer';
-    case 'INCORRECT':
-      return (
-        outcome === 'wrong-answer' ||
-        outcome === 'runtime-error' ||
-        outcome === 'memory-limit-exceeded' ||
-        outcome === 'output-limit-exceeded' ||
-        isSlow(outcome)
-      );
-    case 'RUNTIME_ERROR':
-      return outcome === 'runtime-error';
-    case 'TIME_LIMIT_EXCEEDED':
-      return isSlow(outcome);
-    case 'MEMORY_LIMIT_EXCEEDED':
-      return outcome === 'memory-limit-exceeded';
-    case 'TLE_OR_RTE':
-      return outcome === 'runtime-error' || isSlow(outcome);
-    case 'OUTPUT_LIMIT_EXCEEDED':
-      return outcome === 'output-limit-exceeded';
-    case 'JUDGE_FAILED':
-      return outcome === 'judge-failed';
-    default:
-      return true;
   }
 }

--- a/vscode/src/rbx/outcome.ts
+++ b/vscode/src/rbx/outcome.ts
@@ -64,12 +64,20 @@ export function isSlow(outcome: string): boolean {
 }
 
 /**
- * Worst of a set of outcomes, mirroring `Outcome.worst_outcome()` -- which ranks
- * by declaration index, so SKIPPED is worse than ACCEPTED but better than any
- * real failure.
+ * How bad an outcome is, by the declaration index rbx ranks with.
  *
  * Outcomes this extension does not know come from a newer rbx and rank worst,
  * so they surface instead of hiding behind a green group.
+ */
+export function outcomeRank(outcome: string): number {
+  const known = OUTCOMES.indexOf(outcome as Outcome);
+  return known === -1 ? OUTCOMES.length : known;
+}
+
+/**
+ * Worst of a set of outcomes, mirroring `Outcome.worst_outcome()` -- which ranks
+ * by declaration index, so SKIPPED is worse than ACCEPTED but better than any
+ * real failure.
  */
 export function worstOutcome(outcomes: Iterable<string | undefined>): string | undefined {
   let worst: string | undefined;
@@ -78,8 +86,7 @@ export function worstOutcome(outcomes: Iterable<string | undefined>): string | u
     if (outcome === undefined) {
       continue;
     }
-    const known = OUTCOMES.indexOf(outcome as Outcome);
-    const rank = known === -1 ? OUTCOMES.length : known;
+    const rank = outcomeRank(outcome);
     if (rank > worstRank) {
       worstRank = rank;
       worst = outcome;

--- a/vscode/src/rbx/report.test.ts
+++ b/vscode/src/rbx/report.test.ts
@@ -1,0 +1,114 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+import { parse as parseYaml } from 'yaml';
+
+import { parseReport } from './report';
+
+/** Verbatim from a real `rbx run` of tests/e2e/testdata/outcome-per-group. */
+const REAL_REPORT = `
+version: 1
+solutions:
+- path: sols/main.cpp
+  index: 0
+  expectedOutcome: ACCEPTED
+  outcome: accepted
+  status: OK
+  matchesExpectation: true
+  score: 100
+  maxScore: 100
+  maxTime: 0.009687
+  maxMemory: 11042816
+  failedGroups: []
+  groups:
+  - name: small
+    outcome: accepted
+    matchesExpectation: true
+    score: 40
+    maxScore: 40
+    maxTime: 0.009687
+    maxMemory: 10878976
+  - name: big
+    outcome: accepted
+    matchesExpectation: true
+    score: 60
+    maxScore: 60
+    maxTime: 0.009497
+    maxMemory: 11042816
+- path: sols/mislabeled.cpp
+  index: 2
+  expectedOutcome: INCORRECT
+  outcome: wrong-answer
+  status: UNEXPECTED_VERDICTS
+  matchesExpectation: false
+  score: 40
+  maxScore: 100
+  maxTime: 0.013336
+  maxMemory: 10878976
+  failedGroups:
+  - small
+  - big
+  groups:
+  - name: small
+    outcome: accepted
+    expectedOutcome: TIME_LIMIT_EXCEEDED
+    matchesExpectation: false
+    score: 40
+    maxScore: 40
+`;
+
+test('a real report parses into its aggregates', () => {
+  const report = parseReport(parseYaml(REAL_REPORT));
+  assert.ok(report !== undefined);
+  assert.strictEqual(report.solutions.length, 2);
+
+  const main = report.solutions[0];
+  assert.strictEqual(main.outcome, 'accepted');
+  assert.strictEqual(main.score, 100);
+  assert.strictEqual(main.maxScore, 100);
+  assert.strictEqual(main.matchesExpectation, true);
+  assert.strictEqual(main.groups[1].name, 'big');
+  assert.strictEqual(main.groups[1].score, 60);
+});
+
+test('a per-group expectation failure survives the wire', () => {
+  // The extension could not show this at all before: it only ever read the
+  // pooled `solution.outcome`, which this solution satisfies.
+  const report = parseReport(parseYaml(REAL_REPORT));
+  const mislabeled = report!.solutions[1];
+  assert.strictEqual(mislabeled.index, 2);
+  assert.strictEqual(mislabeled.matchesExpectation, false);
+  assert.deepStrictEqual([...mislabeled.failedGroups], ['small', 'big']);
+  assert.strictEqual(mislabeled.groups[0].expectedOutcome, 'TIME_LIMIT_EXCEEDED');
+  assert.strictEqual(mislabeled.groups[0].matchesExpectation, false);
+});
+
+test('an absent time or memory stays absent rather than becoming zero', () => {
+  const report = parseReport({
+    version: 1,
+    solutions: [
+      { path: 's.cpp', index: 0, status: 'OK', groups: [{ name: 'g' }] },
+    ],
+  });
+  const solution = report!.solutions[0];
+  assert.strictEqual(solution.maxTime, undefined);
+  assert.strictEqual(solution.maxMemory, undefined);
+  assert.strictEqual(solution.groups[0].outcome, undefined);
+});
+
+test('a report of an unknown version is ignored rather than guessed at', () => {
+  assert.strictEqual(parseReport({ version: 2, solutions: [] }), undefined);
+  assert.strictEqual(parseReport({ solutions: [] }), undefined);
+});
+
+test('a missing or malformed report reads as no report', () => {
+  assert.strictEqual(parseReport(undefined), undefined);
+  assert.strictEqual(parseReport('not a report'), undefined);
+});
+
+test('a solution missing its identity is dropped, not defaulted', () => {
+  const report = parseReport({
+    version: 1,
+    solutions: [{ index: 0, status: 'OK' }, { path: 'ok.cpp', index: 1, status: 'OK' }],
+  });
+  assert.deepStrictEqual(report?.solutions.map((s) => s.path), ['ok.cpp']);
+});

--- a/vscode/src/rbx/report.ts
+++ b/vscode/src/rbx/report.ts
@@ -1,0 +1,122 @@
+/**
+ * The run report rbx publishes at `.rbx/runs/report.yml`.
+ *
+ * This is the whole reason the extension no longer decides anything about a
+ * run. Every aggregate below -- the worst verdict, whether a solution met its
+ * declared expectation, the points a group earned -- was computed by
+ * `rbx.box.run_report` from the report `rbx run` was already building. Deriving
+ * any of it here again is how the two implementations drifted in the first
+ * place (see docs/plans/2026-08-16-run-report-artifact-design.md).
+ *
+ * Mirroring the *field names* is fine and deliberate: a renamed field fails
+ * loudly and locally. Mirroring the *decisions* was not.
+ */
+import { Wire, asArray, asBoolean, asNumber, asString, field } from './wire';
+
+/** The only report version this extension understands. */
+export const SUPPORTED_VERSION = 1;
+
+export interface GroupReport {
+  readonly name: string;
+  /** Worst verdict in the group; absent when none of it has been evaluated. */
+  readonly outcome?: string;
+  /** Set only when the solution declares an `outcomePerGroup` covering it. */
+  readonly expectedOutcome?: string;
+  readonly matchesExpectation: boolean;
+  readonly score: number;
+  readonly maxScore: number;
+  /** Seconds. */
+  readonly maxTime?: number;
+  /** Bytes. */
+  readonly maxMemory?: number;
+}
+
+export interface SolutionReport {
+  readonly path: string;
+  readonly index: number;
+  readonly expectedOutcome?: string;
+  readonly outcome?: string;
+  readonly status: string;
+  readonly matchesExpectation: boolean;
+  readonly score: number;
+  readonly maxScore: number;
+  readonly maxTime?: number;
+  readonly maxMemory?: number;
+  readonly failedGroups: readonly string[];
+  readonly groups: readonly GroupReport[];
+}
+
+export interface RunReport {
+  readonly solutions: readonly SolutionReport[];
+}
+
+function parseGroup(raw: Wire): GroupReport | undefined {
+  const name = asString(field(raw, 'name'));
+  if (name === undefined) {
+    return undefined;
+  }
+  return {
+    name,
+    outcome: asString(field(raw, 'outcome')),
+    expectedOutcome: asString(field(raw, 'expectedOutcome')),
+    matchesExpectation: asBoolean(field(raw, 'matchesExpectation')) ?? true,
+    score: asNumber(field(raw, 'score')) ?? 0,
+    maxScore: asNumber(field(raw, 'maxScore')) ?? 0,
+    maxTime: asNumber(field(raw, 'maxTime')),
+    maxMemory: asNumber(field(raw, 'maxMemory')),
+  };
+}
+
+function parseSolution(raw: Wire): SolutionReport | undefined {
+  const path = asString(field(raw, 'path'));
+  const index = asNumber(field(raw, 'index'));
+  if (path === undefined || index === undefined) {
+    return undefined;
+  }
+  const groups: GroupReport[] = [];
+  for (const rawGroup of asArray(field(raw, 'groups'))) {
+    const group = parseGroup(rawGroup);
+    if (group !== undefined) {
+      groups.push(group);
+    }
+  }
+  return {
+    path,
+    index,
+    expectedOutcome: asString(field(raw, 'expectedOutcome')),
+    outcome: asString(field(raw, 'outcome')),
+    status: asString(field(raw, 'status')) ?? 'OK',
+    matchesExpectation: asBoolean(field(raw, 'matchesExpectation')) ?? true,
+    score: asNumber(field(raw, 'score')) ?? 0,
+    maxScore: asNumber(field(raw, 'maxScore')) ?? 0,
+    maxTime: asNumber(field(raw, 'maxTime')),
+    maxMemory: asNumber(field(raw, 'maxMemory')),
+    failedGroups: asArray(field(raw, 'failedGroups'))
+      .map((name) => asString(name))
+      .filter((name): name is string => name !== undefined),
+    groups,
+  };
+}
+
+/**
+ * Parse a report, or return `undefined` when there is nothing usable.
+ *
+ * A version this extension does not know is ignored rather than read
+ * optimistically: rendering a run without aggregates is recoverable, rendering
+ * the wrong verdict is not. The same goes for a missing or half-written file,
+ * which is simply what a run in flight looks like.
+ */
+export function parseReport(raw: Wire): RunReport | undefined {
+  const version = asNumber(field(raw, 'version'));
+  if (version !== SUPPORTED_VERSION) {
+    return undefined;
+  }
+  const solutions: SolutionReport[] = [];
+  for (const rawSolution of asArray(field(raw, 'solutions'))) {
+    const solution = parseSolution(rawSolution);
+    if (solution !== undefined) {
+      solutions.push(solution);
+    }
+  }
+  return { solutions };
+}

--- a/vscode/src/rbx/store.ts
+++ b/vscode/src/rbx/store.ts
@@ -12,6 +12,7 @@ import { parse as parseYaml } from 'yaml';
 import {
   Ext,
   PackageLayout,
+  reportPath,
   runArtifactPath,
   skeletonPath,
   testArtifactPath,
@@ -27,6 +28,7 @@ import {
   parseEvaluation,
   parseSkeleton,
 } from './model';
+import { GroupReport, SolutionReport, parseReport } from './report';
 
 /** One (solution, testcase) pair, with wherever its artifacts live. */
 export interface TestcaseRun {
@@ -49,17 +51,22 @@ export interface TestcaseRun {
 
 export interface GroupRun {
   readonly name: string;
-  /** Points the group is worth, from the skeleton; 0 under binary scoring. */
-  readonly score: number;
   readonly testcases: readonly TestcaseRun[];
+  /**
+   * rbx's aggregates for this group. Absent until the solution finishes, since
+   * that is when rbx publishes them -- so absence means "still running", and
+   * the tree shows progress instead of a verdict.
+   */
+  readonly report?: GroupReport;
 }
 
 export interface SolutionRun {
   readonly solution: SolutionEntry;
   readonly groups: readonly GroupRun[];
+  readonly report?: SolutionReport;
 }
 
-export interface RunReport {
+export interface PackageRun {
   readonly skeleton: Skeleton;
   readonly solutions: readonly SolutionRun[];
 }
@@ -109,8 +116,11 @@ async function loadSolutionRun(
   pkg: PackageLayout,
   skeleton: Skeleton,
   solution: SolutionEntry,
+  report: SolutionReport | undefined,
 ): Promise<SolutionRun> {
-  const scores = new Map(skeleton.groups.map((group) => [group.name, group.score ?? 0]));
+  const groupReports = new Map(
+    (report?.groups ?? []).map((group) => [group.name, group]),
+  );
   const groups = await Promise.all(
     orderedGroups(skeleton).map(async (name): Promise<GroupRun> => {
       const testcases = await Promise.all(
@@ -118,10 +128,10 @@ async function loadSolutionRun(
           loadTestcaseRun(pkg, solution.index, entry),
         ),
       );
-      return { name, score: scores.get(name) ?? 0, testcases };
+      return { name, testcases, report: groupReports.get(name) };
     }),
   );
-  return { solution, groups };
+  return { solution, groups, report };
 }
 
 /**
@@ -132,7 +142,7 @@ async function loadSolutionRun(
  * cheaper than tracking which of them a filesystem event referred to.
  */
 export class ArtifactStore {
-  private cached?: Promise<RunReport | undefined>;
+  private cached?: Promise<PackageRun | undefined>;
 
   constructor(private readonly pkg: PackageLayout) {}
 
@@ -140,20 +150,28 @@ export class ArtifactStore {
     this.cached = undefined;
   }
 
-  load(): Promise<RunReport | undefined> {
+  load(): Promise<PackageRun | undefined> {
     if (this.cached === undefined) {
       this.cached = this.read();
     }
     return this.cached;
   }
 
-  private async read(): Promise<RunReport | undefined> {
+  private async read(): Promise<PackageRun | undefined> {
     const skeleton = parseSkeleton(await readYamlFile(skeletonPath(this.pkg)));
     if (skeleton === undefined) {
       return undefined;
     }
+    // The report is matched to solutions by index, not by position: mid-run it
+    // holds only the solutions that have finished, in the order they finished.
+    const report = parseReport(await readYamlFile(reportPath(this.pkg)));
+    const reports = new Map(
+      (report?.solutions ?? []).map((solution) => [solution.index, solution]),
+    );
     const solutions = await Promise.all(
-      skeleton.solutions.map((solution) => loadSolutionRun(this.pkg, skeleton, solution)),
+      skeleton.solutions.map((solution) =>
+        loadSolutionRun(this.pkg, skeleton, solution, reports.get(solution.index)),
+      ),
     );
     return { skeleton, solutions };
   }

--- a/vscode/src/rbx/store.ts
+++ b/vscode/src/rbx/store.ts
@@ -16,7 +16,6 @@ import {
   skeletonPath,
   testArtifactPath,
 } from './layout';
-import { worstOutcome } from './outcome';
 import {
   Evaluation,
   Skeleton,
@@ -50,6 +49,8 @@ export interface TestcaseRun {
 
 export interface GroupRun {
   readonly name: string;
+  /** Points the group is worth, from the skeleton; 0 under binary scoring. */
+  readonly score: number;
   readonly testcases: readonly TestcaseRun[];
 }
 
@@ -109,6 +110,7 @@ async function loadSolutionRun(
   skeleton: Skeleton,
   solution: SolutionEntry,
 ): Promise<SolutionRun> {
+  const scores = new Map(skeleton.groups.map((group) => [group.name, group.score ?? 0]));
   const groups = await Promise.all(
     orderedGroups(skeleton).map(async (name): Promise<GroupRun> => {
       const testcases = await Promise.all(
@@ -116,7 +118,7 @@ async function loadSolutionRun(
           loadTestcaseRun(pkg, solution.index, entry),
         ),
       );
-      return { name, testcases };
+      return { name, score: scores.get(name) ?? 0, testcases };
     }),
   );
   return { solution, groups };
@@ -155,25 +157,4 @@ export class ArtifactStore {
     );
     return { skeleton, solutions };
   }
-}
-
-/** Worst outcome observed across a solution's testcases so far. */
-export function solutionOutcome(solution: SolutionRun): string | undefined {
-  const outcomes: (string | undefined)[] = [];
-  for (const group of solution.groups) {
-    for (const testcase of group.testcases) {
-      outcomes.push(testcase.evaluation?.outcome);
-    }
-  }
-  return worstOutcome(outcomes);
-}
-
-export function groupOutcome(group: GroupRun): string | undefined {
-  return worstOutcome(group.testcases.map((testcase) => testcase.evaluation?.outcome));
-}
-
-export function isComplete(solution: SolutionRun): boolean {
-  return solution.groups.every((group) =>
-    group.testcases.every((testcase) => testcase.evaluation !== undefined),
-  );
 }

--- a/vscode/src/rbx/summary.test.ts
+++ b/vscode/src/rbx/summary.test.ts
@@ -1,0 +1,163 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import {
+  SummarizableGroup,
+  failingGroups,
+  formatCounts,
+  formatMemory,
+  formatScore,
+  formatTime,
+  groupDescription,
+  solutionDescription,
+  summarizeGroup,
+  summarizeSolution,
+} from './summary';
+
+/** A testcase with an outcome and, optionally, time (seconds) and memory (bytes). */
+function tc(outcome?: string, time?: number, memory?: number) {
+  return outcome === undefined ? {} : { evaluation: { outcome, time, memory } };
+}
+
+function group(name: string, score: number, testcases: ReturnType<typeof tc>[]): SummarizableGroup {
+  return { name, score, testcases };
+}
+
+test('formatTime truncates to whole milliseconds, as rbx does', () => {
+  assert.strictEqual(formatTime(0.1209), '120 ms');
+  assert.strictEqual(formatTime(0), '0 ms');
+  assert.strictEqual(formatTime(undefined), undefined);
+});
+
+test('formatMemory walks the B / KiB / MiB ladder', () => {
+  assert.strictEqual(formatMemory(512), '512 B');
+  assert.strictEqual(formatMemory(2048), '2 KiB');
+  assert.strictEqual(formatMemory(32 * 1024 * 1024), '32 MiB');
+  assert.strictEqual(formatMemory(undefined), undefined);
+});
+
+test('formatScore renders rbx literal brackets', () => {
+  assert.strictEqual(formatScore(70, 100), '[70/100 pts]');
+});
+
+test('a group summary takes the worst outcome and the max time and memory', () => {
+  const summary = summarizeGroup(
+    group('main', 0, [
+      tc('accepted', 0.01, 1024 * 1024),
+      tc('wrong-answer', 0.34, 8 * 1024 * 1024),
+      tc('accepted', 0.12, 2 * 1024 * 1024),
+    ]),
+  );
+  assert.strictEqual(summary.outcome, 'wrong-answer');
+  assert.strictEqual(summary.time, 0.34);
+  assert.strictEqual(summary.memory, 8 * 1024 * 1024);
+  assert.strictEqual(summary.done, 3);
+  assert.strictEqual(summary.total, 3);
+});
+
+test('an unevaluated testcase counts towards total but not done', () => {
+  const summary = summarizeGroup(group('main', 0, [tc('accepted', 0.01), tc(), tc()]));
+  assert.strictEqual(summary.done, 1);
+  assert.strictEqual(summary.total, 3);
+  assert.strictEqual(summary.outcome, 'accepted');
+});
+
+test('a group earns its full score only when every testcase is accepted', () => {
+  assert.strictEqual(summarizeGroup(group('main', 40, [tc('accepted'), tc('accepted')])).score, 40);
+  assert.strictEqual(summarizeGroup(group('main', 40, [tc('accepted'), tc('wrong-answer')])).score, 0);
+  // Still running: nothing earned yet, even though what has run so far passed.
+  assert.strictEqual(summarizeGroup(group('main', 40, [tc('accepted'), tc()])).score, 0);
+  // A skipped testcase means the group was cut short; rbx does not award it.
+  assert.strictEqual(summarizeGroup(group('main', 40, [tc('accepted'), tc('skipped')])).score, 0);
+});
+
+test('a solution sums group scores and aggregates across all groups', () => {
+  const summary = summarizeSolution({
+    groups: [
+      group('samples', 0, [tc('accepted', 0.01, 1024)]),
+      group('easy', 30, [tc('accepted', 0.05, 4096)]),
+      group('hard', 70, [tc('accepted', 0.4, 1024 * 1024), tc('time-limit-exceeded', 2.0)]),
+    ],
+  });
+  assert.strictEqual(summary.outcome, 'time-limit-exceeded');
+  assert.strictEqual(summary.score, 30);
+  assert.strictEqual(summary.maxScore, 100);
+  assert.strictEqual(summary.time, 2.0);
+  assert.strictEqual(summary.total, 4);
+});
+
+test('failingGroups names only the groups whose worst outcome is not accepted', () => {
+  const names = failingGroups({
+    groups: [
+      group('samples', 0, [tc('accepted')]),
+      group('easy', 0, [tc('wrong-answer')]),
+      group('hard', 0, [tc()]),
+    ],
+  }).map((g) => g.name);
+  assert.deepStrictEqual(names, ['easy']);
+});
+
+test('formatCounts orders outcomes best to worst', () => {
+  const summary = summarizeGroup(
+    group('main', 0, [tc('wrong-answer'), tc('accepted'), tc('accepted')]),
+  );
+  assert.strictEqual(formatCounts(summary), '2 AC, 1 WA');
+});
+
+test('a completed group description carries verdict, time and memory', () => {
+  const summary = summarizeGroup(
+    group('main', 0, [tc('accepted', 0.12, 32 * 1024 * 1024), tc('accepted', 0.01, 1024)]),
+  );
+  assert.strictEqual(groupDescription(summary), 'AC · 120 ms · 32 MiB');
+});
+
+test('an in-progress group description leads with the progress counter', () => {
+  const summary = summarizeGroup(
+    group('main', 0, [tc('accepted', 0.09), tc(), tc(), tc(), tc(), tc(), tc(), tc()]),
+  );
+  assert.strictEqual(groupDescription(summary), '1/8 · AC · 90 ms');
+});
+
+test('a group with points shows them once complete, and never mid-run', () => {
+  const complete = summarizeGroup(group('hard', 70, [tc('accepted', 0.12)]));
+  assert.strictEqual(groupDescription(complete), 'AC · [70/70 pts] · 120 ms');
+
+  const running = summarizeGroup(group('hard', 70, [tc('accepted', 0.12), tc()]));
+  assert.strictEqual(groupDescription(running), '1/2 · AC · 120 ms');
+});
+
+test('a solution matching its expectation shows the plain verdict', () => {
+  const summary = summarizeSolution({
+    groups: [group('main', 0, [tc('accepted', 0.12, 32 * 1024 * 1024)])],
+  });
+  assert.strictEqual(solutionDescription(summary, 'ACCEPTED'), 'AC · 120 ms · 32 MiB');
+});
+
+test('a solution contradicting its expectation leads with the mismatch', () => {
+  const summary = summarizeSolution({
+    groups: [group('main', 0, [tc('wrong-answer', 0.34, 32 * 1024 * 1024)])],
+  });
+  assert.strictEqual(
+    solutionDescription(summary, 'ACCEPTED'),
+    'expected AC, got WA · 340 ms · 32 MiB',
+  );
+});
+
+test('a solution whose expectation covers the outcome is not a mismatch', () => {
+  const summary = summarizeSolution({ groups: [group('main', 0, [tc('time-limit-exceeded', 2)])] });
+  assert.strictEqual(solutionDescription(summary, 'ACCEPTED_OR_TLE'), 'TLE · 2000 ms');
+});
+
+test('an in-progress solution never claims a mismatch it cannot yet know', () => {
+  // Only the samples have run and they failed, but the declared WRONG_ANSWER
+  // expectation may still be met -- do not shout "expected WA, got WA" either.
+  const summary = summarizeSolution({
+    groups: [group('main', 0, [tc('wrong-answer', 0.34), tc(), tc()])],
+  });
+  assert.strictEqual(solutionDescription(summary, 'ACCEPTED'), '1/3 · WA · 340 ms');
+});
+
+test('a solution with nothing evaluated yet reads as pending', () => {
+  const summary = summarizeSolution({ groups: [group('main', 0, [tc(), tc()])] });
+  assert.strictEqual(solutionDescription(summary, 'ACCEPTED'), '0/2 · pending');
+});

--- a/vscode/src/rbx/summary.test.ts
+++ b/vscode/src/rbx/summary.test.ts
@@ -1,26 +1,52 @@
 import * as assert from 'assert';
 import { test } from 'node:test';
 
+import type { GroupReport, SolutionReport } from './report';
 import {
-  SummarizableGroup,
-  failingGroups,
   formatCounts,
   formatMemory,
   formatScore,
   formatTime,
   groupDescription,
+  isComplete,
+  progressOf,
   solutionDescription,
-  summarizeGroup,
-  summarizeSolution,
 } from './summary';
 
-/** A testcase with an outcome and, optionally, time (seconds) and memory (bytes). */
-function tc(outcome?: string, time?: number, memory?: number) {
-  return outcome === undefined ? {} : { evaluation: { outcome, time, memory } };
+// Only formatting and progress are tested here. Deciding the verdict, the score
+// and whether a solution met its expectation is rbx's job now, covered by
+// tests/rbx/box/run_report_test.py -- asserting it again in TypeScript is what
+// let the two implementations drift in the first place.
+
+function tc(outcome?: string) {
+  return outcome === undefined ? {} : { evaluation: { outcome } };
 }
 
-function group(name: string, score: number, testcases: ReturnType<typeof tc>[]): SummarizableGroup {
-  return { name, score, testcases };
+function group(over: Partial<GroupReport> = {}): GroupReport {
+  return {
+    name: 'main',
+    outcome: 'accepted',
+    matchesExpectation: true,
+    score: 0,
+    maxScore: 0,
+    ...over,
+  };
+}
+
+function solution(over: Partial<SolutionReport> = {}): SolutionReport {
+  return {
+    path: 'sols/main.cpp',
+    index: 0,
+    expectedOutcome: 'ACCEPTED',
+    outcome: 'accepted',
+    status: 'OK',
+    matchesExpectation: true,
+    score: 0,
+    maxScore: 0,
+    failedGroups: [],
+    groups: [],
+    ...over,
+  };
 }
 
 test('formatTime truncates to whole milliseconds, as rbx does', () => {
@@ -40,124 +66,116 @@ test('formatScore renders rbx literal brackets', () => {
   assert.strictEqual(formatScore(70, 100), '[70/100 pts]');
 });
 
-test('a group summary takes the worst outcome and the max time and memory', () => {
-  const summary = summarizeGroup(
-    group('main', 0, [
-      tc('accepted', 0.01, 1024 * 1024),
-      tc('wrong-answer', 0.34, 8 * 1024 * 1024),
-      tc('accepted', 0.12, 2 * 1024 * 1024),
-    ]),
+test('progress counts the evaluations on disk, not the verdicts in them', () => {
+  const progress = progressOf([tc('accepted'), tc('wrong-answer'), tc(), tc()]);
+  assert.deepStrictEqual(progress, { done: 2, total: 4 });
+  assert.strictEqual(isComplete(progress), false);
+  assert.strictEqual(isComplete(progressOf([tc('accepted')])), true);
+});
+
+test('a completed group carries verdict, time and memory', () => {
+  const report = group({ maxTime: 0.12, maxMemory: 32 * 1024 * 1024 });
+  assert.strictEqual(
+    groupDescription(report, { done: 2, total: 2 }),
+    'AC · 120 ms · 32 MiB',
   );
-  assert.strictEqual(summary.outcome, 'wrong-answer');
-  assert.strictEqual(summary.time, 0.34);
-  assert.strictEqual(summary.memory, 8 * 1024 * 1024);
-  assert.strictEqual(summary.done, 3);
-  assert.strictEqual(summary.total, 3);
 });
 
-test('an unevaluated testcase counts towards total but not done', () => {
-  const summary = summarizeGroup(group('main', 0, [tc('accepted', 0.01), tc(), tc()]));
-  assert.strictEqual(summary.done, 1);
-  assert.strictEqual(summary.total, 3);
-  assert.strictEqual(summary.outcome, 'accepted');
+test('a scored group shows its points', () => {
+  const report = group({ score: 70, maxScore: 70, maxTime: 0.12 });
+  assert.strictEqual(
+    groupDescription(report, { done: 1, total: 1 }),
+    'AC · [70/70 pts] · 120 ms',
+  );
 });
 
-test('a group earns its full score only when every testcase is accepted', () => {
-  assert.strictEqual(summarizeGroup(group('main', 40, [tc('accepted'), tc('accepted')])).score, 40);
-  assert.strictEqual(summarizeGroup(group('main', 40, [tc('accepted'), tc('wrong-answer')])).score, 0);
-  // Still running: nothing earned yet, even though what has run so far passed.
-  assert.strictEqual(summarizeGroup(group('main', 40, [tc('accepted'), tc()])).score, 0);
-  // A skipped testcase means the group was cut short; rbx does not award it.
-  assert.strictEqual(summarizeGroup(group('main', 40, [tc('accepted'), tc('skipped')])).score, 0);
-});
-
-test('a solution sums group scores and aggregates across all groups', () => {
-  const summary = summarizeSolution({
-    groups: [
-      group('samples', 0, [tc('accepted', 0.01, 1024)]),
-      group('easy', 30, [tc('accepted', 0.05, 4096)]),
-      group('hard', 70, [tc('accepted', 0.4, 1024 * 1024), tc('time-limit-exceeded', 2.0)]),
-    ],
+test('a group that missed its own expectation leads with the mismatch', () => {
+  const report = group({
+    outcome: 'accepted',
+    expectedOutcome: 'TIME_LIMIT_EXCEEDED',
+    matchesExpectation: false,
+    maxTime: 0.013,
   });
-  assert.strictEqual(summary.outcome, 'time-limit-exceeded');
-  assert.strictEqual(summary.score, 30);
-  assert.strictEqual(summary.maxScore, 100);
-  assert.strictEqual(summary.time, 2.0);
-  assert.strictEqual(summary.total, 4);
-});
-
-test('failingGroups names only the groups whose worst outcome is not accepted', () => {
-  const names = failingGroups({
-    groups: [
-      group('samples', 0, [tc('accepted')]),
-      group('easy', 0, [tc('wrong-answer')]),
-      group('hard', 0, [tc()]),
-    ],
-  }).map((g) => g.name);
-  assert.deepStrictEqual(names, ['easy']);
-});
-
-test('formatCounts orders outcomes best to worst', () => {
-  const summary = summarizeGroup(
-    group('main', 0, [tc('wrong-answer'), tc('accepted'), tc('accepted')]),
+  assert.strictEqual(
+    groupDescription(report, { done: 1, total: 1 }),
+    'expected TLE, got AC · 13 ms',
   );
-  assert.strictEqual(formatCounts(summary), '2 AC, 1 WA');
-});
-
-test('a completed group description carries verdict, time and memory', () => {
-  const summary = summarizeGroup(
-    group('main', 0, [tc('accepted', 0.12, 32 * 1024 * 1024), tc('accepted', 0.01, 1024)]),
-  );
-  assert.strictEqual(groupDescription(summary), 'AC · 120 ms · 32 MiB');
-});
-
-test('an in-progress group description leads with the progress counter', () => {
-  const summary = summarizeGroup(
-    group('main', 0, [tc('accepted', 0.09), tc(), tc(), tc(), tc(), tc(), tc(), tc()]),
-  );
-  assert.strictEqual(groupDescription(summary), '1/8 · AC · 90 ms');
-});
-
-test('a group with points shows them once complete, and never mid-run', () => {
-  const complete = summarizeGroup(group('hard', 70, [tc('accepted', 0.12)]));
-  assert.strictEqual(groupDescription(complete), 'AC · [70/70 pts] · 120 ms');
-
-  const running = summarizeGroup(group('hard', 70, [tc('accepted', 0.12), tc()]));
-  assert.strictEqual(groupDescription(running), '1/2 · AC · 120 ms');
 });
 
 test('a solution matching its expectation shows the plain verdict', () => {
-  const summary = summarizeSolution({
-    groups: [group('main', 0, [tc('accepted', 0.12, 32 * 1024 * 1024)])],
-  });
-  assert.strictEqual(solutionDescription(summary, 'ACCEPTED'), 'AC · 120 ms · 32 MiB');
-});
-
-test('a solution contradicting its expectation leads with the mismatch', () => {
-  const summary = summarizeSolution({
-    groups: [group('main', 0, [tc('wrong-answer', 0.34, 32 * 1024 * 1024)])],
+  const report = solution({
+    score: 100,
+    maxScore: 100,
+    maxTime: 0.008,
+    maxMemory: 10485760,
   });
   assert.strictEqual(
-    solutionDescription(summary, 'ACCEPTED'),
-    'expected AC, got WA · 340 ms · 32 MiB',
+    solutionDescription(report, { done: 4, total: 4 }),
+    'AC · [100/100 pts] · 8 ms · 10 MiB',
   );
 });
 
-test('a solution whose expectation covers the outcome is not a mismatch', () => {
-  const summary = summarizeSolution({ groups: [group('main', 0, [tc('time-limit-exceeded', 2)])] });
-  assert.strictEqual(solutionDescription(summary, 'ACCEPTED_OR_TLE'), 'TLE · 2000 ms');
-});
-
-test('an in-progress solution never claims a mismatch it cannot yet know', () => {
-  // Only the samples have run and they failed, but the declared WRONG_ANSWER
-  // expectation may still be met -- do not shout "expected WA, got WA" either.
-  const summary = summarizeSolution({
-    groups: [group('main', 0, [tc('wrong-answer', 0.34), tc(), tc()])],
+test('a solution contradicting its pooled expectation leads with the mismatch', () => {
+  const report = solution({
+    outcome: 'wrong-answer',
+    status: 'UNEXPECTED_VERDICTS',
+    matchesExpectation: false,
+    maxTime: 0.34,
   });
-  assert.strictEqual(solutionDescription(summary, 'ACCEPTED'), '1/3 · WA · 340 ms');
+  assert.strictEqual(
+    solutionDescription(report, { done: 4, total: 4 }),
+    'expected AC, got WA · 340 ms',
+  );
 });
 
-test('a solution with nothing evaluated yet reads as pending', () => {
-  const summary = summarizeSolution({ groups: [group('main', 0, [tc(), tc()])] });
-  assert.strictEqual(solutionDescription(summary, 'ACCEPTED'), '0/2 · pending');
+test('a solution caught only per group names the groups, not the expectation', () => {
+  // Its pooled INCORRECT *is* satisfied -- it does fail somewhere -- so saying
+  // "expected INCORRECT, got WA" would name an expectation that was met.
+  const report = solution({
+    expectedOutcome: 'INCORRECT',
+    outcome: 'wrong-answer',
+    status: 'UNEXPECTED_VERDICTS',
+    matchesExpectation: false,
+    failedGroups: ['small', 'big'],
+    maxTime: 0.013,
+  });
+  assert.strictEqual(
+    solutionDescription(report, { done: 2, total: 2 }),
+    'WA · failed small, big · 13 ms',
+  );
+});
+
+test('a binary-scored solution shows no points at all', () => {
+  const report = solution({ maxTime: 0.008 });
+  assert.strictEqual(solutionDescription(report, { done: 1, total: 1 }), 'AC · 8 ms');
+});
+
+test('a solution with no report yet shows only how far it has got', () => {
+  // rbx publishes the report when the solution finishes, so mid-run there is
+  // nothing to aggregate from -- and computing a "worst so far" here is exactly
+  // the duplication the report exists to remove.
+  assert.strictEqual(solutionDescription(undefined, { done: 12, total: 40 }), '12/40');
+  assert.strictEqual(groupDescription(undefined, { done: 3, total: 8 }), '3/8');
+});
+
+test('a solution with no testcases at all reads as pending', () => {
+  assert.strictEqual(solutionDescription(undefined, { done: 0, total: 0 }), 'pending');
+});
+
+test('a report that arrives before every eval is on disk still shows progress', () => {
+  // The report is written per solution, but the watcher may see it before the
+  // last `.eval` symlink lands. Showing both is more honest than either alone.
+  const report = solution({ maxTime: 0.008 });
+  assert.strictEqual(
+    solutionDescription(report, { done: 3, total: 4 }),
+    '3/4 · AC · 8 ms',
+  );
+});
+
+test('formatCounts groups testcases by outcome, most frequent first', () => {
+  assert.strictEqual(
+    formatCounts([tc('wrong-answer'), tc('accepted'), tc('accepted')]),
+    '2 AC, 1 WA',
+  );
+  assert.strictEqual(formatCounts([tc(), tc()]), '');
 });

--- a/vscode/src/rbx/summary.ts
+++ b/vscode/src/rbx/summary.ts
@@ -1,0 +1,220 @@
+/**
+ * Aggregate facts about a solution or a test group, and how they render.
+ *
+ * Kept apart from the tree provider so it stays free of the `vscode` module and
+ * can be unit tested: everything here is outcomes in, strings out.
+ *
+ * The wording and the units deliberately match what `rbx run` prints -- two
+ * surfaces reporting the same run should not disagree on whether 32 MiB is
+ * "32MB". See docs/plans/2026-08-16-vscode-run-summaries-design.md.
+ */
+import type { Evaluation } from './model';
+import { expectedShortName, matches, outcomeRank, shortName, worstOutcome } from './outcome';
+
+/**
+ * The shape summarising needs, rather than the full `TestcaseRun`/`GroupRun`.
+ *
+ * Structural, so `store.ts`'s richer types satisfy it without a conversion and
+ * tests do not have to invent artifact paths they never look at.
+ */
+export interface SummarizableTestcase {
+  readonly evaluation?: Evaluation;
+}
+
+export interface SummarizableGroup {
+  readonly name: string;
+  /** Points this group is worth, from the skeleton; 0 under binary scoring. */
+  readonly score: number;
+  readonly testcases: readonly SummarizableTestcase[];
+}
+
+export interface SummarizableSolution {
+  readonly groups: readonly SummarizableGroup[];
+}
+
+export interface RunSummary {
+  /** Worst outcome observed so far; absent when nothing has been evaluated. */
+  readonly outcome?: string;
+  readonly done: number;
+  readonly total: number;
+  /**
+   * Max over evaluated testcases, not sum or mean -- the worst test is the one
+   * judged against the time limit, and the only one worth a glance.
+   */
+  readonly time?: number;
+  readonly memory?: number;
+  /** Testcases per outcome, worst-first, for the tooltip. */
+  readonly counts: ReadonlyMap<string, number>;
+  /** Points earned; see D3 -- group dependencies are not modelled. */
+  readonly score: number;
+  readonly maxScore: number;
+}
+
+export function isComplete(summary: RunSummary): boolean {
+  return summary.done === summary.total;
+}
+
+/** Mirrors `rbx.box.formatting.get_formatted_time`, including its truncation. */
+export function formatTime(seconds: number | undefined): string | undefined {
+  if (seconds === undefined) {
+    return undefined;
+  }
+  return `${Math.trunc(seconds * 1000)} ms`;
+}
+
+/** Mirrors `rbx.box.formatting.get_formatted_memory`: B / KiB / MiB, not MB. */
+export function formatMemory(bytes: number | undefined): string | undefined {
+  if (bytes === undefined) {
+    return undefined;
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${Math.round(bytes / 1024)} KiB`;
+  }
+  return `${Math.round(bytes / (1024 * 1024))} MiB`;
+}
+
+/** Mirrors `get_solution_score_markup`, whose brackets are literal: `[70/100 pts]`. */
+export function formatScore(score: number, maxScore: number): string {
+  return `[${score}/${maxScore} pts]`;
+}
+
+/**
+ * Did this group earn its points?
+ *
+ * rbx awards a group's score all-or-nothing, and additionally zeroes it when a
+ * group it depends on failed (`_check_deps`). The skeleton carries no
+ * dependency graph, so that gate is not applied here -- a deliberate
+ * over-report on dependent groups, documented in D3.
+ */
+function groupPassed(summary: RunSummary): boolean {
+  return isComplete(summary) && summary.outcome === 'accepted';
+}
+
+function summarize(
+  testcases: readonly SummarizableTestcase[],
+  scored: { score: number; maxScore: number },
+): RunSummary {
+  const outcomes: (string | undefined)[] = [];
+  const counts = new Map<string, number>();
+  let done = 0;
+  let time: number | undefined;
+  let memory: number | undefined;
+
+  for (const testcase of testcases) {
+    const evaluation = testcase.evaluation;
+    if (evaluation === undefined) {
+      continue;
+    }
+    done += 1;
+    outcomes.push(evaluation.outcome);
+    if (evaluation.outcome !== undefined) {
+      counts.set(evaluation.outcome, (counts.get(evaluation.outcome) ?? 0) + 1);
+    }
+    if (evaluation.time !== undefined) {
+      time = time === undefined ? evaluation.time : Math.max(time, evaluation.time);
+    }
+    if (evaluation.memory !== undefined) {
+      memory = memory === undefined ? evaluation.memory : Math.max(memory, evaluation.memory);
+    }
+  }
+
+  return {
+    outcome: worstOutcome(outcomes),
+    done,
+    total: testcases.length,
+    time,
+    memory,
+    counts,
+    score: scored.score,
+    maxScore: scored.maxScore,
+  };
+}
+
+export function summarizeGroup(group: SummarizableGroup): RunSummary {
+  const provisional = summarize(group.testcases, { score: 0, maxScore: group.score });
+  return { ...provisional, score: groupPassed(provisional) ? group.score : 0 };
+}
+
+export function summarizeSolution(solution: SummarizableSolution): RunSummary {
+  const testcases = solution.groups.flatMap((group) => group.testcases);
+  let score = 0;
+  let maxScore = 0;
+  for (const group of solution.groups) {
+    score += summarizeGroup(group).score;
+    maxScore += group.score;
+  }
+  return summarize(testcases, { score, maxScore });
+}
+
+/** Groups whose worst outcome is a failure, for the solution tooltip. */
+export function failingGroups(solution: SummarizableSolution): SummarizableGroup[] {
+  return solution.groups.filter((group) => {
+    const outcome = summarizeGroup(group).outcome;
+    return outcome !== undefined && outcome !== 'accepted';
+  });
+}
+
+function join(parts: (string | undefined)[]): string {
+  return parts.filter((part): part is string => part !== undefined && part !== '').join(' · ');
+}
+
+/**
+ * Score is shown only once the run is complete: a half-finished group has
+ * earned nothing yet, and `[0/100 pts]` mid-run reads as a failure.
+ */
+function scorePart(summary: RunSummary): string | undefined {
+  if (summary.maxScore === 0 || !isComplete(summary)) {
+    return undefined;
+  }
+  return formatScore(summary.score, summary.maxScore);
+}
+
+function progressPart(summary: RunSummary): string | undefined {
+  return isComplete(summary) ? undefined : `${summary.done}/${summary.total}`;
+}
+
+export function groupDescription(summary: RunSummary): string {
+  return join([
+    progressPart(summary),
+    summary.done === 0 ? 'pending' : shortName(summary.outcome),
+    scorePart(summary),
+    formatTime(summary.time),
+    formatMemory(summary.memory),
+  ]);
+}
+
+export function solutionDescription(
+  summary: RunSummary,
+  expectedOutcome: string | undefined,
+): string {
+  // A verdict that contradicts problem.rbx.yml is the headline finding of a
+  // run, so it replaces the bare verdict rather than sitting next to it.
+  const mismatched =
+    isComplete(summary) &&
+    summary.outcome !== undefined &&
+    !matches(expectedOutcome, summary.outcome);
+  const verdict = mismatched
+    ? `expected ${expectedShortName(expectedOutcome)}, got ${shortName(summary.outcome)}`
+    : summary.done === 0
+      ? 'pending'
+      : shortName(summary.outcome);
+
+  return join([
+    progressPart(summary),
+    verdict,
+    scorePart(summary),
+    formatTime(summary.time),
+    formatMemory(summary.memory),
+  ]);
+}
+
+/** `14 AC, 2 WA`, worst outcome last -- the order `OUTCOMES` ranks by. */
+export function formatCounts(summary: RunSummary): string {
+  return [...summary.counts.entries()]
+    .sort(([a], [b]) => outcomeRank(a) - outcomeRank(b))
+    .map(([outcome, count]) => `${count} ${shortName(outcome)}`)
+    .join(', ');
+}

--- a/vscode/src/rbx/summary.ts
+++ b/vscode/src/rbx/summary.ts
@@ -1,57 +1,37 @@
 /**
- * Aggregate facts about a solution or a test group, and how they render.
+ * How a run's aggregates are *rendered*. Nothing here computes them.
  *
- * Kept apart from the tree provider so it stays free of the `vscode` module and
- * can be unit tested: everything here is outcomes in, strings out.
+ * The verdict, the score and the max time and memory all arrive already decided
+ * in `.rbx/runs/report.yml` (report.ts). This file turns them into the strings
+ * the tree shows, and counts how many testcases have landed so far -- which is
+ * a count of files on disk, not a judgement about them.
  *
- * The wording and the units deliberately match what `rbx run` prints -- two
- * surfaces reporting the same run should not disagree on whether 32 MiB is
- * "32MB". See docs/plans/2026-08-16-vscode-run-summaries-design.md.
+ * The units deliberately match `rbx run` itself: two surfaces reporting the
+ * same run should not disagree on whether 32 MiB is "32MB".
  */
 import type { Evaluation } from './model';
-import { expectedShortName, matches, outcomeRank, shortName, worstOutcome } from './outcome';
+import type { GroupReport, SolutionReport } from './report';
+import { expectedShortName, shortName } from './outcome';
 
-/**
- * The shape summarising needs, rather than the full `TestcaseRun`/`GroupRun`.
- *
- * Structural, so `store.ts`'s richer types satisfy it without a conversion and
- * tests do not have to invent artifact paths they never look at.
- */
 export interface SummarizableTestcase {
   readonly evaluation?: Evaluation;
 }
 
-export interface SummarizableGroup {
-  readonly name: string;
-  /** Points this group is worth, from the skeleton; 0 under binary scoring. */
-  readonly score: number;
-  readonly testcases: readonly SummarizableTestcase[];
-}
-
-export interface SummarizableSolution {
-  readonly groups: readonly SummarizableGroup[];
-}
-
-export interface RunSummary {
-  /** Worst outcome observed so far; absent when nothing has been evaluated. */
-  readonly outcome?: string;
+/** How much of a solution or group has been evaluated so far. */
+export interface Progress {
   readonly done: number;
   readonly total: number;
-  /**
-   * Max over evaluated testcases, not sum or mean -- the worst test is the one
-   * judged against the time limit, and the only one worth a glance.
-   */
-  readonly time?: number;
-  readonly memory?: number;
-  /** Testcases per outcome, worst-first, for the tooltip. */
-  readonly counts: ReadonlyMap<string, number>;
-  /** Points earned; see D3 -- group dependencies are not modelled. */
-  readonly score: number;
-  readonly maxScore: number;
 }
 
-export function isComplete(summary: RunSummary): boolean {
-  return summary.done === summary.total;
+export function progressOf(testcases: readonly SummarizableTestcase[]): Progress {
+  return {
+    done: testcases.filter((testcase) => testcase.evaluation !== undefined).length,
+    total: testcases.length,
+  };
+}
+
+export function isComplete(progress: Progress): boolean {
+  return progress.done === progress.total;
 }
 
 /** Mirrors `rbx.box.formatting.get_formatted_time`, including its truncation. */
@@ -81,140 +61,104 @@ export function formatScore(score: number, maxScore: number): string {
   return `[${score}/${maxScore} pts]`;
 }
 
-/**
- * Did this group earn its points?
- *
- * rbx awards a group's score all-or-nothing, and additionally zeroes it when a
- * group it depends on failed (`_check_deps`). The skeleton carries no
- * dependency graph, so that gate is not applied here -- a deliberate
- * over-report on dependent groups, documented in D3.
- */
-function groupPassed(summary: RunSummary): boolean {
-  return isComplete(summary) && summary.outcome === 'accepted';
-}
-
-function summarize(
-  testcases: readonly SummarizableTestcase[],
-  scored: { score: number; maxScore: number },
-): RunSummary {
-  const outcomes: (string | undefined)[] = [];
-  const counts = new Map<string, number>();
-  let done = 0;
-  let time: number | undefined;
-  let memory: number | undefined;
-
-  for (const testcase of testcases) {
-    const evaluation = testcase.evaluation;
-    if (evaluation === undefined) {
-      continue;
-    }
-    done += 1;
-    outcomes.push(evaluation.outcome);
-    if (evaluation.outcome !== undefined) {
-      counts.set(evaluation.outcome, (counts.get(evaluation.outcome) ?? 0) + 1);
-    }
-    if (evaluation.time !== undefined) {
-      time = time === undefined ? evaluation.time : Math.max(time, evaluation.time);
-    }
-    if (evaluation.memory !== undefined) {
-      memory = memory === undefined ? evaluation.memory : Math.max(memory, evaluation.memory);
-    }
-  }
-
-  return {
-    outcome: worstOutcome(outcomes),
-    done,
-    total: testcases.length,
-    time,
-    memory,
-    counts,
-    score: scored.score,
-    maxScore: scored.maxScore,
-  };
-}
-
-export function summarizeGroup(group: SummarizableGroup): RunSummary {
-  const provisional = summarize(group.testcases, { score: 0, maxScore: group.score });
-  return { ...provisional, score: groupPassed(provisional) ? group.score : 0 };
-}
-
-export function summarizeSolution(solution: SummarizableSolution): RunSummary {
-  const testcases = solution.groups.flatMap((group) => group.testcases);
-  let score = 0;
-  let maxScore = 0;
-  for (const group of solution.groups) {
-    score += summarizeGroup(group).score;
-    maxScore += group.score;
-  }
-  return summarize(testcases, { score, maxScore });
-}
-
-/** Groups whose worst outcome is a failure, for the solution tooltip. */
-export function failingGroups(solution: SummarizableSolution): SummarizableGroup[] {
-  return solution.groups.filter((group) => {
-    const outcome = summarizeGroup(group).outcome;
-    return outcome !== undefined && outcome !== 'accepted';
-  });
-}
-
 function join(parts: (string | undefined)[]): string {
   return parts.filter((part): part is string => part !== undefined && part !== '').join(' · ');
 }
 
+function progressPart(progress: Progress): string | undefined {
+  return isComplete(progress) ? undefined : `${progress.done}/${progress.total}`;
+}
+
+function scorePart(score: number, maxScore: number): string | undefined {
+  return maxScore === 0 ? undefined : formatScore(score, maxScore);
+}
+
 /**
- * Score is shown only once the run is complete: a half-finished group has
- * earned nothing yet, and `[0/100 pts]` mid-run reads as a failure.
+ * A node whose report has not been written yet.
+ *
+ * rbx publishes the report once a solution *finishes*, so mid-run there is
+ * nothing to aggregate from and the row shows only how far it has got. That is
+ * the deliberate cost of having no aggregation here: a "worst verdict so far"
+ * computed in this file is exactly the duplication the report exists to remove.
  */
-function scorePart(summary: RunSummary): string | undefined {
-  if (summary.maxScore === 0 || !isComplete(summary)) {
-    return undefined;
+export function pendingDescription(progress: Progress): string {
+  return progress.total === 0 ? 'pending' : `${progress.done}/${progress.total}`;
+}
+
+export function groupDescription(
+  report: GroupReport | undefined,
+  progress: Progress,
+): string {
+  if (report === undefined) {
+    return pendingDescription(progress);
   }
-  return formatScore(summary.score, summary.maxScore);
-}
-
-function progressPart(summary: RunSummary): string | undefined {
-  return isComplete(summary) ? undefined : `${summary.done}/${summary.total}`;
-}
-
-export function groupDescription(summary: RunSummary): string {
+  // A group that missed its own declared expectation is the finding worth
+  // leading with, the way rbx's `_group_failure_lines` does.
+  const verdict = report.matchesExpectation
+    ? shortName(report.outcome)
+    : `expected ${expectedShortName(report.expectedOutcome)}, got ${shortName(report.outcome)}`;
   return join([
-    progressPart(summary),
-    summary.done === 0 ? 'pending' : shortName(summary.outcome),
-    scorePart(summary),
-    formatTime(summary.time),
-    formatMemory(summary.memory),
+    progressPart(progress),
+    verdict,
+    scorePart(report.score, report.maxScore),
+    formatTime(report.maxTime),
+    formatMemory(report.maxMemory),
   ]);
 }
 
 export function solutionDescription(
-  summary: RunSummary,
-  expectedOutcome: string | undefined,
+  report: SolutionReport | undefined,
+  progress: Progress,
 ): string {
-  // A verdict that contradicts problem.rbx.yml is the headline finding of a
-  // run, so it replaces the bare verdict rather than sitting next to it.
-  const mismatched =
-    isComplete(summary) &&
-    summary.outcome !== undefined &&
-    !matches(expectedOutcome, summary.outcome);
-  const verdict = mismatched
-    ? `expected ${expectedShortName(expectedOutcome)}, got ${shortName(summary.outcome)}`
-    : summary.done === 0
-      ? 'pending'
-      : shortName(summary.outcome);
-
+  if (report === undefined) {
+    return pendingDescription(progress);
+  }
   return join([
-    progressPart(summary),
-    verdict,
-    scorePart(summary),
-    formatTime(summary.time),
-    formatMemory(summary.memory),
+    progressPart(progress),
+    solutionVerdict(report),
+    scorePart(report.score, report.maxScore),
+    formatTime(report.maxTime),
+    formatMemory(report.maxMemory),
   ]);
 }
 
-/** `14 AC, 2 WA`, worst outcome last -- the order `OUTCOMES` ranks by. */
-export function formatCounts(summary: RunSummary): string {
-  return [...summary.counts.entries()]
-    .sort(([a], [b]) => outcomeRank(a) - outcomeRank(b))
+/**
+ * The headline finding: a solution that did not behave as declared.
+ *
+ * A solution declares its expectations in two layers and rbx checks both, so
+ * saying which one failed matters. `sols/mislabeled.cpp` in the
+ * `outcome-per-group` fixture satisfies its pooled `INCORRECT` -- it does fail
+ * somewhere -- and is caught only by its per-group expectations. Rendering that
+ * as "expected INCORRECT, got WA" would name an expectation that was in fact
+ * met.
+ */
+function solutionVerdict(report: SolutionReport): string {
+  if (report.matchesExpectation) {
+    return shortName(report.outcome);
+  }
+  if (report.failedGroups.length > 0) {
+    return `${shortName(report.outcome)} · failed ${report.failedGroups.join(', ')}`;
+  }
+  return `expected ${expectedShortName(report.expectedOutcome)}, got ${shortName(report.outcome)}`;
+}
+
+/**
+ * `14 AC, 2 WA`, most frequent first.
+ *
+ * Ordered by count rather than by how bad each outcome is: that ranking is
+ * `Outcome.worst_outcome`'s business, and reproducing its order here would put
+ * a copy of it back in this file.
+ */
+export function formatCounts(testcases: readonly SummarizableTestcase[]): string {
+  const counts = new Map<string, number>();
+  for (const testcase of testcases) {
+    const outcome = testcase.evaluation?.outcome;
+    if (outcome !== undefined) {
+      counts.set(outcome, (counts.get(outcome) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort(([nameA, countA], [nameB, countB]) => countB - countA || nameA.localeCompare(nameB))
     .map(([outcome, count]) => `${count} ${shortName(outcome)}`)
     .join(', ');
 }

--- a/vscode/src/runTree.ts
+++ b/vscode/src/runTree.ts
@@ -11,17 +11,21 @@ import * as vscode from 'vscode';
 import { discoverPackages, packageLabel } from './discovery';
 import { log } from './log';
 import { PackageLayout } from './rbx/layout';
-import { expectedShortName, isAccepted, matches, shortName } from './rbx/outcome';
+import { expectedShortName, isAccepted, shortName } from './rbx/outcome';
+import { ArtifactStore, GroupRun, RunReport, SolutionRun, TestcaseRun } from './rbx/store';
 import {
-  ArtifactStore,
-  GroupRun,
-  RunReport,
-  SolutionRun,
-  TestcaseRun,
-  groupOutcome,
+  RunSummary,
+  failingGroups,
+  formatCounts,
+  formatMemory,
+  formatScore,
+  formatTime,
+  groupDescription,
   isComplete,
-  solutionOutcome,
-} from './rbx/store';
+  solutionDescription,
+  summarizeGroup,
+  summarizeSolution,
+} from './rbx/summary';
 
 export type RunNode = PackageNode | SolutionNode | GroupNode | TestcaseNode;
 
@@ -34,6 +38,13 @@ export interface SolutionNode {
   readonly kind: 'solution';
   readonly pkg: PackageLayout;
   readonly run: SolutionRun;
+  /**
+   * This package's run covered only this solution, so the user is focused on
+   * it and the tree opens it. Mirrors how `rbx run` itself picks
+   * `SingleSolutionRunReporter` -- the only reporter that prints per-testcase
+   * lines -- on `len(skeleton.solutions) == 1`.
+   */
+  readonly solo: boolean;
 }
 
 export interface GroupNode {
@@ -49,22 +60,6 @@ export interface TestcaseNode {
   readonly run: SolutionRun;
   readonly group: GroupRun;
   readonly testcase: TestcaseRun;
-}
-
-/** Milliseconds, from the seconds rbx records. */
-function formatTime(seconds: number | undefined): string | undefined {
-  if (seconds === undefined) {
-    return undefined;
-  }
-  return `${Math.round(seconds * 1000)}ms`;
-}
-
-/** MiB, from the bytes rbx records. */
-function formatMemory(bytes: number | undefined): string | undefined {
-  if (bytes === undefined) {
-    return undefined;
-  }
-  return `${Math.round(bytes / (1024 * 1024))}MB`;
 }
 
 function outcomeIcon(outcome: string | undefined): vscode.ThemeIcon {
@@ -105,7 +100,7 @@ function testcaseItem(node: TestcaseNode): vscode.TreeItem {
   if (evaluation?.message !== undefined && evaluation.message !== '') {
     parts.push(evaluation.message);
   }
-  item.description = evaluation === undefined ? 'pending' : parts.join('  ');
+  item.description = evaluation === undefined ? 'pending' : parts.join(' · ');
 
   const tooltip = new vscode.MarkdownString();
   tooltip.appendMarkdown(`**${node.group.name}/${testcase.entry.index}** \`${testcase.stem}\`\n\n`);
@@ -130,20 +125,41 @@ function testcaseItem(node: TestcaseNode): vscode.TreeItem {
   return item;
 }
 
+/** The aggregate lines both solution and group tooltips share. */
+function appendSummary(tooltip: vscode.MarkdownString, summary: RunSummary): void {
+  tooltip.appendMarkdown(`Verdict: **${shortName(summary.outcome)}**\n\n`);
+  if (summary.maxScore > 0 && isComplete(summary)) {
+    tooltip.appendMarkdown(`Score: ${formatScore(summary.score, summary.maxScore)}\n\n`);
+  }
+  tooltip.appendMarkdown(`Tests: ${summary.done}/${summary.total}`);
+  if (summary.counts.size > 0) {
+    tooltip.appendMarkdown(` (${formatCounts(summary)})`);
+  }
+  tooltip.appendMarkdown('\n\n');
+  // Max, not total: the slowest test is what the time limit is judged against.
+  tooltip.appendMarkdown(`Max time: ${formatTime(summary.time) ?? '-'}\n\n`);
+  tooltip.appendMarkdown(`Max memory: ${formatMemory(summary.memory) ?? '-'}\n`);
+}
+
 function groupItem(node: GroupNode): vscode.TreeItem {
+  // Groups stay expanded even under a collapsed solution: collapsing them too
+  // would put two clicks between the user and any testcase, and the group
+  // breakdown is the reason to open a solution at all.
   const item = new vscode.TreeItem(
     node.group.name,
     vscode.TreeItemCollapsibleState.Expanded,
   );
   item.id = `${node.pkg.root}::${node.run.solution.index}::${node.group.name}`;
   item.contextValue = 'rbx.group';
-  const outcome = groupOutcome(node.group);
-  item.iconPath = outcomeIcon(outcome);
-  const done = node.group.testcases.filter((t) => t.evaluation !== undefined).length;
-  item.description =
-    done === node.group.testcases.length
-      ? shortName(outcome)
-      : `${done}/${node.group.testcases.length}`;
+
+  const summary = summarizeGroup(node.group);
+  item.iconPath = outcomeIcon(summary.outcome);
+  item.description = groupDescription(summary);
+
+  const tooltip = new vscode.MarkdownString();
+  tooltip.appendMarkdown(`**${node.group.name}**\n\n`);
+  appendSummary(tooltip, summary);
+  item.tooltip = tooltip;
   return item;
 }
 
@@ -151,24 +167,30 @@ function solutionItem(node: SolutionNode): vscode.TreeItem {
   const { solution } = node.run;
   const item = new vscode.TreeItem(
     solution.path,
-    vscode.TreeItemCollapsibleState.Expanded,
+    node.solo
+      ? vscode.TreeItemCollapsibleState.Expanded
+      : vscode.TreeItemCollapsibleState.Collapsed,
   );
   item.id = `${node.pkg.root}::${solution.index}`;
   item.contextValue = 'rbx.solution';
   item.resourceUri = vscode.Uri.file(path.join(node.pkg.root, solution.path));
 
-  const outcome = solutionOutcome(node.run);
-  item.iconPath = outcomeIcon(outcome);
+  const summary = summarizeSolution(node.run);
+  item.iconPath = outcomeIcon(summary.outcome);
+  item.description = solutionDescription(summary, solution.expectedOutcome);
 
-  if (!isComplete(node.run)) {
-    item.description = 'running…';
-  } else if (outcome !== undefined && !matches(solution.expectedOutcome, outcome)) {
-    // The headline finding of a run: a solution that did not behave as declared.
-    item.description = `expected ${expectedShortName(solution.expectedOutcome)}, got ${shortName(outcome)}`;
-  } else {
-    item.description = shortName(outcome);
+  const tooltip = new vscode.MarkdownString();
+  tooltip.appendMarkdown(`**${solution.path}**\n\n`);
+  tooltip.appendMarkdown(`Expected: ${expectedShortName(solution.expectedOutcome)}\n\n`);
+  appendSummary(tooltip, summary);
+  const failing = failingGroups(node.run);
+  if (failing.length > 0) {
+    const names = failing
+      .map((group) => `${group.name} (${shortName(summarizeGroup(group).outcome)})`)
+      .join(', ');
+    tooltip.appendMarkdown(`\nFailing groups: ${names}\n`);
   }
-  item.tooltip = `Expected ${expectedShortName(solution.expectedOutcome)}`;
+  item.tooltip = tooltip;
   return item;
 }
 
@@ -302,6 +324,7 @@ export class RunTreeProvider implements vscode.TreeDataProvider<RunNode> {
       return [];
     }
     log(`${pkg.root}: ${report.solutions.length} solution(s) in the last run.`);
-    return report.solutions.map((run): SolutionNode => ({ kind: 'solution', pkg, run }));
+    const solo = report.solutions.length === 1;
+    return report.solutions.map((run): SolutionNode => ({ kind: 'solution', pkg, run, solo }));
   }
 }

--- a/vscode/src/runTree.ts
+++ b/vscode/src/runTree.ts
@@ -11,20 +11,23 @@ import * as vscode from 'vscode';
 import { discoverPackages, packageLabel } from './discovery';
 import { log } from './log';
 import { PackageLayout } from './rbx/layout';
-import { expectedShortName, isAccepted, shortName } from './rbx/outcome';
-import { ArtifactStore, GroupRun, RunReport, SolutionRun, TestcaseRun } from './rbx/store';
+import { expectedShortName, isAccepted, isSkipped, shortName } from './rbx/outcome';
 import {
-  RunSummary,
-  failingGroups,
+  ArtifactStore,
+  GroupRun,
+  PackageRun,
+  SolutionRun,
+  TestcaseRun,
+} from './rbx/store';
+import {
+  Progress,
   formatCounts,
   formatMemory,
   formatScore,
   formatTime,
   groupDescription,
-  isComplete,
+  progressOf,
   solutionDescription,
-  summarizeGroup,
-  summarizeSolution,
 } from './rbx/summary';
 
 export type RunNode = PackageNode | SolutionNode | GroupNode | TestcaseNode;
@@ -68,10 +71,10 @@ function outcomeIcon(outcome: string | undefined): vscode.ThemeIcon {
     // interrupted. Indistinguishable in v1; both read as pending.
     return new vscode.ThemeIcon('circle-outline');
   }
-  if (outcome === 'accepted') {
+  if (isAccepted(outcome)) {
     return new vscode.ThemeIcon('pass', new vscode.ThemeColor('testing.iconPassed'));
   }
-  if (outcome === 'skipped') {
+  if (isSkipped(outcome)) {
     return new vscode.ThemeIcon('debug-step-over', new vscode.ThemeColor('testing.iconSkipped'));
   }
   return new vscode.ThemeIcon('error', new vscode.ThemeColor('testing.iconFailed'));
@@ -125,20 +128,46 @@ function testcaseItem(node: TestcaseNode): vscode.TreeItem {
   return item;
 }
 
-/** The aggregate lines both solution and group tooltips share. */
-function appendSummary(tooltip: vscode.MarkdownString, summary: RunSummary): void {
-  tooltip.appendMarkdown(`Verdict: **${shortName(summary.outcome)}**\n\n`);
-  if (summary.maxScore > 0 && isComplete(summary)) {
-    tooltip.appendMarkdown(`Score: ${formatScore(summary.score, summary.maxScore)}\n\n`);
+/**
+ * The aggregate tooltip lines, from rbx's report.
+ *
+ * `aggregates` is absent until the solution finishes -- rbx publishes the
+ * report per solution -- so mid-run the tooltip says how far it has got and
+ * nothing about verdicts.
+ */
+function appendSummary(
+  tooltip: vscode.MarkdownString,
+  aggregates:
+    | {
+        outcome?: string;
+        score: number;
+        maxScore: number;
+        maxTime?: number;
+        maxMemory?: number;
+      }
+    | undefined,
+  progress: Progress,
+  testcases: readonly TestcaseRun[],
+): void {
+  if (aggregates === undefined) {
+    tooltip.appendMarkdown(`Still running: ${progress.done}/${progress.total} tests\n`);
+    return;
   }
-  tooltip.appendMarkdown(`Tests: ${summary.done}/${summary.total}`);
-  if (summary.counts.size > 0) {
-    tooltip.appendMarkdown(` (${formatCounts(summary)})`);
+  tooltip.appendMarkdown(`Verdict: **${shortName(aggregates.outcome)}**\n\n`);
+  if (aggregates.maxScore > 0) {
+    tooltip.appendMarkdown(
+      `Score: ${formatScore(aggregates.score, aggregates.maxScore)}\n\n`,
+    );
+  }
+  tooltip.appendMarkdown(`Tests: ${progress.done}/${progress.total}`);
+  const counts = formatCounts(testcases);
+  if (counts !== '') {
+    tooltip.appendMarkdown(` (${counts})`);
   }
   tooltip.appendMarkdown('\n\n');
   // Max, not total: the slowest test is what the time limit is judged against.
-  tooltip.appendMarkdown(`Max time: ${formatTime(summary.time) ?? '-'}\n\n`);
-  tooltip.appendMarkdown(`Max memory: ${formatMemory(summary.memory) ?? '-'}\n`);
+  tooltip.appendMarkdown(`Max time: ${formatTime(aggregates.maxTime) ?? '-'}\n\n`);
+  tooltip.appendMarkdown(`Max memory: ${formatMemory(aggregates.maxMemory) ?? '-'}\n`);
 }
 
 function groupItem(node: GroupNode): vscode.TreeItem {
@@ -152,13 +181,17 @@ function groupItem(node: GroupNode): vscode.TreeItem {
   item.id = `${node.pkg.root}::${node.run.solution.index}::${node.group.name}`;
   item.contextValue = 'rbx.group';
 
-  const summary = summarizeGroup(node.group);
-  item.iconPath = outcomeIcon(summary.outcome);
-  item.description = groupDescription(summary);
+  const report = node.group.report;
+  const progress = progressOf(node.group.testcases);
+  item.iconPath = outcomeIcon(report?.outcome);
+  item.description = groupDescription(report, progress);
 
   const tooltip = new vscode.MarkdownString();
   tooltip.appendMarkdown(`**${node.group.name}**\n\n`);
-  appendSummary(tooltip, summary);
+  if (report?.expectedOutcome !== undefined) {
+    tooltip.appendMarkdown(`Expected: ${expectedShortName(report.expectedOutcome)}\n\n`);
+  }
+  appendSummary(tooltip, report, progress, node.group.testcases);
   item.tooltip = tooltip;
   return item;
 }
@@ -175,20 +208,21 @@ function solutionItem(node: SolutionNode): vscode.TreeItem {
   item.contextValue = 'rbx.solution';
   item.resourceUri = vscode.Uri.file(path.join(node.pkg.root, solution.path));
 
-  const summary = summarizeSolution(node.run);
-  item.iconPath = outcomeIcon(summary.outcome);
-  item.description = solutionDescription(summary, solution.expectedOutcome);
+  const report = node.run.report;
+  const testcases = node.run.groups.flatMap((group) => group.testcases);
+  const progress = progressOf(testcases);
+  item.iconPath = outcomeIcon(report?.outcome);
+  item.description = solutionDescription(report, progress);
 
   const tooltip = new vscode.MarkdownString();
   tooltip.appendMarkdown(`**${solution.path}**\n\n`);
+  // The skeleton's declared expectation, which is there even before the report.
   tooltip.appendMarkdown(`Expected: ${expectedShortName(solution.expectedOutcome)}\n\n`);
-  appendSummary(tooltip, summary);
-  const failing = failingGroups(node.run);
-  if (failing.length > 0) {
-    const names = failing
-      .map((group) => `${group.name} (${shortName(summarizeGroup(group).outcome)})`)
-      .join(', ');
-    tooltip.appendMarkdown(`\nFailing groups: ${names}\n`);
+  appendSummary(tooltip, report, progress, testcases);
+  // rbx names the groups that missed their own expectation; which layer caught
+  // the solution -- pooled or per-group -- is its call, already made.
+  if (report !== undefined && report.failedGroups.length > 0) {
+    tooltip.appendMarkdown(`\nFailing groups: ${report.failedGroups.join(', ')}\n`);
   }
   item.tooltip = tooltip;
   return item;
@@ -258,7 +292,7 @@ export class RunTreeProvider implements vscode.TreeDataProvider<RunNode> {
     return store;
   }
 
-  report(pkg: PackageLayout): Promise<RunReport | undefined> {
+  report(pkg: PackageLayout): Promise<PackageRun | undefined> {
     return this.storeFor(pkg).load();
   }
 


### PR DESCRIPTION
Follow-up to #650. Two related changes: the run tree gained summaries, then stopped computing them.

## 1. Expansion and summaries

The tree expanded every solution on load, so a package with a dozen solutions opened as a wall of testcases. It now expands a solution only when the run covered just that one — the same condition `rbx run` uses to pick `SingleSolutionRunReporter` (`rbx/box/solutions.py:2870`). Groups stay expanded, so opening a solution lands on its breakdown.

Solution and group rows carried a verdict short name and nothing else. They now show the verdict, points earned, and the **max** time and memory across their testcases, in rbx's own units (`120 ms`, `32 MiB`).

## 2. That logic belongs in Python

Writing those summaries meant porting `Outcome.worst_outcome()`, `ExpectedOutcome.match()` and a scoring approximation into TypeScript — on top of the ~888 lines of `vscode/src/rbx/` already mirroring Python, with **no test anywhere comparing the two**. Nothing failed if `Outcome` gained a member.

It turned out rbx already computes all of it. `get_solution_outcome_report()` (`solutions.py:1877`, ~156 lines) builds a `SolutionOutcomeReport` with the verdict, per-group expectation results and `gotScorePerGroup` — dependency-gated via `_check_deps` — and then **discards it**. That is the only reason the extension ever had to re-derive anything.

So rbx now publishes it. New `rbx/box/run_report.py` projects it onto a lean, versioned, **structured** shape (enum values, seconds, bytes — no `AC`, no `120 ms`, no `[70/100 pts]`; formatting stays in the client) and writes `.rbx/runs/report.yml` once per solution as it finishes, from the hook both reporters share and from the `--detailed` path. A new skeleton clears it, so absence means "nothing finished yet", never "stale".

**Deleted from TypeScript:** the outcome ranking, `worstOutcome`, `matches`, `isSlow`, and all of `summary.ts`'s aggregation and scoring. `outcome.ts` went 178 → 68 lines. What remains is display and a count of `.eval` files on disk. Line count barely moved (858 vs 888) because `report.ts` replaced it — but the remaining mirror is *field names*, which fail loudly, rather than *decisions*, which drift silently.

### This fixes a bug rather than documenting it

The scoring approximation I shipped in the first commit ignored `_check_deps` — a known over-report on problems with group dependencies. Reading `gotScorePerGroup` makes it cease to exist. There's a regression test (`test_score_honours_group_dependencies`).

### And surfaces something the extension could not see

It only ever read the pooled `solution.outcome`, so a solution caught by its `outcomePerGroup` expectations alone looked fine. `report.yml` carries per-group results, so `sols/mislabeled.cpp` now reads `WA · failed small, big` — naming the groups rather than the pooled `INCORRECT`, which it does satisfy.

## Accepted cost

rbx writes the report per solution, so **a solution still running shows `12/40` and no verdict.** Per-group and per-testcase write granularity were both rejected (D4). Testcase rows still fill in live from their own `.eval` files. A client-side "worst so far" is exactly the duplication this removes.

## Verification

- 8 new Python tests (`tests/rbx/box/run_report_test.py`), including enum-coverage tests so a new `Outcome` fails a test instead of silently rendering `XX` in an editor nobody tests.
- `vscode/` had no test setup; this adds one (`node --test` over esbuild-compiled sources, `npm test` / `mise run vscode:test`) and 21 tests.
- 86 Python tests pass (`run_report_test`, `solutions_test`, `internal`); `ruff check` and `format --check` clean.
- `npm run typecheck`, `npm test` (21/21), `npm run compile` all pass.
- Checked against real runs. `tests/e2e/testdata/outcome-per-group` (scored, 3 solutions) renders exactly what `rbx run` printed:

```
sols/main.cpp          AC · [100/100 pts] · 9 ms · 11 MiB
  small                AC · [40/40 pts] · 9 ms · 10 MiB
  big                  AC · [60/60 pts] · 9 ms · 11 MiB
sols/partial.cpp       WA · [40/100 pts] · 13 ms · 10 MiB
  small                AC · [40/40 pts] · 13 ms · 10 MiB
  big                  WA · [0/60 pts] · 9 ms · 10 MiB
sols/mislabeled.cpp    WA · failed small, big · [40/100 pts] · 13 ms · 10 MiB
  small                expected TLE, got AC · [40/40 pts] · 13 ms · 10 MiB
  big                  expected TLE, got WA · [0/60 pts] · 9 ms · 10 MiB
```

  Also confirmed: rerunning with one solution flips to solo/expanded and clears the stale 3-solution report; `rbx run -d` writes the report; `rbx/testdata/problems/box1` (binary scoring) renders no points at all.

There is no CI for the extension, by design (`mise.toml`).

## Notes

- Shelling out to rbx was considered and rejected. Beyond D2's original reasoning, `rbx/box/cli.py:198-207` `rmtree`s `build/` and `.rbx/` on a cache-fingerprint mismatch — a version-skewed rbx invoked by the extension would destroy the user's cache, not merely race it. Noted in the v1 design doc.
- Publishing JSON schemas for these models is left out of scope. Worth a follow-up: `utils.model_to_yaml` already stamps every `skeleton.yml` with `$schema=.../SolutionReportSkeleton.json`, which is never generated — a dangling URL in shipped fixtures today.
- Pre-existing, not from this change: `box1`'s skeleton lists 5 entries for group `gen1` but rbx writes only 2 `.eval` files, so that package sits at `2/5`. rbx's own live output shows the same two indices.

Design: [`2026-08-16-run-report-artifact-design.md`](docs/plans/2026-08-16-run-report-artifact-design.md) · Plan: [`2026-08-16-run-report-artifact.md`](docs/plans/2026-08-16-run-report-artifact.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
