### PR TITLE
feat(vscode): open a solution's source from the run view

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -112,6 +112,24 @@ A run of a single solution opens expanded, the way `rbx run` prints per-testcase
 lines only when there is one solution to print them for. A run of several opens
 with the solutions collapsed; expanding one reveals its groups already open.
 
+### Opening what a row names
+
+Every row that names a file opens it, and always the same way: <kbd>Enter</kbd>
+on the keyboard, a click on a leaf, a double click on anything that also
+expands.
+
+| Row | Opens |
+|---|---|
+| solution | its source file, for editing -- `sols/wa.cpp` is a file you wrote |
+| testcase | the diff against the expected answer if it failed, the input otherwise |
+| group | nothing; it is a heading over testcases, with no file behind it |
+
+A solution row both expands and opens, so the two gestures are kept apart: a
+single click expands it, as a click on any parent row does, and opening it takes
+<kbd>Enter</kbd> or a double click. The second click of a double click takes the
+first one's expansion back, so the tree is left where it was -- the same net
+effect a double click has on a folder in the Explorer.
+
 ### Naming solutions
 
 Nearly every package keeps its solutions under one directory, so the path rbx
@@ -294,9 +312,11 @@ npm run package    # production bundle
 ```
 
 The tests cover the pure logic only -- deciding what a row displays
-(`src/rbx/viewModel.ts`) and turning that into HTML (`src/webview/render.ts`) --
-which is why both are modules that never import `vscode` and never touch the
-DOM. Interaction and the extension host are left to the F5 development host.
+(`src/rbx/viewModel.ts`), turning that into HTML (`src/webview/render.ts`) and
+deciding what a click on a row means (`src/webview/gesture.ts`) -- which is why
+all three are modules that never import `vscode` and never touch the DOM. The
+extension host and the DOM plumbing around them are left to the F5 development
+host.
 
 From the repository root, the same via mise:
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -126,9 +126,10 @@ expands.
 
 A solution row both expands and opens, so the two gestures are kept apart: a
 single click expands it, as a click on any parent row does, and opening it takes
-<kbd>Enter</kbd> or a double click. The second click of a double click takes the
-first one's expansion back, so the tree is left where it was -- the same net
-effect a double click has on a folder in the Explorer.
+<kbd>Enter</kbd> or a double click. A double click always leaves the row
+**expanded**, whichever way it started -- the second click is not a second
+toggle, because a gesture that opens a file should not also shut the row it was
+opened from.
 
 ### Naming solutions
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -49,6 +49,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "rbx.openSolution",
+        "title": "Open Solution",
+        "category": "rbx",
+        "icon": "$(go-to-file)"
+      },
+      {
         "command": "rbx.openInput",
         "title": "Open Input",
         "category": "rbx",
@@ -95,6 +101,11 @@
         }
       ],
       "webview/context": [
+        {
+          "command": "rbx.openSolution",
+          "when": "webviewSection == 'rbx.solution'",
+          "group": "1_open@1"
+        },
         {
           "command": "rbx.openInput",
           "when": "webviewSection == 'rbx.testcase'",

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -1,14 +1,17 @@
 /**
  * Commands that open artifacts.
  *
- * Everything opens through the read-only `rbx:` scheme (see artifactFs.ts), so
- * a generated file can never be edited by accident and each tab gets a title
- * that says which solution and testcase it belongs to.
+ * Every *generated* file opens through the read-only `rbx:` scheme (see
+ * artifactFs.ts), so it can never be edited by accident and each tab gets a
+ * title that says which solution and testcase it belongs to. A solution's
+ * source is the one thing here rbx did not generate: it opens as itself, on
+ * the `file:` scheme, because editing it is the whole point of reaching it.
  */
 import * as fs from 'fs/promises';
 import * as vscode from 'vscode';
 
 import { artifactUri } from './artifactFs';
+import { solutionSourcePath } from './rbx/layout';
 import { RunNode, TestcaseNode } from './rbx/nodes';
 import { RunDataProvider } from './runData';
 import { RunViewProvider } from './runView';
@@ -78,6 +81,25 @@ export function registerCommands(
   };
 
   register('rbx.refresh', () => data.refresh());
+
+  register('rbx.openSolution', async (node) => {
+    if (node?.kind !== 'solution') {
+      return;
+    }
+    const source = solutionSourcePath(node.pkg, node.run.solution.path);
+    if ((await firstExisting([source])) === undefined) {
+      // The skeleton names a solution `problem.rbx.yml` declares, so a missing
+      // file means the package changed since the run, not that the row is bad.
+      vscode.window.showInformationMessage(
+        `No file at ${node.run.solution.path}. The package may have changed since this run.`,
+      );
+      return;
+    }
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.file(source));
+    // `preview: true` to match every other row in the view: arrowing down a
+    // list of solutions reuses one tab instead of littering the tab bar.
+    await vscode.window.showTextDocument(document, { preview: true });
+  });
 
   register('rbx.openInput', async (node) => {
     if (!isTestcase(node)) {

--- a/vscode/src/rbx/layout.test.ts
+++ b/vscode/src/rbx/layout.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { test } from 'node:test';
+
+import { packageLayout, solutionSourcePath } from './layout';
+
+const pkg = packageLayout(path.join(path.sep, 'work', 'prob'));
+
+test('solutionSourcePath resolves a solution against the package root', () => {
+  assert.strictEqual(
+    solutionSourcePath(pkg, 'sols/wa.cpp'),
+    path.join(path.sep, 'work', 'prob', 'sols', 'wa.cpp'),
+  );
+});
+
+test('solutionSourcePath reads a path recorded on Windows', () => {
+  assert.strictEqual(
+    solutionSourcePath(pkg, 'sols\\wa.cpp'),
+    path.join(path.sep, 'work', 'prob', 'sols', 'wa.cpp'),
+  );
+});
+
+test('solutionSourcePath keeps a solution sitting at the package root', () => {
+  assert.strictEqual(
+    solutionSourcePath(pkg, 'main.cpp'),
+    path.join(path.sep, 'work', 'prob', 'main.cpp'),
+  );
+});

--- a/vscode/src/rbx/layout.ts
+++ b/vscode/src/rbx/layout.ts
@@ -122,3 +122,17 @@ export const IGNORED_DIRS: ReadonlySet<string> = new Set([
   'node_modules',
   '.git',
 ]);
+
+/**
+ * Absolute path to a solution's source file.
+ *
+ * `SolutionEntry.path` is relative to the package root and written with the
+ * separator of the host that ran rbx, so a package generated on Windows and
+ * read on macOS arrives with backslashes -- `path.join` would keep them and
+ * produce one long, nonexistent basename. Splitting on both separators first
+ * is what makes the join mean the same thing on either host.
+ */
+export function solutionSourcePath(pkg: PackageLayout, solutionPath: string): string {
+  const segments = solutionPath.split(/[\\/]+/).filter((segment) => segment !== '');
+  return path.join(pkg.root, ...segments);
+}

--- a/vscode/src/rbx/viewModel.test.ts
+++ b/vscode/src/rbx/viewModel.test.ts
@@ -488,7 +488,16 @@ test('a testcase opens the diff when it failed and the input otherwise', () => {
   assert.strictEqual(rowById(rows, '/w/a::0::main::001').primaryCommand, 'rbx.diffOutput');
   // No evaluation yet: there is nothing to diff against.
   assert.strictEqual(rowById(rows, '/w/a::0::main::002').primaryCommand, 'rbx.openInput');
-  assert.strictEqual(rowById(rows, '/w/a::0').primaryCommand, undefined);
+});
+
+test('a solution opens its source, and a group opens nothing', () => {
+  const one = solution(0, 'sols/main.cpp', 'ACCEPTED', [
+    group('main', [testcase('000', 'accepted')]),
+  ]);
+  const { rows } = buildViewModel([view([one])]);
+  assert.strictEqual(rowById(rows, '/w/a::0').primaryCommand, 'rbx.openSolution');
+  // A group is a heading over testcases; there is no file behind it to open.
+  assert.strictEqual(rowById(rows, '/w/a::0::main').primaryCommand, undefined);
 });
 
 test('a testcase shows time and memory, and not the checker message', () => {

--- a/vscode/src/rbx/viewModel.ts
+++ b/vscode/src/rbx/viewModel.ts
@@ -702,6 +702,11 @@ function solutionRow(node: SolutionNode, depth: number, label: string, parentId?
     detail: solutionDetail(run, mismatch, warnings),
     search: haystack(run.solution.path, verdict, mismatch, declared, warnings),
     section: 'rbx.solution',
+    // The row names a file, so the most obvious gesture in the view -- arrow
+    // down to `sols/wa.cpp` and press Enter -- opens it. A solution row also
+    // expands, so a single click still only expands; opening is Enter and the
+    // double click (see webview/gesture.ts).
+    primaryCommand: 'rbx.openSolution',
   };
 }
 

--- a/vscode/src/webview/gesture.test.ts
+++ b/vscode/src/webview/gesture.test.ts
@@ -1,0 +1,62 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import type { Row } from '../rbx/viewModel';
+import { rowClick } from './gesture';
+
+function row(over: Partial<Row> & Pick<Row, 'id'>): Row {
+  return {
+    depth: 0,
+    kind: 'solution',
+    gutter: 'none',
+    label: over.id,
+    labelBold: false,
+    meta: [],
+    warnings: [],
+    mismatch: false,
+    expandable: false,
+    defaultExpanded: false,
+    search: over.id.toLowerCase(),
+    section: 'rbx.solution',
+    ...over,
+  };
+}
+
+const solution = row({ id: 'sol', expandable: true, primaryCommand: 'rbx.openSolution' });
+const group = row({ id: 'group', kind: 'group', expandable: true, section: 'rbx.group' });
+const testcase = row({
+  id: 'case',
+  kind: 'testcase',
+  section: 'rbx.testcase',
+  primaryCommand: 'rbx.openInput',
+});
+
+test('a single click expands a row that expands', () => {
+  assert.deepStrictEqual(rowClick(solution, 1), { toggle: true, open: false });
+  assert.deepStrictEqual(rowClick(group, 1), { toggle: true, open: false });
+});
+
+test('a single click opens a leaf', () => {
+  assert.deepStrictEqual(rowClick(testcase, 1), { toggle: false, open: true });
+});
+
+test('a double click on a solution opens it and takes the expansion back', () => {
+  assert.deepStrictEqual(rowClick(solution, 2), { toggle: true, open: true });
+});
+
+test('a double click on a group only expands, once', () => {
+  assert.deepStrictEqual(rowClick(group, 2), { toggle: false, open: false });
+});
+
+test('a double click on a leaf does not open it twice', () => {
+  assert.deepStrictEqual(rowClick(testcase, 2), { toggle: false, open: false });
+});
+
+test('a third click adds nothing to the double click', () => {
+  assert.deepStrictEqual(rowClick(solution, 3), { toggle: false, open: false });
+  assert.deepStrictEqual(rowClick(testcase, 3), { toggle: false, open: false });
+});
+
+test('a click on a row that is gone does nothing', () => {
+  assert.deepStrictEqual(rowClick(undefined, 1), { toggle: false, open: false });
+});

--- a/vscode/src/webview/gesture.test.ts
+++ b/vscode/src/webview/gesture.test.ts
@@ -32,31 +32,33 @@ const testcase = row({
 });
 
 test('a single click expands a row that expands', () => {
-  assert.deepStrictEqual(rowClick(solution, 1), { toggle: true, open: false });
-  assert.deepStrictEqual(rowClick(group, 1), { toggle: true, open: false });
+  assert.deepStrictEqual(rowClick(solution, 1), { expansion: 'toggle', invoke: false });
+  assert.deepStrictEqual(rowClick(group, 1), { expansion: 'toggle', invoke: false });
 });
 
 test('a single click opens a leaf', () => {
-  assert.deepStrictEqual(rowClick(testcase, 1), { toggle: false, open: true });
+  assert.deepStrictEqual(rowClick(testcase, 1), { expansion: 'none', invoke: true });
 });
 
-test('a double click on a solution opens it and takes the expansion back', () => {
-  assert.deepStrictEqual(rowClick(solution, 2), { toggle: true, open: true });
+test('a double click on a solution opens it and leaves the row expanded', () => {
+  // Not a second toggle: the first click may have collapsed the row, and a
+  // gesture that opens a file should not shut the thing it opened from.
+  assert.deepStrictEqual(rowClick(solution, 2), { expansion: 'expand', invoke: true });
 });
 
 test('a double click on a group only expands, once', () => {
-  assert.deepStrictEqual(rowClick(group, 2), { toggle: false, open: false });
+  assert.deepStrictEqual(rowClick(group, 2), { expansion: 'none', invoke: false });
 });
 
 test('a double click on a leaf does not open it twice', () => {
-  assert.deepStrictEqual(rowClick(testcase, 2), { toggle: false, open: false });
+  assert.deepStrictEqual(rowClick(testcase, 2), { expansion: 'none', invoke: false });
 });
 
 test('a third click adds nothing to the double click', () => {
-  assert.deepStrictEqual(rowClick(solution, 3), { toggle: false, open: false });
-  assert.deepStrictEqual(rowClick(testcase, 3), { toggle: false, open: false });
+  assert.deepStrictEqual(rowClick(solution, 3), { expansion: 'none', invoke: false });
+  assert.deepStrictEqual(rowClick(testcase, 3), { expansion: 'none', invoke: false });
 });
 
 test('a click on a row that is gone does nothing', () => {
-  assert.deepStrictEqual(rowClick(undefined, 1), { toggle: false, open: false });
+  assert.deepStrictEqual(rowClick(undefined, 1), { expansion: 'none', invoke: false });
 });

--- a/vscode/src/webview/gesture.ts
+++ b/vscode/src/webview/gesture.ts
@@ -1,0 +1,50 @@
+/**
+ * What a click on a row does, as a pure function of the row and the click count.
+ *
+ * Split out of main.ts for the reason stated there: main.ts reads DOM events
+ * and nothing else, so the one question a click asks -- open, expand, or
+ * neither -- is answered here where `node --test` can hold it to account.
+ *
+ * No `vscode` import and no DOM, like render.ts and for the same reason.
+ */
+import type { Row } from '../rbx/viewModel';
+
+export interface RowClick {
+  /**
+   * Flip the row's expansion.
+   *
+   * On the second click of a double click this *undoes* what the first click
+   * did, so a double click leaves the tree where it was and means only "open"
+   * -- the same net effect a double click has on a folder in the Explorer.
+   */
+  readonly toggle: boolean;
+  /** Run the row's `primaryCommand`. */
+  readonly open: boolean;
+}
+
+const NOTHING: RowClick = { toggle: false, open: false };
+
+/**
+ * `detail` is the browser's click count: 1 for a single click, 2 for the second
+ * click of a double click. Both arrive, in that order, so a gesture is decided
+ * across two calls and neither may repeat the other's work -- opening a
+ * testcase twice, or expanding a node and instantly collapsing it again.
+ */
+export function rowClick(row: Row | undefined, detail: number): RowClick {
+  if (row === undefined) {
+    return NOTHING;
+  }
+  const opens = row.primaryCommand !== undefined;
+  if (detail <= 1) {
+    // A parent expands on a click anywhere along it, not just on the 16px
+    // twisty; a leaf opens on a single click, as it did when this view was a
+    // `TreeView` and the row carried `TreeItem.command`.
+    return { toggle: row.expandable, open: !row.expandable && opens };
+  }
+  if (detail === 2 && row.expandable && opens) {
+    // The only gesture that reaches a row which both expands and opens: the
+    // first click expanded it, so this one takes that back and opens instead.
+    return { toggle: true, open: true };
+  }
+  return NOTHING;
+}

--- a/vscode/src/webview/gesture.ts
+++ b/vscode/src/webview/gesture.ts
@@ -11,18 +11,19 @@ import type { Row } from '../rbx/viewModel';
 
 export interface RowClick {
   /**
-   * Flip the row's expansion.
+   * What the click does to the row's expansion.
    *
-   * On the second click of a double click this *undoes* what the first click
-   * did, so a double click leaves the tree where it was and means only "open"
-   * -- the same net effect a double click has on a folder in the Explorer.
+   * `expand` rather than a second `toggle` on the second click of a double
+   * click: the first click may have *collapsed* the row, and a gesture that
+   * opens a file should not also shut the thing it opened from. A double click
+   * therefore always leaves the row expanded, whichever way it started.
    */
-  readonly toggle: boolean;
+  readonly expansion: 'toggle' | 'expand' | 'none';
   /** Run the row's `primaryCommand`. */
-  readonly open: boolean;
+  readonly invoke: boolean;
 }
 
-const NOTHING: RowClick = { toggle: false, open: false };
+const NOTHING: RowClick = { expansion: 'none', invoke: false };
 
 /**
  * `detail` is the browser's click count: 1 for a single click, 2 for the second
@@ -39,12 +40,11 @@ export function rowClick(row: Row | undefined, detail: number): RowClick {
     // A parent expands on a click anywhere along it, not just on the 16px
     // twisty; a leaf opens on a single click, as it did when this view was a
     // `TreeView` and the row carried `TreeItem.command`.
-    return { toggle: row.expandable, open: !row.expandable && opens };
+    return { expansion: row.expandable ? 'toggle' : 'none', invoke: !row.expandable && opens };
   }
   if (detail === 2 && row.expandable && opens) {
-    // The only gesture that reaches a row which both expands and opens: the
-    // first click expanded it, so this one takes that back and opens instead.
-    return { toggle: true, open: true };
+    // The only gesture that reaches a row which both expands and opens.
+    return { expansion: 'expand', invoke: true };
   }
   return NOTHING;
 }

--- a/vscode/src/webview/main.ts
+++ b/vscode/src/webview/main.ts
@@ -11,6 +11,7 @@
  * `vscode` module is impossible in a webview and would not work if it were.
  */
 import type { Row, RunViewModel } from '../rbx/viewModel';
+import { rowClick } from './gesture';
 import { UiState, renderFilter, renderHeader, renderTree, visibleRows } from './render';
 
 interface VsCodeApi {
@@ -243,28 +244,18 @@ tree.addEventListener('click', (event) => {
     return;
   }
   const row = rowById(id);
-  // `detail` is the click count, so the second click of a double click selects
-  // without acting twice -- which would otherwise expand a node and instantly
-  // collapse it again, or open the same testcase twice.
-  const acts = event.detail <= 1;
-  // A click anywhere on a parent row expands it, not just one on the 16px
-  // twisty. The twisty is a target you have to aim at, and every other row in
-  // the view responds to being clicked anywhere along it.
-  if (acts && row?.expandable === true) {
+  const action = rowClick(row, event.detail);
+  if (action.toggle) {
     // Assigned rather than passed through `select`, which renders: `toggle`
     // renders too, and doing both would draw the view twice per click.
     selected = id;
     toggle(id);
-    return;
+  } else {
+    select(id);
   }
-  select(id);
-  if (!acts) {
-    return;
+  if (action.open) {
+    invoke(row);
   }
-  // A leaf opens on a single click, as it did when this view was a `TreeView`
-  // and the row carried `TreeItem.command` -- VS Code fires that on the first
-  // click, and every tree in the product opens a testcase the same way.
-  invoke(row);
 });
 
 tree.addEventListener('keydown', (event) => {

--- a/vscode/src/webview/main.ts
+++ b/vscode/src/webview/main.ts
@@ -245,15 +245,15 @@ tree.addEventListener('click', (event) => {
   }
   const row = rowById(id);
   const action = rowClick(row, event.detail);
-  if (action.toggle) {
+  if (action.expansion === 'none') {
+    select(id);
+  } else {
     // Assigned rather than passed through `select`, which renders: `toggle`
     // renders too, and doing both would draw the view twice per click.
     selected = id;
-    toggle(id);
-  } else {
-    select(id);
+    toggle(id, action.expansion === 'expand' ? true : undefined);
   }
-  if (action.open) {
+  if (action.invoke) {
     invoke(row);
   }
 });


### PR DESCRIPTION
Closes #680.

## What

A solution row in the run view named a file and could not open it. <kbd>Enter</kbd> on `sols/wa.cpp` — the most obvious gesture in the view — did nothing.

- **`rbx.openSolution`**, alongside the existing `rbx.open*` commands, opens the solution's source. It is the one thing in `commands.ts` that rbx did not generate, so it opens as itself on `file:` rather than through the read-only `rbx:` scheme — editing it is the point of reaching it. `preview: true`, like every other row, so arrowing down a list of solutions reuses one tab.
- **`primaryCommand: 'rbx.openSolution'`** on solution rows, so <kbd>Enter</kbd> works through the path that already existed. Group rows keep expand-only.
- **Double click** opens too.

## The open question in the issue

Neither of the two answers the issue offered. Undoing the toggle (its preferred one) means double-clicking an *already-expanded* solution closes it while opening its source — a gesture that opens a file should not shut the row it was opened from.

So the second click **opens** the expansion rather than flipping it again: a double click always leaves the row expanded, whichever way it started.

## Where the decision lives

`main.ts` says of itself that nothing which decides anything may live there. The click gesture is now a decision — three row kinds, three click counts — so it moved into a new pure `src/webview/gesture.ts`, which `node --test` covers directly. That also removed the `acts` flag and the early return the old handler needed.

`solutionSourcePath` went into `layout.ts`, the single place that knows where rbx puts things. It splits on both separators first: rbx records solution paths with the separator of the host that ran it, so a package generated on Windows and read on macOS would otherwise `path.join` into one long nonexistent basename.

## `preserveFocus`

Not passed, on purpose. Opening moves focus to the editor, which is what the testcase rows already do and what every tree in VS Code does on <kbd>Enter</kbd>. Making this one view differ would be the surprise.

`rbx.revealInExplorer` is untouched — it still keys on `rbx.package` — and composes fine: it reveals the package, this opens the file.

## Tests

193 pass (`npm test`), `tsc --noEmit` clean. New coverage: `gesture.test.ts` (7 tests over every row kind × click count), `layout.test.ts` for `solutionSourcePath` including the Windows-separator path, and a view-model test that a solution row opens its source while a group row opens nothing.

The `webview/context` menu gets **Open Solution** on `rbx.solution`, and `README.md` gains an "Opening what a row names" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WZhxh5ABzKsU1EgUtWHRf
