### PR TITLE
feat(vscode): colour the score the way the console colours it

### DIFF
--- a/vscode/src/rbx/hue.test.ts
+++ b/vscode/src/rbx/hue.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { test } from 'node:test';
 
-import { hueOfThemeColor } from './hue';
+import { hueOfScore, hueOfThemeColor } from './hue';
 
 test('the charts palette outcome.ts records maps onto bare hue names', () => {
   assert.strictEqual(hueOfThemeColor('charts.green'), 'green');
@@ -17,4 +17,20 @@ test('the de-emphasized foreground is dim, and anything unknown is neutral', () 
   assert.strictEqual(hueOfThemeColor('charts.lines'), 'neutral');
   assert.strictEqual(hueOfThemeColor(''), 'neutral');
   assert.strictEqual(hueOfThemeColor('constructor'), 'neutral');
+});
+
+test('a score is hued the three ways get_solution_score_style hues it', () => {
+  assert.strictEqual(hueOfScore(100, 100), 'green');
+  assert.strictEqual(hueOfScore(70, 100), 'yellow');
+  assert.strictEqual(hueOfScore(0, 100), 'red');
+});
+
+test('a score at neither end of its range is partial, however small', () => {
+  // The console draws the line at "> 0", not at some fraction of the maximum:
+  // one point out of a hundred is a partial score and not a zero.
+  assert.strictEqual(hueOfScore(1, 100), 'yellow');
+  assert.strictEqual(hueOfScore(99, 100), 'yellow');
+  // And `>=`, like the console, so an overshoot still reads as full.
+  assert.strictEqual(hueOfScore(120, 100), 'green');
+  assert.strictEqual(hueOfScore(0, 0), 'green');
 });

--- a/vscode/src/rbx/hue.ts
+++ b/vscode/src/rbx/hue.ts
@@ -36,3 +36,21 @@ export function hueOfThemeColor(color: string): Hue {
   // Object.prototype, which a plain lookup would return instead of 'neutral'.
   return Object.hasOwn(HUES, color) ? HUES[color] : 'neutral';
 }
+
+/**
+ * The hue of a `[X/Y]` score, mirroring `get_solution_score_style` in
+ * `rbx.box.solutions`: a full score is `success`, anything above zero is
+ * `warning`, and zero is `error`. The console theme resolves those three to
+ * green, yellow and red, which is what this returns so that a score reads the
+ * same in the sidebar as it does under `rbx run`.
+ *
+ * Nothing here divides by `maxScore`, so a zero maximum is not a special case:
+ * `score >= maxScore` holds and the score reads as full, exactly as the console
+ * decides it. Rows with no scoring at all drop the span before reaching here.
+ */
+export function hueOfScore(score: number, maxScore: number): Hue {
+  if (score >= maxScore) {
+    return 'green';
+  }
+  return score > 0 ? 'yellow' : 'red';
+}

--- a/vscode/src/rbx/viewModel.test.ts
+++ b/vscode/src/rbx/viewModel.test.ts
@@ -277,7 +277,11 @@ test('a solution that only missed its score range says so, and accuses no verdic
   const { rows } = buildViewModel([view([scored])]);
   const mismatch = rowById(rows, '/w/a::0').detail?.mismatch;
   assert.strictEqual(mismatch?.pooled, undefined);
-  assert.deepStrictEqual(mismatch?.score, { expected: '40..60', got: '30' });
+  assert.deepStrictEqual(mismatch?.score, {
+    expected: '40..60',
+    got: '30',
+    gotHue: 'yellow',
+  });
 });
 
 test('an open-ended score range is not given a ceiling rbx never declared', () => {
@@ -357,13 +361,36 @@ test('a finished solution shows score, time and memory but never its verdict', (
   // line as the sidebar narrows, so the order is the priority and the score
   // being ahead of both measurements is what keeps it on screen longest.
   assert.deepStrictEqual(row.meta, [
-    { text: '[70/100]', hue: 'neutral', role: 'score' },
+    { text: '[70/100]', hue: 'yellow', role: 'score' },
     { text: '120 ms', hue: 'dim', role: 'time' },
     { text: '2 KiB', hue: 'dim', role: 'memory' },
   ]);
   assert.deepStrictEqual(row.detail?.score, '[70/100]');
+  assert.deepStrictEqual(row.detail?.scoreHue, 'yellow');
   assert.deepStrictEqual(row.detail?.maxTime, '120 ms');
   assert.deepStrictEqual(row.detail?.maxMemory, '2 KiB');
+});
+
+test('the score is hued like the console hues it: full green, zero red', () => {
+  const scoreHueOf = (score: number) => {
+    const run = solution(
+      0,
+      'sols/main.cpp',
+      'ACCEPTED',
+      [],
+      solutionReport({ score, maxScore: 100 }),
+    );
+    const { rows } = buildViewModel([view([run])]);
+    const row = rowById(rows, '/w/a::0');
+    // The meta line and the card must agree: they are the same score twice,
+    // and a row whose `[0/100]` is red above a card whose `[0/100]` is not
+    // reads as two different numbers.
+    assert.strictEqual(row.meta[0]?.hue, row.detail?.scoreHue);
+    return row.meta[0]?.hue;
+  };
+  assert.strictEqual(scoreHueOf(100), 'green');
+  assert.strictEqual(scoreHueOf(30), 'yellow');
+  assert.strictEqual(scoreHueOf(0), 'red');
 });
 
 test('only a group with its own outcomePerGroup declaration gets a gutter', () => {

--- a/vscode/src/rbx/viewModel.ts
+++ b/vscode/src/rbx/viewModel.ts
@@ -19,7 +19,7 @@
 import * as path from 'path';
 
 import { ExpectationDisplay, expectationDisplay } from './expectation';
-import { Hue, hueOfThemeColor } from './hue';
+import { Hue, hueOfScore, hueOfThemeColor } from './hue';
 import {
   GroupNode,
   PackageNode,
@@ -92,6 +92,8 @@ export interface Mismatched {
 export interface ScoreMismatch {
   readonly expected: string;
   readonly got: string;
+  /** How the score it got reads on its own -- see `hueOfScore`. */
+  readonly gotHue: Hue;
 }
 
 /**
@@ -123,6 +125,8 @@ export interface SolutionDetail {
   readonly maxTime?: string;
   readonly maxMemory?: string;
   readonly score?: string;
+  /** Set exactly when `score` is -- see `hueOfScore`. */
+  readonly scoreHue?: Hue;
 }
 
 export interface Row {
@@ -260,7 +264,11 @@ function aggregateMeta(
       : span(`${progress.done}/${progress.total}`, 'dim', 'progress'),
     report.maxScore === 0
       ? undefined
-      : span(formatScore(report.score, report.maxScore), 'neutral', 'score'),
+      : span(
+          formatScore(report.score, report.maxScore),
+          hueOfScore(report.score, report.maxScore),
+          'score',
+        ),
     span(formatTime(report.maxTime), 'dim', 'time'),
     span(formatMemory(report.maxMemory), 'dim', 'memory'),
   ]);
@@ -405,6 +413,7 @@ function mismatchDetail(run: SolutionRun, report: SolutionReport): MismatchDetai
         ? {
             expected: scoreRange(report.expectedScore),
             got: String(report.score),
+            gotHue: hueOfScore(report.score, report.maxScore),
           }
         : undefined,
   };
@@ -424,6 +433,10 @@ function solutionDetail(run: SolutionRun, mismatch: boolean): SolutionDetail {
       report === undefined || report.maxScore === 0
         ? undefined
         : formatScore(report.score, report.maxScore),
+    scoreHue:
+      report === undefined || report.maxScore === 0
+        ? undefined
+        : hueOfScore(report.score, report.maxScore),
   };
 }
 

--- a/vscode/src/webview/render.test.ts
+++ b/vscode/src/webview/render.test.ts
@@ -247,13 +247,13 @@ test('the meta line carries its roles and no separator elements of its own', () 
     kind: 'solution',
     label: 'sols/main.cpp',
     meta: [
-      { text: '[70/100]', hue: 'neutral', role: 'score' },
+      { text: '[70/100]', hue: 'yellow', role: 'score' },
       { text: '120 ms', hue: 'dim', role: 'time' },
       { text: '2 KiB', hue: 'dim', role: 'memory' },
     ],
   });
   const html = renderTree(model([solution]), state({}));
-  assert.ok(html.includes('<span class="span span-score hue-neutral">[70/100]</span>'), html);
+  assert.ok(html.includes('<span class="span span-score hue-yellow">[70/100]</span>'), html);
   assert.ok(html.includes('<span class="span span-time hue-dim">120 ms</span>'), html);
   assert.ok(html.includes('<span class="span span-memory hue-dim">2 KiB</span>'), html);
   // No `.sep` inside the meta line -- the stylesheet owns those now.
@@ -368,12 +368,15 @@ test('a score miss names the range that was declared', () => {
     mismatch: true,
     expandable: true,
     detail: {
-      mismatch: { groups: [], score: { expected: '40..60', got: '30' } },
+      mismatch: { groups: [], score: { expected: '40..60', got: '30', gotHue: 'yellow' } },
       histogram: [],
     },
   });
   const html = renderTree(model([caught]), state({ expanded: new Set(['sol3']) }));
-  assert.ok(html.includes('Expected 40..60 pts, scored 30.'), html);
+  assert.ok(
+    html.includes('Expected 40..60 pts, scored <span class="hue-yellow">30</span>.'),
+    html,
+  );
 });
 
 test('a group name in the card cannot escape into markup', () => {
@@ -430,6 +433,7 @@ test('the histogram sizes each bar by its share of the testcases', () => {
         { short: 'WA', hue: 'red', count: 1 },
       ],
       score: '10/20',
+      scoreHue: 'yellow',
     },
   });
   const html = renderTree(model([solution]), state({ expanded: new Set(['sol0']) }));
