### PR TITLE
feat(vscode): let a setting choose how much of a solution path a row shows

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -50,6 +50,26 @@ A run of a single solution opens expanded, the way `rbx run` prints per-testcase
 lines only when there is one solution to print them for. A run of several opens
 with the solutions collapsed; expanding one reveals its groups already open.
 
+### Naming solutions
+
+Nearly every package keeps its solutions under one directory, so the path rbx
+records repeats that directory on every row and spends the sidebar's narrowest
+column saying nothing. `rbx.solutionLabel` chooses how much of it to keep:
+
+| Value | `sols/main.cpp`, `sols/slow/tle.cpp` |
+|---|---|
+| `full` | `sols/main.cpp`, `sols/slow/tle.cpp` |
+| `trimmed` (default) | `main.cpp`, `slow/tle.cpp` |
+| `basename` | `main.cpp`, `tle.cpp` |
+
+`trimmed` drops the longest directory prefix *that package's* solutions all
+share, so one package that stores its solutions somewhere unusual does not cost
+the others their trimming. It works in whole path segments and never touches a
+file name: `main.cpp` beside `mai_x.cpp` stays both.
+
+Whatever is shown, the filter box still matches the full path, and a shortened
+name carries the whole one as its tooltip.
+
 ## Status
 
 Milestone 1 of the [v1 design](../docs/plans/2026-08-11-vscode-extension-design.md):

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -139,6 +139,21 @@
           "type": "number",
           "default": 3,
           "markdownDescription": "How deep to search workspace folders for `problem.rbx.yml` files."
+        },
+        "rbx.solutionLabel": {
+          "type": "string",
+          "enum": [
+            "full",
+            "trimmed",
+            "basename"
+          ],
+          "default": "trimmed",
+          "markdownDescription": "How the Run view names a solution. Filtering always matches the full path, whatever is shown.",
+          "enumDescriptions": [
+            "The full path, relative to the package root: `sols/main.cpp`.",
+            "The path without the directory every solution in the package shares: `main.cpp`, and `slow/tle.cpp` for one nested deeper.",
+            "The file name alone: `main.cpp`, and `tle.cpp` for `sols/slow/tle.cpp`."
+          ]
         }
       }
     }

