### PR TITLE
fix(cache): validate every hashed output in is_artifact_ok

### DIFF
--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -301,7 +301,7 @@ async def is_artifact_ok(artifact: GradingArtifacts, cacher: FileCacher) -> bool
                 output.digest.value
             ):
                 return False
-            return True
+            continue
         assert output.dest is not None
         file_path: pathlib.Path = artifact.root / output.dest
         if not file_path.is_file():

--- a/tests/rbx/grading/caching_test.py
+++ b/tests/rbx/grading/caching_test.py
@@ -1,11 +1,12 @@
 import pathlib
 import sys
 
-from rbx.grading import steps_with_caching
+from rbx.grading import caching, steps_with_caching
 from rbx.grading.caching import DependencyCache
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.judge.sandbox import SandboxBase, SandboxParams
 from rbx.grading.steps import (
+    DigestHolder,
     GradingArtifacts,
     GradingFileInput,
     GradingFileOutput,
@@ -82,3 +83,80 @@ async def test_cache_misses_when_content_differs(
     assert (cleandir / 'out-b.txt').read_text().strip() == '8'
     assert artifacts.logs is not None
     assert not artifacts.logs.cached
+
+
+async def _run_with_hashed_outputs(
+    src: pathlib.Path,
+    sandbox: SandboxBase,
+    dependency_cache: DependencyCache,
+) -> GradingArtifacts:
+    # Mirrors how a solution run is declared: both stdout and stderr are
+    # captured as hashed outputs.
+    artifacts = GradingArtifacts()
+    artifacts.inputs.append(
+        GradingFileInput(src=src, dest=pathlib.Path('executable.py'))
+    )
+    artifacts.outputs.append(
+        GradingFileOutput(src=pathlib.Path('box-out.txt'), digest=DigestHolder())
+    )
+    artifacts.outputs.append(
+        GradingFileOutput(src=pathlib.Path('box-err.txt'), digest=DigestHolder())
+    )
+    await steps_with_caching.run(
+        f'{sys.executable} executable.py',
+        params=SandboxParams(
+            stdout_file=pathlib.Path('box-out.txt'),
+            stderr_file=pathlib.Path('box-err.txt'),
+        ),
+        sandbox=sandbox,
+        artifacts=artifacts,
+        dependency_cache=dependency_cache,
+        metadata=RunLogMetadata(),
+    )
+    return artifacts
+
+
+async def test_is_artifact_ok_checks_every_hashed_output(file_cacher: FileCacher):
+    present = await file_cacher.put_file_text('present')
+    missing = await file_cacher.put_file_text('missing')
+    await file_cacher.delete(missing)
+
+    artifacts = GradingArtifacts()
+    artifacts.outputs.append(
+        GradingFileOutput(
+            src=pathlib.Path('box-out.txt'), digest=DigestHolder(value=present)
+        )
+    )
+    artifacts.outputs.append(
+        GradingFileOutput(
+            src=pathlib.Path('box-err.txt'), digest=DigestHolder(value=missing)
+        )
+    )
+
+    assert not await caching.is_artifact_ok(artifacts, file_cacher)
+
+
+async def test_cache_misses_when_a_later_hashed_output_is_gone_from_storage(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    src = cleandir / 'executable.py'
+    src.write_text('import sys; print(7); print(8, file=sys.stderr)')
+
+    first = await _run_with_hashed_outputs(src, sandbox, dependency_cache)
+    stderr_digest = first.outputs[1].digest
+    assert stderr_digest is not None and stderr_digest.value is not None
+
+    # The .err blob vanishes from the content store -- a partial clean, an
+    # interrupted write, a storage directory copied between machines.
+    await file_cacher.delete(stderr_digest.value)
+
+    second = await _run_with_hashed_outputs(src, sandbox, dependency_cache)
+
+    assert second.logs is not None
+    assert not second.logs.cached
+    for output in second.outputs:
+        assert output.digest is not None and output.digest.value is not None
+        assert await file_cacher.exists(output.digest.value)


### PR DESCRIPTION
Closes #659.

`is_artifact_ok` returned from inside its loop: once any digest-bearing output validated, every remaining output — digest- or path-bearing — was skipped. The `return True` is now a `continue`.

A solution run declares two hashed outputs, stdout and stderr, so only stdout was ever checked. A missing `.err` blob (partial `rbx clean`, interrupted write, storage copied between machines) left the entry looking intact, so the cache served it and `_copy_hashed_files` then failed to materialize a digest that wasn't there. The same shape applied to any artifact with several outputs.

This is a correctness fix, not a perf one — `cacher.exists` now runs once per hashed output instead of once per lookup, which very slightly increases cache-lookup cost. That is the correct trade.

## Tests

Two new tests in `tests/rbx/grading/caching_test.py`, both verified to fail without the fix:

- `test_is_artifact_ok_checks_every_hashed_output` — two digest outputs, the second blob deleted; asserts the artifact is not OK.
- `test_cache_misses_when_a_later_hashed_output_is_gone_from_storage` — end-to-end: run with hashed stdout+stderr, delete the stderr blob, re-run; asserts a cache miss and that both blobs exist afterwards.

`tests/rbx/grading` passes (396 passed, 1 skipped). The remaining failures in the wider `tests/rbx` run are pre-existing locally on the base commit (C++/sandbox validator tests, `walltime_test`) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)