@@ -437,12 +441,15 @@ test('the histogram sizes each bar by its share of the testcases', () => {
   assert.ok(html.includes('width: 25%'), html);
   assert.ok(html.includes('3 AC'), html);
   assert.ok(html.includes('1 WA'), html);
-  assert.ok(html.includes('10/20'), html);
+  assert.ok(html.includes('<span class="value-text hue-yellow">10/20</span>'), html);
 });
 
 test('the detail card omits maxima it does not have', () => {
   const html = renderTree(model([MAIN]), state({ expanded: new Set(['sol0']) }));
-  assert.ok(html.includes('120 ms'), html);
+  // Neutral rather than unhued: a value with nothing to say about itself still
+  // takes its colour from the `.hue-*` table, which is what leaves the score
+  // free to say something with the same mechanism.
+  assert.ok(html.includes('<span class="value-text hue-neutral">120 ms</span>'), html);
   assert.ok(!html.includes('Max memory'), html);
   assert.ok(!html.includes('Score'), html);
 });

--- a/vscode/src/webview/render.ts
+++ b/vscode/src/webview/render.ts
@@ -291,7 +291,10 @@ function groupLines(groups: readonly GroupMismatch[], held: string | undefined):
 function scoreLine(score: ScoreMismatch): string {
   return (
     '<p class="mismatch-line">Expected ' +
-    `${escapeHtml(score.expected)} pts, scored ${escapeHtml(score.got)}.</p>`
+    // Only what it scored is hued: the expectation is a range the author wrote,
+    // not an outcome, and colouring it would read as a verdict on the
+    // declaration rather than on the run.
+    `${escapeHtml(score.expected)} pts, scored ${hued(score.got, score.gotHue)}.</p>`
   );
 }
 
