### PR TITLE
perf(cache): stop re-deriving what a cache hit already knows

### DIFF
--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -240,7 +240,7 @@ async def _build_cache_input(
                 # Key on content, not on the absolute path. Two byte-identical
                 # files are interchangeable: the compiler command references
                 # `dest`, which stays in the key, so nothing is lost.
-                inferred_digest = digester.digest_file(input.src)
+                inferred_digest = digester.digest_file_memoized(input.src)
             if inferred_digest is not None:
                 # Consume cache from digest instead of file.
                 input.digest = DigestHolder(value=inferred_digest)
@@ -337,6 +337,7 @@ class DependencyCacheBlock:
         self.artifact_list = artifact_list
         self.extra_params = extra_params
         self._key = None
+        self._hit = False
 
     async def __aenter__(self):
         with Profiler('enter_in_cache'):
@@ -356,13 +357,17 @@ class DependencyCacheBlock:
             found = await self.cache.find_in_cache(
                 self.commands, self.artifact_list, self.extra_params, key=self._key
             )
+            self._hit = found
             return found
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         with Profiler('exit_in_cache'):
             if grading_context.is_no_cache():
                 return True if exc_type is NoCacheException else None
-            if exc_type is None:
+            if exc_type is None and not self._hit:
+                # On a hit, `find_in_cache` already validated every fingerprint
+                # it would rewrite, so re-storing is a pure duplicate of the
+                # read path.
                 await self.cache.store_in_cache(
                     self.commands, self.artifact_list, self.extra_params, key=self._key
                 )
@@ -423,13 +428,15 @@ class DependencyCache:
         key: Optional[str] = None,
     ) -> bool:
         async with self.lock:
-            input = await _build_cache_input(
-                commands=commands,
-                artifact_list=artifact_list,
-                extra_params=extra_params,
-                cacher=self.cacher,
-            )
-            key = key or _build_cache_key(input)
+            if key is None:
+                key = _build_cache_key(
+                    await _build_cache_input(
+                        commands=commands,
+                        artifact_list=artifact_list,
+                        extra_params=extra_params,
+                        cacher=self.cacher,
+                    )
+                )
 
             fingerprint = self._find_in_cache(key)
             if fingerprint is None:
@@ -498,13 +505,15 @@ class DependencyCache:
         key: Optional[str] = None,
     ):
         async with self.lock:
-            input = await _build_cache_input(
-                commands=commands,
-                artifact_list=artifact_list,
-                extra_params=extra_params,
-                cacher=self.cacher,
-            )
-            key = key or _build_cache_key(input)
+            if key is None:
+                key = _build_cache_key(
+                    await _build_cache_input(
+                        commands=commands,
+                        artifact_list=artifact_list,
+                        extra_params=extra_params,
+                        cacher=self.cacher,
+                    )
+                )
 
             if not await are_artifacts_ok(artifact_list, self.cacher):
                 return

--- a/rbx/grading/judge/digester.py
+++ b/rbx/grading/judge/digester.py
@@ -1,6 +1,6 @@
 import hashlib
 import pathlib
-from typing import IO
+from typing import IO, Dict, Tuple
 
 
 class Digester:
@@ -36,3 +36,26 @@ def digest_cooperatively(f: IO[bytes], chunk_size: int = 2**20):
 def digest_file(path: pathlib.Path):
     with open(path, 'rb') as f:
         return digest_cooperatively(f)