--- a/vscode/src/rbx/solutionLabel.test.ts
+++ b/vscode/src/rbx/solutionLabel.test.ts
@@ -1,0 +1,90 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import {
+  SolutionLabelStyle,
+  asSolutionLabelStyle,
+  commonDirPrefix,
+  solutionLabels,
+} from './solutionLabel';
+
+/** The labels in input order, which is the order the rows appear in. */
+function labels(paths: readonly string[], style: SolutionLabelStyle): string[] {
+  const map = solutionLabels(paths, style);
+  return paths.map((solutionPath) => map.get(solutionPath) ?? '');
+}
+
+const SOLS = ['sols/main.cpp', 'sols/partial.cpp', 'sols/slow/tle.cpp'];
+
+test('the full style shows the path relative to the package root', () => {
+  assert.deepStrictEqual(labels(SOLS, 'full'), [
+    'sols/main.cpp',
+    'sols/partial.cpp',
+    'sols/slow/tle.cpp',
+  ]);
+});
+
+test('the trimmed style drops the directory every solution shares', () => {
+  assert.deepStrictEqual(labels(SOLS, 'trimmed'), ['main.cpp', 'partial.cpp', 'slow/tle.cpp']);
+});
+
+test('the basename style drops every directory', () => {
+  assert.deepStrictEqual(labels(SOLS, 'basename'), ['main.cpp', 'partial.cpp', 'tle.cpp']);
+});
+
+test('a shared prefix that is not a whole segment is not a prefix', () => {
+  // `sols/` and `solutions/` share four characters and no directory.
+  const mixed = ['sols/main.cpp', 'solutions/other.cpp'];
+  assert.strictEqual(commonDirPrefix(mixed), '');
+  assert.deepStrictEqual(labels(mixed, 'trimmed'), ['sols/main.cpp', 'solutions/other.cpp']);
+});
+
+test('the basename is never eaten by the prefix', () => {
+  // Two files in the same directory whose names share a prefix: character-wise
+  // trimming would show `n.cpp` and `_x.cpp`.
+  const siblings = ['sols/main.cpp', 'sols/mai_x.cpp'];
+  assert.strictEqual(commonDirPrefix(siblings), 'sols/');
+  assert.deepStrictEqual(labels(siblings, 'trimmed'), ['main.cpp', 'mai_x.cpp']);
+});
+
+test('solutions at the package root are left alone', () => {
+  const flat = ['main.cpp', 'wa.cpp'];
+  assert.strictEqual(commonDirPrefix(flat), '');
+  assert.deepStrictEqual(labels(flat, 'trimmed'), ['main.cpp', 'wa.cpp']);
+});
+
+test('a lone solution trims down to its basename', () => {
+  assert.deepStrictEqual(labels(['sols/main.cpp'], 'trimmed'), ['main.cpp']);
+});
+
+test('nested directories are trimmed as deep as they agree', () => {
+  const nested = ['a/b/c/one.cpp', 'a/b/c/two.cpp'];
+  assert.strictEqual(commonDirPrefix(nested), 'a/b/c/');
+  assert.deepStrictEqual(labels(nested, 'trimmed'), ['one.cpp', 'two.cpp']);
+});
+
+test('the prefix stops at the first directory the set disagrees on', () => {
+  const forked = ['a/b/one.cpp', 'a/c/two.cpp'];
+  assert.strictEqual(commonDirPrefix(forked), 'a/');
+  assert.deepStrictEqual(labels(forked, 'trimmed'), ['b/one.cpp', 'c/two.cpp']);
+});
+
+test('windows separators are labelled like the posix paths they mirror', () => {
+  const windows = ['sols\\main.cpp', 'sols\\wa.cpp'];
+  assert.deepStrictEqual(labels(windows, 'trimmed'), ['main.cpp', 'wa.cpp']);
+  assert.deepStrictEqual(labels(windows, 'full'), ['sols/main.cpp', 'sols/wa.cpp']);
+});
+
+test('an empty package has no prefix to compute', () => {
+  assert.strictEqual(commonDirPrefix([]), '');
+  assert.deepStrictEqual(labels([], 'trimmed'), []);
+});
+
+test('the configured style falls back to trimmed for anything unrecognized', () => {
+  assert.strictEqual(asSolutionLabelStyle('full'), 'full');
+  assert.strictEqual(asSolutionLabelStyle('trimmed'), 'trimmed');
+  assert.strictEqual(asSolutionLabelStyle('basename'), 'basename');
+  assert.strictEqual(asSolutionLabelStyle(undefined), 'trimmed');
+  assert.strictEqual(asSolutionLabelStyle('relative'), 'trimmed');
+  assert.strictEqual(asSolutionLabelStyle(3), 'trimmed');
+});