@@ -342,14 +345,18 @@ function histogramCard(histogram: readonly HistogramSlice[]): string {
   return `<div class="histogram"><div class="bars">${bars}</div><div class="counts">${counts}</div></div>`;
 }
 
-function value(label: string, text: string | undefined): string {
+function value(label: string, text: string | undefined, hue?: string): string {
   if (text === undefined || text === '') {
     return '';
   }
+  // Always hued, `neutral` when the value has nothing to say about itself, so
+  // that the colour of a value comes from the one `.hue-*` table like every
+  // other coloured thing in the view rather than from `.value-text` itself.
+  const textClass = `value-text hue-${hue ?? 'neutral'}`;
   return (
     '<span class="value">' +
     `<span class="value-label">${escapeHtml(label)}</span>` +
-    `<span class="value-text">${escapeHtml(text)}</span>` +
+    `<span class="${textClass}">${escapeHtml(text)}</span>` +
     '</span>'
   );
 }
@@ -360,7 +367,7 @@ function valuesCard(detail: SolutionDetail): string {
   const values = [
     value('Max time', detail.maxTime),
     value('Max memory', detail.maxMemory),
-    value('Score', detail.score),
+    value('Score', detail.score, detail.scoreHue),
   ].join('');
   return values === '' ? '' : `<div class="values">${values}</div>`;
 }

--- a/vscode/src/webview/style.css
+++ b/vscode/src/webview/style.css
@@ -427,9 +427,11 @@ body {
   gap: 4px;
 }
 
-.value-text {
-  color: var(--vscode-foreground);
-}
+/* `.value-text` deliberately has no rule of its own. It used to set
+   `color: var(--vscode-foreground)`, which -- sitting after the `.hue-*` table
+   at equal specificity -- would quietly beat the score's hue. The text now
+   carries `hue-neutral` when it has nothing to say and its own hue when it
+   does, so colour comes from that one table like everywhere else in the view. */
 
 .welcome {
   padding: 8px 16px;


### PR DESCRIPTION
The run view drew every `[X/Y]` in the plain foreground, so a solution that scored nothing looked exactly like one that scored everything until you read the two numbers. `rbx run` has never done that: `get_solution_score_style` picks `success`/`warning`/`error`, which the console theme resolves to green, yellow and red.

## What changed

- `hueOfScore(score, maxScore)` in `hue.ts` mirrors `get_solution_score_style` exactly — full is green, anything above zero yellow, zero red, with the same `>=` so an overshoot still reads as full.
- The meta-line score span, the detail card's `Score` value and the `scored X` half of a score-mismatch line all take that hue. The declared range stays uncoloured: it is what the author wrote, not what the run got.
- `.value-text` loses its `color`. Sitting after the `.hue-*` table at equal specificity, it would have quietly beaten the score's hue; card values now carry `hue-neutral` instead, so that table stays the single source of colour in the view.

## Testing

`npm run typecheck` and `npm test` (89 passing) in `vscode/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)