+
+
+_DIGEST_MEMO: Dict[Tuple[str, int, int, int, int], str] = {}
+
+
+def digest_file_memoized(path: pathlib.Path) -> str:
+    """Digest a file, reusing the result while its stat signature is unchanged.
+
+    The same path is hashed many times within a single invocation (every
+    compilation re-keys on the precompiled headers, which are hundreds of
+    megabytes). Keying on identity + size + mtime keeps that to once.
+    """
+    try:
+        st = path.stat()
+    except OSError:
+        return digest_file(path)
+    key = (str(path), st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+    memoized = _DIGEST_MEMO.get(key)
+    if memoized is not None:
+        return memoized
+    digest = digest_file(path)
+    _DIGEST_MEMO[key] = digest
+    return digest


### PR DESCRIPTION
## Summary

A fully cached `rbx run` spent **65% of its time inside the cache machinery**, and nearly all of it was re-deriving things it already knew. This fixes three sources of pure duplicate work in `DependencyCache`. The high-level design is untouched — repopulating artifacts from the cache stays exactly as it is.

The notable twist from profiling: **re-materializing cached files is the cheapest thing in the path (0.06s)**. The cost was never the repopulation, it was the bookkeeping around it.

| benchmark (fully warm) | before | after |
| --- | --- | --- |
| 100 testcases × 2 solutions (830 cached steps) | 5.48s | **2.82s** |
| 10 testcases × 2 solutions | 2.81s | **1.33s** |
| SHA-1 read per warm run | 4.5 GB | 252 MB |

## What was wrong

**1. Every compilation re-hashed 250 MB of precompiled headers (1.81s).**

To build a cache key, `_build_cache_input` content-addresses each input, first trying `cacher.digest_from_symlink(src)` and falling back to a full SHA-1. For `stdc++.h.gch` (162 MB) and `rbx.h.gch` (88 MB) the shortcut *always* missed, so both were hashed in full, once per compilation block, 18× per run:

```
4,508 MB hashed · 285 digest_file calls · 1.81s
  1.129s  n=18  2915 MB  .storage/2426c90c…  stdc++.h.gch
  0.616s  n=18  1584 MB  .storage/e897fee8…  rbx.h.gch
```

It missed for two structural reasons. `path_for_symlink()` hands back the *real* storage file rather than a symlink, so `filename_from_symlink()` bails on its `is_symlink()` check — even though the file's own name **is** its digest. And the header is produced by the **global** cacher but consumed by the **package** cacher, so no single storage could have recognized the path anyway.

Fixed by memoizing on the file's stat signature (path, dev, inode, size, mtime-ns), which is agnostic to which storage owns the file.

**2. The cache input was built three times per step.**

`__aenter__` deep-copies every artifact, hashes every input and serializes a key — then calls `find_in_cache(..., key=self._key)`, which rebuilds the whole input from scratch and *discards* it because the key was already supplied. `store_in_cache` built it a third time. 830 cache blocks produced **2,490** `_build_cache_input` calls; now 830.

**3. Every cache hit immediately rewrote itself into the cache (1.12s).**

On a hit, `__aexit__` still ran the full store path: rebuild the input, re-verify every artifact, re-hash every tracked output into a fresh fingerprint, write to SQLite and commit — 830 times, producing the value that had just been read. `find_in_cache` has already validated everything that store would rewrite.

## Where the time goes now

Non-overlapping buckets, measured in-process with `perf_counter` (excludes ~0.6s interpreter startup):

| bucket | before | after |
| --- | --- | --- |
| cache lookup | 1.86s | 0.70s |
| cache re-store on hit | 1.12s | 0.00s |
| rewriting `.eval` YAML | 0.39s | 0.39s |
| everything else | 1.20s | 1.32s |
| **total** | **4.56s** | **2.41s** |

Cache machinery went from 65% to 29% of the run.

## Verification

- Full suite `tests/rbx --ignore=tests/rbx/box/cli`: **4,536 passed / 35 failed — byte-identical to the clean tree** (all 35 are the known pre-existing local C++/sandbox failures; confirmed by running the same suite on `main` with these changes stashed).
- Hit rate unchanged: `rbx --profiling run` reports 812 cached runs / 0 uncached, before and after.
- Invalidation intact: a semantic edit to a solution re-runs exactly **408** steps and keeps **404** cached — the identical split on both the patched and clean tree. A comment-only edit correctly recompiles but keeps all runs cached, since the binary is byte-identical.
- `ruff check` / `ruff format` clean.

## Follow-ups (not in this PR)

Profiling surfaced a few more, worth separate PRs:

1. **Lazy-import the heavy CLI tail** — `import rbx.box.cli` costs 464ms and pulls in Textual, the BOCA scraper, bs4, GitPython and prompt_toolkit, none of which `rbx run` touches. That is now 44% of the 10-test warm run, and the biggest remaining lever.
2. **Stop rewriting `.eval` YAML on a hit** — 613 serializations per run reproducing identical files (~0.39s).
3. **Carry the known digest instead of a path** — `precompile_header` holds `precompiled_digest.value` and discards it by passing a path. A trusted-digest field on `GradingFileInput` takes the last 252 MB to zero and stops the memo being load-bearing.
4. **One SQLite query per lookup** — `sqlitedict.get` issues `__contains__` then `__getitem__`, 1,660 queries for 830 lookups.
5. **`rbx --profiling` prints means rounded to 2dp**, so every row reads `0.00`. Totals + counts would make the flag actually usable for this kind of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