--- a/vscode/src/rbx/solutionLabel.ts
+++ b/vscode/src/rbx/solutionLabel.ts
@@ -1,0 +1,90 @@
+/**
+ * How a solution row names its solution.
+ *
+ * Packages overwhelmingly keep every solution under one directory -- `sols/` in
+ * the presets -- so the path rbx records repeats that directory on every row
+ * and spends the sidebar's narrow label column saying nothing. The user picks
+ * how much of the path to keep through `rbx.solutionLabel`; this module is the
+ * whole of that decision, kept free of `vscode` so it stays testable under
+ * plain `node --test` like the rest of `rbx/`.
+ */
+import * as path from 'path';
+
+export type SolutionLabelStyle = 'full' | 'trimmed' | 'basename';
+
+export const DEFAULT_SOLUTION_LABEL_STYLE: SolutionLabelStyle = 'trimmed';
+
+/** The configured style, or the default for anything unrecognized. */
+export function asSolutionLabelStyle(value: unknown): SolutionLabelStyle {
+  return value === 'full' || value === 'trimmed' || value === 'basename'
+    ? value
+    : DEFAULT_SOLUTION_LABEL_STYLE;
+}
+
+/**
+ * rbx writes solution paths with the separator of the host that ran it, so a
+ * package generated on Windows and read on macOS arrives with backslashes.
+ * Every rule below is about path *segments*, and it can only be if the two
+ * separators have already been made one.
+ */
+function segments(solutionPath: string): string[] {
+  return solutionPath.split(/[\\/]+/).filter((segment) => segment !== '');
+}
+
+/**
+ * The longest directory prefix every path shares, as a string ending in `/`.
+ *
+ * Whole segments only, and never the basename: `main.cpp` and `mai_x.cpp` share
+ * three characters and nothing that can be dropped, and a package whose
+ * solutions all sit at the root shares no directory at all. Both cases return
+ * the empty prefix, which is what leaves the paths alone.
+ */
+export function commonDirPrefix(paths: readonly string[]): string {
+  if (paths.length === 0) {
+    return '';
+  }
+  const dirs = paths.map((solutionPath) => segments(solutionPath).slice(0, -1));
+  const common: string[] = [];
+  for (let i = 0; i < dirs[0].length; i++) {
+    const segment = dirs[0][i];
+    if (!dirs.every((dir) => dir[i] === segment)) {
+      break;
+    }
+    common.push(segment);
+  }
+  return common.length === 0 ? '' : `${common.join('/')}/`;
+}
+
+/**
+ * The label for each path, keyed by the path itself.
+ *
+ * Computed over the whole list rather than one path at a time because
+ * `trimmed` is a fact about the set: what a row drops depends on what its
+ * siblings kept. Callers pass one package's solutions, so a contest workspace
+ * is not flattened to the least common denominator of every package in it.
+ */
+export function solutionLabels(
+  paths: readonly string[],
+  style: SolutionLabelStyle,
+): Map<string, string> {
+  const prefix = style === 'trimmed' ? commonDirPrefix(paths) : '';
+  const labels = new Map<string, string>();
+  for (const solutionPath of paths) {
+    const normalized = segments(solutionPath).join('/');
+    const label = ((): string => {
+      switch (style) {
+        case 'full':
+          return normalized;
+        case 'basename':
+          return path.posix.basename(normalized);
+        case 'trimmed':
+          // The prefix always stops short of the basename, so the slice is
+          // never empty; the fallback is for a path that somehow did not start
+          // with the prefix its own set produced.
+          return normalized.startsWith(prefix) ? normalized.slice(prefix.length) : normalized;
+      }
+    })();
+    labels.set(solutionPath, label === '' ? solutionPath : label);
+  }
+  return labels;
+}

