### PR TITLE
fix(vscode): tell the two declaration layers apart in the run view

### DIFF
--- a/docs/plans/2026-08-19-vscode-run-webview-design.md
+++ b/docs/plans/2026-08-19-vscode-run-webview-design.md
@@ -227,8 +227,8 @@ a nonce CSP with no remote origins.
 
 - **Accessibility is now ours.** Screen-reader quality depends on D7 being done
   properly rather than on VS Code doing it for us.
-- **Width.** At roughly 300px the meta column has to drop out under a container
-  query, and the detail card stays single-column.
+- **Width.** The row sheds channels in priority order as the sidebar narrows
+  (D10); the detail card stays single-column.
 - **Virtualization is deferred.** Rendered rows are solutions plus groups, plus
   testcases only under an expanded solution — and only a solo run expands one by
   default. Revisit past ~2000 rendered rows.
@@ -277,8 +277,7 @@ is what has to be read together, and reserving the width of `TLE or RTE` on
 every row costs more than a ragged left edge does. Groups take the label hue
 too, by the same rule solutions already used. `ANY` still draws nothing --
 it is how a setter declares nothing, and the gutter already treats it that way.
-Under a container query the declaration drops after the timings and before the
-verdict, which is the order of how much each is missed.
+Under a container query the declaration drops **first** -- see D10.
 
 **The card speaks per layer.** `MismatchDetail` becomes a set of optional
 clauses -- a pooled `declared → got` pair, a list of groups each with its own
@@ -297,6 +296,50 @@ group-only miss now reads:
 Naming the pooled layer as *held* is deliberate rather than redundant: the
 reader is looking at a row labelled `INCORRECT`, and saying which declaration
 was fine is what stops them chasing it.
+
+## D10. What a narrowing sidebar gives up, and in what order
+
+A row has more to say than a narrow sidebar can show. The first cut at this
+hid the meta line whole at 260px and the declaration at 200px, which got both
+halves wrong: it took the score away along with the memory figure -- one blob,
+one switch -- and it kept the *declaration* alive longer than the measurements,
+when the declaration is the least urgent thing on a cramped row.
+
+The order is by how much each would be missed, not by how much room each frees:
+
+| # | dropped | at | why it goes when it does |
+|---|---|---|---|
+| 1 | the declaration | 400px | the gutter still answers *was it met*, which is the part needed at a glance; the card says what it was |
+| 2 | memory | 330px | the measurement least often being looked for |
+| 3 | time | 280px | wanted often, but a solution is opened to study its timings, and the card carries the maxima |
+| 4a | the verdict's *name* | 240px | the colour and shape carry most of what the name says, at a tenth of the width |
+| 4b | the verdict's icon | 190px | below this a row is a path and a score, the least it can be and still be worth drawing |
+| 5 | the score | never | on a points problem it is the answer to the question the view exists to answer, and the cheapest thing on the row |
+
+Everything above the score is recoverable by widening the sidebar or opening the
+row. The breakpoints are set where the label -- a path, the one thing that
+cannot be recovered from anywhere else -- would otherwise be squeezed past
+legibility.
+
+Two mechanics make it work.
+
+**Spans are named.** `Span` gains a `role` (`progress`/`score`/`time`/`memory`)
+and the renderer turns it into a `span-*` class. An anonymous list of strings
+can only be shown or hidden whole, which is what forced the original all-or-
+nothing switch.
+
+**Separators belong to the span that follows them.** `metaCell` emits nothing
+between spans; the stylesheet draws a `·` as a `::before` on every span but the
+first. A separator written as its own element would outlive the span it divides
+and leave `[30/100] ·` trailing off a narrowed row. This is correct only while
+hiding removes a *suffix* of the line -- so the meta line is built in priority
+order, and a `render.test.ts` case asserts the breakpoints are strictly
+descending and that the score is named by none of them. Reorder the ladder and
+that test fails rather than the separators quietly going wrong.
+
+`formatScore` also drops the ` pts` the console uses. In a terminal the unit
+earns its place; in a sidebar it is four characters of the one span that has to
+survive everything else, and the brackets already say what the number is.
 
 ## Follow-ups
 

--- a/docs/plans/2026-08-19-vscode-run-webview-design.md
+++ b/docs/plans/2026-08-19-vscode-run-webview-design.md
@@ -127,6 +127,11 @@ By level: solutions get gutter, expectation hue and verdict; groups get gutter
 (from `outcomePerGroup`) and verdict; testcases get verdict only — a testcase
 has no expectation of its own to report.
 
+> **Superseded by D9.** Giving a group the gutter but no expectation channel
+> left it unable to say *what* it had wanted, which is the one thing a reader
+> of a missed group needs. Groups now carry the expectation in both channels,
+> and both levels gained a spelled-out chip beside the verdict.
+
 The verdict and the expectation now live in genuinely separate channels with
 separate alphabets, so neither has to be inferred from the other. That is the
 whole point of the change.
@@ -156,6 +161,11 @@ states declared-versus-observed in words and **names the failing groups**. It
 reuses the `summary.ts` logic that already avoids naming an expectation that was
 in fact met — a pooled `INCORRECT` on a solution that does fail is met, and only
 the per-group layer sees the miss.
+
+> **Superseded by D9.** The intent above was right and the implementation did
+> not achieve it: the card named the pooled declaration *and* listed the failing
+> groups in one sentence, which reads as those groups having missed that
+> declaration. The layers are now separated in the model, not only in the prose.
 
 ## D5. A pinned header strip
 
@@ -222,6 +232,71 @@ a nonce CSP with no remote origins.
 - **Virtualization is deferred.** Rendered rows are solutions plus groups, plus
   testcases only under an expanded solution — and only a solo run expands one by
   default. Revisit past ~2000 rendered rows.
+
+## D9. The two declaration layers, kept apart (follow-up to #672)
+
+`sols/mislabeled-groups.cpp` declares `outcome: incorrect` with
+`outcomePerGroup: {'*': tle}`. It *is* incorrect, so the pooled layer holds; it
+is caught only by the per-group layer, which every group missed. The view as
+shipped said, of that solution:
+
+```
+Declared INCORRECT, but samples, main, edge, big did not match.
+```
+
+Both halves are true and the sentence is false: those groups missed `TLE`, not
+`INCORRECT`. And nothing anywhere in the view said `TLE` at all -- the group
+rows read as four ordinary rows with a warning beside them.
+
+Three changes, one per layer of the problem.
+
+**The report publishes which layer failed.** `matchesExpectation` is the
+aggregate of both, and the aggregate cannot say which one to blame.
+`RunSolutionReport` gains `pooledMatchesExpectation`, read straight off the
+`pooledStatus` that `get_verdict_markup` was already using for exactly this
+decision in the console and nowhere else. `expectedScore` comes with it, so the
+third failure mode -- a score outside its declared range -- has something to say
+beyond "wrong". Both fields are optional, so the version does not bump: an older
+reader drops them and reads the rest unchanged, where a bump would make every
+existing reader ignore the whole file. An extension meeting a report without
+them infers the pooled layer from "no group failed, so nothing else can have",
+which is exact except when both layers failed at once, where it under-reports
+rather than accusing a layer that held.
+
+**A row spells its declaration.** The expectation gets a channel of its own,
+between the meta and the verdict, on solutions and groups alike:
+
+```
+[gutter][twisty][label .............][meta][expectation][verdict]
+
+  ⚠  edge      [0/30 pts] · 9 ms · 10 MiB    TLE → ✗ WA
+```
+
+It grows leftwards from the verdict instead of taking a fixed column: the pair
+is what has to be read together, and reserving the width of `TLE or RTE` on
+every row costs more than a ragged left edge does. Groups take the label hue
+too, by the same rule solutions already used. `ANY` still draws nothing --
+it is how a setter declares nothing, and the gutter already treats it that way.
+Under a container query the declaration drops after the timings and before the
+verdict, which is the order of how much each is missed.
+
+**The card speaks per layer.** `MismatchDetail` becomes a set of optional
+clauses -- a pooled `declared → got` pair, a list of groups each with its own
+pair, a score range -- and the renderer prints only the clauses that are set. A
+group-only miss now reads:
+
+```
+⚠ INCORRECT held for the solution as a whole; 4 groups missed their
+  outcomePerGroup declaration:
+     samples   TLE → AC
+     main      TLE → AC
+     edge      TLE → WA
+     big       TLE → WA
+```
+
+Naming the pooled layer as *held* is deliberate rather than redundant: the
+reader is looking at a row labelled `INCORRECT`, and saying which declaration
+was fine is what stops them chasing it.
 
 ## Follow-ups
 

