### PR TITLE
feat(vscode): show one problem at a time in the run view

### DIFF
--- a/docs/plans/2026-08-20-vscode-problem-selector-design.md
+++ b/docs/plans/2026-08-20-vscode-problem-selector-design.md
@@ -1,0 +1,119 @@
+# VS Code extension — one problem at a time
+
+Date: 2026-08-20
+Status: design approved
+
+## Problem
+
+The Run view renders every problem package in the workspace at once.
+`discoverPackages` (`vscode/src/discovery.ts:16`) globs `**/problem.rbx.yml`
+across all workspace folders, and `flattenNodes` (`vscode/src/rbx/nodes.ts:85`)
+emits one package section per hit, each with all of its solutions, groups and
+testcases. For a ten-problem contest that is one long scrollable list whose only
+narrowing tool is the filter box.
+
+Three things make it worse than mere length:
+
+- **No contest awareness.** `contest.rbx.yml` appears nowhere under `vscode/`.
+  Packages sort lexicographically by absolute path (`discovery.ts:19`) and are
+  labelled by directory name, so the `short_name` (the A/B/C letter), the
+  contest's declared order and the per-problem `color` are all unused. A
+  contest reads as N unrelated directories that happen to be nearby.
+- **The header summary leaks across packages.** `buildViewModel` computes
+  `mismatches` and `empty` over every row of every package
+  (`vscode/src/rbx/viewModel.ts:642`), so the strip reports a workspace-wide
+  number rather than one about the problem being read.
+- **Every package is parsed on every event.** `loadAll` (`vscode/src/runData.ts:104`)
+  re-reads all packages whenever any one of them changes. The per-package
+  `ArtifactStore` cache absorbs most of the cost, but the work is O(packages)
+  per watcher event regardless.
+
+## Goal
+
+The Run view shows **exactly one problem**, chosen from a dropdown, and follows
+whichever problem is currently running.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | An `ActiveProblem` service in the extension host owns the problem list, the selection and the auto-switch rule | Single source of truth. The webview renders a selection it is told about rather than deciding one, so the quick pick, the watcher and the dropdown cannot disagree |
+| D2 | The host posts `{problems, selected, run}` — a light list plus **one** package's run | Only the selected package's artifacts are parsed and serialized. A ten-problem contest stops paying for nine of them on every event |
+| D3 | The package row is **removed**, not kept as a section header for the selected problem | With one package on screen the row is a permanent parent of everything, one indent level deep, naming what the dropdown already names |
+| D4 | Contest identity resolves by walking up to the nearest `contest.rbx.yml` | Mirrors `find_contest_root` (`rbx/box/contest/contest_package.py:103`). Nothing new on the wire; the file is already there |
+| D5 | Auto-switch is unconditional: newest skeleton wins | `rbx/box/solutions.py:719` — "A new skeleton is what marks a new run". It is written at run *start*, so this makes the view follow the running problem rather than jump to finished ones |
+| D6 | `rbx.packageSearchDepth` is **removed** | Contributed in `package.json` with a default of 3 and never read anywhere in `src/`; discovery globs at unbounded depth. It has never done anything |
+
+### Why not a seen/unseen marker
+
+An earlier draft marked problems in the dropdown with a dot when a run finished
+while the user was elsewhere. Dropped: because the skeleton lands at run *start*
+and the view follows it, the user is auto-switched *to* each problem as it runs,
+so a seen-marker would be cleared by the auto-switch itself and mark almost
+nothing. It also needed run-completion detection and `workspaceState`
+bookkeeping that nothing else wanted.
+
+## Architecture
+
+```
+ActiveProblem (host)
+├─ problems: ProblemChoice[]   root + label + shortName + color, in contest order
+├─ selected: string            package root; persisted in workspaceState
+└─ watcher on **/.rbx/runs/skeleton.yml → select that package
+
+RunViewProvider posts { problems, selected, run } ── webview renders <select> + rows
+                 ◄── { type: 'select', root } ──────
+`rbx: Select Problem` quick pick ──► ActiveProblem
+```
+
+### Contest identity
+
+`src/rbx/contest.ts`, pure logic with no `vscode` import so it stays testable
+under plain `node --test` like its neighbours.
+
+For each discovered root, walk up to the nearest `contest.rbx.yml`, parse its
+`problems`, and match each entry's resolved path (`path`, defaulting to
+`./{short_name}/`) against the root. That yields `short_name`, declared order
+and `color`.
+
+The dropdown shows `A`, `B`, `C` in contest order with the declared colour as a
+dot. Packages in no contest keep today's `packageLabel` and sort after. Two
+contests in one workspace become two `<optgroup>`s.
+
+**Variants.** A `contest.rbx.yml` with `use_variants: true` declares no problems
+of its own. Rather than teach the extension variant selection, gather problems
+from the canonical file plus every `contest.*.rbx.yml` sibling, first file
+naming a given root wins. Mislabelling across variants is possible in principle,
+but the letters are near-always shared and the fallback is today's directory
+name.
+
+## What this deletes
+
+- `showPackages` and the package branch of `flattenNodes` (`nodes.ts:85`), and
+  the depth-offset recomputation it forced (`viewModel.ts:612`).
+- `PackageNode`, `packageRow` (`viewModel.ts:457`) and the `rbx.package`
+  webview section. `rbx.revealInExplorer` re-attaches to the header.
+- Per-package solution-label trimming (`viewModel.ts:585`) collapses to the
+  single-package case.
+- The `mismatches`/`empty` cross-package leak, fixed by construction.
+- The `rbx.packageSearchDepth` setting (D6), and `IGNORED_DIRS`
+  (`layout.ts:114`) — exported, unused, and already drifted from the real
+  exclusion glob in `discovery.ts:12`, which does not exclude `out`/`dist`.
+  One list, used by discovery.
+
+## Edge cases
+
+| Case | Behaviour |
+|---|---|
+| One package | Dropdown hidden; the view looks exactly as it does today |
+| Zero packages | Existing empty state, unchanged |
+| Selected package disappears | Fall back to the first problem in order |
+| Reload | Selected root persisted in `context.workspaceState`, so a reopened window does not land on A every time |
+
+## Testing
+
+Contest resolution, problem ordering and the reduced `flattenNodes`/`viewModel`
+are pure functions under `src/rbx/`, tested with `node --test` alongside the
+existing `nodes.test.ts` and `viewModel.test.ts`. `ActiveProblem` holds only the
+vscode-facing glue — watcher subscription, `workspaceState`, quick pick —
+mirroring how `runData.ts` is already split from `nodes.ts`.

--- a/docs/plans/2026-08-20-vscode-problem-selector-design.md
+++ b/docs/plans/2026-08-20-vscode-problem-selector-design.md
@@ -41,7 +41,7 @@ whichever problem is currently running.
 | D2 | The host posts `{problems, selected, run}` — a light list plus **one** package's run | Only the selected package's artifacts are parsed and serialized. A ten-problem contest stops paying for nine of them on every event |
 | D3 | The package row is **removed**, not kept as a section header for the selected problem | With one package on screen the row is a permanent parent of everything, one indent level deep, naming what the dropdown already names |
 | D4 | Contest identity resolves by walking up to the nearest `contest.rbx.yml` | Mirrors `find_contest_root` (`rbx/box/contest/contest_package.py:103`). Nothing new on the wire; the file is already there |
-| D5 | Auto-switch is unconditional: newest skeleton wins | `rbx/box/solutions.py:719` — "A new skeleton is what marks a new run". It is written at run *start*, so this makes the view follow the running problem rather than jump to finished ones |
+| D5 | Auto-switch is unconditional: newest skeleton wins | `rbx/box/solutions.py:746` — "A new skeleton is what marks a new run". It is written at run *start*, so this makes the view follow the running problem rather than jump to finished ones |
 | D6 | `rbx.packageSearchDepth` is **removed** | Contributed in `package.json` with a default of 3 and never read anywhere in `src/`; discovery globs at unbounded depth. It has never done anything |
 
 ### Why not a seen/unseen marker
@@ -97,7 +97,7 @@ name.
   single-package case.
 - The `mismatches`/`empty` cross-package leak, fixed by construction.
 - The `rbx.packageSearchDepth` setting (D6), and `IGNORED_DIRS`
-  (`layout.ts:114`) — exported, unused, and already drifted from the real
+  (`layout.ts:119`) — exported, unused, and already drifted from the real
   exclusion glob in `discovery.ts:12`, which does not exclude `out`/`dist`.
   One list, used by discovery.
 