--- a/vscode/src/rbx/viewModel.test.ts
+++ b/vscode/src/rbx/viewModel.test.ts
@@ -160,7 +160,9 @@ test('a solution that met its ACCEPTED declaration reads green all the way throu
   assert.strictEqual(row.kind, 'solution');
   assert.strictEqual(row.gutter, 'met');
   assert.strictEqual(row.mismatch, false);
-  assert.strictEqual(row.label, 'sols/main.cpp');
+  // `main.cpp`, not `sols/main.cpp`: the default style trims the directory the
+  // package's solutions share. The styles are pinned on their own below.
+  assert.strictEqual(row.label, 'main.cpp');
   assert.strictEqual(row.labelHue, 'green');
   assert.strictEqual(row.labelBold, true);
   assert.deepStrictEqual(row.verdict, { icon: 'pass', hue: 'green', short: 'AC' });
@@ -547,4 +549,62 @@ test('a package row is labelled by its directory and carries no verdict', () => 
   assert.strictEqual(row.gutter, 'none');
   assert.strictEqual(row.section, 'rbx.package');
   assert.strictEqual(row.defaultExpanded, true);
+});
+
+// `rbx.solutionLabel`. The styles themselves are pinned in solutionLabel.test.ts;
+// what these hold to account is that the view model reaches them and that the
+// row keeps the whole path in the two places the label is not the whole path.
+
+const NESTED = solution(3, 'sols/slow/tle.cpp', 'INCORRECT', [], solutionReport({
+  path: 'sols/slow/tle.cpp',
+  index: 3,
+  expectedOutcome: 'INCORRECT',
+  outcome: 'time-limit-exceeded',
+}));
+
+test('the label style picks how much of a solution path a row shows', () => {
+  const solutions = [MAIN, PARTIAL, NESTED];
+  const labelsOf = (style: Parameters<typeof buildViewModel>[1]): string[] =>
+    buildViewModel([view(solutions)], style)
+      .rows.filter((row) => row.kind === 'solution')
+      .map((row) => row.label);
+
+  assert.deepStrictEqual(labelsOf('full'), [
+    'sols/main.cpp',
+    'sols/partial.cpp',
+    'sols/slow/tle.cpp',
+  ]);
+  assert.deepStrictEqual(labelsOf('trimmed'), ['main.cpp', 'partial.cpp', 'slow/tle.cpp']);
+  assert.deepStrictEqual(labelsOf('basename'), ['main.cpp', 'partial.cpp', 'tle.cpp']);
+  // The default is what the host omits the argument to get.
+  assert.deepStrictEqual(labelsOf(undefined), labelsOf('trimmed'));
+});
+
+test('each package trims by the prefix its own solutions share', () => {
+  const elsewhere = solution(0, 'other/dir/x.cpp', 'ACCEPTED', [], solutionReport({
+    path: 'other/dir/x.cpp',
+  }));
+  const { rows } = buildViewModel(
+    [view([MAIN, PARTIAL]), { pkg: OTHER, run: run([elsewhere]) }],
+    'trimmed',
+  );
+  // `/w/b`'s lone solution lives nowhere near `sols/`, and that costs `/w/a`
+  // nothing: a shared prefix computed across both packages would be empty.
+  assert.strictEqual(rowById(rows, '/w/a::0').label, 'main.cpp');
+  assert.strictEqual(rowById(rows, '/w/a::1').label, 'partial.cpp');
+  assert.strictEqual(rowById(rows, '/w/b::0').label, 'x.cpp');
+});
+
+test('a shortened label keeps the whole path for the tooltip', () => {
+  const { rows } = buildViewModel([view([MAIN, PARTIAL])], 'basename');
+  assert.strictEqual(rowById(rows, '/w/a::0').labelTitle, 'sols/main.cpp');
+  // Nothing was dropped, so there is nothing for a tooltip to add.
+  const full = buildViewModel([view([MAIN, PARTIAL])], 'full');
+  assert.strictEqual(rowById(full.rows, '/w/a::0').labelTitle, undefined);
+});
+
+test('the filter matches the full path whatever the label shows', () => {
+  const { rows } = buildViewModel([view([MAIN, PARTIAL])], 'basename');
+  assert.strictEqual(rowById(rows, '/w/a::0').search, 'sols/main.cpp ac');
+  assert.strictEqual(rowById(rows, '/w/a::1').search, 'sols/partial.cpp wa incorrect');
 });

--- a/vscode/src/rbx/viewModel.ts
+++ b/vscode/src/rbx/viewModel.ts
@@ -31,6 +31,11 @@ import {
 } from './nodes';
 import { isAccepted, outcomeIcon, shortName } from './outcome';
 import { GroupReport, SolutionReport } from './report';