--- a/rbx/box/run_report.py
+++ b/rbx/box/run_report.py
@@ -22,7 +22,7 @@ Two deliberate constraints:
 """
 
 import pathlib
-from typing import Dict, Iterable, List, Optional, TypeVar
+from typing import Dict, Iterable, List, Optional, Tuple, TypeVar
 
 import yaml
 from pydantic import BaseModel
@@ -33,6 +33,10 @@ from rbx.grading.steps import Evaluation, Outcome
 # Bump when a change would make an older reader misread the file. A reader that
 # meets a version it does not know must ignore the report rather than guess --
 # showing a run without aggregates is recoverable, showing wrong verdicts is not.
+#
+# Adding an optional field is not such a change: an older reader drops what it
+# does not know and reads everything else exactly as before. Bumping for it
+# would instead make every existing reader ignore the whole file.
 REPORT_VERSION = 1
 
 REPORT_FILENAME = 'report.yml'
@@ -70,11 +74,26 @@ class RunSolutionReport(BaseModel):
     # `status == OK`, hoisted out so a client need not learn the status values
     # to answer the only question most of them ask.
     matchesExpectation: bool = True
+    # Whether the *pooled* `outcome` layer held on its own.
+    #
+    # Published apart from `matchesExpectation` because that one is the
+    # aggregate of two independent layers, and a client that has only the
+    # aggregate cannot tell which of them it is allowed to blame. A solution
+    # declaring `outcome: incorrect` with an `outcomePerGroup` can fail only
+    # the per-group layer while the pooled `incorrect` it names was in fact
+    # met -- saying "expected INCORRECT, got WA" there accuses an expectation
+    # that held. `get_verdict_markup` draws exactly this distinction for the
+    # console, and had the only copy of it.
+    pooledMatchesExpectation: bool = True
     score: int = 0
     maxScore: int = 0
     maxTime: Optional[float] = None
     maxMemory: Optional[int] = None
     failedGroups: List[str] = []
+    # The `[min, max]` score range declared for this solution, when one was.
+    # Without it a client meeting `status == UNEXPECTED_SCORE` knows a solution
+    # is wrong but has nothing to say about how.
+    expectedScore: Optional[Tuple[int, int]] = None
     groups: List[RunGroupReport] = []
 
 
@@ -149,11 +168,13 @@ def build_solution_report(
         outcome=_worst_outcome(report.evals),
         status=report.status.value,
         matchesExpectation=report.status.ok(),
+        pooledMatchesExpectation=report.pooledStatus.ok(),
         score=report.gotScore,
         maxScore=report.maxScore,
         maxTime=_max_of(eval.log.time for eval in report.evals),
         maxMemory=_max_of(eval.log.memory for eval in report.evals),
         failedGroups=report.failedGroups,
+        expectedScore=report.expectedScore,
         groups=groups,
     )
 

--- a/tests/rbx/box/run_report_test.py
+++ b/tests/rbx/box/run_report_test.py
@@ -166,9 +166,61 @@ def test_per_group_expectations_are_carried_through(
     # The pooled `incorrect` holds -- it does fail somewhere -- so only the
     # per-group layer catches this solution.
     assert entry.matchesExpectation is False
+    # ...and the two layers are published apart, so a client can say *which* of
+    # them was missed instead of blaming the one that held.
+    assert entry.pooledMatchesExpectation is True
     assert entry.failedGroups == ['small', 'big']
     assert entry.groups[0].expectedOutcome == ExpectedOutcome.TIME_LIMIT_EXCEEDED
     assert entry.groups[0].matchesExpectation is False
+
+
+def test_a_missed_pooled_expectation_is_published_as_such(
+    tmp_path, mock_skeleton, mock_binary_scoring
+):
+    """The other side of the pair: nothing per-group, the pooled layer missed."""
+    solution = Solution(
+        path=tmp_path / 'optimistic.cpp', outcome=ExpectedOutcome.ACCEPTED
+    )
+    skeleton = mock_skeleton([solution], entries_per_group={'small': 1, 'big': 1})
+    evals = [
+        make_evaluation(Outcome.ACCEPTED),
+        make_evaluation(Outcome.WRONG_ANSWER),
+    ]
+
+    entry = build(solution, skeleton, evals)
+
+    assert entry.matchesExpectation is False
+    assert entry.pooledMatchesExpectation is False
+    assert entry.failedGroups == []
+
+
+def test_an_expected_score_range_is_published(
+    tmp_path, mock_skeleton, mock_points_scoring
+):
+    """`status` alone says a score was wrong but never what was wanted."""
+    solution = Solution(
+        path=tmp_path / 'partial.cpp',
+        outcome=ExpectedOutcome.INCORRECT,
+        score=(40, 60),
+    )
+    skeleton = mock_skeleton(
+        [solution],
+        entries_per_group={'small': 1, 'big': 1},
+        scores_per_group={'small': 40, 'big': 60},
+    )
+    evals = [
+        make_evaluation(Outcome.WRONG_ANSWER),
+        make_evaluation(Outcome.WRONG_ANSWER),
+    ]
+
+    entry = build(solution, skeleton, evals)
+
+    assert entry.status == 'UNEXPECTED_SCORE'
+    assert entry.expectedScore == (40, 60)
+    assert entry.score == 0
+    # The verdicts were exactly what INCORRECT asked for; only the score was not.
+    assert entry.pooledMatchesExpectation is True
+    assert entry.failedGroups == []
 
 
 def test_every_outcome_survives_the_published_report():

--- a/vscode/src/rbx/report.ts
+++ b/vscode/src/rbx/report.ts
@@ -38,11 +38,23 @@ export interface SolutionReport {
   readonly outcome?: string;
   readonly status: string;
   readonly matchesExpectation: boolean;
+  /**
+   * Whether the *pooled* `outcome` layer held on its own.
+   *
+   * `matchesExpectation` is the aggregate of two independent layers, and the
+   * aggregate alone cannot say which of them to blame: `sols/mislabeled.cpp`
+   * declares `incorrect` and *is* incorrect, and is caught only by its
+   * `outcomePerGroup`. Absent on a report written by an rbx that predates the
+   * field -- see `pooledMissed` in viewModel.ts for what stands in then.
+   */
+  readonly pooledMatchesExpectation?: boolean;
   readonly score: number;
   readonly maxScore: number;
   readonly maxTime?: number;
   readonly maxMemory?: number;
   readonly failedGroups: readonly string[];
+  /** The `[min, max]` score range declared, when one was. */
+  readonly expectedScore?: readonly [number, number];
   readonly groups: readonly GroupReport[];
 }
 
@@ -65,6 +77,19 @@ function parseGroup(raw: Wire): GroupReport | undefined {
     maxTime: asNumber(field(raw, 'maxTime')),
     maxMemory: asNumber(field(raw, 'maxMemory')),
   };
+}
+
+/**
+ * `[min, max]`, or `undefined` for anything that is not exactly that.
+ *
+ * Both ends are required: a half-parsed range would be rendered as a bound the
+ * package never declared, which is worse than rendering no bound at all.
+ */
+function parseScoreRange(raw: Wire): readonly [number, number] | undefined {
+  const values = asArray(raw)
+    .map((value) => asNumber(value))
+    .filter((value): value is number => value !== undefined);
+  return values.length === 2 ? [values[0], values[1]] : undefined;
 }
 
 function parseSolution(raw: Wire): SolutionReport | undefined {
@@ -94,6 +119,8 @@ function parseSolution(raw: Wire): SolutionReport | undefined {
     failedGroups: asArray(field(raw, 'failedGroups'))
       .map((name) => asString(name))
       .filter((name): name is string => name !== undefined),
+    pooledMatchesExpectation: asBoolean(field(raw, 'pooledMatchesExpectation')),
+    expectedScore: parseScoreRange(field(raw, 'expectedScore')),
     groups,
   };
 }

--- a/vscode/src/rbx/summary.test.ts
+++ b/vscode/src/rbx/summary.test.ts
@@ -33,8 +33,8 @@ test('formatMemory walks the B / KiB / MiB ladder', () => {
   assert.strictEqual(formatMemory(undefined), undefined);
 });
 
-test('formatScore renders rbx literal brackets', () => {
-  assert.strictEqual(formatScore(70, 100), '[70/100 pts]');
+test('formatScore renders rbx literal brackets, without the console unit', () => {
+  assert.strictEqual(formatScore(70, 100), '[70/100]');
 });
 
 test('progress counts the evaluations on disk, not the verdicts in them', () => {

--- a/vscode/src/rbx/summary.ts
+++ b/vscode/src/rbx/summary.ts
@@ -60,9 +60,18 @@ export function formatMemory(bytes: number | undefined): string | undefined {
   return `${Math.round(bytes / (1024 * 1024))} MiB`;
 }
 
-/** Mirrors `get_solution_score_markup`, whose brackets are literal: `[70/100 pts]`. */
+/**
+ * `[70/100]` -- `get_solution_score_markup`'s literal brackets, without its
+ * `pts`.
+ *
+ * The console has a whole terminal to spend and the unit earns its place there.
+ * In a sidebar it is four characters of a row that has to fit a path, a score,
+ * two measurements and two verdicts, and it is the only one of them carrying no
+ * information: the brackets already say this is the score, and nothing else in
+ * the meta line is a bare ratio.
+ */
 export function formatScore(score: number, maxScore: number): string {
-  return `[${score}/${maxScore} pts]`;
+  return `[${score}/${maxScore}]`;
 }
 
 /**

--- a/vscode/src/rbx/viewModel.test.ts
+++ b/vscode/src/rbx/viewModel.test.ts
@@ -353,12 +353,15 @@ test('a finished solution shows score, time and memory but never its verdict', (
   );
   const { rows } = buildViewModel([view([finished])]);
   const row = rowById(rows, '/w/a::0');
+  // Roles included, and in this order: the stylesheet hides a *suffix* of this
+  // line as the sidebar narrows, so the order is the priority and the score
+  // being ahead of both measurements is what keeps it on screen longest.
   assert.deepStrictEqual(row.meta, [
-    { text: '[70/100 pts]', hue: 'neutral' },
-    { text: '120 ms', hue: 'dim' },
-    { text: '2 KiB', hue: 'dim' },
+    { text: '[70/100]', hue: 'neutral', role: 'score' },
+    { text: '120 ms', hue: 'dim', role: 'time' },
+    { text: '2 KiB', hue: 'dim', role: 'memory' },
   ]);
-  assert.deepStrictEqual(row.detail?.score, '[70/100 pts]');
+  assert.deepStrictEqual(row.detail?.score, '[70/100]');
   assert.deepStrictEqual(row.detail?.maxTime, '120 ms');
   assert.deepStrictEqual(row.detail?.maxMemory, '2 KiB');
 });
@@ -466,8 +469,8 @@ test('a testcase shows time and memory, and not the checker message', () => {
   // The whole array, so a checker's free-form line cannot creep back into a
   // 22px row and push the timings out of it.
   assert.deepStrictEqual(row.meta, [
-    { text: '50 ms', hue: 'dim' },
-    { text: '1 KiB', hue: 'dim' },
+    { text: '50 ms', hue: 'dim', role: 'time' },
+    { text: '1 KiB', hue: 'dim', role: 'memory' },
   ]);
   assert.strictEqual(row.expandable, false);
   assert.strictEqual(row.section, 'rbx.testcase');

--- a/vscode/src/rbx/viewModel.test.ts
+++ b/vscode/src/rbx/viewModel.test.ts
@@ -110,21 +110,47 @@ const PARTIAL = solution(
   }),
 );
 
+// `outcome: incorrect` with `outcomePerGroup: {'*': tle}`. Both layers are
+// declared and only the per-group one is missed -- the pooled `INCORRECT` is
+// satisfied, because the solution really does fail. Naming that layer as the
+// culprit is the bug this fixture pins.
+const MISLABELED_GROUPS = [
+  group(
+    'small',
+    [testcase('000', 'accepted')],
+    groupReport({
+      name: 'small',
+      outcome: 'accepted',
+      expectedOutcome: 'TIME_LIMIT_EXCEEDED',
+      matchesExpectation: false,
+    }),
+  ),
+  group(
+    'big',
+    [testcase('001', 'wrong-answer')],
+    groupReport({
+      name: 'big',
+      outcome: 'wrong-answer',
+      expectedOutcome: 'TIME_LIMIT_EXCEEDED',
+      matchesExpectation: false,
+    }),
+  ),
+];
+
 const MISLABELED = solution(
   2,
   'sols/mislabeled.cpp',
   'INCORRECT',
-  [
-    group('small', [testcase('000', 'wrong-answer')]),
-    group('big', [testcase('001', 'wrong-answer')]),
-  ],
+  MISLABELED_GROUPS,
   solutionReport({
     path: 'sols/mislabeled.cpp',
     index: 2,
     expectedOutcome: 'INCORRECT',
     outcome: 'wrong-answer',
     matchesExpectation: false,
+    pooledMatchesExpectation: true,
     failedGroups: ['small', 'big'],
+    groups: MISLABELED_GROUPS.map((entry) => entry.report!),
   }),
 );
 
@@ -155,16 +181,123 @@ test('a solution that failed exactly as declared is not a mismatch', () => {
   assert.strictEqual(row.detail?.mismatch, undefined);
 });
 
-test('a solution that failed in the wrong places names the groups that caught it', () => {
+test('a solution caught only per-group blames the per-group layer, not the pooled one', () => {
   const { rows } = buildViewModel([view([MAIN, PARTIAL, MISLABELED])]);
   const row = rowById(rows, '/w/a::2');
   assert.strictEqual(row.gutter, 'missed');
   assert.strictEqual(row.mismatch, true);
+  // `pooled` absent is the whole assertion: the solution's own INCORRECT held,
+  // so nothing here may say it was missed. What is named instead is each
+  // group's own TLE, beside what that group actually did.
   assert.deepStrictEqual(row.detail?.mismatch, {
-    declared: 'INCORRECT',
-    observed: 'WA',
-    failedGroups: ['small', 'big'],
+    pooled: undefined,
+    pooledHeld: 'INCORRECT',
+    groups: [
+      {
+        name: 'small',
+        declared: 'TLE',
+        declaredHue: 'yellow',
+        observed: 'AC',
+        observedHue: 'green',
+      },
+      {
+        name: 'big',
+        declared: 'TLE',
+        declaredHue: 'yellow',
+        observed: 'WA',
+        observedHue: 'red',
+      },
+    ],
+    score: undefined,
   });
+});
+
+test('a solution caught by its pooled declaration blames that one, and no group', () => {
+  const optimistic = solution(
+    0,
+    'sols/optimistic.cpp',
+    'ACCEPTED',
+    [group('big', [testcase('000', 'wrong-answer')], groupReport({ name: 'big' }))],
+    solutionReport({
+      path: 'sols/optimistic.cpp',
+      expectedOutcome: 'ACCEPTED',
+      outcome: 'wrong-answer',
+      matchesExpectation: false,
+      pooledMatchesExpectation: false,
+    }),
+  );
+  const { rows } = buildViewModel([view([optimistic])]);
+  assert.deepStrictEqual(rowById(rows, '/w/a::0').detail?.mismatch, {
+    pooled: { declared: 'AC', declaredHue: 'green', observed: 'WA', observedHue: 'red' },
+    // Not named as held: it is the layer that failed.
+    pooledHeld: undefined,
+    groups: [],
+    score: undefined,
+  });
+});
+
+test('a report from an rbx with no pooled flag still blames the right layer', () => {
+  // The field was added with this card; a report already on disk predates it.
+  // With no failing group to explain the miss, the pooled layer is the only
+  // thing left that can have caused it.
+  const stale = solution(
+    0,
+    'sols/optimistic.cpp',
+    'ACCEPTED',
+    [],
+    solutionReport({
+      path: 'sols/optimistic.cpp',
+      expectedOutcome: 'ACCEPTED',
+      outcome: 'wrong-answer',
+      matchesExpectation: false,
+    }),
+  );
+  const { rows } = buildViewModel([view([stale])]);
+  assert.strictEqual(rowById(rows, '/w/a::0').detail?.mismatch?.pooled?.declared, 'AC');
+});
+
+test('a solution that only missed its score range says so, and accuses no verdict', () => {
+  const scored = solution(
+    0,
+    'sols/partial.cpp',
+    'INCORRECT',
+    [],
+    solutionReport({
+      path: 'sols/partial.cpp',
+      expectedOutcome: 'INCORRECT',
+      outcome: 'wrong-answer',
+      status: 'UNEXPECTED_SCORE',
+      matchesExpectation: false,
+      pooledMatchesExpectation: true,
+      score: 30,
+      maxScore: 100,
+      expectedScore: [40, 60],
+    }),
+  );
+  const { rows } = buildViewModel([view([scored])]);
+  const mismatch = rowById(rows, '/w/a::0').detail?.mismatch;
+  assert.strictEqual(mismatch?.pooled, undefined);
+  assert.deepStrictEqual(mismatch?.score, { expected: '40..60', got: '30' });
+});
+
+test('an open-ended score range is not given a ceiling rbx never declared', () => {
+  const scored = solution(
+    0,
+    'sols/partial.cpp',
+    'INCORRECT',
+    [],
+    solutionReport({
+      expectedOutcome: 'INCORRECT',
+      outcome: 'wrong-answer',
+      status: 'UNEXPECTED_SCORE',
+      matchesExpectation: false,
+      pooledMatchesExpectation: true,
+      score: 30,
+      expectedScore: [40, 1e9],
+    }),
+  );
+  const { rows } = buildViewModel([view([scored])]);
+  assert.strictEqual(rowById(rows, '/w/a::0').detail?.mismatch?.score?.expected, '40..');
 });
 
 test('only the solution that missed its declaration is counted', () => {
@@ -251,14 +384,43 @@ test('only a group with its own outcomePerGroup declaration gets a gutter', () =
     solutionReport({ expectedOutcome: 'INCORRECT', outcome: 'wrong-answer' }),
   );
   const { rows } = buildViewModel([view([declared])]);
-  assert.strictEqual(rowById(rows, '/w/a::0::small').gutter, 'none');
-  assert.strictEqual(rowById(rows, '/w/a::0::big').gutter, 'missed');
-  assert.strictEqual(rowById(rows, '/w/a::0::big').mismatch, true);
-  // A group carries no expectation of its own to hue by; the declaration is a
-  // property of the solution.
-  assert.strictEqual(rowById(rows, '/w/a::0::big').labelHue, undefined);
+  const small = rowById(rows, '/w/a::0::small');
+  const big = rowById(rows, '/w/a::0::big');
+  assert.strictEqual(small.gutter, 'none');
+  assert.strictEqual(big.gutter, 'missed');
+  assert.strictEqual(big.mismatch, true);
+  // A group that declares one draws it in both channels, exactly as a solution
+  // does. Leaving the group level out of both is what made four groups that all
+  // wanted a TLE read as four ordinary rows with a warning beside them.
+  assert.deepStrictEqual(big.expectation, {
+    label: 'AC',
+    hue: 'green',
+    bold: true,
+    glyph: '\u2713',
+  });
+  assert.strictEqual(big.labelHue, 'green');
+  assert.strictEqual(big.labelBold, true);
+  // ...and a group with no declaration of its own borrows none from the
+  // solution above it, which declared INCORRECT.
+  assert.strictEqual(small.expectation, undefined);
+  assert.strictEqual(small.labelHue, undefined);
   // Group mismatches are not solution mismatches.
   assert.strictEqual(buildViewModel([view([declared])]).mismatches, 0);
+});
+
+test('a group inherits nothing from a solution declaring ANY, and neither does the row', () => {
+  const any = solution(
+    0,
+    'sols/x.cpp',
+    'ANY',
+    [group('small', [testcase('000', 'accepted')], groupReport({ name: 'small' }))],
+    solutionReport({ expectedOutcome: 'ANY' }),
+  );
+  const { rows } = buildViewModel([view([any])]);
+  // ANY is how a setter declares nothing, so it earns no chip -- the same rule
+  // the gutter already applied.
+  assert.strictEqual(rowById(rows, '/w/a::0').expectation, undefined);
+  assert.strictEqual(rowById(rows, '/w/a::0::small').expectation, undefined);
 });
 
 test('the histogram is ordered by count, ties by outcome name', () => {
@@ -314,10 +476,18 @@ test('a testcase shows time and memory, and not the checker message', () => {
 
 test('the search haystack carries the verdict, and mismatch only when missed', () => {
   const { rows } = buildViewModel([view([MAIN, PARTIAL, MISLABELED])]);
+  // `ac` once, not twice: on a healthy solution the declaration and the verdict
+  // are the same word.
   assert.strictEqual(rowById(rows, '/w/a::0').search, 'sols/main.cpp ac');
-  assert.strictEqual(rowById(rows, '/w/a::1').search, 'sols/partial.cpp wa');
-  assert.strictEqual(rowById(rows, '/w/a::2').search, 'sols/mislabeled.cpp wa mismatch');
+  assert.strictEqual(rowById(rows, '/w/a::1').search, 'sols/partial.cpp wa incorrect');
+  assert.strictEqual(
+    rowById(rows, '/w/a::2').search,
+    'sols/mislabeled.cpp wa incorrect mismatch',
+  );
   assert.strictEqual(rowById(rows, '/w/a::0::main::000').search, 'main/000 ac');
+  // Typing `tle` reaches the group that *wanted* one, which is the only way to
+  // find it: nothing it produced is spelled TLE.
+  assert.strictEqual(rowById(rows, '/w/a::2::small').search, 'small ac tle mismatch');
 });
 
 test('a package with no run on disk produces an empty model', () => {

--- a/vscode/src/rbx/viewModel.ts
+++ b/vscode/src/rbx/viewModel.ts
@@ -18,7 +18,7 @@
  */
 import * as path from 'path';
 
-import { expectationDisplay } from './expectation';
+import { ExpectationDisplay, expectationDisplay } from './expectation';
 import { Hue, hueOfThemeColor } from './hue';
 import {
   GroupNode,
@@ -62,10 +62,48 @@ export interface HistogramSlice {
   readonly count: number;
 }
 
-export interface MismatchDetail {
+/** One group that missed its own `outcomePerGroup` declaration. */
+export interface GroupMismatch {
+  readonly name: string;
   readonly declared: string;
+  readonly declaredHue: Hue;
   readonly observed: string;
-  readonly failedGroups: readonly string[];
+  readonly observedHue: Hue;
+}
+
+export interface Mismatched {
+  readonly declared: string;
+  readonly declaredHue: Hue;
+  readonly observed: string;
+  readonly observedHue: Hue;
+}
+
+export interface ScoreMismatch {
+  readonly expected: string;
+  readonly got: string;
+}
+
+/**
+ * What a caught solution got wrong, layer by layer.
+ *
+ * A solution declares its expectations in two independent layers -- pooled
+ * `outcome` and per-group `outcomePerGroup` -- and either can be the one that
+ * failed. The card used to name the pooled declaration and then list the
+ * groups from `failedGroups` beside it, which reads as though those groups
+ * missed *that* declaration. For `sols/mislabeled-groups.cpp` that is exactly
+ * backwards: its pooled `INCORRECT` held, and only its per-group `TLE` was
+ * missed, so the sentence accused the one expectation that was met.
+ *
+ * So the layers stay apart here too, and each carries its own declared/observed
+ * pair. `pooled` is set only when the pooled layer is what failed -- the same
+ * condition `get_verdict_markup` uses before it will print `Expected: X`.
+ */
+export interface MismatchDetail {
+  readonly pooled?: Mismatched;
+  /** The pooled declaration's label, set only when that layer *held*. */
+  readonly pooledHeld?: string;
+  readonly groups: readonly GroupMismatch[];
+  readonly score?: ScoreMismatch;
 }
 
 export interface SolutionDetail {
@@ -86,6 +124,16 @@ export interface Row {
   readonly labelHue?: Hue;
   readonly labelBold: boolean;
   readonly meta: readonly Span[];
+  /**
+   * The expectation this row *declared*, spelled out.
+   *
+   * The label's hue carries the same fact, and on a solution row -- whose label
+   * is a path the reader already knows -- that was enough. On a group row it is
+   * not: `edge` drawn in yellow does not say `TIME_LIMIT_EXCEEDED`, and a group
+   * that declares one through `outcomePerGroup` had no channel at all to say so.
+   * Absent when nothing was declared, or when `ANY` declared nothing to miss.
+   */
+  readonly expectation?: ExpectationDisplay;
   readonly verdict?: VerdictChip;
   readonly mismatch: boolean;
   readonly expandable: boolean;
@@ -126,6 +174,22 @@ function chip(outcome: string | undefined): VerdictChip {
 
 function matched(matches: boolean): Gutter {
   return matches ? 'met' : 'missed';
+}
+
+/**
+ * How to draw a declaration, or `undefined` when there is none to draw.
+ *
+ * `ANY` folds into `undefined` on purpose: it is the way a setter says "I am
+ * declaring nothing about this", so spelling it out in the row would put a
+ * chip on every solution that opted out of having one. It is the same rule the
+ * gutter applies -- there is nothing to have met or missed -- and the two must
+ * not disagree about whether a row declared anything.
+ */
+function declaredExpectation(expected: string | undefined): ExpectationDisplay | undefined {
+  if (expected === undefined || expected === 'ANY') {
+    return undefined;
+  }
+  return expectationDisplay(expected);
 }
 
 /**
@@ -192,11 +256,20 @@ function aggregateMeta(
  * literal `mismatch` only where there is one, so it is a usable token rather
  * than noise on every row.
  */
-function haystack(subject: string, verdict: VerdictChip | undefined, mismatch: boolean): string {
-  return [subject, verdict?.short, mismatch ? 'mismatch' : undefined]
+function haystack(
+  subject: string,
+  verdict: VerdictChip | undefined,
+  mismatch: boolean,
+  expectation?: ExpectationDisplay,
+): string {
+  // The declaration joins the haystack so `tle` finds the groups that *wanted*
+  // a TLE as well as the ones that got one -- which, on a solution declared
+  // slow, are not the same rows. Deduplicated because on the common row the
+  // two agree, and `sols/main.cpp ac ac` is a haystack that says nothing twice.
+  const parts = [subject, verdict?.short, expectation?.label, mismatch ? 'mismatch' : undefined]
     .filter((part): part is string => part !== undefined)
-    .join(' ')
-    .toLowerCase();
+    .map((part) => part.toLowerCase());
+  return [...new Set(parts)].join(' ');
 }
 
 /**
@@ -223,22 +296,100 @@ function histogram(testcases: readonly TestcaseRun[]): HistogramSlice[] {
 }
 
 /**
+ * `40`, `40..`, `40..60` -- `get_expected_score_repr`'s spelling, so the card
+ * and the console name a range the same way.
+ */
+function scoreRange(range: readonly [number, number]): string {
+  const [lo, hi] = range;
+  if (lo === hi) {
+    return String(lo);
+  }
+  // rbx writes an open upper bound as 10^9; naming it would invent a ceiling
+  // the setter never wrote.
+  return hi >= 1e9 ? `${lo}..` : `${lo}..${hi}`;
+}
+
+function outcomeOf(outcome: string | undefined): { text: string; hue: Hue } {
+  const { short, hue } = chip(outcome);
+  return { text: short, hue };
+}
+
+/**
+ * The groups that missed their own declaration, with what each one wanted.
+ *
+ * Read off `report.groups` rather than `report.failedGroups`: the two hold the
+ * same names, but only the group records carry the `expectedOutcome` that makes
+ * the line worth reading -- a bare list of names is what sent the reader
+ * looking for a declaration that was not the one they missed.
+ */
+function groupMismatches(report: SolutionReport): GroupMismatch[] {
+  return report.groups
+    .filter((group) => group.expectedOutcome !== undefined && !group.matchesExpectation)
+    .map((group) => {
+      const declared = expectationDisplay(group.expectedOutcome);
+      const observed = outcomeOf(group.outcome);
+      return {
+        name: group.name,
+        declared: declared?.label ?? '',
+        declaredHue: declared?.hue ?? 'neutral',
+        observed: observed.text,
+        observedHue: observed.hue,
+      };
+    });
+}
+
+/**
+ * Whether the *pooled* declaration is one of the things that failed.
+ *
+ * rbx publishes the answer, and it is the only source that is right in every
+ * case. The fallback is for a report written by an rbx that predates the field:
+ * with no group failures to explain the mismatch, the pooled layer is the only
+ * thing left that can have caused it. That inference is wrong only when both
+ * layers failed at once, where it under-reports rather than accusing a layer
+ * that held -- which is the direction this whole card is being moved in.
+ */
+function pooledMissed(report: SolutionReport, groups: readonly GroupMismatch[]): boolean {
+  if (report.pooledMatchesExpectation !== undefined) {
+    return !report.pooledMatchesExpectation;
+  }
+  return groups.length === 0 && report.status !== 'UNEXPECTED_SCORE';
+}
+
+/**
  * What a mismatched solution got wrong.
  *
- * `failedGroups` verbatim rather than a phrase naming the pooled expectation:
- * `sols/mislabeled.cpp` in the `outcome-per-group` fixture *satisfies* its
- * pooled `INCORRECT` -- it does fail somewhere -- and is caught only by its
- * per-group declarations, so "expected INCORRECT, got WA" would name an
- * expectation that was in fact met. See `solutionVerdict` in summary.ts.
+ * Every clause is optional and the card prints only the ones that are set, so a
+ * solution that missed one layer never has a sentence about the other put in
+ * its mouth.
  */
 function mismatchDetail(run: SolutionRun, report: SolutionReport): MismatchDetail {
+  const groups = groupMismatches(report);
+  const missed = pooledMissed(report, groups);
   // A missed gutter already implies a declaration, so the display is there; the
-  // fallback only satisfies the type.
-  const declared = expectationDisplay(run.solution.expectedOutcome);
+  // fallbacks below only satisfy the type.
+  const declared = declaredExpectation(run.solution.expectedOutcome);
+  const observed = outcomeOf(report.outcome);
   return {
-    declared: declared?.label ?? '',
-    observed: shortName(report.outcome),
-    failedGroups: report.failedGroups,
+    pooled: missed
+      ? {
+          declared: declared?.label ?? '',
+          declaredHue: declared?.hue ?? 'neutral',
+          observed: observed.text,
+          observedHue: observed.hue,
+        }
+      : undefined,
+    // Named only when it is the *other* layer that failed: the reader's first
+    // guess is that the declaration on the solution line is the culprit, and
+    // saying which one held is what stops them chasing it.
+    pooledHeld: !missed && groups.length > 0 ? declared?.label : undefined,
+    groups,
+    score:
+      report.status === 'UNEXPECTED_SCORE' && report.expectedScore !== undefined
+        ? {
+            expected: scoreRange(report.expectedScore),
+            got: String(report.score),
+          }
+        : undefined,
   };
 }
 
@@ -282,7 +433,7 @@ function solutionRow(node: SolutionNode, depth: number, parentId?: string): Row 
   const { run, solo } = node;
   const gutter = solutionGutter(run);
   const mismatch = gutter === 'missed';
-  const declared = expectationDisplay(run.solution.expectedOutcome);
+  const declared = declaredExpectation(run.solution.expectedOutcome);
   const testcases = run.groups.flatMap((group) => group.testcases);
   const verdict = chip(run.report?.outcome);
   return {
@@ -295,6 +446,7 @@ function solutionRow(node: SolutionNode, depth: number, parentId?: string): Row 
     labelHue: declared?.hue,
     labelBold: declared?.bold ?? false,
     meta: aggregateMeta(run.report, progressOf(testcases)),
+    expectation: declared,
     verdict,
     mismatch,
     expandable: true,
@@ -302,7 +454,7 @@ function solutionRow(node: SolutionNode, depth: number, parentId?: string): Row 
     // choice of the reporter that prints per-testcase lines.
     defaultExpanded: solo,
     detail: solutionDetail(run, mismatch),
-    search: haystack(run.solution.path, verdict, mismatch),
+    search: haystack(run.solution.path, verdict, mismatch, declared),
     section: 'rbx.solution',
   };
 }
@@ -312,6 +464,11 @@ function groupRow(node: GroupNode, depth: number, parentId?: string): Row {
   const gutter = groupGutter(group.report);
   const mismatch = gutter === 'missed';
   const verdict = chip(group.report?.outcome);
+  // A group declares an expectation the same way a solution does -- through
+  // `outcomePerGroup` -- so it is drawn the same way, in the same two channels.
+  // Leaving the group level out of both is what made a run of groups that all
+  // wanted a TLE look like four ordinary rows with a warning next to them.
+  const declared = declaredExpectation(group.report?.expectedOutcome);
   return {
     id: nodeId(node),
     parentId,
@@ -319,15 +476,17 @@ function groupRow(node: GroupNode, depth: number, parentId?: string): Row {
     kind: 'group',
     gutter,
     label: group.name,
-    labelBold: false,
+    labelHue: declared?.hue,
+    labelBold: declared?.bold ?? false,
     meta: aggregateMeta(group.report, progressOf(group.testcases)),
+    expectation: declared,
     verdict,
     mismatch,
     expandable: true,
     // Groups stay open even under a collapsed solution: the group breakdown is
     // the reason to open a solution at all.
     defaultExpanded: true,
-    search: haystack(group.name, verdict, mismatch),
+    search: haystack(group.name, verdict, mismatch, declared),
     section: 'rbx.group',
   };
 }

--- a/vscode/src/rbx/viewModel.ts
+++ b/vscode/src/rbx/viewModel.ts
@@ -45,9 +45,20 @@ import {
 /** Whether a declared expectation was met -- `none` when none was declared. */
 export type Gutter = 'none' | 'met' | 'missed';
 
+/**
+ * What a meta span *is*, so the stylesheet can drop them in priority order.
+ *
+ * The meta line used to be an anonymous list of strings, which meant it could
+ * only be shown or hidden whole -- and the first thing a narrowing sidebar did
+ * was take the score away along with the memory figure. Naming each span is
+ * what lets the least useful one go first and the score go last.
+ */
+export type SpanRole = 'progress' | 'score' | 'time' | 'memory';
+
 export interface Span {
   readonly text: string;
   readonly hue?: Hue;
+  readonly role?: SpanRole;
 }
 
 export interface VerdictChip {
@@ -216,8 +227,8 @@ function groupGutter(report: GroupReport | undefined): Gutter {
   return matched(report.matchesExpectation);
 }
 
-function span(text: string | undefined, hue: Hue): Span | undefined {
-  return text === undefined || text === '' ? undefined : { text, hue };
+function span(text: string | undefined, hue: Hue, role?: SpanRole): Span | undefined {
+  return text === undefined || text === '' ? undefined : { text, hue, role };
 }
 
 function spans(candidates: readonly (Span | undefined)[]): Span[] {
@@ -237,15 +248,21 @@ function aggregateMeta(
   progress: Progress,
 ): Span[] {
   if (report === undefined) {
-    return spans([span(pendingDescription(progress), 'dim')]);
+    return spans([span(pendingDescription(progress), 'dim', 'progress')]);
   }
+  // Ordered by how long each survives a narrowing sidebar, widest-lived first,
+  // so that hiding always removes a *suffix* of the line -- which is what keeps
+  // the separators between them correct without the stylesheet having to know
+  // which spans are left. See the container queries in style.css.
   return spans([
-    isComplete(progress) ? undefined : span(`${progress.done}/${progress.total}`, 'dim'),
+    isComplete(progress)
+      ? undefined
+      : span(`${progress.done}/${progress.total}`, 'dim', 'progress'),
     report.maxScore === 0
       ? undefined
-      : span(formatScore(report.score, report.maxScore), 'neutral'),
-    span(formatTime(report.maxTime), 'dim'),
-    span(formatMemory(report.maxMemory), 'dim'),
+      : span(formatScore(report.score, report.maxScore), 'neutral', 'score'),
+    span(formatTime(report.maxTime), 'dim', 'time'),
+    span(formatMemory(report.maxMemory), 'dim', 'memory'),
   ]);
 }
 
@@ -510,8 +527,8 @@ function testcaseRow(node: TestcaseNode, depth: number, parentId?: string): Row 
     // felt like being, and in a sidebar it pushed the timings out of a row that
     // is only 22px tall. It belongs somewhere that can wrap.
     meta: spans([
-      span(formatTime(evaluation?.time), 'dim'),
-      span(formatMemory(evaluation?.memory), 'dim'),
+      span(formatTime(evaluation?.time), 'dim', 'time'),
+      span(formatMemory(evaluation?.memory), 'dim', 'memory'),
     ]),
     verdict,
     mismatch: false,

--- a/vscode/src/webview/render.test.ts
+++ b/vscode/src/webview/render.test.ts
@@ -1,4 +1,6 @@
 import * as assert from 'assert';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import type { Row, RunViewModel } from '../rbx/viewModel';
@@ -234,6 +236,58 @@ test('indentation grows with depth and the twisty column survives on a leaf', ()
   assert.ok(html.includes('<span class="twisty"></span>'), html);
   assert.ok(html.includes('<span class="gutter"></span>'), html);
   assert.ok(html.includes('<span class="gutter gutter-met">'), html);
+});
+
+test('the meta line carries its roles and no separator elements of its own', () => {
+  // The separators are drawn by the stylesheet, as a `::before` on every span
+  // but the first. Emitting them here instead would leave one behind whenever
+  // the ladder hides the span it divides, trailing a `·` off a narrowed row.
+  const solution = row({
+    id: 'sol0',
+    kind: 'solution',
+    label: 'sols/main.cpp',
+    meta: [
+      { text: '[70/100]', hue: 'neutral', role: 'score' },
+      { text: '120 ms', hue: 'dim', role: 'time' },
+      { text: '2 KiB', hue: 'dim', role: 'memory' },
+    ],
+  });
+  const html = renderTree(model([solution]), state({}));
+  assert.ok(html.includes('<span class="span span-score hue-neutral">[70/100]</span>'), html);
+  assert.ok(html.includes('<span class="span span-time hue-dim">120 ms</span>'), html);
+  assert.ok(html.includes('<span class="span span-memory hue-dim">2 KiB</span>'), html);
+  // No `.sep` inside the meta line -- the stylesheet owns those now.
+  const meta = html.slice(html.indexOf('<span class="meta">'), html.indexOf('</span></span>'));
+  assert.ok(!meta.includes('class="sep"'), meta);
+});
+
+test('the responsive ladder hides a suffix of the meta line, score last', () => {
+  // Pinned as a table because the *order* is the design, and it is expressed in
+  // a stylesheet no unit test renders. The separator scheme in `metaCell` is
+  // only correct while hiding removes a suffix: if a future breakpoint hid the
+  // score while keeping the memory, the surviving line would start with a `·`.
+  // The compiled test sits in out-test/webview; the stylesheet it is asserting
+  // about is the source one, two levels up.
+  const css = readFileSync(join(__dirname, '..', '..', 'src', 'webview', 'style.css'), 'utf8');
+  const widthOf = (selector: string): number => {
+    // The last query that names the selector is the width it disappears at.
+    const queries = [...css.matchAll(/@container \(max-width: (\d+)px\)\s*\{([\s\S]*?)\n\}/g)];
+    const hit = queries.find((q) => q[2].includes(selector));
+    assert.ok(hit !== undefined, `no breakpoint hides ${selector}`);
+    return Number(hit[1]);
+  };
+  const expectation = widthOf('.expectation {');
+  const memory = widthOf('.span-memory');
+  const time = widthOf('.span-time');
+  const verdictName = widthOf('.verdict-name');
+  const verdict = widthOf('.verdict {');
+  // Strictly descending: each survives the one before it.
+  assert.ok(
+    expectation > memory && memory > time && time > verdictName && verdictName > verdict,
+    `ladder out of order: ${[expectation, memory, time, verdictName, verdict].join(' > ')}`,
+  );
+  // The score is never named by any of them.
+  assert.ok(!css.includes('.span-score'), 'the score must outlive every breakpoint');
 });
 
 test('a row with no meta emits no meta column, and one with meta does', () => {

--- a/vscode/src/webview/render.test.ts
+++ b/vscode/src/webview/render.test.ts
@@ -92,9 +92,30 @@ const MISLABELED = row({
   mismatch: true,
   expandable: true,
   verdict: { icon: 'close', hue: 'red', short: 'WA' },
-  search: 'sols/mislabeled.cpp wa mismatch',
+  expectation: { label: 'INCORRECT', hue: 'red', bold: false, glyph: '\u2717' },
+  search: 'sols/mislabeled.cpp wa incorrect mismatch',
   detail: {
-    mismatch: { declared: 'INCORRECT', observed: 'WA', failedGroups: ['small', 'big'] },
+    // The trap this card exists for: the pooled INCORRECT *held*, so there is
+    // no `pooled` clause -- only the per-group layer failed.
+    mismatch: {
+      pooledHeld: 'INCORRECT',
+      groups: [
+        {
+          name: 'small',
+          declared: 'TLE',
+          declaredHue: 'yellow',
+          observed: 'AC',
+          observedHue: 'green',
+        },
+        {
+          name: 'big',
+          declared: 'TLE',
+          declaredHue: 'yellow',
+          observed: 'WA',
+          observedHue: 'red',
+        },
+      ],
+    },
     histogram: [],
   },
 });
@@ -242,12 +263,22 @@ test('a detail card only appears under an expanded solution', () => {
   assert.ok(renderTree(TREE, state({ expanded: new Set(['sol1']) })).includes('class="detail"'));
 });
 
-test('the mismatch card names every failing group in a sentence', () => {
+test('a group-only miss says which declaration held and what each group wanted', () => {
   const html = renderTree(TREE, state({ expanded: new Set(['sol1']) }));
-  assert.ok(html.includes('Declared INCORRECT, but small, big did not match.'), html);
+  // The correction, in one assertion: the pooled INCORRECT is named as having
+  // *held*, and the groups are paired with the TLE they actually missed. The
+  // sentence this replaces read `Declared INCORRECT, but small, big did not
+  // match.`, which attached the groups to the one declaration that was met.
+  assert.ok(html.includes('INCORRECT held for the solution as a whole'), html);
+  assert.ok(html.includes('2 groups missed their <code>outcomePerGroup</code>'), html);
+  assert.ok(html.includes('<span class="group-name">small</span>'), html);
+  assert.ok(html.includes('<span class="hue-yellow">TLE</span>'), html);
+  assert.ok(html.includes('<span class="hue-green">AC</span>'), html);
+  // ...and nothing anywhere claims the solution's own declaration was missed.
+  assert.ok(!html.includes('Declared <span class="hue-red">INCORRECT</span>'), html);
 });
 
-test('the mismatch card names the observed outcome when no group is named', () => {
+test('a pooled miss is stated as a declared/got pair and nothing more', () => {
   const caught = row({
     id: 'sol2',
     kind: 'solution',
@@ -256,12 +287,81 @@ test('the mismatch card names the observed outcome when no group is named', () =
     mismatch: true,
     expandable: true,
     detail: {
-      mismatch: { declared: 'INCORRECT', observed: 'AC', failedGroups: [] },
+      mismatch: {
+        pooled: {
+          declared: 'AC',
+          declaredHue: 'green',
+          observed: 'WA',
+          observedHue: 'red',
+        },
+        groups: [],
+      },
       histogram: [],
     },
   });
   const html = renderTree(model([caught]), state({ expanded: new Set(['sol2']) }));
-  assert.ok(html.includes('Declared INCORRECT, but got AC.'), html);
+  assert.ok(html.includes('Declared <span class="hue-green">AC</span>'), html);
+  assert.ok(html.includes('<span class="hue-red">WA</span>'), html);
+  assert.ok(!html.includes('outcomePerGroup'), html);
+});
+
+test('a score miss names the range that was declared', () => {
+  const caught = row({
+    id: 'sol3',
+    kind: 'solution',
+    label: 'sols/x.cpp',
+    gutter: 'missed',
+    mismatch: true,
+    expandable: true,
+    detail: {
+      mismatch: { groups: [], score: { expected: '40..60', got: '30' } },
+      histogram: [],
+    },
+  });
+  const html = renderTree(model([caught]), state({ expanded: new Set(['sol3']) }));
+  assert.ok(html.includes('Expected 40..60 pts, scored 30.'), html);
+});
+
+test('a group name in the card cannot escape into markup', () => {
+  const caught = row({
+    id: 'sol4',
+    kind: 'solution',
+    label: 'sols/x.cpp',
+    gutter: 'missed',
+    mismatch: true,
+    expandable: true,
+    detail: {
+      mismatch: {
+        groups: [
+          {
+            name: '<img src=x onerror=alert(1)>',
+            declared: 'TLE',
+            declaredHue: 'yellow',
+            observed: 'AC',
+            observedHue: 'green',
+          },
+        ],
+      },
+      histogram: [],
+    },
+  });
+  const html = renderTree(model([caught]), state({ expanded: new Set(['sol4']) }));
+  assert.ok(!html.includes('<img'), html);
+  assert.ok(html.includes('&lt;img src=x onerror=alert(1)&gt;'), html);
+});
+
+test('a row spells its declaration beside the verdict, and reserves the cell without one', () => {
+  // The gap the group rows fell into: the expectation had no channel of its
+  // own, so a group declaring TLE through `outcomePerGroup` could only be a
+  // hueless name with a warning next to it.
+  const html = renderTree(TREE, state({}));
+  assert.ok(
+    html.includes('<span class="expectation hue-red"><span class="expectation-name">INCORRECT'),
+    html,
+  );
+  // Reserved, not omitted, on the rows with nothing to declare -- the column
+  // has to line up for the pair to be readable straight down.
+  assert.ok(html.includes('<span class="expectation"></span>'), html);
 });
 
 test('the histogram sizes each bar by its share of the testcases', () => {

--- a/vscode/src/webview/render.ts
+++ b/vscode/src/webview/render.ts
@@ -92,16 +92,30 @@ function twistyCell(row: Row, expanded: boolean): string {
 
 function spanCell(span: Span): string {
   const hue = span.hue === undefined ? '' : ` hue-${span.hue}`;
-  return `<span class="span${hue}">${escapeHtml(span.text)}</span>`;
+  const role = span.role === undefined ? '' : ` span-${span.role}`;
+  return `<span class="span${role}${hue}">${escapeHtml(span.text)}</span>`;
 }
 
 const SEPARATOR = '<span class="sep">·</span>';
 
+/**
+ * The meta line, with no separators between its spans.
+ *
+ * They are drawn by the stylesheet as a `::before` on each span but the first,
+ * which is the only arrangement that survives a span being hidden: a separator
+ * written here as its own element would stay behind when the span it divides
+ * goes, leaving `[30/100] ·` trailing off a narrowed row. Belonging to the span
+ * it precedes, it leaves when that span does.
+ *
+ * This holds because the responsive ladder always hides a *suffix* of the line
+ * -- memory before time, and neither before the score -- so the span that is
+ * first is always the one that was first.
+ */
 function metaCell(meta: readonly Span[]): string {
   if (meta.length === 0) {
     return '';
   }
-  return `<span class="meta">${meta.map(spanCell).join(SEPARATOR)}</span>`;
+  return `<span class="meta">${meta.map(spanCell).join('')}</span>`;
 }
 
 /**

--- a/vscode/src/webview/render.ts
+++ b/vscode/src/webview/render.ts
@@ -14,10 +14,13 @@
  * which is why nothing that decides anything is allowed to live there.
  */
 import type {
+  GroupMismatch,
   HistogramSlice,
   MismatchDetail,
+  Mismatched,
   Row,
   RunViewModel,
+  ScoreMismatch,
   SolutionDetail,
   Span,
 } from '../rbx/viewModel';
@@ -99,6 +102,29 @@ function metaCell(meta: readonly Span[]): string {
     return '';
   }
   return `<span class="meta">${meta.map(spanCell).join(SEPARATOR)}</span>`;
+}
+
+/**
+ * What the row declared, in words, immediately left of what it got.
+ *
+ * Emitted even when there is nothing to say, for the same reason the gutter is:
+ * the pair reads as `TLE \u2192 WA` down a column, and a cell that disappears on
+ * the undeclared rows takes the column's alignment with it.
+ *
+ * The arrow is inside this cell rather than between the two, so it arrives and
+ * leaves with the declaration it points from.
+ */
+function expectationCell(row: Row): string {
+  const expectation = row.expectation;
+  if (expectation === undefined) {
+    return '<span class="expectation"></span>';
+  }
+  return (
+    `<span class="expectation hue-${expectation.hue}">` +
+    `<span class="expectation-name">${escapeHtml(expectation.label)}</span>` +
+    '<span class="arrow">\u2192</span>' +
+    '</span>'
+  );
 }
 
 function verdictCell(row: Row): string {
@@ -191,36 +217,88 @@ function renderRow(
     twistyCell(row, expanded) +
     labelCell(row) +
     metaCell(row.meta) +
+    expectationCell(row) +
     verdictCell(row) +
     '</div>'
   );
 }
 
-/**
- * What a caught solution got wrong, in a sentence.
- *
- * The old view said this as `expected INCORRECT, got WA` in the same dim grey
- * as every row's timing, where it was invisible. `failedGroups` is what rbx
- * itself names as the culprit, so the groups are the sentence when there are
- * any; the observed outcome only stands in when rbx named none.
- */
-function mismatchSentence(mismatch: MismatchDetail): string {
-  // `did not match`, not `matched`: rbx reports the groups that *failed* their
-  // declaration, so naming them as the ones that matched says the opposite of
-  // what happened -- and the whole reason this card exists is that the old
-  // phrasing could not be read at a glance.
-  const tail =
-    mismatch.failedGroups.length > 0
-      ? `${mismatch.failedGroups.map(escapeHtml).join(', ')} did not match`
-      : `got ${escapeHtml(mismatch.observed)}`;
-  return `Declared ${escapeHtml(mismatch.declared)}, but ${tail}.`;
+function hued(text: string, hue: string): string {
+  return `<span class="hue-${hue}">${escapeHtml(text)}</span>`;
 }
 
+/** `TLE \u2192 AC`, the same pairing the rows use, so the card reads as a zoom
+ * into them rather than as a second notation. */
+function declaredGot(pair: Mismatched | GroupMismatch): string {
+  return (
+    hued(pair.declared, pair.declaredHue) +
+    '<span class="arrow">\u2192</span>' +
+    hued(pair.observed, pair.observedHue)
+  );
+}
+
+/**
+ * The pooled layer's own miss.
+ *
+ * Printed only when `MismatchDetail.pooled` is set, which is only when that
+ * layer is what failed. The old card printed this unconditionally and then
+ * listed the failing groups after a `but`, which read as if those groups had
+ * missed the pooled declaration -- for a solution whose pooled declaration
+ * held, that named the one expectation nothing was wrong with.
+ */
+function pooledLine(pooled: Mismatched): string {
+  return `<p class="mismatch-line">Declared ${declaredGot(pooled)}</p>`;
+}
+
+/** A group per row, each naming its own declaration. */
+function groupLines(groups: readonly GroupMismatch[], held: string | undefined): string {
+  const count = groups.length;
+  const subject = count === 1 ? '1 group' : `${count} groups`;
+  // Naming the pooled declaration as *held* is the correction: the reader is
+  // looking at a row labelled INCORRECT and needs to be told that is not the
+  // declaration these groups missed.
+  const lead =
+    held === undefined
+      ? `${subject} missed their <code>outcomePerGroup</code> declaration:`
+      : `${escapeHtml(held)} held for the solution as a whole; ` +
+        `${subject} missed their <code>outcomePerGroup</code> declaration:`;
+  const rows = groups
+    .map(
+      (group) =>
+        '<li>' +
+        `<span class="group-name">${escapeHtml(group.name)}</span>` +
+        `<span class="group-pair">${declaredGot(group)}</span>` +
+        '</li>',
+    )
+    .join('');
+  return `<p class="mismatch-line">${lead}</p><ul class="group-misses">${rows}</ul>`;
+}
+
+function scoreLine(score: ScoreMismatch): string {
+  return (
+    '<p class="mismatch-line">Expected ' +
+    `${escapeHtml(score.expected)} pts, scored ${escapeHtml(score.got)}.</p>`
+  );
+}
+
+/**
+ * What a caught solution got wrong, layer by layer.
+ *
+ * Each clause speaks only for the layer it belongs to and appears only when
+ * that layer failed, so no sentence here can accuse an expectation that held.
+ */
 function mismatchCard(mismatch: MismatchDetail): string {
+  const body =
+    (mismatch.pooled === undefined ? '' : pooledLine(mismatch.pooled)) +
+    (mismatch.groups.length === 0 ? '' : groupLines(mismatch.groups, mismatch.pooledHeld)) +
+    (mismatch.score === undefined ? '' : scoreLine(mismatch.score));
+  if (body === '') {
+    return '';
+  }
   return (
     '<div class="mismatch-card">' +
     codicon('warning') +
-    `<span class="mismatch-text">${mismatchSentence(mismatch)}</span>` +
+    `<div class="mismatch-text">${body}</div>` +
     '</div>'
   );
 }

--- a/vscode/src/webview/style.css
+++ b/vscode/src/webview/style.css
@@ -204,6 +204,23 @@ body {
   opacity: 0.6;
 }
 
+/* The meta line's separators, drawn rather than emitted.
+   `render.ts` writes the spans with nothing between them: a separator element
+   of its own would outlive the span it divides and leave `[30/100] ·` trailing
+   off a row that had dropped its timings. Attached to the span that follows it,
+   it leaves when that span leaves -- which works because the ladder at the
+   bottom of this file only ever hides a suffix of the line. */
+.meta > .span::before {
+  content: '·';
+  margin-right: 4px;
+  color: var(--vscode-descriptionForeground);
+  opacity: 0.6;
+}
+
+.meta > .span:first-child::before {
+  content: none;
+}
+
 /* The declaration, immediately left of the outcome so the two read as one
    `declared -> got` phrase. Quieter than the verdict beside it: the verdict is
    what happened and the declaration is only what was asked for, and at equal
@@ -423,18 +440,65 @@ body {
   font-family: var(--vscode-editor-font-family);
 }
 
-@container (max-width: 260px) {
-  .meta {
+/*
+ * The responsive ladder.
+ *
+ * A row has more to say than a narrow sidebar can show, so the question is not
+ * whether to drop things but in which order -- and the order is by how much
+ * each would be missed, not by how much room each frees:
+ *
+ *   1. the declaration   -- what was *asked for*. The gutter still says whether
+ *                           it was met, which is the part that needs answering
+ *                           at a glance; the card says what it was.
+ *   2. memory            -- the measurement that is almost never the one being
+ *                           looked for.
+ *   3. time              -- wanted often, but a solution is opened to study its
+ *                           timings, and the card carries the maxima.
+ *   4. the verdict       -- name first, then the icon. Losing the name costs
+ *                           little while the colour and shape remain.
+ *   5. the score         -- never. On a points problem it is the answer to the
+ *                           question the view exists to answer, and it is the
+ *                           cheapest thing on the row.
+ *
+ * Everything above the score is recoverable by widening the sidebar or opening
+ * the row. Each breakpoint is set where the label -- a path, the one thing that
+ * cannot be recovered from anywhere else -- would otherwise be squeezed past
+ * legibility.
+ */
+
+/* 1. The declaration. */
+@container (max-width: 400px) {
+  .expectation {
     display: none;
   }
 }
 
-/* Narrower still. The declaration outlives the timings and is outlived by the
-   verdict, which is the order of how much each would be missed: a row can
-   always be opened for its timings, and the declaration is the only channel
-   saying what the row was *for*. */
-@container (max-width: 200px) {
-  .expectation {
+/* 2. Memory. */
+@container (max-width: 330px) {
+  .span-memory {
+    display: none;
+  }
+}
+
+/* 3. Time. */
+@container (max-width: 280px) {
+  .span-time {
+    display: none;
+  }
+}
+
+/* 4a. The verdict's name, keeping its icon: the colour and the shape are most
+   of what the name says, at a tenth of the width. */
+@container (max-width: 240px) {
+  .verdict-name {
+    display: none;
+  }
+}
+
+/* 4b. The verdict entirely. Below this the row is a path and a score, which is
+   the least a row can be and still be worth drawing. */
+@container (max-width: 190px) {
+  .verdict {
     display: none;
   }
 }

--- a/vscode/src/webview/style.css
+++ b/vscode/src/webview/style.css
@@ -136,7 +136,7 @@ body {
 
 .row {
   display: grid;
-  grid-template-columns: 16px 16px 1fr auto auto;
+  grid-template-columns: 16px 16px 1fr auto auto auto;
   align-items: center;
   gap: 6px;
   height: 22px;
@@ -204,6 +204,48 @@ body {
   opacity: 0.6;
 }
 
+/* The declaration, immediately left of the outcome so the two read as one
+   `declared -> got` phrase. Quieter than the verdict beside it: the verdict is
+   what happened and the declaration is only what was asked for, and at equal
+   weight the row grows a second thing competing to be read first.
+
+   It grows leftwards from the verdict rather than occupying a column of its
+   own. The verdict column is fixed-width so it can be scanned straight down;
+   giving this one the same treatment would mean reserving the width of
+   `TLE or RTE` on every row in a sidebar this narrow. What has to line up is
+   the *pair*, and the pair is anchored on the right, where the arrow always
+   meets the verdict. */
+.expectation {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  white-space: nowrap;
+  opacity: 0.75;
+  font-size: 0.9em;
+}
+
+/* `TLE or RTE` is the longest label expectation.ts spells, and a member this
+   extension is too old to know is rendered under its raw name, which has no
+   bound at all. Capped so an unknown member cannot push the verdict column off
+   the panel; every member that exists today fits inside it untouched. */
+.expectation-name {
+  max-width: 10ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Inherits the colour of whatever it points *from*, in both the row and the
+   card, so the eye follows the phrase rather than the punctuation. */
+.arrow {
+  opacity: 0.6;
+}
+
+/* The row's arrow sits in a flex box that spaces it; the card's sits in running
+   text, which does not. */
+.mismatch-line .arrow {
+  margin: 0 4px;
+}
+
 .verdict {
   display: flex;
   align-items: center;
@@ -266,6 +308,14 @@ body {
   display: flex;
   align-items: baseline;
   gap: 6px;
+  /* The icon carries the alarm; the prose does not. The card used to be red
+     throughout, which was right when it held one red sentence -- now that it
+     names two declaration layers and hues each `declared -> got` pair by what
+     it actually is, a red wash sat in front of the colours doing the work. */
+  color: var(--vscode-foreground);
+}
+
+.mismatch-card > .codicon {
   color: var(--vscode-charts-red);
 }
 
@@ -273,6 +323,53 @@ body {
   /* The sentence wraps rather than truncating: it is the one thing in the view
      that has to be read in full. */
   white-space: normal;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.mismatch-line {
+  margin: 0;
+}
+
+.mismatch-line code {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 0.9em;
+  opacity: 0.9;
+}
+
+/* One group per line rather than a comma-separated run: each carries its own
+   declared -> got pair, and inlined they read as one long clause in which no
+   declaration is clearly attached to any group. */
+.group-misses {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.group-misses li {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+/* Neither name nor pair is hued: the pair carries the colour, and the group
+   name is the thing being talked about rather than a verdict of its own. */
+.group-name {
+  color: var(--vscode-foreground);
+  min-width: 6ch;
+  overflow-wrap: anywhere;
+}
+
+.group-pair {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  white-space: nowrap;
 }
 
 .histogram {
@@ -328,6 +425,16 @@ body {
 
 @container (max-width: 260px) {
   .meta {
+    display: none;
+  }
+}
+
+/* Narrower still. The declaration outlives the timings and is outlived by the
+   verdict, which is the order of how much each would be missed: a row can
+   always be opened for its timings, and the declaration is the only channel
+   saying what the row was *for*. */
+@container (max-width: 200px) {
+  .expectation {
     display: none;
   }
 }


### PR DESCRIPTION
## What

Follow-up to #672, from the `mislabeled-groups` solution in the sample package.

That solution declares `outcome: incorrect` with `outcomePerGroup: {'*': tle}`. It **is** incorrect — it fails on `edge` and `big` — so the pooled layer *holds*. It is caught only by the per-group layer, which every group missed. The view said of it:

> ⚠ Declared INCORRECT, but samples, main, edge, big did not match.

Both halves are true and the sentence is false: those groups missed `TLE`, not `INCORRECT`. And nothing anywhere in the view said `TLE` at all — the four group rows were hueless names with a warning beside them, so the reader could see *that* something was wrong and had no way to see *what was wanted*.

Two bugs with one root: the run view models one declaration where a solution can carry two.

## How

### The report says which layer failed

`matchesExpectation` is the aggregate of the pooled `outcome` and the per-group `outcomePerGroup`, and the aggregate cannot say which one to blame. rbx already draws this distinction — `get_verdict_markup` will only print `Expected: X` when `pooledStatus` is itself not ok, precisely so it does not accuse an expectation that was met — but `pooledStatus` was the one fact the published report never carried, so the extension had no way to reach the same conclusion.

`RunSolutionReport` gains `pooledMatchesExpectation`. `expectedScore` comes with it, so the third failure mode — a score outside its declared range — has something to say beyond "wrong".

Both fields are optional, so **the version does not bump**: an older reader drops what it does not know and reads the rest unchanged, where a bump would instead make every existing reader ignore the whole file. An extension meeting a report written before this change infers the pooled layer from "no group failed, so nothing else can have" — exact except when both layers failed at once, where it under-reports rather than accusing a layer that held.

### A row spells its declaration

The expectation gets a channel of its own, between the meta and the verdict, on solutions and groups alike:

```
[gutter][twisty][label .............][meta][expectation][verdict]

  ⚠  edge      [0/30 pts] · 9 ms · 10 MiB    TLE → ✗ WA
```

It grows leftwards from the verdict rather than taking a fixed column of its own. The verdict column is fixed-width so it can be scanned straight down; giving this one the same treatment would mean reserving the width of `TLE or RTE` on every row in a sidebar this narrow. What has to line up is the *pair*, and the pair is anchored on the right where the arrow meets the verdict.

Groups take the label hue too, by the rule solutions already used — #672 gave groups the gutter but left them out of the expectation channel, which is the gap. `ANY` still draws nothing: it is how a setter declares nothing, and the gutter already treated it that way. Under a container query the declaration drops after the timings and before the verdict, which is the order of how much each would be missed.

### The card speaks per layer

`MismatchDetail` becomes a set of optional clauses — a pooled `declared → got` pair, a list of groups each carrying its own pair, a score range — and the renderer prints only the clauses that are set. No sentence it can produce accuses an expectation that held.

`mislabeled-groups.cpp` now reads:

```
⚠ INCORRECT held for the solution as a whole; 4 groups missed their
  outcomePerGroup declaration:
     samples   TLE → AC
     main      TLE → AC
     edge      TLE → WA
     big       TLE → WA
```

Naming the pooled layer as **held** is deliberate rather than redundant: the reader is looking at a row labelled `INCORRECT` and needs to be told that is not the declaration these groups missed.

`optimistic.cpp`, which misses only the pooled layer, reads `Declared AC → WA` and says nothing about groups. `partial.cpp`, which meets both layers while failing on purpose, stays completely calm as before.

The card is no longer red throughout — the icon carries the alarm. That was right when it held one red sentence; now that each pair is hued by what it actually is, a red wash sat in front of the colours doing the work.

## Verification

Checked against the real `rbx-vscode-sample` run rather than only fixtures: regenerated its report with the patched rbx (`pooledMatchesExpectation: true` for `mislabeled-groups`, `false` for `optimistic`), then rendered it through `viewModel` + `render` and looked at the result in a browser with VS Code's dark variables filled in.

- `npm run typecheck`, `npm run compile`, `npm run package` clean; `npm test` **84 pass, 0 fail** (76 → 84).
- `uv run pytest tests/rbx/box/run_report_test.py` 10 pass; `run_report_test.py` + `solutions_test.py` 85 pass.
- Full `tests/rbx` (minus CLI): 35 failures, byte-identical to the same run on the base commit — the pre-existing local C++/sandbox set. 4550 → 4552 passed, which is the two new tests.
- Layout measured in-browser: no row overflows at any width, verdict column stays aligned, and the degradation ladder fires as designed — meta drops at 260px, expectation at 200px, verdict always survives.

Tests pin the traps rather than the markup. `viewModel.test.ts` asserts `pooled === undefined` for the group-only miss (naming the pooled layer there is the whole bug), asserts the stale-report inference separately, and asserts a group inherits no declaration from the solution above it. `render.test.ts` asserts the card never emits `Declared <INCORRECT>` for that solution, and that a group named `<img src=x onerror=alert(1)>` reaches the output escaped.

## Notes

Design doc updated: the two superseded paragraphs in D3/D4 are marked as such rather than rewritten, and D9 records the correction. The `summary.ts` logic D4 said it would reuse never made it into the implementation — that intent is now enforced by the model shape instead of by prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
