### PR TITLE
fix(validators): report hit bounds for samples-only packages

### DIFF
--- a/rbx/box/validators.py
+++ b/rbx/box/validators.py
@@ -551,17 +551,13 @@ def print_validation_report(
         return any(not v[0] or not v[1] for v in hit_bounds.values())
 
     # Cleanup entries in hit bounds per group that are totally empty.
-    # Also skip samples.
+    # Samples never get their own group entry; when bounds are not group-specific
+    # they were already merged into the package-wide entry above.
     hit_bounds_per_group = {
         k: v
         for k, v in hit_bounds_per_group.items()
         if _is_hit_bound_good(v) and k != 'samples'
     }
-
-    all_groups = set(info.testcase.group for info in infos if info.testcase is not None)
-    if len(all_groups) == 1 and 'samples' in all_groups:
-        # If there's only the samples group, do not check for hit bounds.
-        hit_bounds_per_group = {}
 
     if not hit_bounds_per_group and not any_failure:
         console.console.print('No validation issues found.')

--- a/tests/rbx/box/validators_test.py
+++ b/tests/rbx/box/validators_test.py
@@ -94,10 +94,11 @@ async def test_main_validator_report_hit_bound_issues(
     assert '- "x": max-value not hit' in out
 
 
-async def test_main_validator_skip_hit_bound_issues_on_samples(
+async def test_main_validator_report_hit_bound_issues_on_samples_only_package(
     testing_pkg: testing_package.TestingPackage,
     capsys: pytest.CaptureFixture[str],
 ):
+    """Samples count towards the package-wide hit bounds when bounds are shared."""
     testing_pkg.add_testgroup_from_glob('samples', 'manual_tests/*.in')
     testing_pkg.add_file('manual_tests/000.in').write_text('59\n')
     testing_pkg.add_file('manual_tests/001.in').write_text('73\n')
@@ -117,9 +118,39 @@ async def test_main_validator_skip_hit_bound_issues_on_samples(
     assert validation_infos[1].hit_bounds == {'"x"': (False, False)}
 
     out = capsys.readouterr().out
-    assert '- "x": min-value not hit' not in out
-    assert '- "x": max-value not hit' not in out
-    assert 'No validation issues found' in out
+    assert 'Hit bounds:' in out
+    assert '- "x": min-value not hit' in out
+    assert '- "x": max-value not hit' in out
+
+
+async def test_samples_do_not_get_their_own_hit_bounds_group(
+    testing_pkg: testing_package.TestingPackage,
+    capsys: pytest.CaptureFixture[str],
+):
+    """With group-specific bounds, samples are left out of the report entirely."""
+    testing_pkg.add_testgroup_from_glob('samples', 'manual_tests/samples/*.in')
+    testing_pkg.add_testgroup_from_glob('main', 'manual_tests/main/*.in')
+    testing_pkg.add_file('manual_tests/samples/000.in').write_text('59\n')
+    testing_pkg.add_file('manual_tests/main/000.in').write_text('73\n')
+
+    testing_pkg.set_validator(
+        'validator.cpp', src='validators/int-validator-bounded.cpp'
+    )
+    testing_pkg.yml.testcases[1].vars = {'N': {'max': 100}}
+    testing_pkg.save()
+
+    assert _has_group_specific_bounds() is True
+
+    await generate_testcases()
+
+    validation_infos = await validate_testcases()
+    print_validation_report(validation_infos)
+
+    assert not has_validation_errors(validation_infos)
+
+    out = capsys.readouterr().out
+    assert 'Group main hit bounds:' in out
+    assert 'samples hit bounds' not in out
 
 
 async def test_main_validator_no_hit_bound_issues(


### PR DESCRIPTION
A package whose only test group is `samples` never printed hit-bound warnings, even with a bounded validator: `print_validation_report` short-circuited the whole report when `samples` was the only group present.

Samples were already contributing to the package-wide hit bounds whenever no group declared its own `validator` or `vars` — they get merged under the `None` key *before* the `k != 'samples'` filter runs, so that filter is a no-op in merged mode. Only the samples-only short-circuit stood in the way; this removes it.

Unchanged: samples never get a `Group samples hit bounds:` row of their own, and when bounds are group-specific they are left out of the report entirely (folding them into per-group buckets would let a sample hitting a bound mask a group that never does).

## Tests

- `test_main_validator_skip_hit_bound_issues_on_samples` inverted and renamed to `test_main_validator_report_hit_bound_issues_on_samples_only_package`.
- New `test_samples_do_not_get_their_own_hit_bounds_group` covers the group-specific arm.

`tests/rbx/box/validators_test.py` has 6 failures on this machine that reproduce identically on the base commit (local clang/sandbox environment); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuXicEm1hD4582Z9KBxCis