### PR TITLE
perf(run): cut warm run-phase overhead by ~27%

### DIFF
--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -63,7 +63,7 @@ def get_testcase_output_path(
     return output_dir / pathlib.PosixPath(stem).with_suffix('.out')
 
 
-def write_evaluation(eval: Evaluation, output_path: pathlib.Path) -> None:
+def write_evaluation(eval: Evaluation, output_path: pathlib.Path) -> str:
     """Persist `eval` to its `.eval` artifact and point its log at the result.
 
     The run explorer never sees the in-memory evaluations: it reads these files,
@@ -74,7 +74,11 @@ def write_evaluation(eval: Evaluation, output_path: pathlib.Path) -> None:
     eval_path = output_path.with_suffix('.eval')
     eval.log.eval_absolute_path = eval_path.absolute()
     eval_path.parent.mkdir(parents=True, exist_ok=True)
-    eval_path.write_text(model_to_yaml(eval))
+    rendered = model_to_yaml(eval)
+    eval_path.write_text(rendered)
+    # The `.log` artifact next to it is byte-identical, so hand the rendered
+    # text back rather than paying for a second dump of the same object.
+    return rendered
 
 
 def _check_stderr(solution: CodeItem, stderr_path: pathlib.Path):
@@ -220,8 +224,7 @@ async def run_solution_on_testcase(
             ),
         )
 
-        write_evaluation(eval, output_path)
-        log_path.write_text(model_to_yaml(eval))
+        log_path.write_text(write_evaluation(eval, output_path))
         return eval
 
     if not use_retries:
@@ -406,8 +409,7 @@ async def _run_communication_solution_on_testcase(
             ),
         )
 
-        write_evaluation(eval, output_path)
-        log_path.write_text(model_to_yaml(eval))
+        log_path.write_text(write_evaluation(eval, output_path))
         interactor_log_path = output_path.with_suffix('.int.log')
         interactor_log_path.unlink(missing_ok=True)
         if interactor_run_log is not None:

--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -384,9 +384,11 @@ class DependencyCache:
     def __init__(self, root: pathlib.Path, cacher: FileCacher):
         self.root = root
         self.cacher = cacher
-        self.db = SqliteDict(self._cache_name(), autocommit=True)
+        self.db = SqliteDict(self._cache_name(), autocommit=True, outer_stack=False)
         tmp_dir = pathlib.Path(tempfile.mkdtemp())
-        self.transient_db = SqliteDict(str(tmp_dir / '.cache_db'), autocommit=True)
+        self.transient_db = SqliteDict(
+            str(tmp_dir / '.cache_db'), autocommit=True, outer_stack=False
+        )
         self.lock = make_async_file_lock(self.root / 'cache.lock')
         atexit.register(lambda: self.db.close())
         atexit.register(lambda: self.transient_db.close())

--- a/rbx/grading/judge/storage.py
+++ b/rbx/grading/judge/storage.py
@@ -1,6 +1,7 @@
 import dataclasses
 import io
 import logging
+import os
 import pathlib
 import tempfile
 import typing
@@ -257,25 +258,24 @@ class FilesystemStorage(Storage):
 
     async def get_file(self, filename: str) -> IO[bytes]:
         """See FileCacherBackend.get_file()."""
-        async with self.lock:
-            file_path = self.path / filename
+        file_path = self.path / filename
 
-            if not file_path.is_file():
-                raise KeyError('File not found.')
+        if not file_path.is_file():
+            raise KeyError('File not found.')
 
-            compression_metadata = await self.get_metadata(
-                filename, 'compression', CompressionMetadata
+        compression_metadata = await self.get_metadata(
+            filename, 'compression', CompressionMetadata
+        )
+        if compression_metadata is not None:
+            return typing.cast(
+                IO[bytes],
+                lz4.frame.open(
+                    file_path,
+                    mode='rb',
+                    compression_level=compression_metadata.compression_level,
+                ),
             )
-            if compression_metadata is not None:
-                return typing.cast(
-                    IO[bytes],
-                    lz4.frame.open(
-                        file_path,
-                        mode='rb',
-                        compression_level=compression_metadata.compression_level,
-                    ),
-                )
-            return file_path.open('rb')
+        return file_path.open('rb')
 
     async def create_file(self, filename: str) -> Optional[PendingFile]:
         """See FileCacherBackend.create_file()."""
@@ -353,7 +353,18 @@ class FilesystemStorage(Storage):
         else:
             metadata_path = self._get_metadata_path(filename, key)
             metadata_path.parent.mkdir(parents=True, exist_ok=True)
-            metadata_path.write_text(value.model_dump_json())
+            # Write through a temporary and rename, so a concurrent reader
+            # never observes a half-written sidecar. This is what lets the
+            # read paths below run without taking the lock.
+            with tempfile.NamedTemporaryFile(
+                'w',
+                delete=False,
+                dir=metadata_path.parent,
+                prefix=f'.tmp.{metadata_path.name}.',
+            ) as f:
+                f.write(value.model_dump_json())
+                tmp_name = f.name
+            os.replace(tmp_name, metadata_path)
 
     async def set_metadata(self, filename: str, key: str, value: Optional[BaseModel]):
         async with self.lock:
@@ -365,37 +376,31 @@ class FilesystemStorage(Storage):
     async def get_metadata(
         self, filename: str, key: str, model_cls: Type[BaseModelT]
     ) -> Optional[BaseModelT]:
-        async with self.lock:
-            path = self._get_metadata_path(filename, key)
-            if not path.is_file():
-                return None
-            return model_cls.model_validate_json(path.read_text())
+        path = self._get_metadata_path(filename, key)
+        if not path.is_file():
+            return None
+        return model_cls.model_validate_json(path.read_text())
 
     async def list_metadata(self, filename: str) -> List[str]:
-        async with self.lock:
-            return [
-                path.stem.split('__')[1]
-                for path in sorted(
-                    (self.path / '.metadata').glob(f'{filename}__*.json')
-                )
-            ]
+        return [
+            path.stem.split('__')[1]
+            for path in sorted((self.path / '.metadata').glob(f'{filename}__*.json'))
+        ]
 
     async def exists(self, filename: str) -> bool:
         """See FileCacherBackend.exists()."""
-        async with self.lock:
-            file_path: pathlib.Path = self.path / filename
+        file_path: pathlib.Path = self.path / filename
 
-            return file_path.is_file()
+        return file_path.is_file()
 
     async def get_size(self, filename: str) -> int:
         """See FileCacherBackend.get_size()."""
-        async with self.lock:
-            file_path: pathlib.Path = self.path / filename
+        file_path: pathlib.Path = self.path / filename
 
-            if not file_path.is_file():
-                raise KeyError('File not found.')
+        if not file_path.is_file():
+            raise KeyError('File not found.')
 
-            return file_path.stat().st_size
+        return file_path.stat().st_size
 
     async def delete(self, filename: str):
         """See FileCacherBackend.delete()."""
@@ -408,71 +413,68 @@ class FilesystemStorage(Storage):
 
     async def list(self) -> List[FileWithMetadata]:
         """See FileCacherBackend.list()."""
-        async with self.lock:
-            res = []
-            for path in self.path.glob('*'):
-                if not path.is_file():
-                    continue
-                filename = str(path.relative_to(self.path))
-                res.append(
-                    FileWithMetadata(
-                        filename=filename,
-                        metadata=await self.list_metadata(filename),
-                    )
+        res = []
+        for path in self.path.glob('*'):
+            if not path.is_file():
+                continue
+            filename = str(path.relative_to(self.path))
+            res.append(
+                FileWithMetadata(
+                    filename=filename,
+                    metadata=await self.list_metadata(filename),
                 )
-            return res
+            )
+        return res
 
     async def path_for_symlink(self, filename: str) -> Optional[pathlib.Path]:
-        async with self.lock:
-            file_path = self.path / filename
-            if not file_path.is_file():
-                raise KeyError('File not found.')
+        file_path = self.path / filename
+        if not file_path.is_file():
+            raise KeyError('File not found.')
 
-            compression_metadata = await self.get_metadata(
-                filename, 'compression', CompressionMetadata
-            )
-            if compression_metadata is not None:
-                return None
-            return file_path
+        compression_metadata = await self.get_metadata(
+            filename, 'compression', CompressionMetadata
+        )
+        if compression_metadata is not None:
+            return None
+        return file_path
 
     async def filename_from_symlink(self, link: pathlib.Path) -> Optional[str]:
-        async with self.lock:
-            if not link.is_symlink():
+        if not link.is_symlink():
+            return None
+
+        # Track visited symlinks to detect circular references
+        visited = set()
+        current = link
+        max_depth = 100  # Reasonable limit to prevent infinite loops
+        depth = 0
+
+        while current.is_symlink() and depth < max_depth:
+            # Convert to absolute path for consistent comparison
+            abs_current = utils.abspath(current)
+
+            # Check for circular reference
+            if abs_current in visited:
                 return None
 
-            # Track visited symlinks to detect circular references
-            visited = set()
-            current = link
-            max_depth = 100  # Reasonable limit to prevent infinite loops
-            depth = 0
+            visited.add(abs_current)
 
-            while current.is_symlink() and depth < max_depth:
-                # Convert to absolute path for consistent comparison
-                abs_current = utils.abspath(current)
+            # Read the target of the symlink
+            target = current.readlink()
 
-                # Check for circular reference
-                if abs_current in visited:
-                    return None
+            # If target is relative, resolve it relative to the symlink's parent directory
+            if not target.is_absolute():
+                current = utils.abspath(current.parent / target)
+            else:
+                current = utils.abspath(target)
 
-                visited.add(abs_current)
+            depth += 1
 
-                # Read the target of the symlink
-                target = current.readlink()
+        # If we hit the depth limit, assume circular reference
+        if depth >= max_depth:
+            return None
 
-                # If target is relative, resolve it relative to the symlink's parent directory
-                if not target.is_absolute():
-                    current = utils.abspath(current.parent / target)
-                else:
-                    current = utils.abspath(target)
-
-                depth += 1
-
-            # If we hit the depth limit, assume circular reference
-            if depth >= max_depth:
-                return None
-
-            if not current.is_file():
-                return None
-            if not current.is_relative_to(self.path):
-                return None
-            return str(current.relative_to(self.path))
+        if not current.is_file():
+            return None
+        if not current.is_relative_to(self.path):
+            return None
+        return str(current.relative_to(self.path))

--- a/rbx/utils.py
+++ b/rbx/utils.py
@@ -345,6 +345,10 @@ def uploaded_schema_path(model: Type[BaseModel]) -> str:
     return f'https://rsalesc.github.io/rbx/schemas/{model.__name__}.json'
 
 
+# libyaml-backed emitter when available: same output, several times faster.
+_SAFE_DUMPER = getattr(yaml, 'CSafeDumper', yaml.SafeDumper)
+
+
 def model_to_yaml(
     model: BaseModel, root: Optional[pathlib.Path] = None, **kwargs
 ) -> str:
@@ -366,8 +370,12 @@ def model_to_yaml(
     path = schema_url(model.__class__, root or pathlib.Path())
     schema_comment = f'# yaml-language-server: $schema={path}\n\n'
 
-    yaml_content = yaml.safe_dump(
-        json_safe_data, sort_keys=False, allow_unicode=True, **kwargs
+    yaml_content = yaml.dump(
+        json_safe_data,
+        Dumper=_SAFE_DUMPER,
+        sort_keys=False,
+        allow_unicode=True,
+        **kwargs,
     )
 
     return schema_comment + yaml_content


### PR DESCRIPTION
## Summary

Four independent costs on the **warm run path**, none of which are the actual work. Measured on a 100-testcase package with two solutions (830 cached steps), fully warm:

| | before | after |
| --- | --- | --- |
| in-process wall (min-of-5) | 2.303s | **1.674s** (−27%) |
| end-to-end incl. interpreter startup | 2.795s | **2.141s** (−23%) |
| cache lookup | 0.684s | 0.446s |
| evaluation YAML | 0.387s | 0.066s |

Nothing here changes the caching design or any on-disk artifact.

## The four changes

**1. `model_to_yaml` used pyyaml's pure-Python emitter.**

`yaml.safe_dump` was 79% of every evaluation dump. libyaml's `CSafeDumper` is ~4.7× faster and produces **byte-identical** output — verified across quoting, unicode, multiline scalars, nesting, long keys and ambiguous strings (`'007'`, `'a: b'`, `'- x'`). Falls back to `yaml.SafeDumper` via `getattr` when libyaml is unavailable.

```
safe_dump 217.6us   CSafeDumper 46.0us   speedup 4.7x
byte-identical on all samples: True
```

**2. Every evaluation was serialized twice.**

`tasks.py` wrote `.eval` via `write_evaluation` and then `.log` via a second `model_to_yaml(eval)` of the *same* object. They are byte-identical by construction: `write_evaluation` mutates `eval.log.eval_absolute_path` and dumps, and the `.log` dump happens afterwards from the same unmodified object. `write_evaluation` now returns the rendered string and the caller writes both files from it. 613 → 307 dumps per run.

**3. `SqliteDict` defaults to `outer_stack=True`.**

That runs `traceback.extract_stack()` on **every query**, `linecache`-resolving every frame — from a ~40-frame async stack, 830 times per run. Measured 208 µs/get with it, 62 µs without. Set `outer_stack=False` on both the persistent and transient DBs.

**4. `FilesystemStorage` took an flock around every read.**

Every `exists`, `get_metadata`, `path_for_symlink`, `filename_from_symlink` etc. acquired a file lock — 7 syscalls, ~35 µs each — on a **content-addressed store whose data files are immutable and committed via atomic rename**. Reads need no lock.

The one thing that wasn't already atomic was the metadata sidecar (`write_text`), so `_set_metadata` now writes through a `NamedTemporaryFile` in the same directory and `os.replace`s it. That is what makes the lock-free read path safe, and it's called out in a comment.

Locks remain on exactly the four write paths: `create_file`, `commit_file`, `set_metadata`, `delete`.

## Verification

- `tests/rbx --ignore=tests/rbx/box/cli`: **4,536 passed / 35 failed — identical to the clean tree** (the 35 are the known pre-existing local C++/sandbox failures; confirmed by stashing these changes and re-running).
- Cache hit rate unchanged: `rbx --profiling run` reports 812 cached / 0 uncached, before and after.
- `ruff check` / `ruff format` clean.
- Benchmarks were min-of-5 because wall-clock noise on this machine is ±0.15s; the in-process instrumentation is stable to ~±0.02s.

## What this deliberately does *not* touch

Profiling the same package uncached showed the run phase is **not** overhead-bound — rbx's per-run wall (p50 10.19 ms) is essentially identical to spawning the same binary with bare `subprocess.Popen` (p50 10.75 ms). The remaining wins there are structural, and are filed separately:

- the evaluation phase runs at a measured concurrency of exactly 1.00 while the build phase runs at 4.09
- the `LiveRunReporter` rebuilds its whole group line on every testcase
- the limits profile is re-parsed from YAML per testcase
- `is_artifact_ok` returns after checking only the first digest output
- `GradingFileInput.symlink` is ignored for non-executable inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
