### PR TITLE
feat(vscode): give each verdict its own icon in the run view

### DIFF
--- a/vscode/src/rbx/outcome.test.ts
+++ b/vscode/src/rbx/outcome.test.ts
@@ -1,0 +1,49 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import { outcomeIcon, shortName } from './outcome';
+
+// The colors are asserted against the CLI palette in
+// `get_outcome_style_verdict` (rbx/box/solutions.py) rather than against
+// "green means good": the two views are read side by side, so a verdict that
+// is yellow in the terminal must not be red in the tree.
+const CLI_PALETTE: Record<string, string> = {
+  accepted: 'charts.green',
+  'wrong-answer': 'charts.red',
+  'time-limit-exceeded': 'charts.yellow',
+  'idleness-limit-exceeded': 'charts.yellow',
+  'memory-limit-exceeded': 'charts.yellow',
+  'output-limit-exceeded': 'charts.orange',
+  'runtime-error': 'charts.blue',
+  'compilation-error': 'charts.blue',
+  'judge-failed': 'charts.purple',
+  'internal-error': 'charts.purple',
+  skipped: 'descriptionForeground',
+};
+
+test('every outcome carries the color the CLI prints it in', () => {
+  for (const [outcome, color] of Object.entries(CLI_PALETTE)) {
+    assert.strictEqual(outcomeIcon(outcome).color, color, outcome);
+  }
+});
+
+test('every outcome gets its own codicon', () => {
+  const icons = Object.keys(CLI_PALETTE).map((o) => outcomeIcon(o).icon);
+  assert.strictEqual(new Set(icons).size, icons.length, icons.join(','));
+});
+
+test('an unevaluated testcase reads as pending, not as a failure', () => {
+  assert.deepStrictEqual(outcomeIcon(undefined), {
+    icon: 'circle-outline',
+    color: 'descriptionForeground',
+  });
+});
+
+test('an outcome rbx grew after this extension shipped is not called a pass', () => {
+  // Same fallback `shortName` takes: unknown is unknown, never green.
+  assert.strictEqual(shortName('teleported'), 'XX');
+  assert.deepStrictEqual(outcomeIcon('teleported'), {
+    icon: 'question',
+    color: 'charts.purple',
+  });
+});

--- a/vscode/src/rbx/outcome.ts
+++ b/vscode/src/rbx/outcome.ts
@@ -19,26 +19,96 @@
  *     typed, and not the `Outcome` spelling either.
  */
 