--- a/docs/plans/2026-08-20-vscode-problem-selector-plan.md
+++ b/docs/plans/2026-08-20-vscode-problem-selector-plan.md
@@ -1,0 +1,1105 @@
+# VS Code problem selector — implementation plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Scope the Run view to one problem, chosen from a dropdown in its header, auto-switching to whichever problem is currently running.
+
+**Architecture:** An `ActiveProblem` service in the extension host owns the ordered problem list, the selected package root and the auto-switch rule. `RunViewProvider` posts `{problems, selected, run}` — a light list plus **one** package's run — instead of every package's artifacts. Contest identity (the A/B/C `short_name`, declared order, colour) comes from walking up to the nearest `contest.rbx.yml`, resolved by a pure module under `src/rbx/`. The package row disappears from the tree entirely.
+
+**Tech Stack:** TypeScript, VS Code extension API, `node --test` (no framework), esbuild, `yaml`.
+
+Design doc: [`2026-08-20-vscode-problem-selector-design.md`](2026-08-20-vscode-problem-selector-design.md).
+
+---
+
+## Orientation for the implementer
+
+Read these before Task 1. The extension is small but its conventions are strict.
+
+**The extension never runs `rbx`.** It is a pure reader of files rbx leaves on disk (design D2/D3, `vscode/src/extension.ts:1-7`). Do not add `child_process`, a terminal, or a `cwd` anywhere. If a task seems to need one, you have misread it.
+
+**Two halves, and the seam matters.** Anything under `vscode/src/rbx/` is pure: **no `import * as vscode`**, ever. That is what lets `node --test` cover it without an editor. Host-facing glue (watchers, `workspaceState`, quick picks, configuration) lives in `vscode/src/*.ts` one level up. Every task below says which half a file belongs to; respect it, because the test strategy depends on it.
+
+**Commands:**
+
+```bash
+cd vscode
+npm run test        # runs pretest (esbuild) then node --test
+npm run typecheck   # tsc --noEmit
+npm run lint        # eslint src
+```
+
+Run all three before each commit. `npm run test` alone will not catch a type error, because esbuild strips types without checking them.
+
+**Test style.** No framework — `node:test` and `node:assert/strict`. Look at `vscode/src/rbx/nodes.test.ts` for the house style before writing the first test.
+
+**Commits.** This project enforces conventional commits via commitizen; the pre-commit hook rejects non-compliant messages. Use the `/commit` skill. Never amend — if the hook rejects, make a new commit.
+
+**A warning about scope.** Tasks 1–3 are pure additions that ship no behaviour change. Task 4 is the switch-over and is the only one that can break the view. Do not start Task 4 until 1–3 are committed and green.
+
+---
+
+## Task 1: Contest identity — parsing
+
+**Files:**
+- Create: `vscode/src/rbx/contest.ts` (pure — no `vscode` import)
+- Create: `vscode/src/rbx/contest.test.ts`
+
+Parse a `contest.rbx.yml` into the problems it declares. This task is parsing only; finding the file is Task 2.
+
+The schema fields that matter (`rbx/box/contest/schema.py:121-165`):
+
+| Field | Meaning |
+|---|---|
+| `short_name` | The A/B/C letter. Required. |
+| `path` | Directory relative to the contest root. **Optional — defaults to `./{short_name}/`.** |
+| `color` | Hex (`#abcdef`/`#abc`) or an X11 colour name. Optional. |
+
+Plus `use_variants: bool` at the top level (`schema.py:213`): when true the file is a dispatcher sentinel declaring no problems of its own.
+
+**Step 1: Write the failing tests**
+
+```ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { parseContest } from './contest';
+
+test('parses declared problems in file order', () => {
+  const contest = parseContest({
+    problems: [
+      { short_name: 'A', color: '#ff0000' },
+      { short_name: 'B', path: 'problems/beta' },
+    ],
+  });
+  assert.deepEqual(contest, {
+    useVariants: false,
+    problems: [
+      { shortName: 'A', path: 'A', color: '#ff0000', order: 0 },
+      { shortName: 'B', path: 'problems/beta', color: undefined, order: 1 },
+    ],
+  });
+});
+
+test('defaults a problem path to its short name', () => {
+  const contest = parseContest({ problems: [{ short_name: 'C' }] });
+  assert.equal(contest.problems[0].path, 'C');
+});
+
+test('reports a dispatcher as declaring no problems', () => {
+  assert.deepEqual(parseContest({ use_variants: true }), { useVariants: true, problems: [] });
+});
+
+test('tolerates a file that is not a contest at all', () => {
+  // Never throws: the walk in Task 2 reads whatever it finds, and a malformed
+  // file must degrade to "no identity", not take the view down.
+  for (const raw of [undefined, null, 'a string', 42, {}, { problems: 'not a list' }]) {
+    assert.deepEqual(parseContest(raw), { useVariants: false, problems: [] });
+  }
+});
+
+test('skips entries with no usable short name', () => {
+  const contest = parseContest({ problems: [{ color: '#fff' }, { short_name: 'B' }] });
+  assert.deepEqual(contest.problems.map((p) => p.shortName), ['B']);
+});
+
+test('numbers order by surviving position, not by input index', () => {
+  // `order` drives display order downstream, so a skipped entry must not leave
+  // a hole that sorts a later problem into the wrong slot.
+  const contest = parseContest({ problems: [{}, { short_name: 'A' }, { short_name: 'B' }] });
+  assert.deepEqual(contest.problems.map((p) => p.order), [0, 1]);
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `cd vscode && npm run test`
+Expected: FAIL — cannot find module `./contest`.
+
+**Step 3: Implement**
+
+```ts
+/**
+ * What a `contest.rbx.yml` says about the problems under it.
+ *
+ * Pure, like its neighbours: finding the file is the host's job (contestIndex.ts),
+ * and this half only turns parsed YAML into identities. Nothing here throws --
+ * a malformed contest file must cost the packages their letters, never the view.
+ */
+
+/** One problem as its contest declares it. */
+export interface ContestProblem {
+  readonly shortName: string;
+  /** Directory, relative to the contest root. Defaults to the short name. */
+  readonly path: string;
+  readonly color?: string;
+  /** Position among the problems that survived parsing. */
+  readonly order: number;
+}
+
+export interface ParsedContest {
+  /** A dispatcher sentinel: the real contests are sibling `contest.<id>.rbx.yml`. */
+  readonly useVariants: boolean;
+  readonly problems: readonly ContestProblem[];
+}
+
+const EMPTY: ParsedContest = { useVariants: false, problems: [] };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+export function parseContest(raw: unknown): ParsedContest {
+  if (!isRecord(raw)) {
+    return EMPTY;
+  }
+  if (raw.use_variants === true) {
+    // A dispatcher declares nothing else; rbx rejects any other field alongside
+    // it (rbx/box/contest/schema.py:242).
+    return { useVariants: true, problems: [] };
+  }
+  if (!Array.isArray(raw.problems)) {
+    return EMPTY;
+  }
+  const problems: ContestProblem[] = [];
+  for (const entry of raw.problems) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const shortName = optionalString(entry.short_name);
+    if (shortName === undefined) {
+      continue;
+    }
+    problems.push({
+      shortName,
+      // rbx defaults an unset path to `./{short_name}/`.
+      path: optionalString(entry.path) ?? shortName,
+      color: optionalString(entry.color),
+      // Counted off the survivors so a skipped entry leaves no hole.
+      order: problems.length,
+    });
+  }
+  return { useVariants: false, problems };
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `cd vscode && npm run test && npm run typecheck && npm run lint`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vscode/src/rbx/contest.ts vscode/src/rbx/contest.test.ts
+# /commit  ->  feat(vscode): parse the problems a contest declares
+```
+
+---
+
+## Task 2: Contest identity — resolving roots to problems
+
+**Files:**
+- Create: `vscode/src/contestIndex.ts` (host half — reads files)
+- Modify: `vscode/src/rbx/contest.ts` (add the pure matching function)
+- Modify: `vscode/src/rbx/contest.test.ts`
+
+Given package roots, produce a display identity for each. Split deliberately: the **matching** is pure and tested; the **file walk** is host-side and thin.
+
+`readYamlFile` already exists in `vscode/src/rbx/store.ts` (used by `declared.ts:45`) and returns `undefined` for a missing or unparseable file. Reuse it — do not add a second YAML reader.
+
+**Step 1: Write the failing test** (append to `contest.test.ts`)
+
+```ts
+import { problemIdentities } from './contest';
+
+test('matches package roots to declared problems', () => {
+  const identities = problemIdentities('/c', parseContest({
+    problems: [{ short_name: 'A' }, { short_name: 'B', path: 'problems/beta' }],
+  }));
+  assert.deepEqual(identities.get('/c/A'), { shortName: 'A', color: undefined, order: 0 });
+  assert.deepEqual(identities.get('/c/problems/beta'), {
+    shortName: 'B',
+    color: undefined,
+    order: 1,
+  });
+});
+
+test('normalizes a declared path before matching', () => {
+  // Contest files are hand-written: `./A/` and `A` name the same directory.
+  const identities = problemIdentities('/c', parseContest({
+    problems: [{ short_name: 'A', path: './A/' }],
+  }));
+  assert.equal(identities.get('/c/A')?.shortName, 'A');
+});
+
+test('declares nothing for a dispatcher', () => {
+  assert.equal(problemIdentities('/c', parseContest({ use_variants: true })).size, 0);
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `cd vscode && npm run test`
+Expected: FAIL — `problemIdentities` is not exported.
+
+**Step 3: Implement the pure half** (append to `contest.ts`)
+
+```ts
+import * as path from 'path';
+
+/** A problem's contest-given identity, keyed by absolute package root. */
+export interface ProblemIdentity {
+  readonly shortName: string;
+  readonly color?: string;
+  readonly order: number;
+}
+
+/**
+ * Resolve each declared problem to the absolute root it names.
+ *
+ * `path.resolve` normalizes the hand-written spellings a contest file carries
+ * -- `./A/`, `A`, `problems/../A` all land on the same key -- so a match is a
+ * plain map lookup downstream rather than a path comparison at every use.
+ */
+export function problemIdentities(
+  contestRoot: string,
+  contest: ParsedContest,
+): Map<string, ProblemIdentity> {
+  const identities = new Map<string, ProblemIdentity>();
+  for (const problem of contest.problems) {
+    identities.set(path.resolve(contestRoot, problem.path), {
+      shortName: problem.shortName,
+      color: problem.color,
+      order: problem.order,
+    });
+  }
+  return identities;
+}
+```
+
+**Step 4: Implement the host half**
+
+Create `vscode/src/contestIndex.ts`:
+
+```ts
+/**
+ * Contest identities for the discovered packages.
+ *
+ * Walks up from each package root to the nearest `contest.rbx.yml`, mirroring
+ * `find_contest_root` (rbx/box/contest/contest_package.py:103). Nothing new is
+ * asked of rbx: the file is already on disk, and reading it is what lets the
+ * selector call a package `A` instead of naming its directory.
+ */
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+import { ProblemIdentity, parseContest, problemIdentities } from './rbx/contest';
+import { readYamlFile } from './rbx/store';
+
+const CONTEST_MANIFEST = 'contest.rbx.yml';
+/** Sibling variant files: `contest.<id>.rbx.yml`. */
+const VARIANT_PREFIX = 'contest.';
+const VARIANT_SUFFIX = '.rbx.yml';
+
+/** The nearest ancestor of `from` holding a contest.rbx.yml, or undefined. */
+async function findContestRoot(from: string): Promise<string | undefined> {
+  let walker = from;
+  for (;;) {
+    try {
+      await fs.access(path.join(walker, CONTEST_MANIFEST));
+      return walker;
+    } catch {
+      // Not here; keep walking.
+    }
+    const parent = path.dirname(walker);
+    if (parent === walker) {
+      return undefined;
+    }
+    walker = parent;
+  }
+}
+
+/**
+ * Every contest file in a root: the canonical one plus its variants.
+ *
+ * A `use_variants: true` canonical declares no problems of its own, so the
+ * letters live only in the siblings. Reading all of them and letting the first
+ * file to name a root win means the extension never has to resolve which
+ * variant is *selected* -- a question only `RBX_CONTEST` can answer, and one
+ * whose answer is almost always the same letters anyway.
+ */
+async function contestFiles(root: string): Promise<string[]> {
+  const files = [path.join(root, CONTEST_MANIFEST)];
+  let entries: string[];
+  try {
+    entries = await fs.readdir(root);
+  } catch {
+    return files;
+  }
+  for (const entry of entries.sort()) {
+    if (
+      entry.startsWith(VARIANT_PREFIX) &&
+      entry.endsWith(VARIANT_SUFFIX) &&
+      entry !== CONTEST_MANIFEST
+    ) {
+      files.push(path.join(root, entry));
+    }
+  }
+  return files;
+}
+
+/** Identities for every root that a contest names, keyed by absolute root. */
+export async function indexContests(
+  roots: readonly string[],
+): Promise<Map<string, ProblemIdentity>> {
+  const index = new Map<string, ProblemIdentity>();
+  const scanned = new Set<string>();
+  for (const root of roots) {
+    const contestRoot = await findContestRoot(root);
+    if (contestRoot === undefined || scanned.has(contestRoot)) {
+      continue;
+    }
+    scanned.add(contestRoot);
+    for (const file of await contestFiles(contestRoot)) {
+      const identities = problemIdentities(contestRoot, parseContest(await readYamlFile(file)));
+      for (const [key, identity] of identities) {
+        // First file to name a root wins; canonical is read first.
+        if (!index.has(key)) {
+          index.set(key, identity);
+        }
+      }
+    }
+  }
+  return index;
+}
+```
+
+**Step 5: Run everything**
+
+Run: `cd vscode && npm run test && npm run typecheck && npm run lint`
+Expected: all PASS.
+
+**Step 6: Commit**
+
+```bash
+git add vscode/src/rbx/contest.ts vscode/src/rbx/contest.test.ts vscode/src/contestIndex.ts
+# /commit  ->  feat(vscode): resolve packages to the letters their contest gives them
+```
+
+---
+
+## Task 3: The problem list
+
+**Files:**
+- Create: `vscode/src/rbx/problems.ts` (pure)
+- Create: `vscode/src/rbx/problems.test.ts`
+
+Turn discovered roots plus contest identities into the ordered list the dropdown renders. Pure, so ordering is tested without a workspace.
+
+Ordering rules:
+1. Problems in a contest come first, grouped by contest root, in declared `order`.
+2. Packages in no contest follow, sorted by path (today's behaviour).
+3. The **group label** is the contest root's directory name, used for `<optgroup>` when more than one group exists.
+
+**Step 1: Write the failing tests**
+
+```ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { problemChoices } from './problems';
+
+const identity = (shortName: string, order: number, color?: string) => ({
+  shortName,
+  order,
+  color,
+});
+
+test('orders contest problems by their declared order, not by path', () => {
+  // `/c/z` is `A` and sorts first despite sorting last lexicographically --
+  // which is the whole point of reading the contest file.
+  const choices = problemChoices(
+    ['/c/a', '/c/z'],
+    new Map([
+      ['/c/z', identity('A', 0)],
+      ['/c/a', identity('B', 1)],
+    ]),
+    () => 'fallback',
+  );
+  assert.deepEqual(choices.map((c) => c.label), ['A', 'B']);
+  assert.deepEqual(choices.map((c) => c.root), ['/c/z', '/c/a']);
+});
+
+test('labels an uncontested package with the host fallback, after the contest', () => {
+  const choices = problemChoices(
+    ['/loose', '/c/A'],
+    new Map([['/c/A', identity('A', 0)]]),
+    (root) => `label:${root}`,
+  );
+  assert.deepEqual(choices.map((c) => c.label), ['A', 'label:/loose']);
+});
+
+test('carries the declared colour through', () => {
+  const choices = problemChoices(['/c/A'], new Map([['/c/A', identity('A', 0, '#f00')]]), () => '');
+  assert.equal(choices[0].color, '#f00');
+});
+
+test('groups by contest only when there is more than one group', () => {
+  const one = problemChoices(['/c/A'], new Map([['/c/A', identity('A', 0)]]), () => '');
+  assert.equal(one[0].group, undefined);
+
+  const two = problemChoices(
+    ['/x/A', '/y/A'],
+    new Map([
+      ['/x/A', identity('A', 0)],
+      ['/y/A', identity('A', 0)],
+    ]),
+    () => '',
+  );
+  assert.deepEqual(two.map((c) => c.group), ['x', 'y']);
+});
+
+test('sorts uncontested packages by path', () => {
+  const choices = problemChoices(['/b', '/a'], new Map(), (root) => root);
+  assert.deepEqual(choices.map((c) => c.root), ['/a', '/b']);
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `cd vscode && npm run test`
+Expected: FAIL — cannot find module `./problems`.
+
+**Step 3: Implement**
+
+```ts
+/**
+ * The problems the selector offers, in the order it offers them.
+ *
+ * Pure: the caller supplies the roots, the contest identities and a fallback
+ * labeller, because naming a package with no contest needs `vscode.workspace`
+ * to say which folder it sits in -- and this module's value is being testable
+ * without the editor API. Same split as `PackageRunView.label`.
+ */
+import * as path from 'path';
+
+import { ProblemIdentity } from './contest';
+
+/** One entry in the dropdown. */
+export interface ProblemChoice {
+  readonly root: string;
+  readonly label: string;
+  /** The contest this belongs to, for `<optgroup>`. Absent when there is one group. */
+  readonly group?: string;
+  readonly color?: string;
+}
+
+/** How a package with no contest is named. Supplied by the host. */
+export type FallbackLabel = (root: string) => string;
+
+interface Entry {
+  readonly root: string;
+  readonly label: string;
+  readonly color?: string;
+  readonly group?: string;
+  readonly order: number;
+}
+
+/**
+ * The contest a root belongs to, as a grouping key.
+ *
+ * Derived from the root's own path rather than tracked through the index: a
+ * problem's contest root is the only ancestor that named it, and for grouping
+ * purposes its parent directory separates two contests exactly as well.
+ */
+function groupKeyOf(root: string): string {
+  return path.dirname(root);
+}
+
+export function problemChoices(
+  roots: readonly string[],
+  identities: ReadonlyMap<string, ProblemIdentity>,
+  fallback: FallbackLabel,
+): ProblemChoice[] {
+  const contested: Entry[] = [];
+  const loose: Entry[] = [];
+  for (const root of roots) {
+    const identity = identities.get(root);
+    if (identity === undefined) {
+      loose.push({ root, label: fallback(root), order: 0 });
+    } else {
+      contested.push({
+        root,
+        label: identity.shortName,
+        color: identity.color,
+        group: groupKeyOf(root),
+        order: identity.order,
+      });
+    }
+  }
+
+  contested.sort((a, b) => {
+    const group = (a.group ?? '').localeCompare(b.group ?? '');
+    return group !== 0 ? group : a.order - b.order;
+  });
+  loose.sort((a, b) => a.root.localeCompare(b.root));
+
+  // One group is no grouping: an `<optgroup>` wrapping every option says
+  // nothing and costs a row of chrome in a narrow sidebar.
+  const groups = new Set(contested.map((entry) => entry.group));
+  const grouped = groups.size > 1;
+
+  return [...contested, ...loose].map((entry) => ({
+    root: entry.root,
+    label: entry.label,
+    color: entry.color,
+    group: grouped && entry.group !== undefined ? path.basename(entry.group) : undefined,
+  }));
+}
+```
+
+**Step 4: Run everything**
+
+Run: `cd vscode && npm run test && npm run typecheck && npm run lint`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vscode/src/rbx/problems.ts vscode/src/rbx/problems.test.ts
+# /commit  ->  feat(vscode): order the problems a selector would offer
+```
+
+---
+
+## Task 4: Scope the view model to one package
+
+**Files:**
+- Modify: `vscode/src/rbx/nodes.ts:85-107` (`flattenNodes`)
+- Modify: `vscode/src/rbx/nodes.ts:14-19` (delete `PackageNode`)
+- Modify: `vscode/src/rbx/viewModel.ts:655-673` (delete `packageRow`), `:819-868` (`buildViewModel`)
+- Modify: `vscode/src/rbx/nodes.test.ts`, `vscode/src/rbx/viewModel.test.ts`
+
+This is the breaking change. `flattenNodes` takes **one** `PackageRunView` and never emits a package row.
+
+**Step 1: Update the existing tests first**
+
+Read `nodes.test.ts` and `viewModel.test.ts` and rewrite every case that passes an array or asserts on a `package` row. Delete tests that only covered the multi-package flatten and the `showPackages` rule — they are asserting behaviour this task removes. Add:
+
+```ts
+test('emits no package row', () => {
+  const nodes = flattenNodes({ pkg, run });
+  assert.equal(nodes.some((node) => node.kind === 'package'), false);
+});
+
+test('yields nothing for a package with no run', () => {
+  assert.deepEqual(flattenNodes({ pkg, run: undefined }), []);
+});
+```
+
+**Step 2: Run to verify they fail**
+
+Run: `cd vscode && npm run test`
+Expected: FAIL — `flattenNodes` still expects an array.
+
+**Step 3: Implement**
+
+In `nodes.ts`: delete the `PackageNode` interface, drop `'package'` from the `RunNode` union and from `nodeId`, and replace `flattenNodes`:
+
+```ts
+/**
+ * Every row of one package's run, in display order, parents before children.
+ *
+ * One package, because the view shows one: the selector upstream decides which,
+ * so there is no package level left to draw and no rule about when to draw it.
+ */
+export function flattenNodes(view: PackageRunView): RunNode[] {
+  const { pkg, run } = view;
+  if (run === undefined) {
+    return [];
+  }
+  const nodes: RunNode[] = [];
+  const solo = run.solutions.length === 1;
+  for (const solutionRun of run.solutions) {
+    nodes.push({ kind: 'solution', pkg, run: solutionRun, solo });
+    for (const group of solutionRun.groups) {
+      nodes.push({ kind: 'group', pkg, run: solutionRun, group });
+      for (const testcase of group.testcases) {
+        nodes.push({ kind: 'testcase', pkg, run: solutionRun, group, testcase });
+      }
+    }
+  }
+  return nodes;
+}
+```
+
+In `viewModel.ts`: delete `packageRow` and `packageName`, drop the `PackageNode` import and the `'package'` case from the switch, and simplify `buildViewModel`:
+
+```ts
+export function buildViewModel(
+  view: PackageRunView,
+  style: SolutionLabelStyle = DEFAULT_SOLUTION_LABEL_STYLE,
+): RunViewModel {
+  const nodes = flattenNodes(view);
+  // One package, so labels are trimmed against its solutions alone -- which is
+  // what `labelsByPackage` was always computing per package anyway.
+  const labels = solutionLabels(
+    view.run?.solutions.map((solution) => solution.solution.path) ?? [],
+    style,
+  );
+  const parents = new Map<number, string>();
+
+  const rows: Row[] = [];
+  for (const node of nodes) {
+    // No offset: with the package level gone, a solution is always depth 0.
+    const depth = DEPTHS[node.kind] - 1;
+    const parentId = parents.get(depth - 1);
+    const row = ((): Row => {
+      switch (node.kind) {
+        case 'solution': {
+          const path = node.run.solution.path;
+          return solutionRow(node, depth, labels.get(path) ?? path, parentId);
+        }
+        case 'group':
+          return groupRow(node, depth, parentId);
+        case 'testcase':
+          return testcaseRow(node, depth, parentId);
+      }
+    })();
+    rows.push(row);
+    parents.set(depth, row.id);
+  }
+
+  return {
+    rows,
+    mismatches: rows.filter((row) => row.kind === 'solution' && row.gutter === 'missed').length,
+    warned: rows.filter(
+      (row) => row.kind === 'solution' && row.gutter !== 'missed' && row.warnings.length > 0,
+    ).length,
+    empty: !rows.some((row) => row.kind === 'solution'),
+  };
+}
+```
+
+Check `solutionLabels`' real signature in `vscode/src/rbx/solutionLabel.ts` before writing this — adapt the call to what it actually takes. Delete `labelsByPackage` (`viewModel.ts:585`) once nothing calls it, and drop `'package'` from the `Row['kind']` union and from `DEPTHS`.
+
+**Step 4: Run everything**
+
+Run: `cd vscode && npm run test && npm run typecheck && npm run lint`
+Expected: PASS. `typecheck` is what proves no `'package'` case survives anywhere; fix every error it reports rather than casting past it.
+
+**Step 5: Commit**
+
+```bash
+git add vscode/src/rbx/
+# /commit  ->  refactor(vscode): build the run model from one package
+```
+
+---
+
+## Task 5: The ActiveProblem service
+
+**Files:**
+- Create: `vscode/src/activeProblem.ts` (host half)
+- Modify: `vscode/src/runData.ts` (expose the roots; keep `discovered()` intact)
+
+`DeclaredIndex` (`vscode/src/declared.ts:29`) calls `data.discovered()` to index **every** package's manifest, and Explorer badges, the solution lens and the status bar all draw from it. **Those stay workspace-wide.** Narrowing `discovered()` would silently strip badges off every unselected problem. Do not touch it.
+
+**Step 1: Implement**
+
+```ts
+/**
+ * Which problem the Run view is showing.
+ *
+ * The single source of truth for the selection: the dropdown, the quick pick
+ * and the auto-switch all go through here, so they cannot disagree about what
+ * is on screen.
+ */
+import * as vscode from 'vscode';
+
+import { indexContests } from './contestIndex';
+import { packageLabel } from './discovery';
+import { log } from './log';
+import { ProblemChoice, problemChoices } from './rbx/problems';
+import { packageLayout } from './rbx/layout';
+import { RunDataProvider } from './runData';
+
+const SELECTED_KEY = 'rbx.selectedProblem';
+
+export class ActiveProblem {
+  private readonly changed = new vscode.EventEmitter<void>();
+  readonly onDidChange: vscode.Event<void> = this.changed.event;
+
+  private choices: ProblemChoice[] = [];
+  private selectedRoot?: string;
+
+  constructor(
+    private readonly data: RunDataProvider,
+    private readonly memento: vscode.Memento,
+  ) {
+    this.selectedRoot = memento.get<string>(SELECTED_KEY);
+  }
+
+  /** Rebuild the list after discovery, keeping the selection if it survived. */
+  async refresh(): Promise<void> {
+    const roots = (await this.data.discovered()).map((pkg) => pkg.root);
+    const identities = await indexContests(roots);
+    this.choices = problemChoices(roots, identities, (root) => packageLabel(packageLayout(root)));
+    if (!this.choices.some((choice) => choice.root === this.selectedRoot)) {
+      // The selected package went away -- deleted, renamed, or moved out of the
+      // glob. Falling back to the first keeps the view showing *something*.
+      this.selectedRoot = this.choices[0]?.root;
+    }
+    this.changed.fire();
+  }
+
+  problems(): readonly ProblemChoice[] {
+    return this.choices;
+  }
+
+  selected(): string | undefined {
+    return this.selectedRoot;
+  }
+
+  /** Show a problem. No-op when it is already showing, or is not a problem. */
+  select(root: string): void {
+    if (root === this.selectedRoot || !this.choices.some((choice) => choice.root === root)) {
+      return;
+    }
+    this.selectedRoot = root;
+    void this.memento.update(SELECTED_KEY, root);
+    log(`Showing ${root}.`);
+    this.changed.fire();
+  }
+
+  /**
+   * Follow a run that just started.
+   *
+   * rbx writes `skeleton.yml` when a run *begins* (rbx/box/solutions.py:746),
+   * so this tracks the problem currently running rather than jumping to one
+   * that already finished -- during `rbx contest each run` the view walks the
+   * contest in step with it.
+   *
+   * Unlike `select`, an unknown root is not ignored: a package can be created
+   * and run before discovery has seen it, and dropping the switch there would
+   * leave the view on the wrong problem until the next rediscovery.
+   */
+  async follow(root: string): Promise<void> {
+    if (!this.choices.some((choice) => choice.root === root)) {
+      await this.refresh();
+    }
+    this.select(root);
+  }
+}
+```
+
+**Step 2: Run typecheck**
+
+Run: `cd vscode && npm run typecheck && npm run lint`
+Expected: PASS. Adjust the `packageLabel`/`packageLayout` imports to their real signatures.
+
+**Step 3: Commit**
+
+```bash
+git add vscode/src/activeProblem.ts
+# /commit  ->  feat(vscode): track which problem the run view is showing
+```
+
+---
+
+## Task 6: Post one problem, and the dropdown
+
+**Files:**
+- Modify: `vscode/src/runView.ts` (`post`, message handling, `html`)
+- Modify: `vscode/src/webview/render.ts` (add `renderSelector`)
+- Modify: `vscode/src/webview/main.ts` (render it, post changes back)
+- Modify: `vscode/src/webview/style.css`
+- Modify: `vscode/src/webview/render.test.ts`
+
+**Step 1: Host — post one package**
+
+In `runView.ts`, take an `ActiveProblem` in the constructor and rewrite `post`:
+
+```ts
+private async post(): Promise<void> {
+  const selected = this.active.selected();
+  const view =
+    selected === undefined
+      ? undefined
+      : { pkg: packageLayout(selected), run: await this.data.report(packageLayout(selected)) };
+  this.nodes = new Map(
+    (view === undefined ? [] : flattenNodes(view)).map((node) => [nodeId(node), node]),
+  );
+  const style = asSolutionLabelStyle(
+    vscode.workspace.getConfiguration('rbx').get('solutionLabel'),
+  );
+  await this.view?.webview.postMessage({
+    type: 'state',
+    model: view === undefined ? EMPTY_MODEL : buildViewModel(view, style),
+    problems: this.active.problems(),
+    selected,
+  });
+}
+```
+
+`data.report(pkg)` already exists (`runData.ts:93`) and goes through the per-package `ArtifactStore` cache. **`loadAll` should now have no callers — delete it.** Subscribe to `active.onDidChange` alongside `data.onDidChange`, and handle the new client message:
+
+```ts
+if (message.type === 'select' && message.root !== undefined) {
+  this.active.select(message.root);
+  return;
+}
+```
+
+Add a `<div id="selector-host"></div>` to the HTML shell, above `#header`.
+
+**Step 2: Client — write the failing test** in `render.test.ts`
+
+```ts
+test('renders one option per problem, marking the selected one', () => {
+  const html = renderSelector(
+    [
+      { root: '/c/A', label: 'A' },
+      { root: '/c/B', label: 'B' },
+    ],
+    '/c/B',
+  );
+  assert.match(html, /<option value="\/c\/A"[^>]*>A<\/option>/);
+  assert.match(html, /<option value="\/c\/B" selected[^>]*>B<\/option>/);
+});
+
+test('renders nothing for a single problem', () => {
+  assert.equal(renderSelector([{ root: '/only', label: 'only' }], '/only'), '');
+});
+
+test('groups options when the problems carry groups', () => {
+  const html = renderSelector(
+    [
+      { root: '/x/A', label: 'A', group: 'x' },
+      { root: '/y/A', label: 'A', group: 'y' },
+    ],
+    '/x/A',
+  );
+  assert.match(html, /<optgroup label="x">/);
+  assert.match(html, /<optgroup label="y">/);
+});
+
+test('escapes a label and a root', () => {
+  const html = renderSelector([{ root: '/a"b', label: '<script>' }, { root: '/c', label: 'c' }], '/c');
+  assert.equal(html.includes('<script>'), false);
+  assert.equal(html.includes('"/a"b"'), false);
+});
+```
+
+**Step 3: Run to verify it fails**
+
+Run: `cd vscode && npm run test`
+Expected: FAIL — `renderSelector` is not exported.
+
+**Step 4: Implement `renderSelector`** in `render.ts`, reusing the existing `escapeHtml`/`escapeAttr`:
+
+```ts
+/**
+ * The problem dropdown.
+ *
+ * Hidden for a single problem: a select with one option is a control that
+ * cannot do anything, and a one-problem workspace should look exactly as it did
+ * before the selector existed.
+ *
+ * The colour dot is a `style` attribute, which the CSP permits on styles only
+ * (see the note in runView.ts) -- and the value is a colour a contest author
+ * wrote, so it goes through `escapeAttr` like everything else.
+ */
+export function renderSelector(problems: readonly ProblemChoice[], selected?: string): string {
+  if (problems.length <= 1) {
+    return '';
+  }
+  const option = (problem: ProblemChoice): string =>
+    `<option value="${escapeAttr(problem.root)}"${problem.root === selected ? ' selected' : ''}>` +
+    escapeHtml(problem.label) +
+    '</option>';
+
+  let body = '';
+  let openGroup: string | undefined;
+  for (const problem of problems) {
+    if (problem.group !== openGroup) {
+      body += openGroup === undefined ? '' : '</optgroup>';
+      openGroup = problem.group;
+      body += openGroup === undefined ? '' : `<optgroup label="${escapeAttr(openGroup)}">`;
+    }
+    body += option(problem);
+  }
+  body += openGroup === undefined ? '' : '</optgroup>';
+
+  const dot = problems.find((problem) => problem.root === selected)?.color;
+  return (
+    '<div class="selector">' +
+    (dot === undefined ? '' : `<span class="selector-dot" style="background:${escapeAttr(dot)}"></span>`) +
+    `<select id="problem">${body}</select>` +
+    '</div>'
+  );
+}
+```
+
+Note the grouped/ungrouped mix cannot interleave, because `problemChoices` sorts by group — the single-pass open/close above is safe *because* of that ordering.
+
+**Step 5: Wire the client** in `main.ts`
+
+Hold `problems`/`selected` from the `state` message, render into `#selector-host` inside `renderAll`, and post back on change:
+
+```ts
+selectorHost.addEventListener('change', (event) => {
+  const target = event.target as HTMLSelectElement;
+  if (target.id === 'problem') {
+    vscode.postMessage({ type: 'select', root: target.value });
+  }
+});
+```
+
+Do **not** persist the selection in webview state — the host owns it and re-posts it. Persisting it in both places is how they drift.
+
+**Step 6: Style it.** Add `.selector` (flex row, full width, small bottom margin) and `.selector-dot` (a ~8px circle, `border-radius:50%`, `flex:none`) to `style.css`, matching the existing `.filter` rules.
+
+**Step 7: Run everything**
+
+Run: `cd vscode && npm run test && npm run typecheck && npm run lint`
+Expected: all PASS.
+
+**Step 8: Commit**
+
+```bash
+git add vscode/src/runView.ts vscode/src/webview/ vscode/src/runData.ts
+# /commit  ->  feat(vscode): pick the problem the run view shows
+```
+
+---
+
+## Task 7: Auto-switch, and the quick pick
+
+**Files:**
+- Modify: `vscode/src/extension.ts` (construct `ActiveProblem`, add the skeleton watcher, refresh)
+- Modify: `vscode/src/commands.ts` (add `rbx.selectProblem`)
+- Modify: `vscode/package.json` (contribute the command; **delete `rbx.packageSearchDepth`**)
+
+**Step 1: Construct and refresh.** In `activate`, build `ActiveProblem` with `context.workspaceState`, pass it to `RunViewProvider`, and refresh it inside `rediscover` **after** `data.refresh()` so it sees the new roots:
+
+```ts
+const rediscover = () => {
+  void data.refresh().then(() => Promise.all([declared.refresh(), active.refresh()]));
+};
+```
+
+**Step 2: Watch the skeleton.**
+
+```ts
+// `skeleton.yml` is written when a run *starts* (rbx/box/solutions.py:746 --
+// "A new skeleton is what marks a new run"), so following it makes the view
+// track the problem currently running: `rbx contest each run` walks the view
+// through the contest in step with the run itself.
+const skeletons = vscode.workspace.createFileSystemWatcher(`**/${CACHE_DIR}/runs/skeleton.yml`);
+const followRun = (uri: vscode.Uri) => {
+  const root = packageRootOf(uri.fsPath);
+  if (root !== undefined) {
+    void active.follow(root);
+  }
+};
+skeletons.onDidCreate(followRun);
+skeletons.onDidChange(followRun);
+context.subscriptions.push(skeletons);
+```
+
+Only create and change — **not delete**. `rbx clean` removes the skeleton, and switching to a package whose run was just deleted is the opposite of following work.
+
+**Step 3: The quick pick,** in `commands.ts`:
+
+```ts
+vscode.commands.registerCommand('rbx.selectProblem', async () => {
+  const problems = active.problems();
+  if (problems.length === 0) {
+    void vscode.window.showInformationMessage('No rbx problem found in this workspace.');
+    return;
+  }
+  const picked = await vscode.window.showQuickPick(
+    problems.map((problem) => ({
+      label: problem.label,
+      description: problem.group,
+      detail: problem.root,
+      root: problem.root,
+    })),
+    { placeHolder: 'Show which problem in the Run view?' },
+  );
+  if (picked !== undefined) {
+    active.select(picked.root);
+  }
+});
+```
+
+**Step 4: Contribute it** in `package.json` — `{"command": "rbx.selectProblem", "title": "Select Problem", "category": "rbx"}` — and add a `view/title` menu entry with `"when": "view == rbx.run"`.
+
+**Step 5: Delete the dead setting.** Remove the whole `rbx.packageSearchDepth` block from `contributes.configuration.properties`. It is contributed with a default of 3 and read nowhere in `src/`; discovery has always globbed unbounded. While here, delete `IGNORED_DIRS` (`vscode/src/rbx/layout.ts:119`) — exported, unused, and already drifted from the real exclusion glob in `discovery.ts:12`.
+
+Verify both are gone:
+
+```bash
+cd vscode && grep -rn "packageSearchDepth\|IGNORED_DIRS" src package.json
+```
+Expected: no output.
+
+**Step 6: Run everything**
+
+Run: `cd vscode && npm run test && npm run typecheck && npm run lint`
+Expected: all PASS.
+
+**Step 7: Commit**
+
+```bash
+git add vscode/src/extension.ts vscode/src/commands.ts vscode/package.json vscode/src/rbx/layout.ts
+# /commit  ->  feat(vscode): follow the problem that is running
+```
+
+---
+
+## Task 8: Manual verification
+
+Automated tests cover the pure half; the wiring needs eyes. Build a scratch contest and press on it.
+
+**Step 1: Launch.** Open `vscode/` in VS Code, press F5 for an Extension Development Host, and open a real multi-problem contest in it.
+
+**Step 2: Walk the checklist.**
+
+| # | Check | Expected |
+|---|---|---|
+| 1 | Open the Run view | A dropdown listing problems as `A`, `B`, `C` — contest order, not path order |
+| 2 | Pick `C` | Only C's solutions. No package row, no extra indent |
+| 3 | Header strip | Counts describe C alone, not the workspace |
+| 4 | `cd A && rbx run` | View switches to A and fills in live |
+| 5 | `rbx contest each run` | View walks A → B → C in step with the run |
+| 6 | Reload the window | Comes back on the last-selected problem |
+| 7 | Open a single-problem package | No dropdown at all; view looks as it did before |
+| 8 | Explorer badges on an **unselected** problem | Still present — `DeclaredIndex` stays workspace-wide |
+| 9 | `rbx: Select Problem` from the palette | Quick pick, same list, same order |
+| 10 | Delete the selected package's directory | Falls back to the first problem; no error |
+| 11 | `rbx clean` in the selected package | View empties; does **not** switch away |
+
+**Step 3: Update the README.** `vscode/README.md` describes the view; add the selector and the auto-switch rule.
+
+**Step 4: Commit**
+
+```bash
+git add vscode/README.md
+# /commit  ->  docs(vscode): describe the problem selector
+```
+
+---
+
+## Done when
+
+- `npm run test`, `npm run typecheck` and `npm run lint` all pass.
+- No `'package'` row kind survives anywhere (`grep -rn "'package'" vscode/src` is empty).
+- `packageSearchDepth` and `IGNORED_DIRS` are gone.
+- The Task 8 checklist passes end to end.

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -45,7 +45,9 @@ contest named none of them and said nothing about the one on screen.
 
 Problems are named by the **contest letter** `contest.rbx.yml` gives them, in
 the order the contest declares them and with its declared colour as a dot,
-rather than by directory name in path order. The nearest `contest.rbx.yml`
+rather than by directory name in path order. The dot shows the **selected**
+problem's colour only, not one per entry: a native `<select>` cannot be relied
+on to colour its options, so an open dropdown is a plain list of letters. The nearest `contest.rbx.yml`
 above a package is the one that names it, a dispatcher's variants included. A
 package no contest claims keeps its directory name and sorts after the ones a
 contest does claim; with more than one contest open, the dropdown groups by

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -35,6 +35,31 @@ Every solution and every group carries its own summary: the verdict underneath
 it, the points it earned, and the **max** time and memory across its testcases
 -- the slowest test being the one the time limit is judged against.
 
+### One problem at a time
+
+The view shows **one package**, and a dropdown in its header picks which. The
+dropdown is hidden when the workspace holds a single package, so a one-problem
+workspace reads exactly as it did before. The header strip's mismatch and
+warning counts are that one problem's -- a count summed over a ten-problem
+contest named none of them and said nothing about the one on screen.
+
+Problems are named by the **contest letter** `contest.rbx.yml` gives them, in
+the order the contest declares them and with its declared colour as a dot,
+rather than by directory name in path order. The nearest `contest.rbx.yml`
+above a package is the one that names it, a dispatcher's variants included. A
+package no contest claims keeps its directory name and sorts after the ones a
+contest does claim; with more than one contest open, the dropdown groups by
+contest.
+
+The view also **follows the problem that is running**. rbx writes a new
+skeleton when a run *begins*, so the selection moves to the problem now being
+run rather than to one that has already finished -- during `rbx contest each
+run` it walks the contest in step. Left alone, the selection is remembered per
+workspace, so reopening the window returns to the problem you were reading.
+
+For the keyboard, `rbx: Select Problem` offers the same list as a quick pick.
+`rbx: Reveal Problem in Explorer` reveals whichever problem is selected.
+
 ### Warnings on a run that passed
 
 A **yellow triangle in the gutter** -- where a met declaration draws a green tick

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -83,8 +83,14 @@
       },
       {
         "command": "rbx.revealInExplorer",
-        "title": "Reveal Package in Explorer",
+        "title": "Reveal Problem in Explorer",
         "category": "rbx"
+      },
+      {
+        "command": "rbx.selectProblem",
+        "title": "Select Problem",
+        "category": "rbx",
+        "icon": "$(list-selection)"
       },
       {
         "command": "rbx.copyPath",
@@ -95,9 +101,14 @@
     "menus": {
       "view/title": [
         {
+          "command": "rbx.selectProblem",
+          "when": "view == rbx.run",
+          "group": "navigation@1"
+        },
+        {
           "command": "rbx.refresh",
           "when": "view == rbx.run",
-          "group": "navigation"
+          "group": "navigation@2"
         }
       ],
       "webview/context": [
@@ -134,11 +145,6 @@
         {
           "command": "rbx.copyPath",
           "when": "webviewSection == 'rbx.testcase'",
-          "group": "3_copy@1"
-        },
-        {
-          "command": "rbx.revealInExplorer",
-          "when": "webviewSection == 'rbx.package'",
           "group": "3_copy@1"
         }
       ]
@@ -197,11 +203,6 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "Show what `problem.rbx.yml` declares a solution to do in the language status area, which stays visible while you scroll."
-        },
-        "rbx.packageSearchDepth": {
-          "type": "number",
-          "default": 3,
-          "markdownDescription": "How deep to search workspace folders for `problem.rbx.yml` files."
         },
         "rbx.solutionLabel": {
           "type": "string",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -227,7 +227,7 @@
     "watch": "node esbuild.mjs --watch",
     "package": "node esbuild.mjs --production",
     "typecheck": "tsc --noEmit",
-    "pretest": "node esbuild.test.mjs",
+    "pretest": "node esbuild.mjs && node esbuild.test.mjs",
     "test": "node --test \"out-test/**/*.test.js\"",
     "lint": "eslint src",
     "vscode:prepublish": "npm run package"

--- a/vscode/src/activeProblem.ts
+++ b/vscode/src/activeProblem.ts
@@ -1,0 +1,103 @@
+/**
+ * Which problem the Run view is showing.
+ *
+ * The single source of truth for the selection: the dropdown, the quick pick
+ * and the auto-switch all go through here, so they cannot disagree about what
+ * is on screen.
+ */
+import * as vscode from 'vscode';
+
+import { indexContests } from './contestIndex';
+import { packageLabel } from './discovery';
+import { log } from './log';
+import { packageLayout } from './rbx/layout';
+import { ProblemChoice, problemChoices } from './rbx/problems';
+import { RunDataProvider } from './runData';
+
+const SELECTED_KEY = 'rbx.selectedProblem';
+
+export class ActiveProblem {
+  private readonly changed = new vscode.EventEmitter<void>();
+  readonly onDidChange: vscode.Event<void> = this.changed.event;
+
+  private choices: ProblemChoice[] = [];
+  private selectedRoot?: string;
+
+  constructor(
+    private readonly data: RunDataProvider,
+    private readonly memento: vscode.Memento,
+  ) {
+    // Remembered across windows so reopening a contest lands back on the
+    // problem being worked on rather than on whichever one sorts first.
+    this.selectedRoot = memento.get<string>(SELECTED_KEY);
+  }
+
+  /** Rebuild the list after discovery, keeping the selection if it survived. */
+  async refresh(): Promise<void> {
+    const roots = (await this.data.discovered()).map((pkg) => pkg.root);
+    const identities = await indexContests(roots);
+    this.choices = problemChoices(roots, identities, (root) => packageLabel(packageLayout(root)));
+    if (!this.knows(this.selectedRoot)) {
+      // The selected package went away -- deleted, renamed, or moved out of the
+      // glob. Falling back to the first keeps the view showing *something*.
+      //
+      // Not written back to the memento: a package that vanished because a
+      // branch was checked out comes back, and the remembered root should come
+      // back with it rather than have been overwritten by the fallback.
+      this.selectedRoot = this.choices[0]?.root;
+    }
+    this.changed.fire();
+  }
+
+  problems(): readonly ProblemChoice[] {
+    return this.choices;
+  }
+
+  selected(): string | undefined {
+    return this.selectedRoot;
+  }
+
+  /** Show a problem. No-op when it is already showing, or is not a problem. */
+  select(root: string): void {
+    if (root === this.selectedRoot || !this.knows(root)) {
+      return;
+    }
+    this.selectedRoot = root;
+    void this.memento.update(SELECTED_KEY, root);
+    log(`Showing ${root}.`);
+    this.changed.fire();
+  }
+
+  /**
+   * Follow a run that just started.
+   *
+   * rbx writes `skeleton.yml` when a run *begins* (rbx/box/solutions.py:746),
+   * so this tracks the problem currently running rather than jumping to one
+   * that already finished -- during `rbx contest each run` the view walks the
+   * contest in step with it.
+   *
+   * Unlike `select`, an unknown root is not ignored: a package can be created
+   * and run before discovery has seen it, and dropping the switch there would
+   * leave the view on the wrong problem until the next rediscovery. Which is
+   * why the rediscovery asked for here is the provider's and not just this
+   * class's: `discovered()` is memoized (see `RunDataProvider.discovery`), so
+   * re-reading it would hand back the very list that is missing the package.
+   */
+  async follow(root: string): Promise<void> {
+    if (!this.knows(root)) {
+      await this.data.refresh();
+      await this.refresh();
+    }
+    if (!this.knows(root)) {
+      // The workspace glob still does not cover it -- a run outside any open
+      // folder, or under one of `discovery.ts`'s exclusions. Saying so beats a
+      // view that silently stays put while a different problem runs.
+      log(`Not following the run in ${root}: it is not a discovered package.`);
+    }
+    this.select(root);
+  }
+
+  private knows(root: string | undefined): boolean {
+    return this.choices.some((choice) => choice.root === root);
+  }
+}

--- a/vscode/src/activeProblem.ts
+++ b/vscode/src/activeProblem.ts
@@ -10,11 +10,33 @@ import * as vscode from 'vscode';
 import { indexContests } from './contestIndex';
 import { packageLabel } from './discovery';
 import { log } from './log';
-import { packageLayout } from './rbx/layout';
+import { manifestPath, packageLayout } from './rbx/layout';
+import { parseProblemName } from './rbx/manifest';
 import { ProblemChoice, problemChoices } from './rbx/problems';
+import { readYamlFile } from './rbx/store';
 import { RunDataProvider } from './runData';
 
 const SELECTED_KEY = 'rbx.selectedProblem';
+
+/**
+ * What each package calls itself, for the letter in the dropdown to sit beside.
+ *
+ * A second read of the manifests `DeclaredIndex` also reads, rather than a
+ * dependency between the two: they refresh on the same events but answer
+ * different questions, and one small YAML per package -- of which a contest has
+ * a dozen -- is cheaper than the coupling. A package that cannot be read simply
+ * has no name, and its row keeps the bare letter.
+ */
+async function declaredNames(roots: readonly string[]): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  for (const root of roots) {
+    const name = parseProblemName(await readYamlFile(manifestPath(packageLayout(root))));
+    if (name !== undefined) {
+      names.set(root, name);
+    }
+  }
+  return names;
+}
 
 export class ActiveProblem {
   private readonly changed = new vscode.EventEmitter<void>();
@@ -36,7 +58,13 @@ export class ActiveProblem {
   async refresh(): Promise<void> {
     const roots = (await this.data.discovered()).map((pkg) => pkg.root);
     const identities = await indexContests(roots);
-    this.choices = problemChoices(roots, identities, (root) => packageLabel(packageLayout(root)));
+    const names = await declaredNames(roots);
+    this.choices = problemChoices(
+      roots,
+      identities,
+      (root) => packageLabel(packageLayout(root)),
+      (root) => names.get(root),
+    );
     if (!this.knows(this.selectedRoot)) {
       // The selected package went away -- deleted, renamed, or moved out of the
       // glob. Falling back to the first keeps the view showing *something*.

--- a/vscode/src/activeProblem.ts
+++ b/vscode/src/activeProblem.ts
@@ -57,15 +57,14 @@ export class ActiveProblem {
     return this.selectedRoot;
   }
 
-  /** Show a problem. No-op when it is already showing, or is not a problem. */
+  /**
+   * Show a problem the user picked. No-op when already showing, or unknown.
+   *
+   * The explicit path, and the only one that writes the memento: the dropdown
+   * and the quick pick both land here.
+   */
   select(root: string): void {
-    if (root === this.selectedRoot || !this.knows(root)) {
-      return;
-    }
-    this.selectedRoot = root;
-    void this.memento.update(SELECTED_KEY, root);
-    log(`Showing ${root}.`);
-    this.changed.fire();
+    this.show(root, true);
   }
 
   /**
@@ -82,6 +81,12 @@ export class ActiveProblem {
    * why the rediscovery asked for here is the provider's and not just this
    * class's: `discovered()` is memoized (see `RunDataProvider.discovery`), so
    * re-reading it would hand back the very list that is missing the package.
+   *
+   * Shown but not remembered, for the same reason `refresh`'s fallback is not:
+   * nobody chose this. `rbx contest each run` would otherwise persist whichever
+   * problem the contest run happened to touch last, and a user who deliberately
+   * picked D would reopen the window on some other letter. Auto-switching is
+   * the feature; auto-persisting the auto-switch is a side effect of it.
    */
   async follow(root: string): Promise<void> {
     if (!this.knows(root)) {
@@ -94,7 +99,20 @@ export class ActiveProblem {
       // view that silently stays put while a different problem runs.
       log(`Not following the run in ${root}: it is not a discovered package.`);
     }
-    this.select(root);
+    this.show(root, false);
+  }
+
+  /** The one place the selection moves. `remember` writes it to the memento. */
+  private show(root: string, remember: boolean): void {
+    if (root === this.selectedRoot || !this.knows(root)) {
+      return;
+    }
+    this.selectedRoot = root;
+    if (remember) {
+      void this.memento.update(SELECTED_KEY, root);
+    }
+    log(`Showing ${root}.`);
+    this.changed.fire();
   }
 
   private knows(root: string | undefined): boolean {

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -10,6 +10,7 @@
 import * as fs from 'fs/promises';
 import * as vscode from 'vscode';
 
+import { ActiveProblem } from './activeProblem';
 import { artifactUri } from './artifactFs';
 import { solutionSourcePath } from './rbx/layout';
 import { RunNode, TestcaseNode } from './rbx/nodes';
@@ -57,6 +58,7 @@ export function registerCommands(
   context: vscode.ExtensionContext,
   view: RunViewProvider,
   data: RunDataProvider,
+  active: ActiveProblem,
 ): void {
   /**
    * The seam where two invocation paths arrive in two shapes.
@@ -189,17 +191,47 @@ export function registerCommands(
     await vscode.env.clipboard.writeText(node.testcase.inputPath);
   });
 
-  register('rbx.revealInExplorer', async (node) => {
-    // The package row this hung off is gone, so nothing invokes it right now --
-    // a later step re-attaches it to the view's header. Every node still names
-    // the package it came from, so the body is left standing rather than
-    // guessing at what the header will pass.
-    if (node === undefined) {
-      return;
-    }
-    await vscode.commands.executeCommand(
-      'revealInExplorer',
-      vscode.Uri.file(node.pkg.root),
-    );
-  });
+  // Not registered through `register`: this one takes no row.
+  //
+  // It used to hang off the package row, and when that row went away its
+  // `webview/context` entry became unreachable -- no row emits
+  // `webviewSection == 'rbx.package'` any more. Rather than re-point it at a
+  // row that means something else, it is now a palette command over the *view*:
+  // the view shows one problem, so "reveal the package" has exactly one answer
+  // without a row to ask.
+  context.subscriptions.push(
+    vscode.commands.registerCommand('rbx.revealInExplorer', async () => {
+      const root = active.selected();
+      if (root === undefined) {
+        vscode.window.showInformationMessage('No rbx problem found in this workspace.');
+        return;
+      }
+      await vscode.commands.executeCommand('revealInExplorer', vscode.Uri.file(root));
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('rbx.selectProblem', async () => {
+      const problems = active.problems();
+      if (problems.length === 0) {
+        void vscode.window.showInformationMessage('No rbx problem found in this workspace.');
+        return;
+      }
+      // The palette twin of the dropdown, and the only way to switch problems
+      // when the dropdown is hidden -- `renderSelector` draws nothing for a
+      // single problem, and a keyboard user may never open the sidebar at all.
+      const picked = await vscode.window.showQuickPick(
+        problems.map((problem) => ({
+          label: problem.label,
+          description: problem.group,
+          detail: problem.root,
+          root: problem.root,
+        })),
+        { placeHolder: 'Show which problem in the Run view?' },
+      );
+      if (picked !== undefined) {
+        active.select(picked.root);
+      }
+    }),
+  );
 }

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -190,7 +190,11 @@ export function registerCommands(
   });
 
   register('rbx.revealInExplorer', async (node) => {
-    if (node?.kind !== 'package') {
+    // The package row this hung off is gone, so nothing invokes it right now --
+    // a later step re-attaches it to the view's header. Every node still names
+    // the package it came from, so the body is left standing rather than
+    // guessing at what the header will pass.
+    if (node === undefined) {
       return;
     }
     await vscode.commands.executeCommand(

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -82,7 +82,12 @@ export function registerCommands(
     );
   };
 
-  register('rbx.refresh', () => data.refresh());
+  // The manual escape hatch, so it has to cover everything a watcher can miss
+  // -- the runs *and* the problem list. Rebuilding only the runs would re-post
+  // the stale choices, leaving the button unable to fix the one thing a user
+  // reaches for it to fix. `data` first: `active.refresh()` reads the roots it
+  // rediscovers.
+  register('rbx.refresh', () => data.refresh().then(() => active.refresh()));
 
   register('rbx.openSolution', async (node) => {
     if (node?.kind !== 'solution') {

--- a/vscode/src/contestIndex.test.ts
+++ b/vscode/src/contestIndex.test.ts
@@ -29,10 +29,26 @@ async function withTree(
   }
 }
 
-test('finds the contest above a nested package root', async () => {
-  await withTree({ 'contest.rbx.yml': 'problems:\n  - short_name: A\n' }, async (root) => {
-    const index = await indexContests([path.join(root, 'A')]);
-    assert.strictEqual(index.get(path.join(root, 'A'))?.shortName, 'A');
+test('climbs past intermediate directories to find the contest', async () => {
+  // Several levels, not one: the walk being unbounded is a decided design
+  // point (a setter opening `contest/A` leaves the contest file above the
+  // workspace root), so a regression clamping it must fail here.
+  await withTree(
+    { 'contest.rbx.yml': 'problems:\n  - short_name: A\n    path: x/y/A\n' },
+    async (root) => {
+      const pkg = path.join(root, 'x/y/A');
+      const index = await indexContests([pkg]);
+      assert.strictEqual(index.get(pkg)?.shortName, 'A');
+    },
+  );
+});
+
+test('gives no identity to a package with no contest above it', async () => {
+  // Only as reliable as the absence of a stray contest.rbx.yml somewhere above
+  // the temp dir -- inherent to the unbounded walk, and recorded here so a
+  // future flake is diagnosable rather than mysterious.
+  await withTree({ 'A/problem.rbx.yml': 'name: a\n' }, async (root) => {
+    assert.strictEqual((await indexContests([path.join(root, 'A')])).size, 0);
   });
 });
 
@@ -44,6 +60,8 @@ test('lets the first variant name a root the later ones also name', async () => 
       'contest.rbx.yml': 'use_variants: true\n',
       'contest.div1.rbx.yml': 'problems:\n  - short_name: A\n    path: shared\n',
       'contest.div2.rbx.yml': 'problems:\n  - short_name: Z\n    path: shared\n',
+      // Sorts first (`b` < `r`) and would win if the id were not validated.
+      'contest.div1.bak.rbx.yml': 'problems:\n  - short_name: X\n    path: shared\n',
     },
     async (root) => {
       const index = await indexContests([path.join(root, 'shared')]);
@@ -54,8 +72,8 @@ test('lets the first variant name a root the later ones also name', async () => 
 
 test('scans one contest once for every package under it', async () => {
   // Rescanning is idempotent rather than wrong, so this pins the outcome the
-  // `scanned` set and the canonical-vs-variant filename filter protect: every
-  // package under the contest gets its own letter, and none gets a second one.
+  // `scanned` set protects rather than the saved read: every package under the
+  // contest gets its own letter, and a repeated root adds nothing.
   await withTree(
     { 'contest.rbx.yml': 'problems:\n  - short_name: A\n  - short_name: B\n' },
     async (root) => {

--- a/vscode/src/contestIndex.test.ts
+++ b/vscode/src/contestIndex.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The only file-touching tests in the suite, because this is the only host-side
+ * module that never imports `vscode`: the walk-up, the variant glob and the
+ * merge order are reachable from `node --test` with nothing but a temp dir.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs/promises';
+import { test } from 'node:test';
+import * as os from 'os';
+import * as path from 'path';
+
+import { indexContests } from './contestIndex';
+
+/** Builds a tree of `relative path -> file contents`, and always removes it. */
+async function withTree(
+  files: Record<string, string>,
+  body: (root: string) => Promise<void>,
+): Promise<void> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'rbx-contest-'));
+  try {
+    for (const [name, contents] of Object.entries(files)) {
+      const file = path.join(root, name);
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, contents);
+    }
+    await body(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+test('finds the contest above a nested package root', async () => {
+  await withTree({ 'contest.rbx.yml': 'problems:\n  - short_name: A\n' }, async (root) => {
+    const index = await indexContests([path.join(root, 'A')]);
+    assert.strictEqual(index.get(path.join(root, 'A'))?.shortName, 'A');
+  });
+});
+
+test('lets the first variant name a root the later ones also name', async () => {
+  // The canonical dispatcher declares nothing, so the letters live only in the
+  // siblings -- and the extension picks one without resolving `RBX_CONTEST`.
+  await withTree(
+    {
+      'contest.rbx.yml': 'use_variants: true\n',
+      'contest.div1.rbx.yml': 'problems:\n  - short_name: A\n    path: shared\n',
+      'contest.div2.rbx.yml': 'problems:\n  - short_name: Z\n    path: shared\n',
+    },
+    async (root) => {
+      const index = await indexContests([path.join(root, 'shared')]);
+      assert.strictEqual(index.get(path.join(root, 'shared'))?.shortName, 'A');
+    },
+  );
+});
+
+test('scans one contest once for every package under it', async () => {
+  // Rescanning is idempotent rather than wrong, so this pins the outcome the
+  // `scanned` set and the canonical-vs-variant filename filter protect: every
+  // package under the contest gets its own letter, and none gets a second one.
+  await withTree(
+    { 'contest.rbx.yml': 'problems:\n  - short_name: A\n  - short_name: B\n' },
+    async (root) => {
+      const roots = [path.join(root, 'A'), path.join(root, 'B'), path.join(root, 'A')];
+      const index = await indexContests(roots);
+      assert.deepStrictEqual(
+        [...index].map(([key, identity]) => [path.relative(root, key), identity.shortName]),
+        [
+          ['A', 'A'],
+          ['B', 'B'],
+        ],
+      );
+    },
+  );
+});

--- a/vscode/src/contestIndex.ts
+++ b/vscode/src/contestIndex.ts
@@ -9,13 +9,14 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-import { ProblemIdentity, parseContest, problemIdentities } from './rbx/contest';
+import {
+  CONTEST_MANIFEST,
+  ProblemIdentity,
+  isContestVariantFile,
+  parseContest,
+  problemIdentities,
+} from './rbx/contest';
 import { readYamlFile } from './rbx/store';
-
-const CONTEST_MANIFEST = 'contest.rbx.yml';
-/** Sibling variant files: `contest.<id>.rbx.yml`. */
-const VARIANT_PREFIX = 'contest.';
-const VARIANT_SUFFIX = '.rbx.yml';
 
 /**
  * The nearest ancestor of `from` holding a contest.rbx.yml, or undefined.
@@ -28,8 +29,12 @@ async function findContestRoot(from: string): Promise<string | undefined> {
   let walker = from;
   for (;;) {
     try {
-      await fs.access(path.join(walker, CONTEST_MANIFEST));
-      return walker;
+      // `isFile`, not mere existence: rbx checks `is_file()` too
+      // (contest_package.py:111), and a *directory* named contest.rbx.yml
+      // would otherwise stop the walk and shadow the real contest above it.
+      if ((await fs.stat(path.join(walker, CONTEST_MANIFEST))).isFile()) {
+        return walker;
+      }
     } catch {
       // Not here; keep walking.
     }
@@ -59,11 +64,7 @@ async function contestFiles(root: string): Promise<string[]> {
     return files;
   }
   for (const entry of entries.sort()) {
-    if (
-      entry.startsWith(VARIANT_PREFIX) &&
-      entry.endsWith(VARIANT_SUFFIX) &&
-      entry !== CONTEST_MANIFEST
-    ) {
+    if (isContestVariantFile(entry)) {
       files.push(path.join(root, entry));
     }
   }
@@ -83,7 +84,8 @@ export async function indexContests(
     }
     scanned.add(contestRoot);
     for (const file of await contestFiles(contestRoot)) {
-      const identities = problemIdentities(contestRoot, parseContest(await readYamlFile(file)));
+      const contest = parseContest(await readYamlFile(file));
+      const identities = problemIdentities(contestRoot, contest);
       for (const [key, identity] of identities) {
         // First file to name a root wins; canonical is read first.
         if (!index.has(key)) {

--- a/vscode/src/contestIndex.ts
+++ b/vscode/src/contestIndex.ts
@@ -1,0 +1,90 @@
+/**
+ * Contest identities for the discovered packages.
+ *
+ * Walks up from each package root to the nearest `contest.rbx.yml`, mirroring
+ * `find_contest_root` (rbx/box/contest/contest_package.py:103). Nothing new is
+ * asked of rbx: the file is already on disk, and reading it is what lets the
+ * selector call a package `A` instead of naming its directory.
+ */
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+import { ProblemIdentity, parseContest, problemIdentities } from './rbx/contest';
+import { readYamlFile } from './rbx/store';
+
+const CONTEST_MANIFEST = 'contest.rbx.yml';
+/** Sibling variant files: `contest.<id>.rbx.yml`. */
+const VARIANT_PREFIX = 'contest.';
+const VARIANT_SUFFIX = '.rbx.yml';
+
+/** The nearest ancestor of `from` holding a contest.rbx.yml, or undefined. */
+async function findContestRoot(from: string): Promise<string | undefined> {
+  let walker = from;
+  for (;;) {
+    try {
+      await fs.access(path.join(walker, CONTEST_MANIFEST));
+      return walker;
+    } catch {
+      // Not here; keep walking.
+    }
+    const parent = path.dirname(walker);
+    if (parent === walker) {
+      return undefined;
+    }
+    walker = parent;
+  }
+}
+
+/**
+ * Every contest file in a root: the canonical one plus its variants.
+ *
+ * A `use_variants: true` canonical declares no problems of its own, so the
+ * letters live only in the siblings. Reading all of them and letting the first
+ * file to name a root win means the extension never has to resolve which
+ * variant is *selected* -- a question only `RBX_CONTEST` can answer, and one
+ * whose answer is almost always the same letters anyway.
+ */
+async function contestFiles(root: string): Promise<string[]> {
+  const files = [path.join(root, CONTEST_MANIFEST)];
+  let entries: string[];
+  try {
+    entries = await fs.readdir(root);
+  } catch {
+    return files;
+  }
+  for (const entry of entries.sort()) {
+    if (
+      entry.startsWith(VARIANT_PREFIX) &&
+      entry.endsWith(VARIANT_SUFFIX) &&
+      entry !== CONTEST_MANIFEST
+    ) {
+      files.push(path.join(root, entry));
+    }
+  }
+  return files;
+}
+
+/** Identities for every root that a contest names, keyed by absolute root. */
+export async function indexContests(
+  roots: readonly string[],
+): Promise<Map<string, ProblemIdentity>> {
+  const index = new Map<string, ProblemIdentity>();
+  const scanned = new Set<string>();
+  for (const root of roots) {
+    const contestRoot = await findContestRoot(root);
+    if (contestRoot === undefined || scanned.has(contestRoot)) {
+      continue;
+    }
+    scanned.add(contestRoot);
+    for (const file of await contestFiles(contestRoot)) {
+      const identities = problemIdentities(contestRoot, parseContest(await readYamlFile(file)));
+      for (const [key, identity] of identities) {
+        // First file to name a root wins; canonical is read first.
+        if (!index.has(key)) {
+          index.set(key, identity);
+        }
+      }
+    }
+  }
+  return index;
+}

--- a/vscode/src/contestIndex.ts
+++ b/vscode/src/contestIndex.ts
@@ -17,7 +17,13 @@ const CONTEST_MANIFEST = 'contest.rbx.yml';
 const VARIANT_PREFIX = 'contest.';
 const VARIANT_SUFFIX = '.rbx.yml';
 
-/** The nearest ancestor of `from` holding a contest.rbx.yml, or undefined. */
+/**
+ * The nearest ancestor of `from` holding a contest.rbx.yml, or undefined.
+ *
+ * Deliberately unbounded by the workspace folder: opening `contest/A` directly
+ * is common, and that puts the contest file above the workspace root -- exactly
+ * the case that would lose its letters if the walk stopped there.
+ */
 async function findContestRoot(from: string): Promise<string | undefined> {
   let walker = from;
   for (;;) {

--- a/vscode/src/discovery.ts
+++ b/vscode/src/discovery.ts
@@ -2,8 +2,8 @@
  * Finds rbx problem packages in the open workspace.
  *
  * A package is any directory holding a `problem.rbx.yml`. A contest workspace
- * holds several; a single-problem workspace holds one, and the tree flattens
- * that case away.
+ * holds several; a single-problem workspace holds one. Which of them the Run
+ * view shows is not decided here but in `activeProblem.ts`.
  */
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -9,6 +9,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+import { ActiveProblem } from './activeProblem';
 import { ArtifactFileSystemProvider, SCHEME } from './artifactFs';
 import { registerCommands } from './commands';
 import { DeclaredIndex } from './declared';
@@ -42,7 +43,11 @@ export function activate(context: vscode.ExtensionContext): void {
   initLog(context);
   log('rbx extension activated.');
   const data = new RunDataProvider();
-  const view = new RunViewProvider(data, context.extensionUri);
+  // `workspaceState`, not `globalState`: the problem being worked on is a fact
+  // about this contest checkout, and remembering it across unrelated windows
+  // would land each of them on a root the other opened.
+  const active = new ActiveProblem(data, context.workspaceState);
+  const view = new RunViewProvider(data, active, context.extensionUri);
   const declared = new DeclaredIndex(data);
   context.subscriptions.push(declared);
   registerDecorations(context, declared);
@@ -113,8 +118,14 @@ export function activate(context: vscode.ExtensionContext): void {
   // from, which is why the index is re-read on all three events and the run
   // view on only two.
   const manifests = vscode.workspace.createFileSystemWatcher(`**/${PROBLEM_MANIFEST}`);
+  // The choices are rebuilt after every rediscovery, not just at startup: a
+  // package appearing or disappearing changes what the dropdown can offer, and
+  // may take the selected problem with it.
   const rediscover = () => {
-    void data.refresh().then(() => declared.refresh());
+    void data
+      .refresh()
+      .then(() => active.refresh())
+      .then(() => declared.refresh());
   };
   manifests.onDidCreate(rediscover);
   manifests.onDidDelete(rediscover);

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -62,7 +62,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }),
   );
 
-  registerCommands(context, view, data);
+  registerCommands(context, view, data, active);
 
   // Artifacts land incrementally as evaluations resolve, which is what gives
   // the view live progress without any streaming protocol: each new `.eval`
@@ -103,6 +103,29 @@ export function activate(context: vscode.ExtensionContext): void {
   // itself being created or removed -- which is all `rbx clean` produces.
   watch(`**/${CACHE_DIR}/**`);
   watch(`**/${CACHE_DIR}`);
+
+  // A third glob, for a different question: the two above ask *what changed*,
+  // this one asks *what is running*. `skeleton.yml` is written when a run
+  // starts (rbx/box/solutions.py:746 -- "A new skeleton is what marks a new
+  // run"), so following it makes the view track the problem currently running:
+  // `rbx contest each run` walks the view through the contest in step with the
+  // run itself.
+  //
+  // Create and change only, never delete: `rbx clean` removes the skeleton,
+  // and switching to a package whose run was just deleted is the opposite of
+  // following work.
+  const skeletons = vscode.workspace.createFileSystemWatcher(
+    `**/${CACHE_DIR}/runs/skeleton.yml`,
+  );
+  const followRun = (uri: vscode.Uri) => {
+    const root = packageRootOf(uri.fsPath);
+    if (root !== undefined) {
+      void active.follow(root);
+    }
+  };
+  skeletons.onDidCreate(followRun);
+  skeletons.onDidChange(followRun);
+  context.subscriptions.push(skeletons);
 
   context.subscriptions.push(new vscode.Disposable(() => {
     if (timer !== undefined) {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -15,6 +15,7 @@ import { registerCommands } from './commands';
 import { DeclaredIndex } from './declared';
 import { registerDecorations } from './decorations';
 import { initLog, log } from './log';
+import { CONTEST_FILE_GLOB, CONTEST_MANIFEST, isContestVariantFile } from './rbx/contest';
 import { CACHE_DIR, PROBLEM_MANIFEST } from './rbx/layout';
 import { RunDataProvider } from './runData';
 import { RunViewProvider } from './runView';
@@ -157,6 +158,36 @@ export function activate(context: vscode.ExtensionContext): void {
     manifests,
     vscode.workspace.onDidChangeWorkspaceFolders(rediscover),
   );
+
+  // The dropdown's letters, order and colours come from `contest.rbx.yml`, and
+  // nothing above watches it: renaming `A` to `B`, adding a colour, reordering
+  // the list or adding an entry would otherwise reach the view only on a window
+  // reload.
+  //
+  // All three events, unlike the manifest watcher just above -- and for the
+  // mirror-image reason. There, an *edit* changes no root and so does not
+  // concern the selector; here the identities live *inside* the file, so an
+  // edit is the common case, while a create or delete just means a package
+  // gained or lost its contest.
+  //
+  // `active.refresh()` alone, not `rediscover`: a contest file names problems,
+  // it does not create packages. The set of package roots is exactly what it
+  // was, so re-globbing the workspace and re-reading every manifest would buy
+  // nothing but the hitch.
+  const contests = vscode.workspace.createFileSystemWatcher(`**/${CONTEST_FILE_GLOB}`);
+  const recontest = (uri: vscode.Uri) => {
+    // The glob is deliberately loose (see `CONTEST_FILE_GLOB`), so the basename
+    // is checked against the names rbx would actually load.
+    const name = path.basename(uri.fsPath);
+    if (name === CONTEST_MANIFEST || isContestVariantFile(name)) {
+      log(`${uri.fsPath} changed; rebuilding the problem list.`);
+      void active.refresh();
+    }
+  };
+  contests.onDidCreate(recontest);
+  contests.onDidChange(recontest);
+  contests.onDidDelete(recontest);
+  context.subscriptions.push(contests);
 
   rediscover();
 }

--- a/vscode/src/rbx/contest.test.ts
+++ b/vscode/src/rbx/contest.test.ts
@@ -1,7 +1,12 @@
 import * as assert from 'assert';
 import { test } from 'node:test';
+import { parse as parseYaml } from 'yaml';
 
-import { parseContest } from './contest';
+import { ParsedContest, parseContest } from './contest';
+
+function contest(yaml: string): ParsedContest {
+  return parseContest(parseYaml(yaml));
+}
 
 test('parses declared problems in file order', () => {
   const contest = parseContest({
@@ -25,7 +30,10 @@ test('defaults a problem path to its short name', () => {
 });
 
 test('reports a dispatcher as declaring no problems', () => {
-  assert.deepStrictEqual(parseContest({ use_variants: true }), {
+  // The problems are listed to pin the branch: rbx rejects this file outright,
+  // and reading its list anyway would give a dispatcher directory letters that
+  // belong to whichever variant is actually selected.
+  assert.deepStrictEqual(parseContest({ use_variants: true, problems: [{ short_name: 'A' }] }), {
     useVariants: true,
     problems: [],
   });
@@ -54,5 +62,35 @@ test('numbers order by surviving position, not by input index', () => {
   assert.deepStrictEqual(
     contest.problems.map((p) => p.order),
     [0, 1],
+  );
+});
+
+/**
+ * The shapes below come from YAML rather than object literals because they are
+ * the ones only a real, hand-edited file produces: a key with nothing after it
+ * parses as `null`, not as an absent key, and an unquoted letter-free
+ * short_name arrives as a number.
+ */
+test('a key left blank reads as unset, not as a value', () => {
+  const parsed = contest(`
+problems:
+  - short_name: A
+    path:
+    color:
+`);
+  assert.deepStrictEqual(parsed.problems, [
+    { shortName: 'A', path: 'A', color: undefined, order: 0 },
+  ]);
+});
+
+test('skips a short name YAML did not give us as a string', () => {
+  const parsed = contest(`
+problems:
+  - short_name: 1
+  - short_name: B
+`);
+  assert.deepStrictEqual(
+    parsed.problems.map((p) => p.shortName),
+    ['B'],
   );
 });

--- a/vscode/src/rbx/contest.test.ts
+++ b/vscode/src/rbx/contest.test.ts
@@ -2,7 +2,12 @@ import * as assert from 'assert';
 import { test } from 'node:test';
 import { parse as parseYaml } from 'yaml';
 
-import { ParsedContest, parseContest, problemIdentities } from './contest';
+import {
+  ParsedContest,
+  isContestVariantFile,
+  parseContest,
+  problemIdentities,
+} from './contest';
 
 function contest(yaml: string): ParsedContest {
   return parseContest(parseYaml(yaml));
@@ -65,6 +70,75 @@ test('numbers order by surviving position, not by input index', () => {
   );
 });
 
+test('matches package roots to declared problems', () => {
+  const identities = problemIdentities(
+    '/c',
+    parseContest({
+      problems: [{ short_name: 'A' }, { short_name: 'B', path: 'problems/beta' }],
+    }),
+  );
+  assert.deepStrictEqual(identities.get('/c/A'), {
+    shortName: 'A',
+    color: undefined,
+    order: 0,
+    contestRoot: '/c',
+  });
+  assert.deepStrictEqual(identities.get('/c/problems/beta'), {
+    shortName: 'B',
+    color: undefined,
+    order: 1,
+    // The contest that named it, even though it sits two levels down.
+    contestRoot: '/c',
+  });
+});
+
+test('normalizes a declared path before matching', () => {
+  // Contest files are hand-written: `./A/` and `A` name the same directory.
+  const identities = problemIdentities(
+    '/c',
+    parseContest({ problems: [{ short_name: 'A', path: './A/' }] }),
+  );
+  assert.strictEqual(identities.get('/c/A')?.shortName, 'A');
+});
+
+test('keeps the first of two problems naming the same directory', () => {
+  // Duplicating a problem block is how a setter adds one, and the file is read
+  // mid-keystroke -- before rbx has had any chance to reject the duplicate.
+  const identities = problemIdentities(
+    '/c',
+    parseContest({
+      problems: [{ short_name: 'A' }, { short_name: 'B', path: './A' }],
+    }),
+  );
+  assert.strictEqual(identities.size, 1);
+  assert.strictEqual(identities.get('/c/A')?.shortName, 'A');
+});
+
+test('declares nothing for a dispatcher', () => {
+  assert.strictEqual(problemIdentities('/c', parseContest({ use_variants: true })).size, 0);
+});
+
+test('accepts exactly the variant filenames rbx would load', () => {
+  // Variants merge first-wins in filename order, so a name rbx rejects does not
+  // merely add noise -- `contest.div1.bak.rbx.yml` sorts before
+  // `contest.div1.rbx.yml` and would hand the backup's letters to the contest.
+  const accepted = [
+    'contest.div1.rbx.yml',
+    'contest.A.rbx.yml',
+    'contest.a_b-c9.rbx.yml',
+  ];
+  const rejected = [
+    'contest.rbx.yml', // The canonical, not a variant.
+    'contest..rbx.yml', // Empty id; `.` sorts before every real sibling.
+    'contest.div1.bak.rbx.yml', // A hand-made backup: `.` is not in the id set.
+    'contest.9x.rbx.yml', // Leading digit.
+    'contest.rbx.yml.bak', // Wrong suffix.
+    'problem.rbx.yml',
+  ];
+  assert.deepStrictEqual(accepted.filter(isContestVariantFile), accepted);
+  assert.deepStrictEqual(rejected.filter(isContestVariantFile), []);
+});
+
 /**
  * The shapes below come from YAML rather than object literals because they are
  * the ones only a real, hand-edited file produces: a key with nothing after it
@@ -93,49 +167,4 @@ problems:
     parsed.problems.map((p) => p.shortName),
     ['B'],
   );
-});
-
-test('matches package roots to declared problems', () => {
-  const identities = problemIdentities(
-    '/c',
-    parseContest({
-      problems: [{ short_name: 'A' }, { short_name: 'B', path: 'problems/beta' }],
-    }),
-  );
-  assert.deepStrictEqual(identities.get('/c/A'), {
-    shortName: 'A',
-    color: undefined,
-    order: 0,
-  });
-  assert.deepStrictEqual(identities.get('/c/problems/beta'), {
-    shortName: 'B',
-    color: undefined,
-    order: 1,
-  });
-});
-
-test('normalizes a declared path before matching', () => {
-  // Contest files are hand-written: `./A/` and `A` name the same directory.
-  const identities = problemIdentities(
-    '/c',
-    parseContest({ problems: [{ short_name: 'A', path: './A/' }] }),
-  );
-  assert.strictEqual(identities.get('/c/A')?.shortName, 'A');
-});
-
-test('keeps the first of two problems naming the same directory', () => {
-  // Duplicating a problem block is how a setter adds one, and the file is read
-  // mid-keystroke -- before rbx has had any chance to reject the duplicate.
-  const identities = problemIdentities(
-    '/c',
-    parseContest({
-      problems: [{ short_name: 'A' }, { short_name: 'B', path: './A' }],
-    }),
-  );
-  assert.strictEqual(identities.size, 1);
-  assert.strictEqual(identities.get('/c/A')?.shortName, 'A');
-});
-
-test('declares nothing for a dispatcher', () => {
-  assert.strictEqual(problemIdentities('/c', parseContest({ use_variants: true })).size, 0);
 });

--- a/vscode/src/rbx/contest.test.ts
+++ b/vscode/src/rbx/contest.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { test } from 'node:test';
 import { parse as parseYaml } from 'yaml';
 
-import { ParsedContest, parseContest } from './contest';
+import { ParsedContest, parseContest, problemIdentities } from './contest';
 
 function contest(yaml: string): ParsedContest {
   return parseContest(parseYaml(yaml));
@@ -93,4 +93,49 @@ problems:
     parsed.problems.map((p) => p.shortName),
     ['B'],
   );
+});
+
+test('matches package roots to declared problems', () => {
+  const identities = problemIdentities(
+    '/c',
+    parseContest({
+      problems: [{ short_name: 'A' }, { short_name: 'B', path: 'problems/beta' }],
+    }),
+  );
+  assert.deepStrictEqual(identities.get('/c/A'), {
+    shortName: 'A',
+    color: undefined,
+    order: 0,
+  });
+  assert.deepStrictEqual(identities.get('/c/problems/beta'), {
+    shortName: 'B',
+    color: undefined,
+    order: 1,
+  });
+});
+
+test('normalizes a declared path before matching', () => {
+  // Contest files are hand-written: `./A/` and `A` name the same directory.
+  const identities = problemIdentities(
+    '/c',
+    parseContest({ problems: [{ short_name: 'A', path: './A/' }] }),
+  );
+  assert.strictEqual(identities.get('/c/A')?.shortName, 'A');
+});
+
+test('keeps the first of two problems naming the same directory', () => {
+  // Duplicating a problem block is how a setter adds one, and the file is read
+  // mid-keystroke -- before rbx has had any chance to reject the duplicate.
+  const identities = problemIdentities(
+    '/c',
+    parseContest({
+      problems: [{ short_name: 'A' }, { short_name: 'B', path: './A' }],
+    }),
+  );
+  assert.strictEqual(identities.size, 1);
+  assert.strictEqual(identities.get('/c/A')?.shortName, 'A');
+});
+
+test('declares nothing for a dispatcher', () => {
+  assert.strictEqual(problemIdentities('/c', parseContest({ use_variants: true })).size, 0);
 });

--- a/vscode/src/rbx/contest.test.ts
+++ b/vscode/src/rbx/contest.test.ts
@@ -157,6 +157,27 @@ problems:
   ]);
 });
 
+test('keeps a colour only when it is one', () => {
+  // rbx validates `color` (rbx/box/contest/schema.py), but nothing here has
+  // asked rbx anything: the file is read straight off disk, so a value rbx has
+  // never seen -- or would reject -- arrives intact. It is interpolated into a
+  // `style` attribute downstream, where the third value below is not a colour
+  // but a dot stretched over the whole view.
+  const parsed = parseContest({
+    problems: [
+      { short_name: 'A', color: '#ff0000' },
+      { short_name: 'B', color: 'red' },
+      { short_name: 'C', color: 'red;position:fixed;inset:0;width:100vw;height:100vh' },
+      { short_name: 'D', color: '#12345' },
+      { short_name: 'E', color: 'rgb(1,2,3)' },
+    ],
+  });
+  assert.deepStrictEqual(
+    parsed.problems.map((p) => p.color),
+    ['#ff0000', 'red', undefined, undefined, undefined],
+  );
+});
+
 test('skips a short name YAML did not give us as a string', () => {
   const parsed = contest(`
 problems:

--- a/vscode/src/rbx/contest.test.ts
+++ b/vscode/src/rbx/contest.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import { parseContest } from './contest';
+
+test('parses declared problems in file order', () => {
+  const contest = parseContest({
+    problems: [
+      { short_name: 'A', color: '#ff0000' },
+      { short_name: 'B', path: 'problems/beta' },
+    ],
+  });
+  assert.deepStrictEqual(contest, {
+    useVariants: false,
+    problems: [
+      { shortName: 'A', path: 'A', color: '#ff0000', order: 0 },
+      { shortName: 'B', path: 'problems/beta', color: undefined, order: 1 },
+    ],
+  });
+});
+
+test('defaults a problem path to its short name', () => {
+  const contest = parseContest({ problems: [{ short_name: 'C' }] });
+  assert.strictEqual(contest.problems[0].path, 'C');
+});
+
+test('reports a dispatcher as declaring no problems', () => {
+  assert.deepStrictEqual(parseContest({ use_variants: true }), {
+    useVariants: true,
+    problems: [],
+  });
+});
+
+test('tolerates a file that is not a contest at all', () => {
+  // Never throws: the walk in contestIndex reads whatever it finds, and a
+  // malformed file must degrade to "no identity", not take the view down.
+  for (const raw of [undefined, null, 'a string', 42, {}, { problems: 'not a list' }]) {
+    assert.deepStrictEqual(parseContest(raw), { useVariants: false, problems: [] });
+  }
+});
+
+test('skips entries with no usable short name', () => {
+  const contest = parseContest({ problems: [{ color: '#fff' }, { short_name: 'B' }] });
+  assert.deepStrictEqual(
+    contest.problems.map((p) => p.shortName),
+    ['B'],
+  );
+});
+
+test('numbers order by surviving position, not by input index', () => {
+  // `order` drives display order downstream, so a skipped entry must not leave
+  // a hole that sorts a later problem into the wrong slot.
+  const contest = parseContest({ problems: [{}, { short_name: 'A' }, { short_name: 'B' }] });
+  assert.deepStrictEqual(
+    contest.problems.map((p) => p.order),
+    [0, 1],
+  );
+});

--- a/vscode/src/rbx/contest.ts
+++ b/vscode/src/rbx/contest.ts
@@ -10,7 +10,12 @@ import { Wire, asArray, asRecord, asString } from './wire';
 /** One problem as its contest declares it. */
 export interface ContestProblem {
   readonly shortName: string;
-  /** Directory, relative to the contest root. Defaults to the short name. */
+  /**
+   * Directory, relative to the contest root. Defaults to the short name.
+   *
+   * Passed through exactly as written -- resolving and normalizing it is the
+   * host's job, so that `./A/`, `A` and `A//B` collapse onto one key there.
+   */
   readonly path: string;
   readonly color?: string;
   /** Position among the problems that survived parsing. */
@@ -23,7 +28,12 @@ export interface ParsedContest {
   readonly problems: readonly ContestProblem[];
 }
 
-const EMPTY: ParsedContest = { useVariants: false, problems: [] };
+// Both are handed out to every caller that hits their branch, so both are
+// frozen: `readonly` is compile-time only, and one cast-and-push downstream
+// would otherwise poison every later parse.
+const NO_PROBLEMS: readonly ContestProblem[] = Object.freeze([]);
+const EMPTY: ParsedContest = Object.freeze({ useVariants: false, problems: NO_PROBLEMS });
+const DISPATCHER: ParsedContest = Object.freeze({ useVariants: true, problems: NO_PROBLEMS });
 
 /** Reads a field as a string, treating the empty string as absent. */
 function nonEmptyString(value: Wire): string | undefined {
@@ -37,8 +47,9 @@ export function parseContest(raw: Wire): ParsedContest {
   }
   if (record.use_variants === true) {
     // A dispatcher declares nothing else; rbx rejects any other field alongside
-    // it (rbx/box/contest/schema.py:242).
-    return { useVariants: true, problems: [] };
+    // it (rbx/box/contest/schema.py:242), so anything listed here is ignored
+    // rather than trusted.
+    return DISPATCHER;
   }
   const problems: ContestProblem[] = [];
   for (const entry of asArray(record.problems)) {

--- a/vscode/src/rbx/contest.ts
+++ b/vscode/src/rbx/contest.ts
@@ -9,6 +9,32 @@ import * as path from 'path';
 
 import { Wire, asArray, asRecord, asString } from './wire';
 
+export const CONTEST_MANIFEST = 'contest.rbx.yml';
+/** Sibling variant files: `contest.<id>.rbx.yml` (rbx's `VARIANT_GLOB`). */
+const VARIANT_PREFIX = 'contest.';
+const VARIANT_SUFFIX = '.rbx.yml';
+/** rbx's `VARIANT_ID_PATTERN` (rbx/box/contest/contest_state.py:6). */
+const VARIANT_ID = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+/**
+ * Whether `name` is a contest variant file rbx would actually load.
+ *
+ * The id between the fixed affixes is checked, not just the affixes: rbx skips
+ * a non-matching sibling with a warning (contest_package.py:38-46), and reading
+ * one here would be worse than merely redundant. Variants merge first-wins in
+ * filename order, so a hand-made `contest.div1.bak.rbx.yml` sorts *before*
+ * `contest.div1.rbx.yml` and its stale letters would win.
+ */
+export function isContestVariantFile(name: string): boolean {
+  return (
+    name.startsWith(VARIANT_PREFIX) &&
+    name.endsWith(VARIANT_SUFFIX) &&
+    // The affixes overlap on the canonical name itself, whose id is empty.
+    name !== CONTEST_MANIFEST &&
+    VARIANT_ID.test(name.slice(VARIANT_PREFIX.length, -VARIANT_SUFFIX.length))
+  );
+}
+
 /** One problem as its contest declares it. */
 export interface ContestProblem {
   readonly shortName: string;
@@ -80,6 +106,15 @@ export interface ProblemIdentity {
   readonly shortName: string;
   readonly color?: string;
   readonly order: number;
+  /**
+   * The contest root that named this problem, for grouping.
+   *
+   * Carried rather than re-derived from the package root: a contest is free to
+   * nest its problems (`path: problems/beta`), so the root's parent directory
+   * is not the contest, and two contests that both nest under `problems/`
+   * would otherwise be indistinguishable in a heading.
+   */
+  readonly contestRoot: string;
 }
 
 /**
@@ -104,6 +139,7 @@ export function problemIdentities(
         shortName: problem.shortName,
         color: problem.color,
         order: problem.order,
+        contestRoot,
       });
     }
   }

--- a/vscode/src/rbx/contest.ts
+++ b/vscode/src/rbx/contest.ts
@@ -1,0 +1,63 @@
+/**
+ * What a `contest.rbx.yml` says about the problems under it.
+ *
+ * Pure, like its neighbours: finding the file is the host's job, and this half
+ * only turns parsed YAML into identities. Nothing here throws -- a malformed
+ * contest file must cost the packages their letters, never the view.
+ */
+import { Wire, asArray, asRecord, asString } from './wire';
+
+/** One problem as its contest declares it. */
+export interface ContestProblem {
+  readonly shortName: string;
+  /** Directory, relative to the contest root. Defaults to the short name. */
+  readonly path: string;
+  readonly color?: string;
+  /** Position among the problems that survived parsing. */
+  readonly order: number;
+}
+
+export interface ParsedContest {
+  /** A dispatcher sentinel: the real contests are sibling `contest.<id>.rbx.yml`. */
+  readonly useVariants: boolean;
+  readonly problems: readonly ContestProblem[];
+}
+
+const EMPTY: ParsedContest = { useVariants: false, problems: [] };
+
+/** Reads a field as a string, treating the empty string as absent. */
+function nonEmptyString(value: Wire): string | undefined {
+  return asString(value) || undefined;
+}
+
+export function parseContest(raw: Wire): ParsedContest {
+  const record = asRecord(raw);
+  if (record === undefined) {
+    return EMPTY;
+  }
+  if (record.use_variants === true) {
+    // A dispatcher declares nothing else; rbx rejects any other field alongside
+    // it (rbx/box/contest/schema.py:242).
+    return { useVariants: true, problems: [] };
+  }
+  const problems: ContestProblem[] = [];
+  for (const entry of asArray(record.problems)) {
+    const fields = asRecord(entry);
+    if (fields === undefined) {
+      continue;
+    }
+    const shortName = nonEmptyString(fields.short_name);
+    if (shortName === undefined) {
+      continue;
+    }
+    problems.push({
+      shortName,
+      // rbx defaults an unset path to `./{short_name}/`.
+      path: nonEmptyString(fields.path) ?? shortName,
+      color: nonEmptyString(fields.color),
+      // Counted off the survivors so a skipped entry leaves no hole.
+      order: problems.length,
+    });
+  }
+  return { useVariants: false, problems };
+}

--- a/vscode/src/rbx/contest.ts
+++ b/vscode/src/rbx/contest.ts
@@ -5,6 +5,8 @@
  * only turns parsed YAML into identities. Nothing here throws -- a malformed
  * contest file must cost the packages their letters, never the view.
  */
+import * as path from 'path';
+
 import { Wire, asArray, asRecord, asString } from './wire';
 
 /** One problem as its contest declares it. */
@@ -71,4 +73,39 @@ export function parseContest(raw: Wire): ParsedContest {
     });
   }
   return { useVariants: false, problems };
+}
+
+/** A problem's contest-given identity, keyed by absolute package root. */
+export interface ProblemIdentity {
+  readonly shortName: string;
+  readonly color?: string;
+  readonly order: number;
+}
+
+/**
+ * Resolve each declared problem to the absolute root it names.
+ *
+ * `path.resolve` normalizes the hand-written spellings a contest file carries
+ * -- `./A/`, `A`, `problems/../A` all land on the same key -- so a match is a
+ * plain map lookup downstream rather than a path comparison at every use.
+ */
+export function problemIdentities(
+  contestRoot: string,
+  contest: ParsedContest,
+): Map<string, ProblemIdentity> {
+  const identities = new Map<string, ProblemIdentity>();
+  for (const problem of contest.problems) {
+    const root = path.resolve(contestRoot, problem.path);
+    // First declaration of a directory wins, the same rule `indexContests`
+    // applies across files -- a half-typed duplicate block must not steal the
+    // letter off the problem that is already there.
+    if (!identities.has(root)) {
+      identities.set(root, {
+        shortName: problem.shortName,
+        color: problem.color,
+        order: problem.order,
+      });
+    }
+  }
+  return identities;
 }

--- a/vscode/src/rbx/contest.ts
+++ b/vscode/src/rbx/contest.ts
@@ -17,6 +17,15 @@ const VARIANT_SUFFIX = '.rbx.yml';
 const VARIANT_ID = /^[A-Za-z][A-Za-z0-9_-]*$/;
 
 /**
+ * A glob loose enough to catch both spellings, for a host that wants to watch.
+ *
+ * Deliberately looser than either name -- a single `*` cannot say "either no id
+ * or a valid one" -- so a host matching with it must still put the basename
+ * through `CONTEST_MANIFEST`/`isContestVariantFile` before believing it.
+ */
+export const CONTEST_FILE_GLOB = `${VARIANT_PREFIX.slice(0, -1)}*${VARIANT_SUFFIX}`;
+
+/**
  * Whether `name` is a contest variant file rbx would actually load.
  *
  * The id between the fixed affixes is checked, not just the affixes: rbx skips
@@ -51,7 +60,13 @@ export interface ContestProblem {
 }
 
 export interface ParsedContest {
-  /** A dispatcher sentinel: the real contests are sibling `contest.<id>.rbx.yml`. */
+  /**
+   * A dispatcher sentinel: the real contests are sibling `contest.<id>.rbx.yml`.
+   *
+   * Informational only -- nothing branches on it. `contestIndex.ts` reads the
+   * canonical file *and* every variant unconditionally and merges them
+   * first-wins, precisely so it never has to ask which contest is selected.
+   */
   readonly useVariants: boolean;
   readonly problems: readonly ContestProblem[];
 }
@@ -66,6 +81,23 @@ const DISPATCHER: ParsedContest = Object.freeze({ useVariants: true, problems: N
 /** Reads a field as a string, treating the empty string as absent. */
 function nonEmptyString(value: Wire): string | undefined {
   return asString(value) || undefined;
+}
+
+/** A hex triplet (`#rgb`/`#rrggbb`) or a bare X11 colour name, and nothing else. */
+const COLOR = /^(#[0-9A-Fa-f]{3}|#[0-9A-Fa-f]{6}|[A-Za-z]+)$/;
+
+/**
+ * Keep a declared colour only if it is one.
+ *
+ * rbx validates `color` as hex-or-X11 (rbx/box/contest/schema.py), but the
+ * extension never asks rbx anything -- it reads `contest.rbx.yml` straight off
+ * disk, so a file rbx has never run against (or would reject outright) reaches
+ * the view unfiltered. The value ends up interpolated into a `style` attribute
+ * on the selector's dot, where `red;position:fixed;inset:0;width:100vw` is not
+ * a colour but a full-view overlay. Anything unrecognized loses its dot.
+ */
+function safeColor(value: string | undefined): string | undefined {
+  return value !== undefined && COLOR.test(value) ? value : undefined;
 }
 
 export function parseContest(raw: Wire): ParsedContest {
@@ -93,7 +125,7 @@ export function parseContest(raw: Wire): ParsedContest {
       shortName,
       // rbx defaults an unset path to `./{short_name}/`.
       path: nonEmptyString(fields.path) ?? shortName,
-      color: nonEmptyString(fields.color),
+      color: safeColor(nonEmptyString(fields.color)),
       // Counted off the survivors so a skipped entry leaves no hole.
       order: problems.length,
     });

--- a/vscode/src/rbx/layout.ts
+++ b/vscode/src/rbx/layout.ts
@@ -115,14 +115,6 @@ export function testArtifactPath(
   return path.join(testsDir(pkg), group, `${stem}${ext}`);
 }
 
-/** Directories whose contents should never be scanned when discovering packages. */
-export const IGNORED_DIRS: ReadonlySet<string> = new Set([
-  CACHE_DIR,
-  BUILD_DIR,
-  'node_modules',
-  '.git',
-]);
-
 /**
  * Absolute path to a solution's source file.
  *

--- a/vscode/src/rbx/manifest.test.ts
+++ b/vscode/src/rbx/manifest.test.ts
@@ -2,7 +2,12 @@ import * as assert from 'assert';
 import { test } from 'node:test';
 import { parse as parseYaml } from 'yaml';
 
-import { DeclaredAsset, normalizeExpectation, parseManifest } from './manifest';
+import {
+  DeclaredAsset,
+  normalizeExpectation,
+  parseManifest,
+  parseProblemName,
+} from './manifest';
 
 function assets(yaml: string): DeclaredAsset[] {
   return parseManifest(parseYaml(yaml));
@@ -234,6 +239,21 @@ test('an open bound is filled the way rbx fills it', () => {
     scoreOf(assets('solutions:\n  - path: s.cpp\n    score: [null, 80]\n'), 's.cpp'),
     [0, 80],
   );
+});
+
+test('reads the name a package declares', () => {
+  assert.strictEqual(parseProblemName(parseYaml('name: sum-of-pairs\n')), 'sum-of-pairs');
+});
+
+test('a package that declares no usable name has none', () => {
+  // Each of these is a manifest mid-edit rather than one whose name is
+  // genuinely blank, and the selector must fall back to the bare letter.
+  for (const yaml of ['timeLimit: 1000\n', 'name:\n', "name: ''\n", 'name: [a, b]\n']) {
+    assert.strictEqual(parseProblemName(parseYaml(yaml)), undefined);
+  }
+  for (const raw of [undefined, null, 'a string', 42, []]) {
+    assert.strictEqual(parseProblemName(raw), undefined);
+  }
 });
 
 test('a score that is not a number or a pair is read as none at all', () => {

--- a/vscode/src/rbx/manifest.ts
+++ b/vscode/src/rbx/manifest.ts
@@ -255,6 +255,26 @@ function collectStatements(collector: Collector, list: Wire): void {
 }
 
 /**
+ * What the package calls itself, or `undefined` if it does not say.
+ *
+ * The selector pairs this with the contest letter, because a letter alone does
+ * not say which problem it is. The *declared* name rather than the directory:
+ * rbx defaults a problem's path to its short name, so a contest laid out the
+ * default way has every package sitting in a directory called `A`, `B`, `C`,
+ * and a basename would render the useless `A - A`.
+ */
+export function parseProblemName(raw: Wire): string | undefined {
+  const root = asRecord(raw);
+  if (root === undefined) {
+    return undefined;
+  }
+  const name = asString(root.name);
+  // An empty `name:` is a name the setter has not written yet, not a name that
+  // happens to be blank -- the manifest is usually half-typed when we read it.
+  return name === '' ? undefined : name;
+}
+
+/**
  * Every asset `problem.rbx.yml` declares, in no particular order.
  *
  * Returns an empty list rather than throwing for anything it cannot read,

--- a/vscode/src/rbx/nodes.test.ts
+++ b/vscode/src/rbx/nodes.test.ts
@@ -55,6 +55,21 @@ test('emits no package row', () => {
   assert.deepStrictEqual([...kinds], ['solution', 'group', 'testcase']);
 });
 
+test('two packages laid out alike never share a row id', () => {
+  // Why the root still leads every id although no row draws it: the host
+  // resolves a context-menu command through a map of ids, and the client keeps
+  // a selection across a switch of problem. Two packages laid out identically
+  // -- which is what a contest's problems are -- must not collide there.
+  const ids = (root: string): string[] => flattenNodes({ pkg: { root }, run: ONE.run }).map(nodeId);
+  const here = ids('/w/a');
+  const there = ids('/w/b');
+  assert.strictEqual(here.length, there.length);
+  assert.strictEqual(
+    here.some((id) => there.includes(id)),
+    false,
+  );
+});
+
 test('yields nothing for a package with no run', () => {
   assert.deepStrictEqual(flattenNodes({ pkg: PKG, run: undefined }), []);
 });

--- a/vscode/src/rbx/nodes.test.ts
+++ b/vscode/src/rbx/nodes.test.ts
@@ -30,7 +30,6 @@ function run(solutions: readonly SolutionRun[]): PackageRun {
 }
 
 const PKG: PackageLayout = { root: '/w/a' };
-const OTHER: PackageLayout = { root: '/w/b' };
 
 const ONE: PackageRunView = {
   pkg: PKG,
@@ -38,53 +37,50 @@ const ONE: PackageRunView = {
 };
 
 test('ids spell out the path from package root down to testcase stem', () => {
-  const nodes = flattenNodes([ONE, { pkg: OTHER, run: run([solution(0, [])]) }]);
-  assert.deepStrictEqual(nodes.map(nodeId), [
-    '/w/a',
+  // The root still leads every id even though no row draws it: ids outlive the
+  // rows the client is showing, and two packages must never collide in the map
+  // the host resolves context-menu commands through.
+  assert.deepStrictEqual(flattenNodes(ONE).map(nodeId), [
     '/w/a::0',
     '/w/a::0::main',
     '/w/a::0::main::000',
     '/w/a::0::main::001',
-    '/w/b',
-    '/w/b::0',
   ]);
 });
 
-test('a single package is flattened away, since there is nothing to choose', () => {
-  assert.deepStrictEqual(
-    flattenNodes([ONE]).map((node) => node.kind),
-    ['solution', 'group', 'testcase', 'testcase'],
-  );
+test('emits no package row', () => {
+  const kinds = new Set(flattenNodes(ONE).map((node) => node.kind));
+  // `'package'` is not in `RunNode` at all any more, so writing the comparison
+  // would not even compile -- hence the set of what is left.
+  assert.deepStrictEqual([...kinds], ['solution', 'group', 'testcase']);
 });
 
-test('two packages keep their package rows, parents before their children', () => {
-  const nodes = flattenNodes([ONE, { pkg: OTHER, run: run([solution(3, [])]) }]);
-  assert.deepStrictEqual(
-    nodes.map((node) => node.kind),
-    ['package', 'solution', 'group', 'testcase', 'testcase', 'package', 'solution'],
-  );
+test('yields nothing for a package with no run', () => {
+  assert.deepStrictEqual(flattenNodes({ pkg: PKG, run: undefined }), []);
 });
 
-test('a package with no run on disk contributes nothing', () => {
-  const nodes = flattenNodes([ONE, { pkg: OTHER, run: undefined }]);
+test('every solution is emitted before its own groups and testcases', () => {
+  const nodes = flattenNodes({
+    pkg: PKG,
+    run: run([solution(0, [group('main', ['000'])]), solution(1, [group('edge', ['100'])])]),
+  });
   assert.deepStrictEqual(nodes.map(nodeId), [
-    '/w/a',
     '/w/a::0',
     '/w/a::0::main',
     '/w/a::0::main::000',
-    '/w/a::0::main::001',
+    '/w/a::1',
+    '/w/a::1::edge',
+    '/w/a::1::edge::100',
   ]);
 });
 
 test('solo is true only when the package ran exactly one solution', () => {
-  const solos = flattenNodes([ONE])
+  const solos = flattenNodes(ONE)
     .filter((node) => node.kind === 'solution')
     .map((node) => (node.kind === 'solution' ? node.solo : undefined));
   assert.deepStrictEqual(solos, [true]);
 
-  const many = flattenNodes([
-    { pkg: PKG, run: run([solution(0, []), solution(1, [])]) },
-  ])
+  const many = flattenNodes({ pkg: PKG, run: run([solution(0, []), solution(1, [])]) })
     .filter((node) => node.kind === 'solution')
     .map((node) => (node.kind === 'solution' ? node.solo : undefined));
   assert.deepStrictEqual(many, [false, false]);

--- a/vscode/src/rbx/nodes.ts
+++ b/vscode/src/rbx/nodes.ts
@@ -62,15 +62,6 @@ export function nodeId(node: RunNode): string {
 export interface PackageRunView {
   readonly pkg: PackageLayout;
   readonly run: PackageRun | undefined;
-  /**
-   * What to call this package in the view.
-   *
-   * Supplied by the host rather than derived here, because telling two packages
-   * named `prob` apart needs `vscode.workspace` to say which folder each sits
-   * in -- and this module's value is being testable without the editor API.
-   * Absent in tests and wherever the basename is unambiguous.
-   */
-  readonly label?: string;
 }
 
 /**

--- a/vscode/src/rbx/nodes.ts
+++ b/vscode/src/rbx/nodes.ts
@@ -9,14 +9,7 @@
 import { PackageLayout } from './layout';
 import { GroupRun, PackageRun, SolutionRun, TestcaseRun } from './store';
 
-export type RunNode = PackageNode | SolutionNode | GroupNode | TestcaseNode;
-
-export interface PackageNode {
-  readonly kind: 'package';
-  readonly pkg: PackageLayout;
-  /** The host's disambiguated label, when it supplied one. */
-  readonly label?: string;
-}
+export type RunNode = SolutionNode | GroupNode | TestcaseNode;
 
 export interface SolutionNode {
   readonly kind: 'solution';
@@ -46,11 +39,16 @@ export interface TestcaseNode {
   readonly testcase: TestcaseRun;
 }
 
-/** The stable row id. Identical to the `TreeItem.id`s the tree used. */
+/**
+ * The stable row id. Identical to the `TreeItem.id`s the tree used.
+ *
+ * Still rooted at the package directory even though no row draws that level:
+ * the ids outlive the package on screen -- the client keeps a selection, and
+ * the host resolves context-menu commands through a map of them -- so an id
+ * from one package must never name a row of another.
+ */
 export function nodeId(node: RunNode): string {
   switch (node.kind) {
-    case 'package':
-      return node.pkg.root;
     case 'solution':
       return `${node.pkg.root}::${node.run.solution.index}`;
     case 'group':
@@ -76,31 +74,24 @@ export interface PackageRunView {
 }
 
 /**
- * Every row in display order, each parent immediately before its children.
+ * Every row of one package's run, in display order, parents before children.
  *
- * The package level is dropped when the workspace holds exactly one package --
- * the common case, where making the user expand one node forever buys nothing.
- * The count is of discovered packages, not of packages that have run, so the
- * view does not gain and lose a level as runs come and go.
+ * One package, because the view shows one: the selector upstream decides which,
+ * so there is no package level left to draw and no rule about when to draw it.
  */
-export function flattenNodes(packages: readonly PackageRunView[]): RunNode[] {
-  const showPackages = packages.length > 1;
+export function flattenNodes(view: PackageRunView): RunNode[] {
+  const { pkg, run } = view;
+  if (run === undefined) {
+    return [];
+  }
   const nodes: RunNode[] = [];
-  for (const { pkg, run, label } of packages) {
-    if (run === undefined) {
-      continue;
-    }
-    if (showPackages) {
-      nodes.push({ kind: 'package', pkg, label });
-    }
-    const solo = run.solutions.length === 1;
-    for (const solutionRun of run.solutions) {
-      nodes.push({ kind: 'solution', pkg, run: solutionRun, solo });
-      for (const group of solutionRun.groups) {
-        nodes.push({ kind: 'group', pkg, run: solutionRun, group });
-        for (const testcase of group.testcases) {
-          nodes.push({ kind: 'testcase', pkg, run: solutionRun, group, testcase });
-        }
+  const solo = run.solutions.length === 1;
+  for (const solutionRun of run.solutions) {
+    nodes.push({ kind: 'solution', pkg, run: solutionRun, solo });
+    for (const group of solutionRun.groups) {
+      nodes.push({ kind: 'group', pkg, run: solutionRun, group });
+      for (const testcase of group.testcases) {
+        nodes.push({ kind: 'testcase', pkg, run: solutionRun, group, testcase });
       }
     }
   }

--- a/vscode/src/rbx/problems.test.ts
+++ b/vscode/src/rbx/problems.test.ts
@@ -12,6 +12,36 @@ const identity = (shortName: string, order: number, color?: string, contestRoot 
   contestRoot,
 });
 
+test('pairs the contest letter with the name the package declares', () => {
+  const names = new Map([['/c/z', 'sum-of-pairs']]);
+  const choices = problemChoices(
+    ['/c/z'],
+    new Map([['/c/z', identity('A', 0)]]),
+    () => 'fallback',
+    (root) => names.get(root),
+  );
+  assert.strictEqual(choices[0].label, 'A · sum-of-pairs');
+});
+
+test('a package that declares no name keeps the bare letter', () => {
+  // No dangling separator: rbx does not require `name:`, and a manifest is
+  // usually half-typed when the extension reads it.
+  const choices = problemChoices(
+    ['/c/z'],
+    new Map([['/c/z', identity('A', 0)]]),
+    () => 'fallback',
+    () => undefined,
+  );
+  assert.strictEqual(choices[0].label, 'A');
+});
+
+test('a package no contest claims is named by the host alone', () => {
+  // The name would be redundant here: the fallback label is already the
+  // package's own path, and there is no letter for it to disambiguate.
+  const choices = problemChoices(['/loose'], new Map(), () => 'loose-label', () => 'declared');
+  assert.strictEqual(choices[0].label, 'loose-label');
+});
+
 test('orders contest problems by their declared order, not by path', () => {
   // `/c/z` is `A` and sorts first despite sorting last lexicographically --
   // which is the whole point of reading the contest file.

--- a/vscode/src/rbx/problems.test.ts
+++ b/vscode/src/rbx/problems.test.ts
@@ -1,0 +1,96 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import { problemChoices } from './problems';
+
+const identity = (shortName: string, order: number, color?: string) => ({
+  shortName,
+  order,
+  color,
+});
+
+test('orders contest problems by their declared order, not by path', () => {
+  // `/c/z` is `A` and sorts first despite sorting last lexicographically --
+  // which is the whole point of reading the contest file.
+  const choices = problemChoices(
+    ['/c/a', '/c/z'],
+    new Map([
+      ['/c/z', identity('A', 0)],
+      ['/c/a', identity('B', 1)],
+    ]),
+    () => 'fallback',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.label),
+    ['A', 'B'],
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.root),
+    ['/c/z', '/c/a'],
+  );
+});
+
+test('labels an uncontested package with the host fallback, after the contest', () => {
+  const choices = problemChoices(
+    ['/loose', '/c/A'],
+    new Map([['/c/A', identity('A', 0)]]),
+    (root) => `label:${root}`,
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.label),
+    ['A', 'label:/loose'],
+  );
+});
+
+test('carries the declared colour through', () => {
+  const choices = problemChoices(
+    ['/c/A'],
+    new Map([['/c/A', identity('A', 0, '#f00')]]),
+    () => '',
+  );
+  assert.strictEqual(choices[0].color, '#f00');
+});
+
+test('groups by contest only when there is more than one group', () => {
+  const one = problemChoices(['/c/A'], new Map([['/c/A', identity('A', 0)]]), () => '');
+  assert.strictEqual(one[0].group, undefined);
+
+  const two = problemChoices(
+    ['/x/A', '/y/A'],
+    new Map([
+      ['/x/A', identity('A', 0)],
+      ['/y/A', identity('A', 0)],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    two.map((c) => c.group),
+    ['x', 'y'],
+  );
+});
+
+test('sorts uncontested packages by path', () => {
+  const choices = problemChoices(['/b', '/a'], new Map(), (root) => root);
+  assert.deepStrictEqual(
+    choices.map((c) => c.root),
+    ['/a', '/b'],
+  );
+});
+
+test('breaks a collision between two variants by short name', () => {
+  // `order` is counted per contest file, so two problems merged out of
+  // `contest.div1.rbx.yml` and `contest.div2.rbx.yml` can both claim 1.
+  // Discovery order must not be what decides which one shows first.
+  const choices = problemChoices(
+    ['/c/C', '/c/B'],
+    new Map([
+      ['/c/C', identity('C', 1)],
+      ['/c/B', identity('B', 1)],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.label),
+    ['B', 'C'],
+  );
+});

--- a/vscode/src/rbx/problems.test.ts
+++ b/vscode/src/rbx/problems.test.ts
@@ -3,10 +3,11 @@ import { test } from 'node:test';
 
 import { problemChoices } from './problems';
 
-const identity = (shortName: string, order: number, color?: string) => ({
+const identity = (shortName: string, order: number, color?: string, contestRoot = '/c') => ({
   shortName,
   order,
   color,
+  contestRoot,
 });
 
 test('orders contest problems by their declared order, not by path', () => {
@@ -58,13 +59,31 @@ test('groups by contest only when there is more than one group', () => {
   const two = problemChoices(
     ['/x/A', '/y/A'],
     new Map([
-      ['/x/A', identity('A', 0)],
-      ['/y/A', identity('A', 0)],
+      ['/x/A', identity('A', 0, undefined, '/x')],
+      ['/y/A', identity('A', 0, undefined, '/y')],
     ]),
     () => '',
   );
   assert.deepStrictEqual(
     two.map((c) => c.group),
+    ['x', 'y'],
+  );
+});
+
+test('heads a nested problem with its contest, not its parent directory', () => {
+  // `path: problems/beta` puts the package two levels down. Grouping by the
+  // parent would head this "problems" -- a name no contest has, and one every
+  // contest that nests would share.
+  const choices = problemChoices(
+    ['/x/problems/beta', '/y/A'],
+    new Map([
+      ['/x/problems/beta', identity('A', 0, undefined, '/x')],
+      ['/y/A', identity('A', 0, undefined, '/y')],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.group),
     ['x', 'y'],
   );
 });

--- a/vscode/src/rbx/problems.test.ts
+++ b/vscode/src/rbx/problems.test.ts
@@ -96,20 +96,71 @@ test('sorts uncontested packages by path', () => {
   );
 });
 
-test('breaks a collision between two variants by short name', () => {
+test('breaks a collision between two variants by short name, not by root', () => {
   // `order` is counted per contest file, so two problems merged out of
   // `contest.div1.rbx.yml` and `contest.div2.rbx.yml` can both claim 1.
   // Discovery order must not be what decides which one shows first.
+  //
+  // The directories are named against the letters on purpose: sorting by root
+  // would answer `C, B` here, so only the short name can produce `B, C`.
   const choices = problemChoices(
-    ['/c/C', '/c/B'],
+    ['/c/1', '/c/2'],
     new Map([
-      ['/c/C', identity('C', 1)],
-      ['/c/B', identity('B', 1)],
+      ['/c/1', identity('C', 1)],
+      ['/c/2', identity('B', 1)],
     ]),
     () => '',
   );
   assert.deepStrictEqual(
     choices.map((c) => c.label),
     ['B', 'C'],
+  );
+});
+
+test('breaks a full collision by root', () => {
+  // Two variants may go further and give one letter to two directories. The
+  // root is the last thing left that tells them apart.
+  const choices = problemChoices(
+    ['/c/second', '/c/first'],
+    new Map([
+      ['/c/second', identity('B', 1)],
+      ['/c/first', identity('B', 1)],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.root),
+    ['/c/first', '/c/second'],
+  );
+});
+
+test('heads the contest once an uncontested package shares the list', () => {
+  // The loose packages are a group of their own: a contest butting straight up
+  // against a run of bare folder names is exactly when a heading earns itself.
+  const choices = problemChoices(
+    ['/loose', '/c/A'],
+    new Map([['/c/A', identity('A', 0)]]),
+    (root) => root,
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.group),
+    ['c', undefined],
+  );
+});
+
+test('heads contests by the name the heading shows, not by their full path', () => {
+  // `/z/alpha` and `/a/beta` head as `alpha` and `beta`; ordering by the full
+  // root would print them the other way round.
+  const choices = problemChoices(
+    ['/z/alpha/A', '/a/beta/A'],
+    new Map([
+      ['/z/alpha/A', identity('A', 0, undefined, '/z/alpha')],
+      ['/a/beta/A', identity('A', 0, undefined, '/a/beta')],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.group),
+    ['alpha', 'beta'],
   );
 });

--- a/vscode/src/rbx/problems.test.ts
+++ b/vscode/src/rbx/problems.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert';
 import { test } from 'node:test';
+import * as path from 'path';
 
+import { parseContest, problemIdentities } from './contest';
 import { problemChoices } from './problems';
 
 const identity = (shortName: string, order: number, color?: string, contestRoot = '/c') => ({
@@ -163,4 +165,47 @@ test('heads contests by the name the heading shows, not by their full path', () 
     choices.map((c) => c.group),
     ['alpha', 'beta'],
   );
+});
+
+test('offers nothing when nothing was discovered', () => {
+  // What makes a workspace with no packages hide the dropdown and select
+  // nothing at all, rather than show an empty control over an empty view.
+  assert.deepStrictEqual(
+    problemChoices([], new Map(), () => 'unused'),
+    [],
+  );
+});
+
+test('leaves a lone contest problem ungrouped', () => {
+  // A one-problem workspace has to read exactly as it did before the selector:
+  // one option, and no `<optgroup>` heading over it.
+  const choices = problemChoices(['/c/A'], new Map([['/c/A', identity('A', 0)]]), () => '');
+  assert.deepStrictEqual(choices, [
+    { root: '/c/A', label: 'A', color: undefined, group: undefined },
+  ]);
+});
+
+test('names two same-basename packages apart, if the host does', () => {
+  // The contract the fallback labeller carries: two packages can share a
+  // basename, and telling them apart needs the workspace folders only the host
+  // can see. This module asks for a label and prints whatever it is handed.
+  const choices = problemChoices(['/one/prob', '/two/prob'], new Map(), (root) => root.slice(1));
+  assert.deepStrictEqual(
+    choices.map((c) => c.label),
+    ['one/prob', 'two/prob'],
+  );
+});
+
+test('a contest that names nothing usable costs its packages their letters only', () => {
+  // The promise in contest.ts's header: a malformed contest file must cost the
+  // packages their letters, never the view. Every package falls through to the
+  // loose branch and keeps its directory name.
+  for (const raw of [{ problems: [] }, { problems: [{ path: 'A' }, 'nonsense', 42] }]) {
+    const identities = problemIdentities('/c', parseContest(raw));
+    const choices = problemChoices(['/c/A', '/c/B'], identities, (root) => path.basename(root));
+    assert.deepStrictEqual(choices, [
+      { root: '/c/A', label: 'A', color: undefined, group: undefined },
+      { root: '/c/B', label: 'B', color: undefined, group: undefined },
+    ]);
+  }
 });

--- a/vscode/src/rbx/problems.ts
+++ b/vscode/src/rbx/problems.ts
@@ -26,6 +26,18 @@ export interface ProblemChoice {
 /** How a package with no contest is named. Supplied by the host. */
 export type FallbackLabel = (root: string) => string;
 
+/**
+ * What a package calls itself, when it says so. Supplied by the host.
+ *
+ * Injected rather than read here for the same reason as `FallbackLabel`:
+ * reaching the manifest means touching the disk, and this module's value is
+ * being decidable without it.
+ */
+export type ProblemName = (root: string) => string | undefined;
+
+/** Separates the contest letter from the problem's own name. */
+const NAME_SEPARATOR = ' · ';
+
 /** A package a contest named: it always has a contest to group under. */
 interface ContestedEntry {
   readonly root: string;
@@ -70,6 +82,7 @@ export function problemChoices(
   roots: readonly string[],
   identities: ReadonlyMap<string, ProblemIdentity>,
   fallback: FallbackLabel,
+  name: ProblemName = () => undefined,
 ): ProblemChoice[] {
   const contested: ContestedEntry[] = [];
   const loose: LooseEntry[] = [];
@@ -78,9 +91,16 @@ export function problemChoices(
     if (identity === undefined) {
       loose.push({ root, label: fallback(root) });
     } else {
+      // The letter carries the ordering and the contest's own vocabulary; the
+      // name says which problem it actually is. A package that declares no
+      // name keeps the bare letter rather than growing an empty separator.
+      const declared = name(root);
       contested.push({
         root,
-        label: identity.shortName,
+        label:
+          declared === undefined
+            ? identity.shortName
+            : `${identity.shortName}${NAME_SEPARATOR}${declared}`,
         color: identity.color,
         // The contest that named the problem, not the problem's parent: a
         // contest may nest its problems, and the intermediate directory is

--- a/vscode/src/rbx/problems.ts
+++ b/vscode/src/rbx/problems.ts
@@ -4,7 +4,7 @@
  * Pure: the caller supplies the roots, the contest identities and a fallback
  * labeller, because naming a package with no contest needs `vscode.workspace`
  * to say which folder it sits in -- and this module's value is being testable
- * without the editor API. Same split as `PackageRunView.label`.
+ * without the editor API.
  *
  * `roots` is taken as already de-duplicated: a repeated root becomes a repeated
  * choice. `discovery.ts` collects them through a `Set`, and keeping the rule on

--- a/vscode/src/rbx/problems.ts
+++ b/vscode/src/rbx/problems.ts
@@ -42,20 +42,6 @@ function compare(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
-/**
- * The contest a root belongs to, as a grouping key.
- *
- * Derived from the root's own path rather than tracked through the index: a
- * problem's contest root is the only ancestor that named it, and for grouping
- * purposes its parent directory separates two contests exactly as well. A
- * contest that nests its problems (`path: problems/beta`) groups under that
- * subdirectory instead of the contest root, which only changes the heading
- * text and stays one group as long as the contest nests consistently.
- */
-function groupKeyOf(root: string): string {
-  return path.dirname(root);
-}
-
 export function problemChoices(
   roots: readonly string[],
   identities: ReadonlyMap<string, ProblemIdentity>,
@@ -72,7 +58,10 @@ export function problemChoices(
         root,
         label: identity.shortName,
         color: identity.color,
-        group: groupKeyOf(root),
+        // The contest that named the problem, not the problem's parent: a
+        // contest may nest its problems, and the intermediate directory is
+        // neither the contest's name nor unique across contests.
+        group: identity.contestRoot,
         order: identity.order,
       });
     }

--- a/vscode/src/rbx/problems.ts
+++ b/vscode/src/rbx/problems.ts
@@ -1,0 +1,107 @@
+/**
+ * The problems the selector offers, in the order it offers them.
+ *
+ * Pure: the caller supplies the roots, the contest identities and a fallback
+ * labeller, because naming a package with no contest needs `vscode.workspace`
+ * to say which folder it sits in -- and this module's value is being testable
+ * without the editor API. Same split as `PackageRunView.label`.
+ */
+import * as path from 'path';
+
+import { ProblemIdentity } from './contest';
+
+/** One entry in the dropdown. */
+export interface ProblemChoice {
+  readonly root: string;
+  readonly label: string;
+  /** The contest this belongs to, for `<optgroup>`. Absent when there is one group. */
+  readonly group?: string;
+  readonly color?: string;
+}
+
+/** How a package with no contest is named. Supplied by the host. */
+export type FallbackLabel = (root: string) => string;
+
+interface Entry {
+  readonly root: string;
+  readonly label: string;
+  readonly color?: string;
+  readonly group?: string;
+  readonly order: number;
+}
+
+/**
+ * Order two strings by code unit, the way a bare `Array.prototype.sort` does.
+ *
+ * Not `localeCompare`: it answers by locale and can call two distinct strings
+ * equal, which is exactly what the tie-breaks below exist to rule out. Plain
+ * comparison also keeps this in step with `discovery.ts`, which hands over
+ * roots already sorted that way.
+ */
+function compare(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * The contest a root belongs to, as a grouping key.
+ *
+ * Derived from the root's own path rather than tracked through the index: a
+ * problem's contest root is the only ancestor that named it, and for grouping
+ * purposes its parent directory separates two contests exactly as well. A
+ * contest that nests its problems (`path: problems/beta`) groups under that
+ * subdirectory instead of the contest root, which only changes the heading
+ * text and stays one group as long as the contest nests consistently.
+ */
+function groupKeyOf(root: string): string {
+  return path.dirname(root);
+}
+
+export function problemChoices(
+  roots: readonly string[],
+  identities: ReadonlyMap<string, ProblemIdentity>,
+  fallback: FallbackLabel,
+): ProblemChoice[] {
+  const contested: Entry[] = [];
+  const loose: Entry[] = [];
+  for (const root of roots) {
+    const identity = identities.get(root);
+    if (identity === undefined) {
+      loose.push({ root, label: fallback(root), order: 0 });
+    } else {
+      contested.push({
+        root,
+        label: identity.shortName,
+        color: identity.color,
+        group: groupKeyOf(root),
+        order: identity.order,
+      });
+    }
+  }
+
+  contested.sort((a, b) => {
+    const group = compare(a.group ?? '', b.group ?? '');
+    if (group !== 0) {
+      return group;
+    }
+    // `order` is counted per contest file, and `indexContests` merges a
+    // dispatcher's variants (`contest.div1.rbx.yml`, `contest.div2.rbx.yml`)
+    // into one index, so two problems in the same group really can both claim
+    // order 1. Falling through to the label and then the root keeps the
+    // dropdown from reshuffling with whatever order discovery happened to
+    // yield -- these tie-breaks are not redundant.
+    return a.order - b.order || compare(a.label, b.label) || compare(a.root, b.root);
+  });
+  loose.sort((a, b) => compare(a.root, b.root));
+
+  // One group is no grouping: an `<optgroup>` wrapping every option says
+  // nothing and costs a row of chrome in a narrow sidebar.
+  const groups = new Set(contested.map((entry) => entry.group));
+  const grouped = groups.size > 1;
+
+  return [...contested, ...loose].map((entry) => ({
+    root: entry.root,
+    label: entry.label,
+    color: entry.color,
+    group: grouped && entry.group !== undefined ? path.basename(entry.group) : undefined,
+  }));
+}

--- a/vscode/src/rbx/problems.ts
+++ b/vscode/src/rbx/problems.ts
@@ -114,12 +114,25 @@ export function problemChoices(
   const groups = new Set(contested.map((entry) => entry.group));
   const grouped = groups.size + (loose.length > 0 ? 1 : 0) > 1;
 
-  return [...contested, ...loose].map((entry) => ({
-    root: entry.root,
-    label: entry.label,
-    color: entry.color,
-    // `group` is absent on every loose entry, so this both narrows the union
-    // and leaves the loose run headingless.
-    group: grouped && 'group' in entry ? path.basename(entry.group) : undefined,
-  }));
+  // Mapped per array rather than over the concatenation: only a contested
+  // entry has a contest to head, and two maps say so outright. Narrowing the
+  // union back apart with `'group' in entry` would not even work -- since TS
+  // 4.9 that widens the loose half to `Record<'group', unknown>` on the true
+  // branch instead of dropping it.
+  return [
+    ...contested.map((entry) => ({
+      root: entry.root,
+      label: entry.label,
+      color: entry.color,
+      group: grouped ? path.basename(entry.group) : undefined,
+    })),
+    ...loose.map((entry) => ({
+      root: entry.root,
+      label: entry.label,
+      color: entry.color,
+      // Never headed, however many groups there are: a heading over the
+      // packages no contest claimed would have no name to carry.
+      group: undefined,
+    })),
+  ];
 }

--- a/vscode/src/rbx/problems.ts
+++ b/vscode/src/rbx/problems.ts
@@ -5,6 +5,10 @@
  * labeller, because naming a package with no contest needs `vscode.workspace`
  * to say which folder it sits in -- and this module's value is being testable
  * without the editor API. Same split as `PackageRunView.label`.
+ *
+ * `roots` is taken as already de-duplicated: a repeated root becomes a repeated
+ * choice. `discovery.ts` collects them through a `Set`, and keeping the rule on
+ * that side leaves this module free of an opinion about identity.
  */
 import * as path from 'path';
 
@@ -22,12 +26,20 @@ export interface ProblemChoice {
 /** How a package with no contest is named. Supplied by the host. */
 export type FallbackLabel = (root: string) => string;
 
-interface Entry {
+/** A package a contest named: it always has a contest to group under. */
+interface ContestedEntry {
   readonly root: string;
   readonly label: string;
   readonly color?: string;
-  readonly group?: string;
+  readonly group: string;
   readonly order: number;
+}
+
+/** A package no contest named: nothing orders it but its own path. */
+interface LooseEntry {
+  readonly root: string;
+  readonly label: string;
+  readonly color?: string;
 }
 
 /**
@@ -42,17 +54,29 @@ function compare(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
+/**
+ * Order two contests the way their headings read.
+ *
+ * By basename first, because that is the whole of what the `<optgroup>` shows:
+ * ordering by the full root would print `beta` above `alpha` for `/z/alpha` and
+ * `/a/beta`. The full root then settles two contests in same-named directories,
+ * whose headings collide anyway but must at least not shuffle.
+ */
+function compareGroups(a: string, b: string): number {
+  return compare(path.basename(a), path.basename(b)) || compare(a, b);
+}
+
 export function problemChoices(
   roots: readonly string[],
   identities: ReadonlyMap<string, ProblemIdentity>,
   fallback: FallbackLabel,
 ): ProblemChoice[] {
-  const contested: Entry[] = [];
-  const loose: Entry[] = [];
+  const contested: ContestedEntry[] = [];
+  const loose: LooseEntry[] = [];
   for (const root of roots) {
     const identity = identities.get(root);
     if (identity === undefined) {
-      loose.push({ root, label: fallback(root), order: 0 });
+      loose.push({ root, label: fallback(root) });
     } else {
       contested.push({
         root,
@@ -68,7 +92,7 @@ export function problemChoices(
   }
 
   contested.sort((a, b) => {
-    const group = compare(a.group ?? '', b.group ?? '');
+    const group = compareGroups(a.group, b.group);
     if (group !== 0) {
       return group;
     }
@@ -83,14 +107,19 @@ export function problemChoices(
   loose.sort((a, b) => compare(a.root, b.root));
 
   // One group is no grouping: an `<optgroup>` wrapping every option says
-  // nothing and costs a row of chrome in a narrow sidebar.
+  // nothing and costs a row of chrome in a narrow sidebar. The loose packages
+  // count as a group of their own even though they render without a heading --
+  // a contest sitting flush against a run of bare folder names is the case a
+  // heading most needs to explain.
   const groups = new Set(contested.map((entry) => entry.group));
-  const grouped = groups.size > 1;
+  const grouped = groups.size + (loose.length > 0 ? 1 : 0) > 1;
 
   return [...contested, ...loose].map((entry) => ({
     root: entry.root,
     label: entry.label,
     color: entry.color,
-    group: grouped && entry.group !== undefined ? path.basename(entry.group) : undefined,
+    // `group` is absent on every loose entry, so this both narrows the union
+    // and leaves the loose run headingless.
+    group: grouped && 'group' in entry ? path.basename(entry.group) : undefined,
   }));
 }

--- a/vscode/src/rbx/solutionLabel.ts
+++ b/vscode/src/rbx/solutionLabel.ts
@@ -8,8 +8,6 @@
  * whole of that decision, kept free of `vscode` so it stays testable under
  * plain `node --test` like the rest of `rbx/`.
  */
-import * as path from 'path';
-
 export type SolutionLabelStyle = 'full' | 'trimmed' | 'basename';
 
 export const DEFAULT_SOLUTION_LABEL_STYLE: SolutionLabelStyle = 'trimmed';
@@ -70,13 +68,18 @@ export function solutionLabels(
   const prefix = style === 'trimmed' ? commonDirPrefix(paths) : '';
   const labels = new Map<string, string>();
   for (const solutionPath of paths) {
-    const normalized = segments(solutionPath).join('/');
+    const parts = segments(solutionPath);
+    const normalized = parts.join('/');
     const label = ((): string => {
       switch (style) {
         case 'full':
           return normalized;
         case 'basename':
-          return path.posix.basename(normalized);
+          // The last segment, not `path.posix.basename`: this module is reached
+          // by the webview bundle, which is built for the browser and cannot
+          // resolve a node builtin. `segments` has already dropped the empty
+          // pieces, so there is no trailing-slash case for basename to handle.
+          return parts[parts.length - 1] ?? '';
         case 'trimmed':
           // The prefix always stops short of the basename, so the slice is
           // never empty; the fallback is for a path that somehow did not start

--- a/vscode/src/rbx/viewModel.test.ts
+++ b/vscode/src/rbx/viewModel.test.ts
@@ -543,6 +543,16 @@ test('a package with no run on disk produces an empty model', () => {
   assert.strictEqual(model.mismatches, 0);
 });
 
+test('a run that covered no solution is empty too', () => {
+  // A different thing from no run at all, and the one the view actually meets
+  // while a run is starting: `skeleton.yml` is written before the first
+  // solution resolves, so the report is readable and lists nothing.
+  const model = buildViewModel(view([]));
+  assert.deepStrictEqual(model.rows, []);
+  assert.strictEqual(model.empty, true);
+  assert.strictEqual(model.mismatches, 0);
+});
+
 test('a lone solution opens by default; one of several does not', () => {
   const solo = buildViewModel(view([MAIN]));
   const soloRow = rowById(solo.rows, '/w/a::0');

--- a/vscode/src/rbx/viewModel.test.ts
+++ b/vscode/src/rbx/viewModel.test.ts
@@ -13,7 +13,6 @@ import { Row, buildViewModel } from './viewModel';
 // naive encoding folds into one red row.
 
 const PKG: PackageLayout = { root: '/w/a' };
-const OTHER: PackageLayout = { root: '/w/b' };
 
 function testcase(stem: string, outcome?: string, over: Partial<TestcaseRun> = {}): TestcaseRun {
   return {
@@ -160,7 +159,7 @@ const MISLABELED = solution(
 );
 
 test('a solution that met its ACCEPTED declaration reads green all the way through', () => {
-  const { rows } = buildViewModel([view([MAIN])]);
+  const { rows } = buildViewModel(view([MAIN]));
   const row = rowById(rows, '/w/a::0');
   assert.strictEqual(row.kind, 'solution');
   assert.strictEqual(row.gutter, 'met');
@@ -175,7 +174,7 @@ test('a solution that met its ACCEPTED declaration reads green all the way throu
 });
 
 test('a solution that failed exactly as declared is not a mismatch', () => {
-  const { rows } = buildViewModel([view([MAIN, PARTIAL])]);
+  const { rows } = buildViewModel(view([MAIN, PARTIAL]));
   const row = rowById(rows, '/w/a::1');
   assert.strictEqual(row.gutter, 'met');
   // The whole point of the change: partial.cpp is *declared* INCORRECT and it
@@ -189,7 +188,7 @@ test('a solution that failed exactly as declared is not a mismatch', () => {
 });
 
 test('a solution caught only per-group blames the per-group layer, not the pooled one', () => {
-  const { rows } = buildViewModel([view([MAIN, PARTIAL, MISLABELED])]);
+  const { rows } = buildViewModel(view([MAIN, PARTIAL, MISLABELED]));
   const row = rowById(rows, '/w/a::2');
   assert.strictEqual(row.gutter, 'missed');
   assert.strictEqual(row.mismatch, true);
@@ -233,7 +232,7 @@ test('a solution caught by its pooled declaration blames that one, and no group'
       pooledMatchesExpectation: false,
     }),
   );
-  const { rows } = buildViewModel([view([optimistic])]);
+  const { rows } = buildViewModel(view([optimistic]));
   assert.deepStrictEqual(rowById(rows, '/w/a::0').detail?.mismatch, {
     pooled: { declared: 'AC', declaredHue: 'green', observed: 'WA', observedHue: 'red' },
     // Not named as held: it is the layer that failed.
@@ -259,7 +258,7 @@ test('a report from an rbx with no pooled flag still blames the right layer', ()
       matchesExpectation: false,
     }),
   );
-  const { rows } = buildViewModel([view([stale])]);
+  const { rows } = buildViewModel(view([stale]));
   assert.strictEqual(rowById(rows, '/w/a::0').detail?.mismatch?.pooled?.declared, 'AC');
 });
 
@@ -281,7 +280,7 @@ test('a solution that only missed its score range says so, and accuses no verdic
       expectedScore: [40, 60],
     }),
   );
-  const { rows } = buildViewModel([view([scored])]);
+  const { rows } = buildViewModel(view([scored]));
   const mismatch = rowById(rows, '/w/a::0').detail?.mismatch;
   assert.strictEqual(mismatch?.pooled, undefined);
   assert.deepStrictEqual(mismatch?.score, {
@@ -307,12 +306,12 @@ test('an open-ended score range is not given a ceiling rbx never declared', () =
       expectedScore: [40, 1e9],
     }),
   );
-  const { rows } = buildViewModel([view([scored])]);
+  const { rows } = buildViewModel(view([scored]));
   assert.strictEqual(rowById(rows, '/w/a::0').detail?.mismatch?.score?.expected, '40..');
 });
 
 test('only the solution that missed its declaration is counted', () => {
-  const model = buildViewModel([view([MAIN, PARTIAL, MISLABELED])]);
+  const model = buildViewModel(view([MAIN, PARTIAL, MISLABELED]));
   assert.strictEqual(model.mismatches, 1);
   assert.strictEqual(model.empty, false);
 });
@@ -320,7 +319,7 @@ test('only the solution that missed its declaration is counted', () => {
 test('an undeclared or ANY expectation leaves the gutter alone', () => {
   const undeclared = solution(0, 'sols/x.cpp', undefined, [], solutionReport({ index: 0 }));
   const any = solution(1, 'sols/y.cpp', 'ANY', [], solutionReport({ index: 1 }));
-  const { rows } = buildViewModel([view([undeclared, any])]);
+  const { rows } = buildViewModel(view([undeclared, any]));
   assert.strictEqual(rowById(rows, '/w/a::0').gutter, 'none');
   assert.strictEqual(rowById(rows, '/w/a::0').labelHue, undefined);
   assert.strictEqual(rowById(rows, '/w/a::0').labelBold, false);
@@ -331,7 +330,7 @@ test('a solution still running has no gutter and never spells a verdict in its m
   const pending = solution(0, 'sols/main.cpp', 'ACCEPTED', [
     group('main', [testcase('000', 'accepted'), testcase('001')]),
   ]);
-  const { rows } = buildViewModel([view([pending])]);
+  const { rows } = buildViewModel(view([pending]));
   const row = rowById(rows, '/w/a::0');
   assert.strictEqual(row.gutter, 'none');
   assert.strictEqual(row.mismatch, false);
@@ -347,7 +346,7 @@ test('a solution still running has no gutter and never spells a verdict in its m
 });
 
 test('a solution with no testcases at all reads as pending', () => {
-  const { rows } = buildViewModel([view([solution(0, 'sols/main.cpp', 'ACCEPTED', [])])]);
+  const { rows } = buildViewModel(view([solution(0, 'sols/main.cpp', 'ACCEPTED', [])]));
   assert.deepStrictEqual(
     rowById(rows, '/w/a::0').meta.map((span) => span.text),
     ['pending'],
@@ -362,7 +361,7 @@ test('a finished solution shows score, time and memory but never its verdict', (
     [group('main', [testcase('000', 'accepted')], groupReport())],
     solutionReport({ score: 70, maxScore: 100, maxTime: 0.12, maxMemory: 2048 }),
   );
-  const { rows } = buildViewModel([view([finished])]);
+  const { rows } = buildViewModel(view([finished]));
   const row = rowById(rows, '/w/a::0');
   // Roles included, and in this order: the stylesheet hides a *suffix* of this
   // line as the sidebar narrows, so the order is the priority and the score
@@ -387,7 +386,7 @@ test('the score is hued like the console hues it: full green, zero red', () => {
       [],
       solutionReport({ score, maxScore: 100 }),
     );
-    const { rows } = buildViewModel([view([run])]);
+    const { rows } = buildViewModel(view([run]));
     const row = rowById(rows, '/w/a::0');
     // The meta line and the card must agree: they are the same score twice,
     // and a row whose `[0/100]` is red above a card whose `[0/100]` is not
@@ -420,7 +419,7 @@ test('only a group with its own outcomePerGroup declaration gets a gutter', () =
     ],
     solutionReport({ expectedOutcome: 'INCORRECT', outcome: 'wrong-answer' }),
   );
-  const { rows } = buildViewModel([view([declared])]);
+  const { rows } = buildViewModel(view([declared]));
   const small = rowById(rows, '/w/a::0::small');
   const big = rowById(rows, '/w/a::0::big');
   assert.strictEqual(small.gutter, 'none');
@@ -443,7 +442,7 @@ test('only a group with its own outcomePerGroup declaration gets a gutter', () =
   assert.strictEqual(small.expectation, undefined);
   assert.strictEqual(small.labelHue, undefined);
   // Group mismatches are not solution mismatches.
-  assert.strictEqual(buildViewModel([view([declared])]).mismatches, 0);
+  assert.strictEqual(buildViewModel(view([declared])).mismatches, 0);
 });
 
 test('a group inherits nothing from a solution declaring ANY, and neither does the row', () => {
@@ -454,7 +453,7 @@ test('a group inherits nothing from a solution declaring ANY, and neither does t
     [group('small', [testcase('000', 'accepted')], groupReport({ name: 'small' }))],
     solutionReport({ expectedOutcome: 'ANY' }),
   );
-  const { rows } = buildViewModel([view([any])]);
+  const { rows } = buildViewModel(view([any]));
   // ANY is how a setter declares nothing, so it earns no chip -- the same rule
   // the gutter already applied.
   assert.strictEqual(rowById(rows, '/w/a::0').expectation, undefined);
@@ -471,7 +470,7 @@ test('the histogram is ordered by count, ties by outcome name', () => {
       testcase('004'),
     ]),
   ], solutionReport({ outcome: 'wrong-answer', matchesExpectation: false }));
-  const { rows } = buildViewModel([view([many])]);
+  const { rows } = buildViewModel(view([many]));
   assert.deepStrictEqual(rowById(rows, '/w/a::0').detail?.histogram, [
     { short: 'WA', hue: 'red', count: 2 },
     { short: 'AC', hue: 'green', count: 1 },
@@ -483,7 +482,7 @@ test('a testcase opens the diff when it failed and the input otherwise', () => {
   const mixed = solution(0, 'sols/main.cpp', 'ACCEPTED', [
     group('main', [testcase('000', 'accepted'), testcase('001', 'wrong-answer'), testcase('002')]),
   ]);
-  const { rows } = buildViewModel([view([mixed])]);
+  const { rows } = buildViewModel(view([mixed]));
   assert.strictEqual(rowById(rows, '/w/a::0::main::000').primaryCommand, 'rbx.openInput');
   assert.strictEqual(rowById(rows, '/w/a::0::main::001').primaryCommand, 'rbx.diffOutput');
   // No evaluation yet: there is nothing to diff against.
@@ -494,7 +493,7 @@ test('a solution opens its source, and a group opens nothing', () => {
   const one = solution(0, 'sols/main.cpp', 'ACCEPTED', [
     group('main', [testcase('000', 'accepted')]),
   ]);
-  const { rows } = buildViewModel([view([one])]);
+  const { rows } = buildViewModel(view([one]));
   assert.strictEqual(rowById(rows, '/w/a::0').primaryCommand, 'rbx.openSolution');
   // A group is a heading over testcases; there is no file behind it to open.
   assert.strictEqual(rowById(rows, '/w/a::0::main').primaryCommand, undefined);
@@ -508,7 +507,7 @@ test('a testcase shows time and memory, and not the checker message', () => {
       }),
     ]),
   ]);
-  const { rows } = buildViewModel([view([one])]);
+  const { rows } = buildViewModel(view([one]));
   const row = rowById(rows, '/w/a::0::main::000');
   // The whole array, so a checker's free-form line cannot creep back into a
   // 22px row and push the timings out of it.
@@ -522,7 +521,7 @@ test('a testcase shows time and memory, and not the checker message', () => {
 });
 
 test('the search haystack carries the verdict, and mismatch only when missed', () => {
-  const { rows } = buildViewModel([view([MAIN, PARTIAL, MISLABELED])]);
+  const { rows } = buildViewModel(view([MAIN, PARTIAL, MISLABELED]));
   // `ac` once, not twice: on a healthy solution the declaration and the verdict
   // are the same word.
   assert.strictEqual(rowById(rows, '/w/a::0').search, 'sols/main.cpp ac');
@@ -538,59 +537,40 @@ test('the search haystack carries the verdict, and mismatch only when missed', (
 });
 
 test('a package with no run on disk produces an empty model', () => {
-  const model = buildViewModel([{ pkg: PKG, run: undefined }]);
+  const model = buildViewModel({ pkg: PKG, run: undefined });
   assert.deepStrictEqual(model.rows, []);
   assert.strictEqual(model.empty, true);
   assert.strictEqual(model.mismatches, 0);
 });
 
 test('a lone solution opens by default; one of several does not', () => {
-  const solo = buildViewModel([view([MAIN])]);
+  const solo = buildViewModel(view([MAIN]));
   const soloRow = rowById(solo.rows, '/w/a::0');
   assert.strictEqual(soloRow.expandable, true);
   assert.strictEqual(soloRow.defaultExpanded, true);
 
-  const many = buildViewModel([view([MAIN, PARTIAL])]);
+  const many = buildViewModel(view([MAIN, PARTIAL]));
   assert.strictEqual(rowById(many.rows, '/w/a::0').defaultExpanded, false);
   assert.strictEqual(rowById(many.rows, '/w/a::0::main').defaultExpanded, true);
   assert.strictEqual(rowById(many.rows, '/w/a::0::main::000').expandable, false);
 });
 
-test('depth and parentId follow the level the walk actually emitted', () => {
-  const single = buildViewModel([view([MAIN])]);
+test('a solution starts at depth 0, and every child names the row above it', () => {
+  // Depth 0 for the solution is the whole of what dropping the package level
+  // bought: the selector says which package this is, so nothing indents under
+  // it and there is no offset to derive from the walk.
+  const { rows } = buildViewModel(view([MAIN, PARTIAL]));
   assert.deepStrictEqual(
-    single.rows.map((row) => [row.id, row.depth, row.parentId]),
+    rows.map((row) => [row.id, row.kind, row.depth, row.parentId]),
     [
-      ['/w/a::0', 0, undefined],
-      ['/w/a::0::main', 1, '/w/a::0'],
-      ['/w/a::0::main::000', 2, '/w/a::0::main'],
+      ['/w/a::0', 'solution', 0, undefined],
+      ['/w/a::0::main', 'group', 1, '/w/a::0'],
+      ['/w/a::0::main::000', 'testcase', 2, '/w/a::0::main'],
+      ['/w/a::1', 'solution', 0, undefined],
+      ['/w/a::1::big', 'group', 1, '/w/a::1'],
+      ['/w/a::1::big::001', 'testcase', 2, '/w/a::1::big'],
     ],
   );
-
-  const two = buildViewModel([view([MAIN]), { pkg: OTHER, run: run([MAIN]) }]);
-  assert.deepStrictEqual(
-    two.rows.map((row) => [row.id, row.kind, row.depth, row.parentId]),
-    [
-      ['/w/a', 'package', 0, undefined],
-      ['/w/a::0', 'solution', 1, '/w/a'],
-      ['/w/a::0::main', 'group', 2, '/w/a::0'],
-      ['/w/a::0::main::000', 'testcase', 3, '/w/a::0::main'],
-      ['/w/b', 'package', 0, undefined],
-      ['/w/b::0', 'solution', 1, '/w/b'],
-      ['/w/b::0::main', 'group', 2, '/w/b::0'],
-      ['/w/b::0::main::000', 'testcase', 3, '/w/b::0::main'],
-    ],
-  );
-});
-
-test('a package row is labelled by its directory and carries no verdict', () => {
-  const { rows } = buildViewModel([view([MAIN]), { pkg: OTHER, run: run([MAIN]) }]);
-  const row = rowById(rows, '/w/a');
-  assert.strictEqual(row.label, 'a');
-  assert.strictEqual(row.verdict, undefined);
-  assert.strictEqual(row.gutter, 'none');
-  assert.strictEqual(row.section, 'rbx.package');
-  assert.strictEqual(row.defaultExpanded, true);
 });
 
 // `rbx.solutionLabel`. The styles themselves are pinned in solutionLabel.test.ts;
@@ -607,7 +587,7 @@ const NESTED = solution(3, 'sols/slow/tle.cpp', 'INCORRECT', [], solutionReport(
 test('the label style picks how much of a solution path a row shows', () => {
   const solutions = [MAIN, PARTIAL, NESTED];
   const labelsOf = (style: Parameters<typeof buildViewModel>[1]): string[] =>
-    buildViewModel([view(solutions)], style)
+    buildViewModel(view(solutions), style)
       .rows.filter((row) => row.kind === 'solution')
       .map((row) => row.label);
 
@@ -622,31 +602,29 @@ test('the label style picks how much of a solution path a row shows', () => {
   assert.deepStrictEqual(labelsOf(undefined), labelsOf('trimmed'));
 });
 
-test('each package trims by the prefix its own solutions share', () => {
-  const elsewhere = solution(0, 'other/dir/x.cpp', 'ACCEPTED', [], solutionReport({
+test('trimming is computed over this package alone', () => {
+  const elsewhere = solution(1, 'other/dir/x.cpp', 'ACCEPTED', [], solutionReport({
     path: 'other/dir/x.cpp',
+    index: 1,
   }));
-  const { rows } = buildViewModel(
-    [view([MAIN, PARTIAL]), { pkg: OTHER, run: run([elsewhere]) }],
-    'trimmed',
-  );
-  // `/w/b`'s lone solution lives nowhere near `sols/`, and that costs `/w/a`
-  // nothing: a shared prefix computed across both packages would be empty.
-  assert.strictEqual(rowById(rows, '/w/a::0').label, 'main.cpp');
-  assert.strictEqual(rowById(rows, '/w/a::1').label, 'partial.cpp');
-  assert.strictEqual(rowById(rows, '/w/b::0').label, 'x.cpp');
+  // A sibling package keeping its solutions somewhere unusual can no longer
+  // reach this model at all -- only the selected package's solutions decide
+  // what the prefix is, and here they share nothing, so nothing is dropped.
+  const { rows } = buildViewModel(view([MAIN, elsewhere]), 'trimmed');
+  assert.strictEqual(rowById(rows, '/w/a::0').label, 'sols/main.cpp');
+  assert.strictEqual(rowById(rows, '/w/a::1').label, 'other/dir/x.cpp');
 });
 
 test('a shortened label keeps the whole path for the tooltip', () => {
-  const { rows } = buildViewModel([view([MAIN, PARTIAL])], 'basename');
+  const { rows } = buildViewModel(view([MAIN, PARTIAL]), 'basename');
   assert.strictEqual(rowById(rows, '/w/a::0').labelTitle, 'sols/main.cpp');
   // Nothing was dropped, so there is nothing for a tooltip to add.
-  const full = buildViewModel([view([MAIN, PARTIAL])], 'full');
+  const full = buildViewModel(view([MAIN, PARTIAL]), 'full');
   assert.strictEqual(rowById(full.rows, '/w/a::0').labelTitle, undefined);
 });
 
 test('the filter matches the full path whatever the label shows', () => {
-  const { rows } = buildViewModel([view([MAIN, PARTIAL])], 'basename');
+  const { rows } = buildViewModel(view([MAIN, PARTIAL]), 'basename');
   assert.strictEqual(rowById(rows, '/w/a::0').search, 'sols/main.cpp ac');
   assert.strictEqual(rowById(rows, '/w/a::1').search, 'sols/partial.cpp wa incorrect');
 });
@@ -686,7 +664,7 @@ const BORDERLINE_SLOW = solution(
 );
 
 test('a solution that only fit in double TL is warned about while still matching', () => {
-  const { rows } = buildViewModel([view([BORDERLINE_SLOW])]);
+  const { rows } = buildViewModel(view([BORDERLINE_SLOW]));
   const row = rowById(rows, '/w/a::0');
 
   // The gutter says warned, not missed: the declaration held, and `mismatch`
@@ -701,13 +679,13 @@ test('a solution that only fit in double TL is warned about while still matching
 });
 
 test('a solution warning names the groups it came from', () => {
-  const { rows } = buildViewModel([view([BORDERLINE_SLOW])]);
+  const { rows } = buildViewModel(view([BORDERLINE_SLOW]));
   const row = rowById(rows, '/w/a::0');
   assert.deepStrictEqual(row.warnings[0].groups, ['big']);
 });
 
 test('a group carries its own warning, with no attribution to repeat', () => {
-  const { rows } = buildViewModel([view([BORDERLINE_SLOW])]);
+  const { rows } = buildViewModel(view([BORDERLINE_SLOW]));
   assert.deepStrictEqual(rowById(rows, '/w/a::0::small').warnings, []);
   const big = rowById(rows, '/w/a::0::big');
   assert.strictEqual(big.gutter, 'warned');
@@ -740,7 +718,7 @@ test('the two double-TL facts stay independent rather than merging', () => {
       ],
     }),
   );
-  const row = rowById(buildViewModel([view([both])]).rows, '/w/a::0');
+  const row = rowById(buildViewModel(view([both])).rows, '/w/a::0');
 
   assert.deepStrictEqual(
     row.warnings.map((warning) => warning.kind),
@@ -756,26 +734,26 @@ test('the two double-TL facts stay independent rather than merging', () => {
 });
 
 test('a warned solution is counted apart from a mismatched one', () => {
-  const { mismatches, warned } = buildViewModel([view([MAIN, BORDERLINE_SLOW])]);
+  const { mismatches, warned } = buildViewModel(view([MAIN, BORDERLINE_SLOW]));
   // A run where every declaration held still has something to report.
   assert.strictEqual(mismatches, 0);
   assert.strictEqual(warned, 1);
 });
 
 test('a testcase is never warned: the fact is decided a layer above it', () => {
-  const { rows } = buildViewModel([view([BORDERLINE_SLOW])]);
+  const { rows } = buildViewModel(view([BORDERLINE_SLOW]));
   assert.deepStrictEqual(rowById(rows, '/w/a::0::big::001').warnings, []);
 });
 
 test('a warned row is reachable by filtering for it', () => {
-  const { rows } = buildViewModel([view([BORDERLINE_SLOW])]);
+  const { rows } = buildViewModel(view([BORDERLINE_SLOW]));
   const search = rowById(rows, '/w/a::0').search;
   assert.ok(search.includes('warning'));
   assert.ok(search.includes('double-tl'));
 });
 
 test('a solution rbx did not warn about carries no warnings', () => {
-  const { rows, warned } = buildViewModel([view([MAIN])]);
+  const { rows, warned } = buildViewModel(view([MAIN]));
   assert.deepStrictEqual(rowById(rows, '/w/a::0').warnings, []);
   assert.strictEqual(rowById(rows, '/w/a::0').gutter, 'met');
   assert.strictEqual(warned, 0);
@@ -796,7 +774,7 @@ test('a solution that both missed and warned draws the miss', () => {
       runUnderDoubleTl: true,
     }),
   );
-  const { rows, mismatches, warned } = buildViewModel([view([both])]);
+  const { rows, mismatches, warned } = buildViewModel(view([both]));
   const row = rowById(rows, '/w/a::0');
 
   assert.strictEqual(row.gutter, 'missed');
@@ -836,7 +814,7 @@ const HIDDEN_WA = solution(
 );
 
 test('a testcase shows the verdict a soft TLE hid, beside the one it got', () => {
-  const { rows } = buildViewModel([view([HIDDEN_WA])]);
+  const { rows } = buildViewModel(view([HIDDEN_WA]));
   const leaf = rowById(rows, '/w/a::0::big::001');
 
   assert.strictEqual(leaf.verdict?.short, 'TLE');
@@ -847,7 +825,7 @@ test('a testcase shows the verdict a soft TLE hid, beside the one it got', () =>
 });
 
 test('a testcase with no hidden verdict shows only what it got', () => {
-  const { rows } = buildViewModel([view([HIDDEN_WA])]);
+  const { rows } = buildViewModel(view([HIDDEN_WA]));
   assert.strictEqual(rowById(rows, '/w/a::0::big::000').verdict?.under, undefined);
 });
 
@@ -872,7 +850,7 @@ test('a hidden verdict rbx did not flag is not shown', () => {
     ],
     solutionReport({ expectedOutcome: 'INCORRECT', outcome: 'time-limit-exceeded' }),
   );
-  const { rows } = buildViewModel([view([quiet])]);
+  const { rows } = buildViewModel(view([quiet]));
   assert.strictEqual(rowById(rows, '/w/a::0::big::000').verdict?.under, undefined);
 });
 
@@ -886,12 +864,12 @@ test('a hidden verdict is not shown before its group has a report', () => {
       }),
     ]),
   ]);
-  const { rows } = buildViewModel([view([pending])]);
+  const { rows } = buildViewModel(view([pending]));
   assert.strictEqual(rowById(rows, '/w/a::0::big::000').verdict?.under, undefined);
 });
 
 test('the hidden verdict joins the row it is on in the filter', () => {
-  const { rows } = buildViewModel([view([HIDDEN_WA])]);
+  const { rows } = buildViewModel(view([HIDDEN_WA]));
   // Typing `wa` has to find the testcases where a soft TLE hid one; they are
   // exactly the rows a WA filter would otherwise miss.
   assert.ok(rowById(rows, '/w/a::0::big::001').search.includes('wa'));
@@ -900,7 +878,7 @@ test('the hidden verdict joins the row it is on in the filter', () => {
 test('only leaves carry a hidden verdict', () => {
   // It is a fact about one run of one testcase. A group or a solution that
   // aggregated them would be inventing a verdict nothing produced.
-  const { rows } = buildViewModel([view([HIDDEN_WA])]);
+  const { rows } = buildViewModel(view([HIDDEN_WA]));
   assert.strictEqual(rowById(rows, '/w/a::0').verdict?.under, undefined);
   assert.strictEqual(rowById(rows, '/w/a::0::big').verdict?.under, undefined);
 });

--- a/vscode/src/rbx/viewModel.ts
+++ b/vscode/src/rbx/viewModel.ts
@@ -214,9 +214,9 @@ export interface Row {
    * The whole of what the label is a shortening of, for the row's tooltip.
    *
    * Only solution rows carry one, and only because `rbx.solutionLabel` lets the
-   * label stop short of the path: a user reading `main.cpp` under two packages
-   * still has somewhere to find out which `sols/` it came from. Absent when the
-   * label is already the whole truth.
+   * label stop short of the path: a user reading `main.cpp` still has somewhere
+   * to find out which `sols/` it came from. Absent when the label is already
+   * the whole truth.
    */
   readonly labelTitle?: string;
   readonly labelHue?: Hue;
@@ -259,6 +259,15 @@ export interface RunViewModel {
   readonly warned: number;
   readonly empty: boolean;
 }
+
+/**
+ * The model of a view with no problem behind it at all.
+ *
+ * Distinct from `buildViewModel` of a package with no run: there is no package,
+ * so there is no layout to invent one for. Shared by both halves so the client's
+ * starting state and the host's answer for an empty workspace cannot drift.
+ */
+export const EMPTY_MODEL: RunViewModel = { rows: [], mismatches: 0, warned: 0, empty: true };
 
 function chip(outcome: string | undefined, under?: WarningVerdict): VerdictChip {
   const { icon, color } = outcomeIcon(outcome);

--- a/vscode/src/rbx/viewModel.ts
+++ b/vscode/src/rbx/viewModel.ts
@@ -16,13 +16,10 @@
  * Pure by design, like nodes.ts: no `vscode` import, so `node --test` can hold
  * the whole thing to account.
  */
-import * as path from 'path';
-
 import { ExpectationDisplay, expectationDisplay } from './expectation';
 import { Hue, hueOfScore, hueOfThemeColor } from './hue';
 import {
   GroupNode,
-  PackageNode,
   PackageRunView,
   SolutionNode,
   TestcaseNode,
@@ -210,7 +207,7 @@ export interface Row {
   readonly id: string;
   readonly parentId?: string;
   readonly depth: number;
-  readonly kind: 'package' | 'solution' | 'group' | 'testcase';
+  readonly kind: 'solution' | 'group' | 'testcase';
   readonly gutter: Gutter;
   readonly label: string;
   /**
@@ -261,18 +258,6 @@ export interface RunViewModel {
   /** Solutions that passed but carry at least one warning. */
   readonly warned: number;
   readonly empty: boolean;
-}
-
-/**
- * What to call a package.
- *
- * The host disambiguates two packages both named `prob` by asking
- * `vscode.workspace` which folder each sits in, and passes the answer down --
- * importing that here would drag the editor API into a module whose whole value
- * is being testable without it. The basename is right whenever it did not.
- */
-function packageName(node: PackageNode): string {
-  return node.label ?? path.basename(node.pkg.root);
 }
 
 function chip(outcome: string | undefined, under?: WarningVerdict): VerdictChip {
@@ -652,26 +637,6 @@ function solutionDetail(
   };
 }
 
-function packageRow(node: PackageNode, depth: number, parentId?: string): Row {
-  const label = packageName(node);
-  return {
-    id: nodeId(node),
-    parentId,
-    depth,
-    kind: 'package',
-    gutter: 'none',
-    label,
-    labelBold: false,
-    meta: [],
-    warnings: [],
-    mismatch: false,
-    expandable: true,
-    defaultExpanded: true,
-    search: haystack(label, undefined, false),
-    section: 'rbx.package',
-  };
-}
-
 function solutionRow(node: SolutionNode, depth: number, label: string, parentId?: string): Row {
   const { run, solo } = node;
   const warnings = warningsOf(run.report, true);
@@ -786,61 +751,40 @@ function testcaseRow(node: TestcaseNode, depth: number, parentId?: string): Row 
   };
 }
 
-/** How deep each kind sits, given whether the walk emitted package rows. */
+/** How deep each kind sits, counting the solution as the top level. */
 const DEPTHS: Record<Row['kind'], number> = {
-  package: 0,
-  solution: 1,
-  group: 2,
-  testcase: 3,
+  solution: 0,
+  group: 1,
+  testcase: 2,
 };
 
-/**
- * Every package's solution labels, by package root and then by solution path.
- *
- * Computed package by package, so the prefix `trimmed` drops is the one *that*
- * package's solutions share -- a contest workspace where one package keeps its
- * solutions somewhere unusual does not cost every other package its trimming.
- */
-function labelsByPackage(
-  packages: readonly PackageRunView[],
-  style: SolutionLabelStyle,
-): Map<string, Map<string, string>> {
-  const labels = new Map<string, Map<string, string>>();
-  for (const { pkg, run } of packages) {
-    if (run === undefined) {
-      continue;
-    }
-    const paths = run.solutions.map((solutionRun) => solutionRun.solution.path);
-    labels.set(pkg.root, solutionLabels(paths, style));
-  }
-  return labels;
-}
-
 export function buildViewModel(
-  packages: readonly PackageRunView[],
+  view: PackageRunView,
   style: SolutionLabelStyle = DEFAULT_SOLUTION_LABEL_STYLE,
 ): RunViewModel {
-  const nodes = flattenNodes(packages);
-  const labels = labelsByPackage(packages, style);
-  // `flattenNodes` drops the package level for a single package, so the offset
-  // has to come from the walk it actually performed rather than from the input.
-  const hasPackages = nodes.some((node) => node.kind === 'package');
-  const offset = hasPackages ? 0 : 1;
+  const nodes = flattenNodes(view);
+  // Over the selected package's solutions alone, which is what the label
+  // styles have always meant: the prefix `trimmed` drops is the one *this*
+  // package's solutions share, so a sibling keeping its solutions somewhere
+  // unusual cannot cost this one its trimming. It no longer even can -- the
+  // sibling does not reach this function any more.
+  const labels = solutionLabels(
+    view.run?.solutions.map((solution) => solution.solution.path) ?? [],
+    style,
+  );
   // The most recent row at each level, so a child can name its parent without
   // the walk having to carry a stack.
   const parents = new Map<number, string>();
 
   const rows: Row[] = [];
   for (const node of nodes) {
-    const depth = DEPTHS[node.kind] - offset;
+    const depth = DEPTHS[node.kind];
     const parentId = parents.get(depth - 1);
     const row = ((): Row => {
       switch (node.kind) {
-        case 'package':
-          return packageRow(node, depth, parentId);
         case 'solution': {
           const path = node.run.solution.path;
-          return solutionRow(node, depth, labels.get(node.pkg.root)?.get(path) ?? path, parentId);
+          return solutionRow(node, depth, labels.get(path) ?? path, parentId);
         }
         case 'group':
           return groupRow(node, depth, parentId);

--- a/vscode/src/runData.ts
+++ b/vscode/src/runData.ts
@@ -97,10 +97,9 @@ export class RunDataProvider {
   /**
    * Every discovered package paired with whatever run is on disk for it.
    *
-   * Packages with no readable run are kept rather than filtered: `flattenNodes`
-   * already drops them, and the rule that hides the package level counts
-   * *discovered* packages, so dropping them here would make the view gain and
-   * lose a level as runs come and go.
+   * Packages with no readable run are kept rather than filtered: a package the
+   * user can select must still be listed when it has never been run, and
+   * `flattenNodes` renders it as nothing.
    */
   async loadAll(): Promise<PackageRunView[]> {
     await this.ensureDiscovered();

--- a/vscode/src/runData.ts
+++ b/vscode/src/runData.ts
@@ -3,15 +3,14 @@
  *
  * Split out of the old tree provider so that nothing about *drawing* the view
  * lives next to what feeds it: this half talks to the workspace and the disk,
- * the webview half turns what it loads into rows. The two meet at
- * `PackageRunView`, which carries no editor API.
+ * the webview half turns what it loads into rows. The two meet at `PackageRun`,
+ * which carries no editor API.
  */
 import * as vscode from 'vscode';
 
-import { discoverPackages, packageLabel } from './discovery';
+import { discoverPackages } from './discovery';
 import { log } from './log';
 import { PackageLayout } from './rbx/layout';
-import { PackageRunView } from './rbx/nodes';
 import { ArtifactStore, PackageRun } from './rbx/store';
 
 export class RunDataProvider {
@@ -90,29 +89,13 @@ export class RunDataProvider {
     return store;
   }
 
+  /**
+   * Whatever run is on disk for one package, or undefined if none is readable.
+   *
+   * A package with no readable run is not an error: one that has never been run
+   * still has to be selectable, and `flattenNodes` renders it as nothing.
+   */
   report(pkg: PackageLayout): Promise<PackageRun | undefined> {
     return this.storeFor(pkg).load();
-  }
-
-  /**
-   * Every discovered package paired with whatever run is on disk for it.
-   *
-   * Packages with no readable run are kept rather than filtered: a package the
-   * user can select must still be listed when it has never been run, and
-   * `flattenNodes` renders it as nothing.
-   */
-  async loadAll(): Promise<PackageRunView[]> {
-    await this.ensureDiscovered();
-    const views: PackageRunView[] = [];
-    for (const pkg of this.packages) {
-      const run = await this.report(pkg);
-      if (run === undefined) {
-        log(`No readable run for ${pkg.root} -- run \`rbx run\` in that directory.`);
-      } else {
-        log(`${pkg.root}: ${run.solutions.length} solution(s) in the last run.`);
-      }
-      views.push({ pkg, run, label: packageLabel(pkg) });
-    }
-    return views;
   }
 }

--- a/vscode/src/runView.ts
+++ b/vscode/src/runView.ts
@@ -15,17 +15,22 @@
 import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 
+import { ActiveProblem } from './activeProblem';
 import { packageLayout } from './rbx/layout';
 import { PackageRunView, RunNode, flattenNodes, nodeId } from './rbx/nodes';
 import { asSolutionLabelStyle } from './rbx/solutionLabel';
-import { buildViewModel } from './rbx/viewModel';
+import { EMPTY_MODEL, buildViewModel } from './rbx/viewModel';
 import { RunDataProvider } from './runData';
 
-/** What main.ts posts back: a load announcement, or a row's primary command. */
+/**
+ * What main.ts posts back: a load announcement, a row's primary command, or the
+ * problem the dropdown was just set to.
+ */
 interface ClientMessage {
   readonly type?: string;
   readonly commandId?: string;
   readonly nodeId?: string;
+  readonly root?: string;
 }
 
 /** A CSP nonce. Fresh per resolve, from a real random source. */
@@ -48,6 +53,7 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
 
   constructor(
     private readonly data: RunDataProvider,
+    private readonly active: ActiveProblem,
     private readonly extensionUri: vscode.Uri,
   ) {}
 
@@ -62,6 +68,12 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
     view.webview.onDidReceiveMessage((message: ClientMessage) => {
       if (message.type === 'ready') {
         void this.post();
+        return;
+      }
+      if (message.type === 'select' && message.root !== undefined) {
+        // No `post` here: `ActiveProblem` fires its change event, which is
+        // already subscribed below. Posting as well would draw the view twice.
+        this.active.select(message.root);
         return;
       }
       if (message.type === 'invoke' && message.commandId !== undefined) {
@@ -80,6 +92,9 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
     // paying to keep a hidden view alive would buy nothing back.
     const subscriptions = [
       this.data.onDidChange(() => void this.post()),
+      // Both, and they are different events: `data` changes what the selected
+      // problem's run says, `active` changes which problem that is.
+      this.active.onDidChange(() => void this.post()),
       // `rbx.solutionLabel` changes nothing on disk, so no reload will bring the
       // new labels in on its own -- the view has to rebuild the model itself.
       vscode.workspace.onDidChangeConfiguration((event) => {
@@ -100,25 +115,41 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
   }
 
   /**
-   * Load everything and hand the client a whole new model.
+   * Load the selected problem's run and hand the client a whole new model.
+   *
+   * One problem, not every discovered one: only the selected package is read
+   * from disk, so a contest of thirty problems costs one package's artifacts
+   * per tick rather than thirty.
    *
    * The id map is rebuilt in the same pass, from the same `PackageRunView`, so
    * an id the client can see always resolves to the node it was built from.
+   *
+   * The dropdown's contents ride along with the model rather than on a message
+   * of their own: they are answers to the same question -- what is the view
+   * showing -- and posting them separately would let the client draw a
+   * selection the model does not match.
    */
   private async post(): Promise<void> {
-    const packages = await this.data.loadAll();
-    // Placeholder: the view now renders one package, but nothing chooses which
-    // yet -- the selector lands in a later step and replaces this with the
-    // user's choice. Until then the first package discovered stands in, and an
-    // empty workspace gets a view with no run, which draws as the empty state.
-    const selected: PackageRunView = packages[0] ?? { pkg: packageLayout(''), run: undefined };
-    this.nodes = new Map(flattenNodes(selected).map((node) => [nodeId(node), node]));
+    const selected = this.active.selected();
+    // Undefined and not an empty layout: no package was discovered, so there is
+    // nothing to load and the client draws its empty state.
+    const pkg = selected === undefined ? undefined : packageLayout(selected);
+    const view: PackageRunView | undefined =
+      pkg === undefined ? undefined : { pkg, run: await this.data.report(pkg) };
+    this.nodes = new Map(
+      (view === undefined ? [] : flattenNodes(view)).map((node) => [nodeId(node), node]),
+    );
     // Read per post rather than cached: the setting is window-scoped and the
     // configuration API is the only place its current value lives.
     const style = asSolutionLabelStyle(
       vscode.workspace.getConfiguration('rbx').get('solutionLabel'),
     );
-    await this.view?.webview.postMessage({ type: 'state', model: buildViewModel(selected, style) });
+    await this.view?.webview.postMessage({
+      type: 'state',
+      model: view === undefined ? EMPTY_MODEL : buildViewModel(view, style),
+      problems: this.active.problems(),
+      selected,
+    });
   }
 
   private html(webview: vscode.Webview): string {
@@ -158,6 +189,7 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
     <title>rbx Run</title>
   </head>
   <body>
+    <div id="selector-host"></div>
     <div id="header"></div>
     <div id="filter-host"></div>
     <div id="tree" role="tree" tabindex="-1"></div>

--- a/vscode/src/runView.ts
+++ b/vscode/src/runView.ts
@@ -15,7 +15,8 @@
 import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 
-import { RunNode, flattenNodes, nodeId } from './rbx/nodes';
+import { packageLayout } from './rbx/layout';
+import { PackageRunView, RunNode, flattenNodes, nodeId } from './rbx/nodes';
 import { asSolutionLabelStyle } from './rbx/solutionLabel';
 import { buildViewModel } from './rbx/viewModel';
 import { RunDataProvider } from './runData';
@@ -101,18 +102,23 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
   /**
    * Load everything and hand the client a whole new model.
    *
-   * The id map is rebuilt in the same pass, from the same `PackageRunView`s, so
+   * The id map is rebuilt in the same pass, from the same `PackageRunView`, so
    * an id the client can see always resolves to the node it was built from.
    */
   private async post(): Promise<void> {
     const packages = await this.data.loadAll();
-    this.nodes = new Map(flattenNodes(packages).map((node) => [nodeId(node), node]));
+    // Placeholder: the view now renders one package, but nothing chooses which
+    // yet -- the selector lands in a later step and replaces this with the
+    // user's choice. Until then the first package discovered stands in, and an
+    // empty workspace gets a view with no run, which draws as the empty state.
+    const selected: PackageRunView = packages[0] ?? { pkg: packageLayout(''), run: undefined };
+    this.nodes = new Map(flattenNodes(selected).map((node) => [nodeId(node), node]));
     // Read per post rather than cached: the setting is window-scoped and the
     // configuration API is the only place its current value lives.
     const style = asSolutionLabelStyle(
       vscode.workspace.getConfiguration('rbx').get('solutionLabel'),
     );
-    await this.view?.webview.postMessage({ type: 'state', model: buildViewModel(packages, style) });
+    await this.view?.webview.postMessage({ type: 'state', model: buildViewModel(selected, style) });
   }
 
   private html(webview: vscode.Webview): string {

--- a/vscode/src/runView.ts
+++ b/vscode/src/runView.ts
@@ -16,6 +16,7 @@ import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 
 import { ActiveProblem } from './activeProblem';
+import { log } from './log';
 import { packageLayout } from './rbx/layout';
 import { PackageRunView, RunNode, flattenNodes, nodeId } from './rbx/nodes';
 import { asSolutionLabelStyle } from './rbx/solutionLabel';
@@ -50,6 +51,14 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
    */
   private nodes = new Map<string, RunNode>();
   private view?: vscode.WebviewView;
+  /**
+   * What the last post said, so the log can report edges instead of ticks.
+   *
+   * `post` runs on every debounced watcher tick -- many per run -- so logging
+   * unconditionally would bury the output channel. Only a change of problem, or
+   * of whether that problem has a readable run at all, is news.
+   */
+  private posted?: { readonly root?: string; readonly readable: boolean };
 
   constructor(
     private readonly data: RunDataProvider,
@@ -139,6 +148,20 @@ export class RunViewProvider implements vscode.WebviewViewProvider {
     this.nodes = new Map(
       (view === undefined ? [] : flattenNodes(view)).map((node) => [nodeId(node), node]),
     );
+    const readable = view?.run !== undefined;
+    const posted = this.posted;
+    if (posted === undefined || posted.root !== selected || posted.readable !== readable) {
+      // Nothing said for an undefined selection: discovery already logged that
+      // it found no package, and repeating it here adds no fact.
+      if (selected !== undefined) {
+        log(
+          readable
+            ? `Loaded the run in ${selected}.`
+            : `No readable run for ${selected} -- run \`rbx run\` in that directory.`,
+        );
+      }
+      this.posted = { root: selected, readable };
+    }
     // Read per post rather than cached: the setting is window-scoped and the
     // configuration API is the only place its current value lives.
     const style = asSolutionLabelStyle(

--- a/vscode/src/webview/main.ts
+++ b/vscode/src/webview/main.ts
@@ -10,9 +10,17 @@
  * It talks to the extension host only through `acquireVsCodeApi`; importing the
  * `vscode` module is impossible in a webview and would not work if it were.
  */
-import type { Row, RunViewModel } from '../rbx/viewModel';
+import type { ProblemChoice } from '../rbx/problems';
+import { EMPTY_MODEL, type Row, type RunViewModel } from '../rbx/viewModel';
 import { rowClick } from './gesture';
-import { UiState, renderFilter, renderHeader, renderTree, visibleRows } from './render';
+import {
+  UiState,
+  renderFilter,
+  renderHeader,
+  renderSelector,
+  renderTree,
+  visibleRows,
+} from './render';
 
 interface VsCodeApi {
   postMessage(message: unknown): void;
@@ -40,11 +48,19 @@ declare function acquireVsCodeApi(): VsCodeApi;
 
 const vscode = acquireVsCodeApi();
 
-const EMPTY_MODEL: RunViewModel = { rows: [], mismatches: 0, warned: 0, empty: true };
-
 const persisted = vscode.getState();
 
 let model: RunViewModel = EMPTY_MODEL;
+/**
+ * The dropdown's contents, and the host's answer for what is showing.
+ *
+ * Deliberately *not* in `PersistedState`: the host owns the selection and
+ * re-posts it with every model, so a second copy here could only ever drift
+ * from it -- and would win on reload, showing a problem the host is not
+ * loading.
+ */
+let problems: readonly ProblemChoice[] = [];
+let selectedProblem: string | undefined;
 let expanded = new Set<string>(persisted?.expanded ?? []);
 const touched = new Set<string>(persisted?.touched ?? []);
 let selected: string | undefined = persisted?.selected;
@@ -52,6 +68,7 @@ let filter = persisted?.filter ?? '';
 let pendingScrollTop: number | undefined = persisted?.scrollTop ?? 0;
 
 const header = document.getElementById('header') as HTMLElement;
+const selectorHost = document.getElementById('selector-host') as HTMLElement;
 const filterHost = document.getElementById('filter-host') as HTMLElement;
 const tree = document.getElementById('tree') as HTMLElement;
 
@@ -84,6 +101,39 @@ function filterInput(): HTMLInputElement | null {
   return document.getElementById('filter') as HTMLInputElement | null;
 }
 
+function problemSelect(): HTMLSelectElement | null {
+  return document.getElementById('problem') as HTMLSelectElement | null;
+}
+
+/** What `selectorHost` currently holds, so an unchanged dropdown is left alone. */
+let selectorHtml = '';
+
+/**
+ * Redraw the dropdown, but only when it would actually differ.
+ *
+ * A `<select>` is the one control in the view that cannot survive being
+ * rebuilt: replacing the element drops the focus and, on some platforms, snaps
+ * the open list shut. The host re-posts the whole model on every file-watcher
+ * tick of a run, so without this guard a run would fight anyone trying to use
+ * the dropdown. During a run the problems and the selection are exactly what
+ * does *not* change, so comparing the markup skips almost every tick.
+ *
+ * The rebuild that does happen -- a package appearing, or the selection moving
+ * -- still puts the focus back, the way `renderAll` does for the filter box.
+ */
+function renderSelectorHost(): void {
+  const next = renderSelector(problems, selectedProblem);
+  if (next === selectorHtml) {
+    return;
+  }
+  const focused = document.activeElement === problemSelect();
+  selectorHtml = next;
+  selectorHost.innerHTML = next;
+  if (focused) {
+    problemSelect()?.focus();
+  }
+}
+
 /** Re-render the tree, keeping scroll where it was. */
 function render(): void {
   const scrollTop = tree.scrollTop;
@@ -105,6 +155,7 @@ function renderAll(): void {
   // holding it -- which would drop a keyboard or screen-reader user out to
   // `<body>` on every tick of a run.
   const inTree = tree.contains(document.activeElement);
+  renderSelectorHost();
   filterHost.innerHTML = renderFilter(uiState());
   render();
   if (inFilter) {
@@ -339,9 +390,28 @@ header.addEventListener('click', (event) => {
   }
 });
 
+// Delegated to the host element rather than bound to the `<select>`, because
+// `renderSelectorHost` replaces that element whenever the list changes and a
+// listener on it would go with it.
+selectorHost.addEventListener('change', (event) => {
+  const target = event.target as HTMLSelectElement;
+  if (target.id === 'problem') {
+    // Nothing is re-rendered here: the host is the one that decides what is
+    // showing, and it answers with a fresh `state` message.
+    vscode.postMessage({ type: 'select', root: target.value });
+  }
+});
+
 window.addEventListener('message', (event: MessageEvent) => {
-  const message = event.data as { type?: string; model?: RunViewModel };
+  const message = event.data as {
+    type?: string;
+    model?: RunViewModel;
+    problems?: readonly ProblemChoice[];
+    selected?: string;
+  };
   if (message.type === 'state' && message.model !== undefined) {
+    problems = message.problems ?? [];
+    selectedProblem = message.selected;
     setModel(message.model);
   }
 });

--- a/vscode/src/webview/render.test.ts
+++ b/vscode/src/webview/render.test.ts
@@ -11,6 +11,7 @@ import {
   matchesFilter,
   renderFilter,
   renderHeader,
+  renderSelector,
   renderTree,
   visibleRows,
 } from './render';
@@ -504,6 +505,89 @@ test('the filter box escapes a quote rather than closing its own attribute', () 
   const html = renderFilter(state({ filter: 'say "hi" & <b>' }));
   assert.ok(html.includes('value="say &quot;hi&quot; &amp; &lt;b&gt;"'), html);
   assert.ok(!html.includes('<b>'), html);
+});
+
+test('renders one option per problem, marking the selected one', () => {
+  const html = renderSelector(
+    [
+      { root: '/c/A', label: 'A' },
+      { root: '/c/B', label: 'B' },
+    ],
+    '/c/B',
+  );
+  assert.match(html, /<option value="\/c\/A"[^>]*>A<\/option>/);
+  assert.match(html, /<option value="\/c\/B" selected[^>]*>B<\/option>/);
+});
+
+test('renders nothing for a single problem', () => {
+  // A select with one option is a control that cannot do anything, and the
+  // one-problem workspace has to look exactly as it did before the selector.
+  assert.strictEqual(renderSelector([{ root: '/only', label: 'only' }], '/only'), '');
+});
+
+test('groups options when the problems carry groups', () => {
+  const html = renderSelector(
+    [
+      { root: '/x/A', label: 'A', group: 'x' },
+      { root: '/y/A', label: 'A', group: 'y' },
+    ],
+    '/x/A',
+  );
+  assert.match(html, /<optgroup label="x">/);
+  assert.match(html, /<optgroup label="y">/);
+  assert.strictEqual(html.match(/<\/optgroup>/g)?.length, 2);
+});
+
+test('closes the last group before the problems no contest claimed', () => {
+  // The order `problemChoices` yields: every contested problem first, the loose
+  // ones last. The loose options must land outside the group, and the group
+  // must still be closed -- which is the one sequence a single-pass
+  // open-on-change loop can get wrong.
+  const html = renderSelector(
+    [
+      { root: '/x/A', label: 'A', group: 'x' },
+      { root: '/x/B', label: 'B', group: 'x' },
+      { root: '/loose', label: 'loose' },
+    ],
+    '/x/A',
+  );
+  assert.strictEqual(html.match(/<optgroup label="x">/g)?.length, 1);
+  assert.strictEqual(html.match(/<\/optgroup>/g)?.length, 1);
+  assert.match(html, /<\/optgroup><option value="\/loose">loose<\/option>/);
+});
+
+test('escapes a label and a root', () => {
+  const html = renderSelector(
+    [
+      { root: '/a"b', label: '<script>' },
+      { root: '/c', label: 'c' },
+    ],
+    '/c',
+  );
+  assert.strictEqual(html.includes('<script>'), false);
+  assert.strictEqual(html.includes('"/a"b"'), false);
+});
+
+test('the dot takes the colour of the selected problem, escaped', () => {
+  const html = renderSelector(
+    [
+      { root: '/c/A', label: 'A', color: 'red' },
+      { root: '/c/B', label: 'B', color: 'blue"' },
+    ],
+    '/c/B',
+  );
+  assert.match(html, /class="selector-dot" style="background:blue&quot;"/);
+});
+
+test('a selected problem with no colour renders no dot', () => {
+  const html = renderSelector(
+    [
+      { root: '/c/A', label: 'A' },
+      { root: '/c/B', label: 'B' },
+    ],
+    '/c/A',
+  );
+  assert.strictEqual(html.includes('selector-dot'), false);
 });
 
 // Every verdict short name in outcome.ts, plus the pending and unknown ones.

--- a/vscode/src/webview/render.test.ts
+++ b/vscode/src/webview/render.test.ts
@@ -466,9 +466,11 @@ test('the detail card omits maxima it does not have', () => {
 
 test('the empty model renders the welcome copy that viewsWelcome used to hold', () => {
   const html = renderTree(model([]), state());
-  assert.ok(html.includes('No rbx run found in this workspace.'), html);
+  // One problem's, not the workspace's: nine of ten problems having run says
+  // nothing about the one on screen.
+  assert.ok(html.includes('No rbx run found for this problem.'), html);
   assert.ok(
-    html.includes('Run <code>rbx run</code> in the terminal and the results will show up here.'),
+    html.includes('Run <code>rbx run</code> in its directory and the results will show up here.'),
     html,
   );
   assert.ok(!html.includes('class="row'), html);

--- a/vscode/src/webview/render.ts
+++ b/vscode/src/webview/render.ts
@@ -13,6 +13,7 @@
  * events, focus, persistence -- precisely because that part cannot be tested,
  * which is why nothing that decides anything is allowed to live there.
  */
+import type { ProblemChoice } from '../rbx/problems';
 import type {
   GroupMismatch,
   HistogramSlice,
@@ -665,6 +666,58 @@ export function renderFilter(state: UiState): string {
   return (
     '<div class="filter">' +
     `<input id="filter" type="search" placeholder="Filter" value="${escapeAttr(state.filter)}">` +
+    '</div>'
+  );
+}
+
+/**
+ * The problem dropdown.
+ *
+ * Hidden for a single problem: a select with one option is a control that
+ * cannot do anything, and a one-problem workspace should look exactly as it did
+ * before the selector existed.
+ *
+ * The colour dot is a `style` attribute, which the CSP permits on styles only
+ * (see the note in runView.ts) -- and the value is a colour a contest author
+ * wrote, so it goes through `escapeAttr` like everything else.
+ */
+export function renderSelector(problems: readonly ProblemChoice[], selected?: string): string {
+  if (problems.length <= 1) {
+    return '';
+  }
+  const option = (problem: ProblemChoice): string =>
+    `<option value="${escapeAttr(problem.root)}"${problem.root === selected ? ' selected' : ''}>` +
+    escapeHtml(problem.label) +
+    '</option>';
+
+  // One pass, opening a group when it changes and closing the one before it.
+  // Safe only because `problemChoices` sorts by group: a grouped and an
+  // ungrouped run cannot interleave, so a group is never reopened. The tail of
+  // ungrouped options -- the packages no contest claimed, which `problemChoices`
+  // puts last -- closes the final group on the way past and needs no close at
+  // the end, which is why the trailing close is conditional on `openGroup`.
+  let body = '';
+  let openGroup: string | undefined;
+  for (const problem of problems) {
+    if (problem.group !== openGroup) {
+      body += openGroup === undefined ? '' : '</optgroup>';
+      openGroup = problem.group;
+      body += openGroup === undefined ? '' : `<optgroup label="${escapeAttr(openGroup)}">`;
+    }
+    body += option(problem);
+  }
+  body += openGroup === undefined ? '' : '</optgroup>';
+
+  const dot = problems.find((problem) => problem.root === selected)?.color;
+  return (
+    '<div class="selector">' +
+    (dot === undefined
+      ? ''
+      : `<span class="selector-dot" style="background:${escapeAttr(dot)}"></span>`) +
+    // Named outright rather than by a visible `<label>`: the sidebar has no
+    // room for one, and a screen reader announcing an unnamed combo box leaves
+    // the user to guess what the option list is a list of.
+    `<select id="problem" aria-label="Problem">${body}</select>` +
     '</div>'
   );
 }

--- a/vscode/src/webview/render.ts
+++ b/vscode/src/webview/render.ts
@@ -558,8 +558,11 @@ export function visibleRows(model: RunViewModel, state: UiState): Row[] {
 /** The welcome text, verbatim from the `viewsWelcome` block it replaces. */
 const WELCOME =
   '<div class="welcome">' +
-  '<p>No rbx run found in this workspace.</p>' +
-  '<p>Run <code>rbx run</code> in the terminal and the results will show up here.</p>' +
+  // Not "in this workspace": the view is one problem's now, and in a contest
+  // where nine problems have run and the selected one has not, a sentence about
+  // the workspace is simply false.
+  '<p>No rbx run found for this problem.</p>' +
+  '<p>Run <code>rbx run</code> in its directory and the results will show up here.</p>' +
   '</div>';
 
 /**
@@ -679,7 +682,10 @@ export function renderFilter(state: UiState): string {
  *
  * The colour dot is a `style` attribute, which the CSP permits on styles only
  * (see the note in runView.ts) -- and the value is a colour a contest author
- * wrote, so it goes through `escapeAttr` like everything else.
+ * wrote, so it goes through `escapeAttr` like everything else. Escaping alone
+ * would not be enough: a declared colour needs no markup to be a whole extra
+ * declaration, which is why `contest.ts` drops anything that is not a colour
+ * before it ever gets here.
  */
 export function renderSelector(problems: readonly ProblemChoice[], selected?: string): string {
   if (problems.length <= 1) {

--- a/vscode/src/webview/style.css
+++ b/vscode/src/webview/style.css
@@ -109,6 +109,43 @@ body {
   background: var(--vscode-button-secondaryHoverBackground);
 }
 
+.selector {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+}
+
+/* The contest's own colour, so the two contests open in one window are told
+   apart by the same mark the Explorer badges them with. `flex: none` because a
+   circle that a long problem name squeezed into an ellipse would read as a
+   different mark. */
+.selector-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+/* `min-width: 0` because a `<select>` defaults to `min-width: auto` and would
+   refuse to shrink below its longest option, pushing the dot off a narrow
+   sidebar rather than truncating the name. */
+.selector select {
+  flex: 1;
+  min-width: 0;
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--vscode-dropdown-foreground);
+  background: var(--vscode-dropdown-background);
+  border: 1px solid var(--vscode-dropdown-border, transparent);
+  padding: 2px 4px;
+}
+
+.selector select:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+}
+
 .filter {
   padding: 4px 8px;
 }


### PR DESCRIPTION
## The problem

The Run view rendered **every** problem package in the workspace at once. For a ten-problem contest that meant one long scrollable list whose only narrowing tool was the filter box — and three things made it worse than mere length:

- **No contest awareness.** `contest.rbx.yml` appeared nowhere under `vscode/`. Packages sorted lexicographically by absolute path and were labelled by directory name, so the `short_name` (the A/B/C letter), the contest's declared order and the per-problem `color` were all unused. A contest read as N unrelated directories that happened to be nearby.
- **The header summary leaked across packages.** `mismatches` and `warned` were computed over every row of every package, so the strip reported a workspace-wide number rather than one about the problem being read.
- **Every package was parsed on every event.** `loadAll` re-read all packages whenever any one of them changed.

## What this does

The Run view now shows **one problem**, chosen from a dropdown in its header, and follows whichever problem is currently running.

- The dropdown reads `A · sum-of-pairs`, `B · apples` — the contest letter paired with the package's declared `name:`, in the contest's declared order, with the declared colour as a dot. It is hidden entirely for a single-package workspace, which therefore looks exactly as it did before.
- **Auto-switch follows the running problem.** rbx writes `skeleton.yml` when a run *begins* (`solutions.py` — "A new skeleton is what marks a new run"), so `rbx contest each run` walks the view through the contest in step with the run rather than jumping to problems that already finished.
- `rbx: Select Problem` does the same from the command palette, for keyboard users.
- The header's mismatch/warning counts now describe the selected problem alone — fixed by construction rather than by patching the arithmetic.
- Only the selected package's artifacts are parsed and serialized, so a ten-problem contest stops paying for nine of them on every watcher tick.

Design and plan: `docs/plans/2026-08-20-vscode-problem-selector-design.md` and `-plan.md`.

## Decisions worth a reviewer's attention

**The name comes from `problem.rbx.yml`'s `name:`, not the directory.** rbx defaults a problem's path to its short name, so a contest laid out the conventional way has its packages in directories literally called `A/`, `B/`, `C/` — a basename would render the useless `A · A`.

**The contest walk is deliberately *not* clamped at the workspace folder.** Setters commonly open `contest/A` directly, which puts `contest.rbx.yml` *above* the workspace root; walking up is exactly what gives those problems their letters. Clamping would regress them to directory names.

**`loadAll` survives, for the Problems panel only.** It was deleted as callerless, then restored when main's compilation findings needed it. The Problems panel is workspace-wide on purpose — a compile error in B must show while you read A, the same way the Explorer badges every package. The run view still loads only the selected problem.

**Explorer badges, the solution lens and the status bar stay workspace-wide.** They draw from `discovered()`, which was deliberately left untouched; narrowing it would silently strip badges off every unselected problem.

**Two dead things removed.** `rbx.packageSearchDepth` was contributed with a default of 3 and read nowhere — discovery has always globbed at unbounded depth — and `IGNORED_DIRS` was exported, unused, and already drifted from the real exclusion glob.

## Bugs caught while building this

- **A backup file could silently override a real contest variant.** `contest.div1.bak.rbx.yml` passed the variant filter and, because `b` < `r`, sorted ahead of `contest.div1.rbx.yml` and won the first-wins merge — showing wrong letters, from a file rbx itself refuses to load. The filter now mirrors rbx's `VARIANT_ID_PATTERN`.
- **The production build was broken and the tests could not see it.** Sharing `EMPTY_MODEL` with the client made `main.ts` value-import `viewModel.ts`, which reaches `solutionLabel.ts` and its `path` import — a node builtin the browser bundle cannot resolve. Tests build through a different esbuild entry and stayed green while `dist/` failed to build. Fixed at the root (one `path.posix.basename` call became the last path segment) and `pretest` now builds the shipped bundles, so a broken build fails `npm run test`.
- **A grouping key that was a guess.** The contest group was derived via `path.dirname(root)`, which is wrong for a nested `path:` — two contests both nesting under `problems/` would render two identically-labelled groups. It now carries the real contest root.

## Merge with main

`origin/main`'s compilation findings (#688) touches nearly the same files. Six conflicts, resolved so that main's feature keeps working in the one-problem world — notably, label trimming still spans solutions **and** findings, because a solution that failed to compile is in neither `solutions` nor the rows and would otherwise trim against a different prefix.

## Verification

- **280 tests pass**, `tsc --noEmit` clean. `pretest` builds the shipped bundles, so the extension and webview bundles are verified too.
- Contest resolution, ordering, labelling and the run model were exercised against a real two-problem contest fixture whose directory names deliberately disagree with the contest order (`apples` sorts before `sum-of-pairs`), so path-order behaviour would visibly fail.
- Several fixes were mutation-verified rather than assumed — reverting the variant-id check, the tie-break comparisons, the group key or the `path` import each fails exactly the test that claims to cover it.

**Not yet done:** the manual Extension Development Host checklist in the plan (Task 8). The highest-value rows are watching `rbx contest each run` walk the view A → B, and confirming Explorer badges still appear on *unselected* problems.

**Note for testing the findings panel:** it needs an rbx built from main. Its Python half landed in #688, so a released rbx writes no `compilation:` section and the panel stays empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9PofLzRZpWxUXabVxpneL