+import {
+  DEFAULT_SOLUTION_LABEL_STYLE,
+  SolutionLabelStyle,
+  solutionLabels,
+} from './solutionLabel';
 import { SolutionRun, TestcaseRun } from './store';
 import {
   Progress,
@@ -132,6 +137,15 @@ export interface Row {
   readonly kind: 'package' | 'solution' | 'group' | 'testcase';
   readonly gutter: Gutter;
   readonly label: string;
+  /**
+   * The whole of what the label is a shortening of, for the row's tooltip.
+   *
+   * Only solution rows carry one, and only because `rbx.solutionLabel` lets the
+   * label stop short of the path: a user reading `main.cpp` under two packages
+   * still has somewhere to find out which `sols/` it came from. Absent when the
+   * label is already the whole truth.
+   */
+  readonly labelTitle?: string;
   readonly labelHue?: Hue;
   readonly labelBold: boolean;
   readonly meta: readonly Span[];
@@ -446,7 +460,7 @@ function packageRow(node: PackageNode, depth: number, parentId?: string): Row {
   };
 }
 
-function solutionRow(node: SolutionNode, depth: number, parentId?: string): Row {
+function solutionRow(node: SolutionNode, depth: number, label: string, parentId?: string): Row {
   const { run, solo } = node;
   const gutter = solutionGutter(run);
   const mismatch = gutter === 'missed';
@@ -459,7 +473,8 @@ function solutionRow(node: SolutionNode, depth: number, parentId?: string): Row 
     depth,
     kind: 'solution',
     gutter,
-    label: run.solution.path,
+    label,
+    labelTitle: label === run.solution.path ? undefined : run.solution.path,
     labelHue: declared?.hue,
     labelBold: declared?.bold ?? false,
     meta: aggregateMeta(run.report, progressOf(testcases)),
@@ -553,8 +568,34 @@ const DEPTHS: Record<Row['kind'], number> = {
   testcase: 3,
 };
 
-export function buildViewModel(packages: readonly PackageRunView[]): RunViewModel {
+/**
+ * Every package's solution labels, by package root and then by solution path.
+ *
+ * Computed package by package, so the prefix `trimmed` drops is the one *that*
+ * package's solutions share -- a contest workspace where one package keeps its
+ * solutions somewhere unusual does not cost every other package its trimming.
+ */
+function labelsByPackage(
+  packages: readonly PackageRunView[],
+  style: SolutionLabelStyle,
+): Map<string, Map<string, string>> {
+  const labels = new Map<string, Map<string, string>>();
+  for (const { pkg, run } of packages) {
+    if (run === undefined) {
+      continue;
+    }
+    const paths = run.solutions.map((solutionRun) => solutionRun.solution.path);
+    labels.set(pkg.root, solutionLabels(paths, style));
+  }
+  return labels;
+}
+
+export function buildViewModel(
+  packages: readonly PackageRunView[],
+  style: SolutionLabelStyle = DEFAULT_SOLUTION_LABEL_STYLE,
+): RunViewModel {
   const nodes = flattenNodes(packages);
+  const labels = labelsByPackage(packages, style);
   // `flattenNodes` drops the package level for a single package, so the offset
   // has to come from the walk it actually performed rather than from the input.
   const hasPackages = nodes.some((node) => node.kind === 'package');
@@ -571,8 +612,10 @@ export function buildViewModel(packages: readonly PackageRunView[]): RunViewMode
       switch (node.kind) {
         case 'package':
           return packageRow(node, depth, parentId);
-        case 'solution':
-          return solutionRow(node, depth, parentId);
+        case 'solution': {
+          const path = node.run.solution.path;
+          return solutionRow(node, depth, labels.get(node.pkg.root)?.get(path) ?? path, parentId);
+        }
         case 'group':
           return groupRow(node, depth, parentId);
         case 'testcase':

--- a/vscode/src/runView.ts
+++ b/vscode/src/runView.ts
@@ -16,6 +16,7 @@ import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 
 import { RunNode, flattenNodes, nodeId } from './rbx/nodes';
+import { asSolutionLabelStyle } from './rbx/solutionLabel';
 import { buildViewModel } from './rbx/viewModel';
 import { RunDataProvider } from './runData';
 
@@ -76,9 +77,18 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
     // No `retainContextWhenHidden`: the client persists its own state through
     // `setState` and the host re-posts the whole model on every change, so
     // paying to keep a hidden view alive would buy nothing back.
-    const subscription = this.data.onDidChange(() => void this.post());
+    const subscriptions = [
+      this.data.onDidChange(() => void this.post()),
+      // `rbx.solutionLabel` changes nothing on disk, so no reload will bring the
+      // new labels in on its own -- the view has to rebuild the model itself.
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        if (event.affectsConfiguration('rbx.solutionLabel')) {
+          void this.post();
+        }
+      }),
+    ];
     view.onDidDispose(() => {
-      subscription.dispose();
+      subscriptions.forEach((subscription) => subscription.dispose());
       this.view = undefined;
     });
   }
@@ -97,7 +107,12 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
   private async post(): Promise<void> {
     const packages = await this.data.loadAll();
     this.nodes = new Map(flattenNodes(packages).map((node) => [nodeId(node), node]));
-    await this.view?.webview.postMessage({ type: 'state', model: buildViewModel(packages) });
+    // Read per post rather than cached: the setting is window-scoped and the
+    // configuration API is the only place its current value lives.
+    const style = asSolutionLabelStyle(
+      vscode.workspace.getConfiguration('rbx').get('solutionLabel'),
+    );
+    await this.view?.webview.postMessage({ type: 'state', model: buildViewModel(packages, style) });
   }
 
   private html(webview: vscode.Webview): string {

--- a/vscode/src/webview/render.test.ts
+++ b/vscode/src/webview/render.test.ts
@@ -573,3 +573,16 @@ test('sibling rank follows model order across two families of siblings', () => {
   const roots = html.slice(html.indexOf('data-id="sol1"'));
   assert.ok(roots.includes('aria-posinset="2"'), roots);
 });
+
+test('a shortened label carries its full path as a tooltip, escaped', () => {
+  const html = renderTree(
+    model([row({ id: 'sol0', label: 'main.cpp', labelTitle: 'sols/"a b"/main.cpp' })]),
+    state(),
+  );
+  assert.ok(html.includes('title="sols/&quot;a b&quot;/main.cpp"'), html);
+});
+
+test('a row whose label is already the whole path gets no tooltip', () => {
+  const html = renderTree(model([MAIN]), state());
+  assert.ok(!html.includes('title='), html);
+});

--- a/vscode/src/webview/render.ts
+++ b/vscode/src/webview/render.ts
@@ -162,7 +162,11 @@ function labelCell(row: Row): string {
   if (row.labelBold) {
     classes.push('bold');
   }
-  return `<span class="${classes.join(' ')}">${escapeHtml(row.label)}</span>`;
+  // The title is the only channel a shortened label has for the path it stands
+  // for; rows whose label is already the whole path get no tooltip, so hovering
+  // one never pops a box repeating what is on screen.
+  const title = row.labelTitle === undefined ? '' : ` title="${escapeAttr(row.labelTitle)}"`;
+  return `<span class="${classes.join(' ')}"${title}>${escapeHtml(row.label)}</span>`;
 }
 
 /**


### PR DESCRIPTION
Solution rows in the run view print the path rbx records, which in nearly every package repeats one shared directory (`sols/`) on every row -- in the sidebar's narrowest column.

`rbx.solutionLabel` now picks how much of that path a row keeps:

| Value | `sols/main.cpp`, `sols/slow/tle.cpp` |
|---|---|
| `full` | `sols/main.cpp`, `sols/slow/tle.cpp` |
| `trimmed` (default) | `main.cpp`, `slow/tle.cpp` |
| `basename` | `main.cpp`, `tle.cpp` |

### Notes

- The prefix is the longest one **that package's** solutions share, so a contest workspace where one package stores its solutions somewhere unusual does not cost the others their trimming.
- It is computed over whole path segments and never consumes a file name: `main.cpp` beside `mai_x.cpp` stays both. Solutions at the package root are left alone.
- The filter box keeps matching the **full** path whatever is displayed, so typing `sols/` still finds everything in `basename` mode; a shortened label carries the whole path as its tooltip.
- The default changes what existing users see. `full` restores today's rendering.

### Shape

`src/rbx/solutionLabel.ts` is the whole of the decision and imports no `vscode`, like the rest of `src/rbx/`; `buildViewModel` takes the style and resolves labels per package; `runView.ts` reads the setting per post and re-posts on `onDidChangeConfiguration`.

### Verification

`npm test` (104 pass, 0 fail -- 13 new for the label rules, 4 for the wiring), `npm run typecheck`, `npm run compile`. `npm run lint` cannot run here: `eslint` is not a devDependency on `main` either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)