### PR TITLE
feat(timing): pull inferenceTimeout up to the timing level

### DIFF
--- a/docs/plans/2026-08-21-timing-level-inference-timeout-design.md
+++ b/docs/plans/2026-08-21-timing-level-inference-timeout-design.md
@@ -1,0 +1,83 @@
+# A `timing`-level `inferenceTimeout`
+
+Closes [#694](https://github.com/rsalesc/rbx/issues/694).
+
+## The problem
+
+`inferenceTimeout` is the cap a solution runs under while `rbx time` estimates a
+time limit. It lives under `timing.multipliers`, and it is honoured only when the
+environment estimates with ratios *and* `timeLimitToTle` is set *and* the package
+has a solution to bound the limit from above (`timing.py:_run_for_inference`).
+
+Two things are wrong with that:
+
+1. **It is not a ratio.** The multipliers say what relation the limit must have to
+   the measured times. The cap says how long rbx is willing to wait for a
+   measurement in the first place -- a property of the estimation run, not of the
+   arithmetic that follows it.
+2. **A formula estimate has no cap at all.** Its accepted solutions run unbounded,
+   so one that loops forever hangs `rbx time` with nothing to report. Raising the
+   cap for such a problem is not even expressible: writing
+   `timing.multipliers.inferenceTimeout` in a formula-mode package is rejected,
+   since the environment has no multipliers block to override.
+
+## The change
+
+`inferenceTimeout` becomes a `timing`-level field, in `env.rbx.yml` and in
+`problem.rbx.yml` alike:
+
+```yaml
+timing:
+  inferenceTimeout: 10000
+  multipliers:
+    acToTimeLimit: 2.0
+    timeLimitToTle: 1.5
+```
+
+It applies to **every** estimation run. Semantics per solution are unchanged, and
+now reach the formula path too:
+
+- an upper-bound solution that hits it is dropped from the upper bound, with a
+  warning (and the "the cap bounded this estimate" warning still fires when the
+  resolved limit is above `inferenceTimeout / timeLimitToTle`);
+- a lower-bound solution that hits it is an error -- its measurement is truncated,
+  so it bounds nothing;
+- either way the solution stops there, so its remaining testcases are skipped.
+
+### Resolution
+
+One function, `timing_config.resolve_inference_timeout`, most specific first:
+
+| # | Source |
+| - | ------ |
+| 1 | `problem.rbx.yml` → `timing.inferenceTimeout` |
+| 2 | `problem.rbx.yml` → `timing.multipliers.inferenceTimeout` (deprecated) |
+| 3 | `env.rbx.yml` → `timing.inferenceTimeout` |
+| 4 | `env.rbx.yml` → `timing.multipliers.inferenceTimeout` (deprecated) |
+| 5 | `DEFAULT_INFERENCE_TIMEOUT` (10s) |
+
+The resolved value is carried on `TimingStrategy` next to the formula/multipliers,
+so no consumer re-derives it -- including `rbx time --formula`, whose custom
+formula overrides how the limit is derived but not the cap it is measured under,
+and the MOJ packager, which feeds it to `CALIBRATIONTL`.
+
+### Backwards compatibility
+
+`timing.multipliers.inferenceTimeout` keeps working, in both files, and is marked
+deprecated in the schema. It becomes `Optional` there (it no longer carries the
+10s default, which moved to the resolution above), so a persisted limits profile
+written from now on simply omits it.
+
+Declaring both spellings **in the same file** is a validation error: they are one
+setting, and silently preferring one would hide a typo'd cap. Declaring the new
+one in the problem while the environment still uses the old one is fine -- that is
+rule 1 beating rule 4, and it is how a package migrates ahead of its preset.
+
+## Behavior change
+
+An estimation that was previously uncapped is now capped at 10s by default: a
+formula-mode problem, and a ratio-mode one with no `timeLimitToTle` or no slow
+solutions. A package whose accepted solutions legitimately take longer than that
+now fails the estimate with the message that names the fix
+(`raise inferenceTimeout`). That is the point of the field -- an accepted solution
+that runs longer than rbx is willing to wait was never measured, it was truncated.

--- a/docs/setters/packaging-walkthrough.md
+++ b/docs/setters/packaging-walkthrough.md
@@ -89,7 +89,6 @@ multipliers:
   acToTimeLimit: 2.0
   timeLimitToTle: 1.5
   timeResolution: 100
-  inferenceTimeout: 10000
 ```
 
 You can also add per-language overrides if your contest accepts solutions in multiple

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -40,7 +40,7 @@ solutions and applying the estimation strategy configured in the environment: ei
 
 1. **Displays current profile** -- If a profile already exists for the given name, its current limits are shown.
 2. **Strategy selection** -- You are prompted to choose how to define the time limit (unless `--auto` or `--strategy` is used).
-3. **Solution execution** -- For estimating strategies, the solutions the limit is inferred from are run against all testcases, so that their true execution times can be measured. Accepted solutions run with no time limit enforced; solutions expected to be too slow, which only run when the ratios bound the limit from above, are capped at `inferenceTimeout`.
+3. **Solution execution** -- For estimating strategies, the solutions the limit is inferred from are run against all testcases, so that their true execution times can be measured. Every one of them is capped at [`inferenceTimeout`](#the-estimation-cap); solutions expected to be too slow only run at all when the ratios bound the limit from above.
 4. **Time report** -- The fastest and slowest solution times are shown, along with per-language breakdowns if solutions in multiple languages exist.
 5. **Estimation** -- The ratios (or the formula) are applied to compute the estimated time limit.
 6. **Language groups** -- You are shown every environment language and can place each one into a group, so related languages (e.g. `c`/`cpp`, or `java`/`kotlin`) share a single estimated limit and unrepresented languages inherit a sensible limit instead of falling back to the base. See [Language groups](#language-groups).
@@ -111,7 +111,6 @@ to be too slow are allowed:
 | `acToTimeLimit` | The time limit is **at least** this multiple of the slowest accepted solution. |
 | `timeLimitToTle` | The time limit times this must still fit within the fastest solution expected to be too slow. Omit it to leave the limit unbounded from above. |
 | `timeResolution` | The time limit is rounded up to a multiple of this, in milliseconds. |
-| `inferenceTimeout` | Solutions expected to be too slow are run with this timeout, in milliseconds. One that hits it is dropped from the upper bound, with a warning. |
 
 Unlike a formula, the ratios bound the time limit from **both** sides, so a limit that would
 let a solution meant to time out pass is caught while estimating: when no limit satisfies the
@@ -127,7 +126,6 @@ timing:
     acToTimeLimit: 2.0
     timeLimitToTle: 1.5
     timeResolution: 100
-    inferenceTimeout: 10000
 ```
 
 A single problem can override any subset of them in its `problem.rbx.yml`; the ratios it does
@@ -136,8 +134,42 @@ not mention are inherited from the environment:
 ```yaml
 timing:
   multipliers:
-    inferenceTimeout: 60000   # this problem's solutions are slower than most
+    timeLimitToTle: 2.0   # this problem's slow solutions are further apart
 ```
+
+## The estimation cap
+
+While the limit is being estimated there is no limit to enforce yet, so a solution left to run
+freely could run forever. `timing.inferenceTimeout` is the cap every solution runs under during
+`rbx time`, in milliseconds, whichever strategy estimates the limit -- ratios or formula:
+
+```yaml
+timing:
+  inferenceTimeout: 10000   # ms; defaults to 10s
+```
+
+- A solution expected to be **too slow** that hits the cap is dropped from the upper bound,
+  with a warning: it did not finish, so how long it would have taken is unknown. If the limit
+  then resolves above what the cap alone allows (`inferenceTimeout / timeLimitToTle`), `rbx`
+  says so -- the cap, not the solutions, bounded the estimate.
+- An **accepted** solution that hits it is an error: its measured time is truncated, so it
+  cannot bound the limit from below. Raise the cap, or speed the solution up.
+
+Either way, the solution stops there: its remaining testcases are skipped, since they would
+measure nothing usable.
+
+A single problem can raise it in its `problem.rbx.yml`:
+
+```yaml
+timing:
+  inferenceTimeout: 60000   # this problem's solutions are slower than most
+```
+
+!!! note "The old spelling"
+
+    This used to live under `timing.multipliers`, where it only applied to ratio-based
+    estimation. That spelling still works in both files, but it is deprecated, and declaring
+    both in the same file is an error.
 
 ### Which solutions bound which side
 
@@ -352,7 +384,6 @@ multipliers:
   acToTimeLimit: 2.0
   timeLimitToTle: 1.5
   timeResolution: 100
-  inferenceTimeout: 10000
 
 # How languages were grouped during estimation (presentation-only metadata,
 # written automatically by `rbx time`; never used for limit resolution).

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -190,6 +190,26 @@ Last but not least, you can configure how time limits are estimated when running
 express that exclusivity, so your editor will happily autocomplete both keys — {{rbx}} rejects
 the file at load time.
 
+### The estimation cap
+
+`timing.inferenceTimeout` caps how long any solution may run while the limit is being
+estimated, whichever strategy estimates it:
+
+```yaml
+timing:
+  inferenceTimeout: 10000   # ms; defaults to 10s
+```
+
+A solution expected to be too slow that hits the cap is dropped from the upper bound, with a
+warning; an accepted one that hits it is an error, since its measurement is truncated and
+bounds nothing. Raise it for an environment whose solutions are legitimately slow.
+
+!!! note "The old spelling"
+
+    Before this was a `timing`-level field it lived under `timing.multipliers`, where it only
+    applied to ratio-based estimation. That spelling still works, but it is deprecated, and
+    declaring both in the same file is an error.
+
 ### Ratios
 
 `timing.multipliers` bounds the time limit from both sides:
@@ -200,15 +220,12 @@ timing:
     acToTimeLimit: 2.0        # required whenever the block is present
     timeLimitToTle: 1.5       # optional; omit to leave the limit unbounded above
     timeResolution: 100       # ms; defaults to 100
-    inferenceTimeout: 10000   # ms; defaults to 10s
 ```
 
 - `acToTimeLimit`: the limit is at least this multiple of the slowest accepted solution.
 - `timeLimitToTle`: the limit times this must still fit within the fastest solution expected
   to be too slow. When it is unset, those solutions are not run at all.
 - `timeResolution`: the limit is rounded up to a multiple of this.
-- `inferenceTimeout`: solutions expected to be too slow are run with this timeout. One that
-  hits it is dropped from the upper bound, with a warning.
 
 If no limit satisfies the ratios, the estimation fails naming the solution that binds each
 side, and nothing is written to the limits profile. A problem may override any subset of the

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -359,6 +359,9 @@ class LanguageGroup(BaseModel):
 
 DEFAULT_TIMING_FORMULA = 'step_up(max(fastest * 3, slowest * 1.5), 100)'
 
+# The cap enforced on solutions during estimation when nothing configures one.
+DEFAULT_INFERENCE_TIMEOUT = 10000
+
 
 class TimingConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -377,6 +380,15 @@ used.""",
         default=None,
         description="""Ratios used to infer the time limit from the measured
 solutions. Mutually exclusive with `formula`.""",
+    )
+
+    inferenceTimeout: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description="""Time limit (in milliseconds) enforced on every solution run
+while the time limit is estimated, whatever the estimation strategy is. A solution
+expected to be too slow that hits it is dropped from the upper bound; an accepted one
+that hits it is an error. Defaults to 10s.""",
     )
 
     groups: List[LanguageGroup] = Field(
@@ -410,6 +422,19 @@ solutions. Mutually exclusive with `formula`.""",
         return self
 
     @model_validator(mode='after')
+    def _validate_single_inference_timeout(self):
+        if (
+            self.inferenceTimeout is not None
+            and self.multipliers is not None
+            and self.multipliers.inferenceTimeout is not None
+        ):
+            raise ValueError(
+                'timing.inferenceTimeout and timing.multipliers.inferenceTimeout '
+                'are the same setting; keep only timing.inferenceTimeout.'
+            )
+        return self
+
+    @model_validator(mode='after')
     def _validate_exclusive_strategies(self):
         if self.formula is not None and self.multipliers is not None:
             raise ValueError(
@@ -417,6 +442,17 @@ solutions. Mutually exclusive with `formula`.""",
                 'set exactly one of them.'
             )
         return self
+
+    def resolved_inference_timeout(self) -> int:
+        """The cap in effect for this environment, old spelling included."""
+        if self.inferenceTimeout is not None:
+            return self.inferenceTimeout
+        if (
+            self.multipliers is not None
+            and self.multipliers.inferenceTimeout is not None
+        ):
+            return self.multipliers.inferenceTimeout
+        return DEFAULT_INFERENCE_TIMEOUT
 
     def resolved_formula(self) -> Optional[str]:
         """The formula to estimate with, or None when multipliers are in use."""

--- a/rbx/box/packaging/moj/packager.py
+++ b/rbx/box/packaging/moj/packager.py
@@ -94,14 +94,16 @@ def _resolved_multipliers() -> Optional[TimingMultipliers]:
     return strategy.multipliers_or_die()
 
 
-def _inference_timeout_ms() -> Optional[int]:
-    """The cap rbx enforced on a solution while estimating, when there is one.
+def _inference_timeout_ms() -> int:
+    """The cap rbx enforced on a solution while estimating.
 
-    Fed to `CALIBRATIONTL` so calibration waits at least as long as estimation did;
-    a formula-mode problem defines no such cap, and the 5s default stands.
+    Fed to `CALIBRATIONTL` so calibration waits at least as long as estimation did.
+    Every strategy estimates under a cap, formula mode included.
     """
-    multipliers = _resolved_multipliers()
-    return multipliers.inferenceTimeout if multipliers is not None else None
+    return timing_config.resolve_inference_timeout(
+        environment.get_environment().timing,
+        package.find_problem_package_or_die().timing,
+    )
 
 
 def _ac_to_time_limit_or_die() -> float:

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -855,13 +855,12 @@ fastest solution expected to be too slow. When omitted, solutions expected to be
 slow are not run and the time limit is not bounded from above.""",
     )
 
-    inferenceTimeout: int = Field(
-        default=10000,
+    inferenceTimeout: Optional[int] = Field(
+        default=None,
         gt=0,
-        description="""Time limit (in milliseconds) enforced on solutions while
-estimating. Only used when `timeLimitToTle` is set. A solution expected to be too
-slow that hits it is dropped from the upper bound; an accepted one that hits it is
-an error.""",
+        description="""Deprecated: use `timing.inferenceTimeout`, which applies to
+every estimation strategy instead of only to multiplier-based ones. Kept for
+backwards compatibility; setting both is an error.""",
     )
 
     timeResolution: int = Field(
@@ -894,9 +893,9 @@ the estimated time limit from above.""",
     inferenceTimeout: Optional[int] = Field(
         default=None,
         gt=0,
-        description="""Overrides the environment `inferenceTimeout`: the time limit
-(in milliseconds) enforced on solutions while estimating. Raise it for a problem whose
-solutions are slower than the environment expects.""",
+        description="""Deprecated: use `timing.inferenceTimeout`, which applies to
+every estimation strategy instead of only to multiplier-based ones. Kept for
+backwards compatibility; setting both is an error.""",
     )
 
     timeResolution: Optional[int] = Field(
@@ -910,11 +909,33 @@ solutions are slower than the environment expects.""",
 class PackageTiming(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
+    inferenceTimeout: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description="""Overrides the environment `inferenceTimeout`: the time limit
+(in milliseconds) enforced on every solution run while the time limit is estimated,
+whatever the estimation strategy is. Raise it for a problem whose solutions are
+slower than the environment expects.""",
+    )
+
     multipliers: Optional[TimingMultipliersOverride] = Field(
         default=None,
         description="""Per-problem overrides of the environment's timing
 multipliers. Only the declared fields are overridden.""",
     )
+
+    @model_validator(mode='after')
+    def _validate_single_inference_timeout(self):
+        if (
+            self.inferenceTimeout is not None
+            and self.multipliers is not None
+            and self.multipliers.inferenceTimeout is not None
+        ):
+            raise ValueError(
+                'timing.inferenceTimeout and timing.multipliers.inferenceTimeout '
+                'are the same setting; keep only timing.inferenceTimeout.'
+            )
+        return self
 
 
 class TimingGroupOrigin(str, enum.Enum):

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -556,8 +556,12 @@ def _describe_strategy(strategy: timing_config.TimingStrategy) -> str:
     is the single most important fact about such a run, so it is spelled out
     instead of merely omitted.
     """
+    cap_line = (
+        f'  every solution runs capped at {strategy.inferenceTimeout} ms '
+        f'(inferenceTimeout)'
+    )
     if not strategy.uses_multipliers:
-        return f'Using formula: {strategy.formula_or_die()}'
+        return f'Using formula: {strategy.formula_or_die()}\n{cap_line}'
     multipliers = strategy.multipliers_or_die()
     lines = [
         'Using ratios:',
@@ -567,8 +571,7 @@ def _describe_strategy(strategy: timing_config.TimingStrategy) -> str:
     if multipliers.timeLimitToTle is not None:
         lines.append(
             f'  and at most 1/{multipliers.timeLimitToTle} of the fastest solution '
-            f'expected to be too slow (timeLimitToTle); those solutions run '
-            f'capped at {multipliers.inferenceTimeout} ms (inferenceTimeout)'
+            f'expected to be too slow (timeLimitToTle)'
         )
     else:
         lines.append(
@@ -580,6 +583,7 @@ def _describe_strategy(strategy: timing_config.TimingStrategy) -> str:
         f'  rounded up to a multiple of {multipliers.timeResolution} ms '
         f'(timeResolution)'
     )
+    lines.append(cap_line)
     return '\n'.join(lines)
 
 
@@ -786,20 +790,23 @@ async def estimate_time_limit(
 
 @dataclasses.dataclass(frozen=True)
 class _InferenceCap:
-    """The cap a capped estimation run enforced, with the ratio that justifies it.
+    """The cap an estimation run enforced, with the ratio that justifies it.
 
-    Its presence *is* the answer to "was this run capped?", so no caller has to
-    re-derive that from a timelimit override or re-narrow an optional
-    multipliers block.
+    Every estimation run is capped -- the cap is a property of the estimation,
+    not of the multipliers -- but only a run that bounds the limit from above has
+    a `timeLimitToTle` to weigh a dropped solution against.
     """
 
     timeout: int
-    time_limit_to_tle: float
+    time_limit_to_tle: Optional[float] = None
 
     @property
     def largest_bounded_limit(self) -> int:
         """The largest limit a solution stopped at the cap could still justify.
         Above it, the cap -- not the solution -- is what bounded the estimate."""
+        assert self.time_limit_to_tle is not None, (
+            'Only a run bounded from above can drop a solution at the cap.'
+        )
         return math.floor(self.timeout / _exact(self.time_limit_to_tle))
 
 
@@ -994,8 +1001,8 @@ class _InferenceRun:
 
     result: RunSolutionResult
     strategy: timing_config.TimingStrategy
-    # The cap this run enforced, or None when it ran unbounded.
-    cap: Optional[_InferenceCap] = None
+    # The cap this run enforced. Always present: every run is capped.
+    cap: _InferenceCap
     # Slow solutions the cap stopped, so they measure nothing usable.
     dropped_upper: List[Solution] = dataclasses.field(default_factory=list)
 
@@ -1011,14 +1018,19 @@ class _InferenceRun:
 def _resolve_inference_strategy(
     formula: Optional[str],
 ) -> timing_config.TimingStrategy:
+    env_timing = environment.get_environment().timing
+    package_timing = package.find_problem_package_or_die().timing
     # A formula passed in here is the CLI's custom-formula escape hatch: it forces
     # the formula path for this run regardless of what the environment configures.
+    # The cap is not part of that escape hatch -- it still comes from the config.
     if formula is not None:
-        return timing_config.TimingStrategy(formula=formula)
-    return timing_config.resolve_strategy(
-        environment.get_environment().timing,
-        package.find_problem_package_or_die().timing,
-    )
+        return timing_config.TimingStrategy(
+            formula=formula,
+            inferenceTimeout=timing_config.resolve_inference_timeout(
+                env_timing, package_timing
+            ),
+        )
+    return timing_config.resolve_strategy(env_timing, package_timing)
 
 
 async def _run_for_inference(
@@ -1039,19 +1051,18 @@ async def _run_for_inference(
         raise MissingLowerBoundError(_NO_LOWER_BOUND_MESSAGE)
 
     upper_solutions: List[Solution] = []
-    cap: Optional[_InferenceCap] = None
-    if multipliers is not None and multipliers.timeLimitToTle is not None:
+    time_limit_to_tle = multipliers.timeLimitToTle if multipliers is not None else None
+    if time_limit_to_tle is not None:
         # The slow solutions are only worth running when their timings bound
-        # something, and they only terminate under a cap.
+        # something -- and they only terminate because of the cap below.
         upper_solutions = get_inference_solutions(InferenceRole.UPPER)
-        if upper_solutions:
-            cap = _InferenceCap(
-                timeout=multipliers.inferenceTimeout,
-                time_limit_to_tle=multipliers.timeLimitToTle,
-            )
-        # With no slow solution there is nothing to bound the limit from above,
-        # so the cap would buy nothing and only add a way for a legitimately
-        # slow accepted solution to fail the estimate.
+    # Every estimation run is capped, whatever it estimates with: a solution that
+    # outruns the cap measures nothing usable, and waiting on it forever measures
+    # nothing either.
+    cap = _InferenceCap(
+        timeout=strategy.inferenceTimeout,
+        time_limit_to_tle=time_limit_to_tle if upper_solutions else None,
+    )
 
     status = (
         'Running solutions for time estimation...'
@@ -1070,17 +1081,13 @@ async def _run_for_inference(
             # doubling the limit here would double the very cap that exists to
             # bound the solutions running under it.
             verification=_INFERENCE_VERIFICATION,
-            timelimit_override=cap.timeout if cap is not None else -1,
+            timelimit_override=cap.timeout,
             nruns=runs,
             # A solution killed at the cap has its measurement dropped either
             # way -- an upper-bound one bounds nothing, a lower-bound one fails
             # the estimate outright -- so its remaining tests only cost wall
-            # clock. With no cap there is no timeout to hit.
-            abort_on=(
-                (lambda ctx: ctx.evaluation.result.outcome.is_slow())
-                if cap is not None
-                else None
-            ),
+            # clock.
+            abort_on=lambda ctx: ctx.evaluation.result.outcome.is_slow(),
         )
 
     console.console.print()
@@ -1099,12 +1106,10 @@ async def _run_for_inference(
         gating_solutions={str(solution.path) for solution in lower_solutions},
     )
 
-    dropped_upper: List[Solution] = []
-    if cap is not None:
-        diagnosis = await _diagnose_inference_run(result)
-        if not _report_inference_diagnosis(diagnosis, cap):
-            return None
-        dropped_upper = diagnosis.dropped_upper
+    diagnosis = await _diagnose_inference_run(result)
+    if not _report_inference_diagnosis(diagnosis, cap):
+        return None
+    dropped_upper = diagnosis.dropped_upper
 
     if not ok:
         console.console.print(
@@ -1150,8 +1155,7 @@ async def compute_time_limits(
     if estimated_tl is None:
         return None
 
-    if run.cap is not None:
-        _warn_if_the_cap_bounded_the_estimate(estimated_tl, run.cap, run.dropped_upper)
+    _warn_if_the_cap_bounded_the_estimate(estimated_tl, run.cap, run.dropped_upper)
 
     limits_path = package.get_limits_file(profile)
     console.console.print(

--- a/rbx/box/timing_config.py
+++ b/rbx/box/timing_config.py
@@ -2,14 +2,15 @@
 
 The environment picks between a formula and a set of multipliers, and a problem
 may override any subset of the multipliers. This module owns that decision so
-that callers do not have to re-derive which of the two modes is active.
+that callers do not have to re-derive which of the two modes is active, and it
+resolves the estimation cap (`inferenceTimeout`), which applies to both modes.
 """
 
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from rbx.box.environment import TimingConfig
+from rbx.box.environment import DEFAULT_INFERENCE_TIMEOUT, TimingConfig
 from rbx.box.exception import RbxException
 from rbx.box.schema import PackageTiming, TimingMultipliers
 
@@ -24,12 +25,24 @@ class TimingStrategyError(RbxException):
 
 
 class TimingStrategy(BaseModel):
-    """How to estimate a time limit. Exactly one of the fields is set."""
+    """How to estimate a time limit.
+
+    Exactly one of `formula` and `multipliers` is set; `inferenceTimeout` applies
+    to both.
+    """
 
     model_config = ConfigDict(extra='forbid', frozen=True)
 
     formula: Optional[str] = None
     multipliers: Optional[TimingMultipliers] = None
+
+    inferenceTimeout: int = Field(
+        default=DEFAULT_INFERENCE_TIMEOUT,
+        gt=0,
+        description="""The cap enforced on every solution run while estimating.
+It is a property of the estimation, not of the multipliers, so it is resolved even
+in formula mode.""",
+    )
 
     @model_validator(mode='after')
     def _validate_exactly_one_strategy(self):
@@ -82,12 +95,39 @@ def resolve_multipliers(
     return TimingMultipliers(**merged)
 
 
+def resolve_inference_timeout(
+    env_timing: TimingConfig,
+    package_timing: Optional[PackageTiming],
+) -> int:
+    """The cap in effect for this problem, most specific declaration first.
+
+    The `timing`-level spelling wins over the deprecated `timing.multipliers` one,
+    and the problem wins over the environment. Unlike the multipliers, this is
+    resolved whatever the estimation strategy is, so a formula-mode problem can
+    raise it too.
+    """
+    if package_timing is not None:
+        if package_timing.inferenceTimeout is not None:
+            return package_timing.inferenceTimeout
+        if (
+            package_timing.multipliers is not None
+            and package_timing.multipliers.inferenceTimeout is not None
+        ):
+            return package_timing.multipliers.inferenceTimeout
+    return env_timing.resolved_inference_timeout()
+
+
 def resolve_strategy(
     env_timing: TimingConfig,
     package_timing: Optional[PackageTiming],
 ) -> TimingStrategy:
     """The estimation strategy in effect for this problem."""
     multipliers = resolve_multipliers(env_timing, package_timing)
+    inference_timeout = resolve_inference_timeout(env_timing, package_timing)
     if multipliers is not None:
-        return TimingStrategy(multipliers=multipliers)
-    return TimingStrategy(formula=env_timing.resolved_formula())
+        return TimingStrategy(
+            multipliers=multipliers, inferenceTimeout=inference_timeout
+        )
+    return TimingStrategy(
+        formula=env_timing.resolved_formula(), inferenceTimeout=inference_timeout
+    )

--- a/rbx/resources/presets/default/env.rbx.yml
+++ b/rbx/resources/presets/default/env.rbx.yml
@@ -3,17 +3,19 @@ sandbox: "stupid"
 timing:
   wallTimeMultiplier: 2.0
   wallTimeIncrement: 500
+  # Cap (in ms) every solution runs under while the time limit is estimated,
+  # whatever it is estimated with. A solution expected to be too slow that hits
+  # it bounds nothing from above; an accepted one that hits it is an error.
+  inferenceTimeout: 10000
   multipliers:
     # Ratios the estimated time limit must satisfy. It is at least
     # `acToTimeLimit` times the slowest accepted solution, and small enough that
     # `timeLimitToTle` times the limit still fits within the fastest solution
     # expected to be too slow. The estimate is rounded up to a multiple of
-    # `timeResolution`, and solutions expected to be too slow are run with
-    # `inferenceTimeout` (in ms) as their cap while estimating.
+    # `timeResolution`.
     acToTimeLimit: 2.0
     timeLimitToTle: 1.5
     timeResolution: 100
-    inferenceTimeout: 10000
   groups:
     # c and cpp are left ungrouped: they share the leftover pool and are
     # estimated together from their accepted-solution timings.

--- a/tests/e2e/testdata/inference-abort/problem.rbx.yml
+++ b/tests/e2e/testdata/inference-abort/problem.rbx.yml
@@ -5,11 +5,10 @@ timeLimit: 300
 memoryLimit: 256
 
 timing:
-  multipliers:
-    # Small enough to keep the scenario quick: the hopeless solution is killed
-    # at the cap on the very first testcase, and the ones after it are skipped
-    # instead of costing another cap each.
-    inferenceTimeout: 500
+  # Small enough to keep the scenario quick: the hopeless solution is killed at
+  # the cap on the very first testcase, and the ones after it are skipped
+  # instead of costing another cap each.
+  inferenceTimeout: 500
 
 generators:
   - name: gen

--- a/tests/rbx/box/test_environment_multipliers.py
+++ b/tests/rbx/box/test_environment_multipliers.py
@@ -11,7 +11,8 @@ from rbx.box.environment import (
 def test_multipliers_defaults():
     m = TimingMultipliers(acToTimeLimit=2.0)
     assert m.timeLimitToTle is None
-    assert m.inferenceTimeout == 10000
+    # Deprecated here: the cap is resolved from `timing.inferenceTimeout`.
+    assert m.inferenceTimeout is None
     assert m.timeResolution == 100
 
 

--- a/tests/rbx/box/test_timing.py
+++ b/tests/rbx/box/test_timing.py
@@ -411,8 +411,10 @@ class TestComputeTimeLimits:
     @mock.patch('rbx.box.timing.run_solutions')
     @mock.patch('rbx.box.timing.print_run_report')
     @mock.patch('rbx.box.timing.estimate_time_limit')
+    @mock.patch('rbx.box.timing.consume_and_key_evaluation_items', return_value={})
     async def test_compute_time_limits_success(
         self,
+        mock_consume_evaluations,
         mock_estimate_time_limit,
         mock_print_run_report,
         mock_run_solutions,
@@ -454,8 +456,10 @@ class TestComputeTimeLimits:
     @mock.patch('rbx.box.timing.get_inference_solutions')
     @mock.patch('rbx.box.timing.run_solutions')
     @mock.patch('rbx.box.timing.print_run_report')
+    @mock.patch('rbx.box.timing.consume_and_key_evaluation_items', return_value={})
     async def test_compute_time_limits_failed_run_report(
         self,
+        mock_consume_evaluations,
         mock_print_run_report,
         mock_run_solutions,
         mock_get_inference_solutions,
@@ -470,6 +474,7 @@ class TestComputeTimeLimits:
         mock_get_inference_solutions.side_effect = only_lower_bound([mock_solution])
 
         mock_result = mock.Mock()
+        mock_result.skeleton.solutions = [mock_solution]
         mock_run_solutions.return_value = mock_result
 
         # Mock print_run_report to return False (failure)
@@ -523,8 +528,10 @@ class TestTimingIntegration:
     @mock.patch('rbx.box.timing.run_solutions')
     @mock.patch('rbx.box.timing.print_run_report')
     @mock.patch('rbx.box.timing.estimate_time_limit')
+    @mock.patch('rbx.box.timing.consume_and_key_evaluation_items', return_value={})
     async def test_timing_with_real_problem(
         self,
+        mock_consume_evaluations,
         mock_estimate_time_limit,
         mock_print_run_report,
         mock_run_solutions,

--- a/tests/rbx/box/test_timing_config.py
+++ b/tests/rbx/box/test_timing_config.py
@@ -1,6 +1,11 @@
 import pytest
+from pydantic import ValidationError
 
-from rbx.box.environment import DEFAULT_TIMING_FORMULA, TimingConfig
+from rbx.box.environment import (
+    DEFAULT_INFERENCE_TIMEOUT,
+    DEFAULT_TIMING_FORMULA,
+    TimingConfig,
+)
 from rbx.box.exception import RbxException
 from rbx.box.schema import (
     PackageTiming,
@@ -10,6 +15,7 @@ from rbx.box.schema import (
 from rbx.box.timing_config import (
     TimingStrategy,
     TimingStrategyError,
+    resolve_inference_timeout,
     resolve_multipliers,
     resolve_strategy,
 )
@@ -131,3 +137,79 @@ def test_strategy_requires_exactly_one_mode():
             formula='slowest * 2',
             multipliers=TimingMultipliers(acToTimeLimit=2.0),
         )
+
+
+def test_inference_timeout_defaults_when_nothing_declares_one():
+    assert resolve_inference_timeout(TimingConfig(), None) == DEFAULT_INFERENCE_TIMEOUT
+
+
+def test_environment_inference_timeout_applies_in_formula_mode():
+    env = TimingConfig(formula='slowest * 2', inferenceTimeout=30000)
+    assert resolve_inference_timeout(env, None) == 30000
+    assert resolve_strategy(env, None) == TimingStrategy(
+        formula='slowest * 2', inferenceTimeout=30000
+    )
+
+
+def test_the_deprecated_spelling_still_configures_the_cap():
+    env = TimingConfig(
+        multipliers=TimingMultipliers(acToTimeLimit=2.0, inferenceTimeout=25000)
+    )
+    assert resolve_inference_timeout(env, None) == 25000
+    assert resolve_strategy(env, None).inferenceTimeout == 25000
+
+
+def test_the_problem_overrides_the_environment_cap():
+    env = TimingConfig(formula='slowest * 2', inferenceTimeout=30000)
+    pkg = PackageTiming(inferenceTimeout=45000)
+    assert resolve_inference_timeout(env, pkg) == 45000
+
+
+def test_the_problem_overrides_the_cap_of_a_multipliers_environment():
+    env = TimingConfig(
+        multipliers=TimingMultipliers(acToTimeLimit=2.0, inferenceTimeout=25000)
+    )
+    pkg = PackageTiming(inferenceTimeout=45000)
+    assert resolve_strategy(env, pkg).inferenceTimeout == 45000
+
+
+def test_the_deprecated_problem_spelling_still_overrides_the_environment():
+    env = TimingConfig(
+        multipliers=TimingMultipliers(acToTimeLimit=2.0), inferenceTimeout=25000
+    )
+    pkg = PackageTiming(multipliers=TimingMultipliersOverride(inferenceTimeout=45000))
+    assert resolve_inference_timeout(env, pkg) == 45000
+
+
+def test_the_timing_level_spelling_wins_over_the_deprecated_one():
+    # They cannot be declared together in one file, but a problem raising the cap
+    # the new way must not be undercut by an environment still on the old one.
+    env = TimingConfig(
+        multipliers=TimingMultipliers(acToTimeLimit=2.0, inferenceTimeout=25000)
+    )
+    pkg = PackageTiming(inferenceTimeout=1000)
+    assert resolve_inference_timeout(env, pkg) == 1000
+
+
+def test_declaring_the_cap_twice_in_the_environment_is_an_error():
+    with pytest.raises(ValidationError, match='keep only timing.inferenceTimeout'):
+        TimingConfig(
+            inferenceTimeout=1000,
+            multipliers=TimingMultipliers(acToTimeLimit=2.0, inferenceTimeout=2000),
+        )
+
+
+def test_declaring_the_cap_twice_in_the_problem_is_an_error():
+    with pytest.raises(ValidationError, match='keep only timing.inferenceTimeout'):
+        PackageTiming(
+            inferenceTimeout=1000,
+            multipliers=TimingMultipliersOverride(inferenceTimeout=2000),
+        )
+
+
+def test_a_formula_environment_accepts_a_problem_cap():
+    # The whole point of pulling the field up: raising the cap no longer drags in
+    # a multipliers block the environment does not have.
+    env = TimingConfig(formula='slowest * 2')
+    strategy = resolve_strategy(env, PackageTiming(inferenceTimeout=45000))
+    assert strategy == TimingStrategy(formula='slowest * 2', inferenceTimeout=45000)

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -32,7 +32,12 @@ def _formula(formula: str) -> TimingStrategy:
 
 
 def _multipliers(**kwargs) -> TimingStrategy:
-    return TimingStrategy(multipliers=TimingMultipliers(**kwargs))
+    # `inferenceTimeout` belongs to the strategy, not to the ratios.
+    inference_timeout = kwargs.pop('inferenceTimeout', None)
+    strategy_kwargs = (
+        {} if inference_timeout is None else {'inferenceTimeout': inference_timeout}
+    )
+    return TimingStrategy(multipliers=TimingMultipliers(**kwargs), **strategy_kwargs)
 
 
 def _measured_groups(profile_kwargs) -> Dict[int, GroupMeasurements]:
@@ -383,7 +388,10 @@ def test_no_lower_bound_measurements_raise_a_setter_facing_error():
 
 
 def test_strategy_is_described_as_a_formula_or_as_ratios():
-    assert _describe_strategy(_formula('slowest * 2')) == 'Using formula: slowest * 2'
+    formula_described = _describe_strategy(_formula('slowest * 2'))
+    assert 'Using formula: slowest * 2' in formula_described
+    # The cap applies to a formula estimate too, so it is spelled out there.
+    assert 'capped at 10000 ms (inferenceTimeout)' in formula_described
     described = _describe_strategy(
         _multipliers(
             acToTimeLimit=2.0,

--- a/tests/rbx/box/test_timing_inference_run.py
+++ b/tests/rbx/box/test_timing_inference_run.py
@@ -165,17 +165,20 @@ def pkg(testing_pkg: testing_package.TestingPackage):
     return testing_pkg
 
 
-async def test_formula_mode_runs_only_lower_solutions_uncapped(pkg):
+async def test_formula_mode_runs_only_lower_solutions_under_the_cap(pkg):
     ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
     tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
     run, result = await _compute(
         pkg,
-        timing_config=TimingConfig(formula='slowest * 2'),
+        timing_config=TimingConfig(formula='slowest * 2', inferenceTimeout=7000),
         lower=[ac],
         upper=[tle],
     )
     assert run.tracked == [str(ac.path)]
-    assert run.timelimit_override == -1
+    # A formula estimate has no upper bound to run the slow solutions for, but
+    # the cap is a property of the estimation, not of the ratios: it still
+    # bounds how long the accepted solutions may run.
+    assert run.timelimit_override == 7000
     assert result is not None
 
 
@@ -191,7 +194,7 @@ async def test_multipliers_without_tle_ratio_runs_only_lower_solutions(pkg):
         upper=[tle],
     )
     assert run.tracked == [str(ac.path)]
-    assert run.timelimit_override == -1
+    assert run.timelimit_override == 7000
     # Nothing about the run differs from the formula path: every solution that
     # ran still gates the report, and nothing was dropped.
     assert run.print_run_report.call_args.kwargs['gating_solutions'] == set(run.tracked)
@@ -221,11 +224,10 @@ async def test_multipliers_with_tle_ratio_runs_both_capped(pkg):
     assert run.timelimit_override == 7000
 
 
-async def test_multipliers_with_tle_ratio_but_no_slow_solutions_stay_uncapped(pkg):
+async def test_multipliers_with_tle_ratio_but_no_slow_solutions_still_cap(pkg):
     # The path most existing packages take once the default preset ships
-    # timeLimitToTle: nothing bounds the limit from above, so the cap would buy
-    # nothing and only add a way for a legitimately slow accepted solution to
-    # fail the estimate.
+    # timeLimitToTle: nothing bounds the limit from above, so there is nothing
+    # to drop -- but the accepted solutions still run under the cap.
     ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
     run, result = await _compute(
         pkg,
@@ -238,8 +240,8 @@ async def test_multipliers_with_tle_ratio_but_no_slow_solutions_stay_uncapped(pk
         upper=[],
     )
     assert run.tracked == [str(ac.path)]
-    assert run.timelimit_override == -1
-    # And with no cap there is nothing to diagnose.
+    assert run.timelimit_override == 7000
+    # With no slow solution there is nothing to drop from the upper bound.
     assert result is not None
     assert run.estimate.call_args.kwargs['dropped_upper_per_language'] == {}
 
@@ -250,14 +252,17 @@ async def test_custom_formula_forces_formula_mode_over_multipliers(pkg):
     run, _ = await _compute(
         pkg,
         timing_config=TimingConfig(
-            multipliers=TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5)
+            inferenceTimeout=6000,
+            multipliers=TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
         ),
         lower=[ac],
         upper=[tle],
         formula='slowest * 3',
     )
     assert run.tracked == [str(ac.path)]
-    assert run.timelimit_override == -1
+    # The custom formula overrides how the limit is derived, not the cap the
+    # solutions are measured under -- that still comes from the configuration.
+    assert run.timelimit_override == 6000
     assert run.estimate.call_args.args[2].formula == 'slowest * 3'
 
 
@@ -409,6 +414,26 @@ async def test_a_lower_solution_at_the_cap_is_an_error(pkg, capsys):
     assert '✗' in printed
     assert 'ac.cpp' in printed
     assert 'cannot bound the time limit from below' in printed
+
+
+async def test_a_lower_solution_at_the_cap_is_an_error_in_formula_mode_too(pkg, capsys):
+    # Nothing bounds a formula estimate from above, but a truncated measurement
+    # is just as worthless there: the formula reads the measured times.
+    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
+    run, result = await _compute(
+        pkg,
+        timing_config=TimingConfig(formula='slowest * 2', inferenceTimeout=7000),
+        lower=[ac],
+        upper=[],
+        structured=_structured({ac: [_evaluation(7000, Outcome.TIME_LIMIT_EXCEEDED)]}),
+        run_report_ok=False,
+    )
+    assert result is None
+    run.estimate.assert_not_called()
+    printed = _printed(capsys)
+    assert 'ac.cpp' in printed
+    assert 'cannot bound the time limit from below' in printed
+    assert '7000 ms' in printed
 
 
 async def test_a_lower_solution_failing_for_a_non_timing_reason_uses_the_plain_gate(
@@ -783,9 +808,8 @@ async def _time_a_real_package(*, abort: bool, profile: str) -> _RealRun:
     env = environment.get_environment()
     capped = env.timing.model_copy(
         update={
-            'multipliers': TimingMultipliers(
-                acToTimeLimit=2.0, timeLimitToTle=1.5, inferenceTimeout=500
-            ),
+            'inferenceTimeout': 500,
+            'multipliers': TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
             'formula': None,
         }
     )


### PR DESCRIPTION
Closes #694.

`inferenceTimeout` is the cap a solution runs under while `rbx time` estimates a limit. It lived under `timing.multipliers` and was honoured only when the environment estimated with ratios **and** `timeLimitToTle` was set **and** the package had a slow solution to bound the limit from above. So a formula estimate ran its accepted solutions unbounded — and a formula-mode package could not even express a cap, since overriding `timing.multipliers` there is rejected outright.

## What changed

`timing.inferenceTimeout` now sits next to `formula`/`multipliers`, in `env.rbx.yml` and `problem.rbx.yml` alike:

```yaml
timing:
  inferenceTimeout: 10000
  multipliers:
    acToTimeLimit: 2.0
    timeLimitToTle: 1.5
```

It applies to **every** estimation run. Per-solution semantics are unchanged and now reach the formula path too: an upper-bound solution that hits the cap is dropped from the upper bound with a warning, a lower-bound one that hits it is an error (truncated measurement), and either way the solution stops there instead of burning the cap on every remaining testcase.

Resolution lives in `timing_config.resolve_inference_timeout`, most specific first: problem `timing.inferenceTimeout` → problem `timing.multipliers.inferenceTimeout` → environment `timing.inferenceTimeout` → environment `timing.multipliers.inferenceTimeout` → 10s. The resolved value is carried on `TimingStrategy`, so no consumer re-derives it — including `rbx time --formula` (the custom formula overrides how the limit is derived, not the cap it is measured under) and the MOJ packager, which feeds it to `CALIBRATIONTL` and no longer falls back to 5s in formula mode.

## Backwards compatibility

`timing.multipliers.inferenceTimeout` keeps working in both files and is marked deprecated in the schema. It becomes `Optional` there — the 10s default moved to the resolution above — so newly written limits profiles simply omit it. Declaring both spellings in the *same* file is a validation error naming the fix; declaring the new one in a problem whose environment still uses the old one is fine, which is how a package migrates ahead of its preset.

## Behavior change worth calling out

An estimation that was previously uncapped is now capped at 10s by default (formula mode, and ratio mode with no `timeLimitToTle` or no slow solutions). A package whose accepted solutions legitimately take longer fails the estimate with the message that names the fix. That is the intent of the field: an accepted solution that runs longer than rbx is willing to wait was never measured, it was truncated.

## Testing

- `resolve_inference_timeout` precedence, both deprecated spellings, both duplicate-declaration errors, and a formula environment accepting a problem-level cap — `tests/rbx/box/test_timing_config.py`.
- The estimation run now caps in formula mode, in ratio mode without `timeLimitToTle`, with no slow solutions, and under `--formula`; a lower-bound solution at the cap is an error in formula mode too — `tests/rbx/box/test_timing_inference_run.py`.
- The `inference-abort` e2e fixture moved to the new spelling and still passes unchanged.
- Full suite (`pytest --ignore=tests/rbx/box/cli -n auto`) shows the same failure set as the untouched tree on this machine (63 pre-existing local C++/sandbox/e2e failures, plus one flaky temp-dir test that also fails on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FpN29T3TsWSe1iGr9vsRW