-/** Mirrors `Outcome.short_name()`; unknown values render `XX`, as rbx does. */
-const SHORT_NAMES: Record<string, string> = {
-  accepted: 'AC',
-  skipped: 'SKIP',
-  'wrong-answer': 'WA',
-  'time-limit-exceeded': 'TLE',
-  'idleness-limit-exceeded': 'ILE',
-  'memory-limit-exceeded': 'MLE',
-  'runtime-error': 'RTE',
-  'output-limit-exceeded': 'OLE',
-  'judge-failed': 'FL',
-  'internal-error': 'IE',
-  'compilation-error': 'CE',
+/** A codicon id and a theme color id -- what the tree needs to draw a verdict. */
+export interface OutcomeIcon {
+  readonly icon: string;
+  readonly color: string;
+}
+
+interface OutcomeDisplay {
+  /** Mirrors `Outcome.short_name()`. */
+  readonly short: string;
+  readonly icon: string;
+  readonly color: string;
+}
+
+/**
+ * How each verdict is spelled and drawn.
+ *
+ * The colors are the terminal palette of `get_outcome_style_verdict`
+ * (rbx/box/solutions.py) transposed onto VS Code's `charts.*` hues, which is
+ * the only family that offers all six the CLI uses. Deliberately the whole
+ * palette and not a pass/fail pair: the tree sits next to the terminal that
+ * printed the same run, and a TLE that is yellow there must not be red here.
+ * `magenta`, which the CLI keeps for verdicts that are nobody's fault but the
+ * setup's, becomes `charts.purple`; `bright_black` becomes the dim foreground
+ * VS Code already uses for de-emphasized text.
+ *
+ * The icon, unlike the color, is one per verdict -- the whole point is that WA,
+ * TLE and RTE stop looking alike -- so keep them distinguishable at 16px and
+ * prefer a codicon whose usual meaning already fits.
+ */
+const DISPLAY: Record<string, OutcomeDisplay> = {
+  accepted: { short: 'AC', icon: 'pass', color: 'charts.green' },
+  skipped: {
+    short: 'SKIP',
+    icon: 'debug-step-over',
+    color: 'descriptionForeground',
+  },
+  'wrong-answer': { short: 'WA', icon: 'close', color: 'charts.red' },
+  'time-limit-exceeded': { short: 'TLE', icon: 'watch', color: 'charts.yellow' },
+  'idleness-limit-exceeded': {
+    short: 'ILE',
+    icon: 'debug-pause',
+    color: 'charts.yellow',
+  },
+  'memory-limit-exceeded': {
+    short: 'MLE',
+    icon: 'server',
+    color: 'charts.yellow',
+  },
+  'runtime-error': { short: 'RTE', icon: 'zap', color: 'charts.blue' },
+  'output-limit-exceeded': {
+    short: 'OLE',
+    icon: 'arrow-both',
+    color: 'charts.orange',
+  },
+  'judge-failed': { short: 'FL', icon: 'law', color: 'charts.purple' },
+  'internal-error': { short: 'IE', icon: 'alert', color: 'charts.purple' },
+  'compilation-error': { short: 'CE', icon: 'tools', color: 'charts.blue' },
 };
 
-export function shortName(outcome: string | undefined): string {
+/** A verdict this extension is too old to know; `XX`, as rbx renders it too. */
+const UNKNOWN: OutcomeDisplay = {
+  short: 'XX',
+  icon: 'question',
+  color: 'charts.purple',
+};
+
+/**
+ * No evaluation on disk yet: either still running, or the run was interrupted.
+ * Indistinguishable in v1; both read as pending.
+ */
+const PENDING: OutcomeDisplay = {
+  short: '?',
+  icon: 'circle-outline',
+  color: 'descriptionForeground',
+};
+
+function display(outcome: string | undefined): OutcomeDisplay {
   if (outcome === undefined) {
-    return '?';
+    return PENDING;
   }
-  return SHORT_NAMES[outcome] ?? 'XX';
+  return DISPLAY[outcome] ?? UNKNOWN;
+}
+
+export function shortName(outcome: string | undefined): string {
+  return display(outcome).short;
+}
+
+export function outcomeIcon(outcome: string | undefined): OutcomeIcon {
+  const { icon, color } = display(outcome);
+  return { icon, color };
 }
 
 export function isAccepted(outcome: string | undefined): boolean {

--- a/vscode/src/runTree.ts
+++ b/vscode/src/runTree.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode';
 import { discoverPackages, packageLabel } from './discovery';
 import { log } from './log';
 import { PackageLayout } from './rbx/layout';
-import { expectedShortName, isAccepted, isSkipped, shortName } from './rbx/outcome';
+import { expectedShortName, isAccepted, outcomeIcon, shortName } from './rbx/outcome';
 import {
   ArtifactStore,
   GroupRun,
@@ -65,19 +65,18 @@ export interface TestcaseNode {
   readonly testcase: TestcaseRun;
 }
 
-function outcomeIcon(outcome: string | undefined): vscode.ThemeIcon {
-  if (outcome === undefined) {
-    // No evaluation on disk yet: either still running, or the run was
-    // interrupted. Indistinguishable in v1; both read as pending.
-    return new vscode.ThemeIcon('circle-outline');
-  }
-  if (isAccepted(outcome)) {
-    return new vscode.ThemeIcon('pass', new vscode.ThemeColor('testing.iconPassed'));
-  }
-  if (isSkipped(outcome)) {
-    return new vscode.ThemeIcon('debug-step-over', new vscode.ThemeColor('testing.iconSkipped'));
-  }
-  return new vscode.ThemeIcon('error', new vscode.ThemeColor('testing.iconFailed'));
+/**
+ * The verdict's own icon, from the table in outcome.ts.
+ *
+ * Note this reads the *outcome*, not `matchesExpectation`: a solution declared
+ * `WRONG_ANSWER` that answers wrongly is doing its job, and still gets the WA
+ * icon. Whether that met the expectation is what the description and the
+ * tooltip say -- same split the CLI makes, which also colors the verdict by
+ * what happened rather than by whether it was wanted.
+ */
+function themeIconFor(outcome: string | undefined): vscode.ThemeIcon {
+  const { icon, color } = outcomeIcon(outcome);
+  return new vscode.ThemeIcon(icon, new vscode.ThemeColor(color));
 }
 
 function testcaseItem(node: TestcaseNode): vscode.TreeItem {
@@ -88,7 +87,7 @@ function testcaseItem(node: TestcaseNode): vscode.TreeItem {
     vscode.TreeItemCollapsibleState.None,
   );
   item.id = `${node.pkg.root}::${node.run.solution.index}::${node.group.name}::${testcase.stem}`;
-  item.iconPath = outcomeIcon(evaluation?.outcome);
+  item.iconPath = themeIconFor(evaluation?.outcome);
   item.contextValue = 'rbx.testcase';
 
   const parts = [shortName(evaluation?.outcome)];
@@ -183,7 +182,7 @@ function groupItem(node: GroupNode): vscode.TreeItem {
 
   const report = node.group.report;
   const progress = progressOf(node.group.testcases);
-  item.iconPath = outcomeIcon(report?.outcome);
+  item.iconPath = themeIconFor(report?.outcome);
   item.description = groupDescription(report, progress);
 
   const tooltip = new vscode.MarkdownString();
@@ -211,7 +210,7 @@ function solutionItem(node: SolutionNode): vscode.TreeItem {
   const report = node.run.report;
   const testcases = node.run.groups.flatMap((group) => group.testcases);
   const progress = progressOf(testcases);
-  item.iconPath = outcomeIcon(report?.outcome);
+  item.iconPath = themeIconFor(report?.outcome);
   item.description = solutionDescription(report, progress);
 
   const tooltip = new vscode.MarkdownString();


### PR DESCRIPTION
## What

The Run view drew every non-AC, non-skipped outcome as the same red `error`
codicon, so WA, TLE, MLE, RTE and CE were indistinguishable until you read the
description text beside them. Each verdict now gets its own icon.

| | icon | color | CLI style |
|---|---|---|---|
| AC | `pass` | `charts.green` | green |
| WA | `close` | `charts.red` | red |
| TLE | `watch` | `charts.yellow` | yellow |
| ILE | `debug-pause` | `charts.yellow` | yellow |
| MLE | `server` | `charts.yellow` | yellow |
| OLE | `arrow-both` | `charts.orange` | orange1 |
| RTE | `zap` | `charts.blue` | blue |
| CE | `tools` | `charts.blue` | blue |
| FL | `law` | `charts.purple` | magenta |
| IE | `alert` | `charts.purple` | magenta |
| SKIP | `debug-step-over` | `descriptionForeground` | bright_black |
| pending / unknown | `circle-outline` / `question` | dim / purple | -- |

## Why these colors

They are `get_outcome_style_verdict` (`rbx/box/solutions.py`) transposed onto
VS Code's `charts.*` family, which is the only one carrying all six hues the CLI
uses. The tree is read next to the terminal that printed the same run, so a TLE
that is yellow there must not be red here. `magenta` -- which the CLI reserves
for verdicts that are the setup's fault rather than the solution's -- becomes
`charts.purple`; `bright_black` becomes the dim foreground.

## Notes

- The icon reads the **outcome**, not `matchesExpectation`: a solution declared
  `WRONG_ANSWER` that answers wrongly gets the WA icon. Whether that met the
  expectation is what the description and tooltip say -- the same split the CLI
  makes.
- The short-name lookup and the icon/color table are now one record per outcome,
  so the two cannot drift apart.
- The mapping stays in `rbx/outcome.ts` with no `vscode` import, so it is
  covered by `node --test` like the rest of that directory; `runTree.ts` only
  wraps it into a `ThemeIcon`.
- Pending rows are now dimmed rather than tree-foreground.

## Testing

- `npm run typecheck`, `npm test` (25 pass, 4 new), `npm run compile` -- all clean.
- Every codicon id and theme-color id above was grepped out of an installed
  VS Code build to confirm it exists.
- Exercised against a sample package producing AC, WA, TLE, ILE, RTE, MLE and
  SKIP in one report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
