### PR TITLE
feat(timing): split rbx time into estimation and validation phases

### DIFF
--- a/docs/plans/2026-08-21-time-two-phase-design.md
+++ b/docs/plans/2026-08-21-time-two-phase-design.md
@@ -1,0 +1,144 @@
+# Two-phase `rbx time`
+
+Design for [#693](https://github.com/rsalesc/rbx/issues/693).
+
+## Problem
+
+`rbx time` runs the solutions that bound the limit from below (`inference: lower`,
+the accepted ones) and the solutions that bound it from above (`inference: upper`,
+the ones expected to be too slow) in a single step, all capped at
+`inferenceTimeout`. That single cap serves two incompatible purposes.
+
+For the lower side it is a safety net: an accepted solution that reaches it fails
+the estimate. For the upper side it is the only thing that makes the run
+terminate at all -- a solution expected to be too slow is expected to run
+forever -- and it distorts the measurement it is supposed to produce. A slow
+solution killed at the cap measures nothing, so it bounds nothing
+(`_InferenceRun.dropped_upper`), and one that survives the cap is measured under
+a limit far above the real one. `_warn_if_the_cap_bounded_the_estimate` exists
+only to tell the setter that the estimate they are looking at was decided by the
+cap rather than by their slow solutions.
+
+The upper side does not need to be measured. It needs to be *checked*: given a
+time limit `TL`, every slow solution must take at least `TL * timeLimitToTle`.
+That is a question with a cheap answer, and it can only be asked once `TL` is
+known.
+
+## Shape
+
+Two phases, one compilation. Every solution is still compiled up front.
+
+**Phase 1 -- estimate.** Only the lower-bound solutions run, capped at
+`inferenceTimeout`. The estimate proceeds with an empty upper side, the language
+group picker previews lower bounds only, and a candidate `TimingProfile` comes
+out.
+
+**Phase 2 -- validate.** Each language group `g` has an estimated limit `TL_g`.
+Its slow solutions run at the probe limit
+
+```
+L_g = ceil(TL_g * timeLimitToTle)      # exact Fraction arithmetic
+```
+
+with `abort_on` slow verdicts, so the first TLE ends that solution's run. Each
+slow solution lands in one of two states:
+
+- **TLE at `L_g`** -- validated. Its runtime exceeds `L_g >= TL_g * timeLimitToTle`,
+  which is exactly the constraint `compute_bounds` enforces. It contributes no
+  measurement.
+- **Finished** -- violation, with an exact time. That time feeds
+  `slow_timing_per_solution_per_language` unchanged, so `compute_bounds` and
+  `_check_bounds` produce the existing "no valid time limit exists for this
+  group" diagnostic, naming the binding solution on each side.
+
+The probe limit is chosen so that the two states partition cleanly: a solution
+that finishes within `L_g` is measured exactly and judged by the existing
+`Fraction` comparison, and one that does not finish is known to clear the bound
+without needing a number at all.
+
+## The loop
+
+A violation is not fatal. The measurements phase 2 produced are carried back
+into the picker, which re-opens with real upper bounds -- so the live preview now
+shows infeasible groupings as the user moves through them, using the
+`_check_bounds` machinery that already exists. The picker has three exits:
+
+- **confirm** a new assignment -- phase 2 re-runs against the new limits;
+- **proceed anyway** -- accept the current limits despite the violation;
+- **cancel** -- abandon the estimate, nothing is written.
+
+The loop terminates on any of the three. The profile is written once, after the
+loop settles.
+
+Re-running phase 2 after a re-pick is cheap because knowledge about a slow
+solution is monotone. Per solution we keep either an exact time or a lower bound
+`>= L` from a TLE, and:
+
+- an exact time never needs re-running -- the check is pure arithmetic;
+- a solution that TLE'd at `L` still clears any probe limit `L' <= L`, since a
+  lower limit is a weaker demand.
+
+Only solutions whose new probe limit exceeds what is already known are executed
+again. In practice a re-pick that lowers a group's limit costs nothing.
+
+## Escapes
+
+`--skip-slow` stops after phase 1: the limit is estimated and written with its
+upper bound unchecked, recorded as such in the profile.
+
+Where there is no picker to re-enter -- `--auto`, a single-language problem (the
+picker only opens with two or more languages), or a cancelled picker -- the
+violation is recorded, warned about loudly, and the profile is written anyway.
+This means `rbx time --auto` does not fail on a violated upper bound; the
+violation is visible in the profile and in the console output instead.
+
+## What changes
+
+**`rbx/box/timing.py`**
+
+- `_run_for_inference` is parameterized over the solutions it runs and the cap it
+  enforces, and called once per phase. Phase 1 passes the lower solutions; this
+  is already the code path taken today when `timeLimitToTle` is unset.
+- `_InferenceCap.largest_bounded_limit` and
+  `_warn_if_the_cap_bounded_the_estimate` are deleted. The cap can no longer
+  bound the upper side, because the upper side is no longer in that run.
+- `_diagnose_inference_run`'s `dropped_upper` disappears from phase 1 and is
+  replaced in phase 2 by the validation record below. The verdict that used to
+  mean "unmeasurable, bounds nothing" now means "confirmed too slow".
+- `build_timing_profile` gains a mode in which a violated upper bound is recorded
+  rather than raised, shared by the "proceed anyway" and the no-picker paths.
+- New: the probe-limit computation, the per-solution knowledge cache, and the
+  phase-2 driver that decides what to re-run.
+
+**`rbx/box/schema.py`** -- `TimingGroupReport.droppedUpper` is replaced by a
+validation record: solutions confirmed too slow, solutions that violated (with
+the measured time), and solutions not run. `upperBound` is populated only when a
+violation supplied a real measurement.
+
+**`rbx/box/solutions.py`** -- `run_solutions` gains a per-language time limit
+override. Today `timelimit_override` is a scalar, but phase 2 needs one limit per
+group. `tasks.run_solution_on_testcase` already accepts `limits_override`, so
+this is a plumb through `_get_report_skeleton` and `_run_solution`. Report gating
+inverts in phase 2: the slow solutions gate the report, TLE being the expected
+verdict there.
+
+**`rbx/box/timing_group_picker.py`** -- `GroupAssignment` gains `force: bool`, and
+a key binding exits with it. The binding and its legend line are enabled only
+when the caller reports a violation to override.
+
+`_INFERENCE_VERIFICATION` stays `ALL_SOLUTIONS` in both phases: `FULL` would turn
+on `isDoubleTL` and double the very limits phase 2 probes at.
+`build_preview_renderer`'s `lru_cache` is rebuilt per loop iteration, since the
+measurements it closes over change between iterations.
+
+## Testing
+
+- Probe-limit arithmetic, including the exactness of `ceil(TL * timeLimitToTle)`
+  and the boundary where a solution's time equals `TL * timeLimitToTle`.
+- The knowledge cache's re-run decisions: exact time never re-runs, a TLE at `L`
+  covers any `L' <= L`, a higher `L'` re-runs.
+- `test_timing_inference_run.py` moves from `call_args` to `call_args_list`, with
+  cases pinning the two calls' distinct solution sets and limits.
+- The violation path end to end: phase 2 finds a fast slow solution, the picker
+  re-opens, a re-pick validates, one profile is written.
+- `--skip-slow`, and the no-picker warn-and-write path.

--- a/docs/plans/2026-08-21-time-two-phase.md
+++ b/docs/plans/2026-08-21-time-two-phase.md
@@ -1,0 +1,1013 @@
+# Two-Phase `rbx time` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Split `rbx time` into a phase that estimates the time limit from accepted solutions and a phase that validates the estimate against the solutions expected to be too slow.
+
+**Architecture:** Phase 1 runs only `inference: lower` solutions under `inferenceTimeout` and produces a candidate `TimingProfile`. Phase 2 runs each `inference: upper` solution at `ceil(TL_lang * timeLimitToTle)`, where a TLE confirms the solution is too slow and a finish is a violation carrying an exact measurement. A violation re-opens the language-group picker with those measurements; the user re-picks, forces the current limit through, or cancels. The profile is written once, after that loop settles.
+
+**Tech Stack:** Python 3, Pydantic v2, Typer, prompt_toolkit, pytest, `uv run`.
+
+**Design doc:** [`docs/plans/2026-08-21-time-two-phase-design.md`](2026-08-21-time-two-phase-design.md)
+
+**Background reading before starting:** `rbx/box/CLAUDE.md`, `rbx/grading/CLAUDE.md`, and the design doc above. The whole feature lives in `rbx/box/timing.py` (1248 lines) plus small changes in five other modules; read `timing.py` end to end before Task 4.
+
+**Conventions that apply to every task:**
+- Single quotes. Absolute imports only. `uv run ruff check --fix . && uv run ruff format .` before every commit.
+- Commit with the `/commit` skill's conventional-commit format (`.claude/skills/commit.md`), always with the `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.
+- Run tests with `uv run pytest`. Never run `tests/docker/`.
+- Never mock private functions of the module under test. Prefer asserting over whole objects.
+
+---
+
+### Task 1: Per-language time limit override in `run_solutions`
+
+Phase 2 needs a different enforced limit per language, because each language group gets its own estimated limit. Today `timelimit_override` is a single `int` threaded from `run_solutions` down to `tasks.get_limits_for_language`. Widen it to accept a `{language: limit}` mapping, resolved at the two places that already know the language.
+
+**Files:**
+- Modify: `rbx/box/solutions.py` (`_get_report_skeleton:706`, `_produce_solution_items:795`, `_run_solution:563`, `run_solutions:872`)
+- Test: `tests/rbx/box/test_solutions_timelimit_override.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+"""The enforced time limit may vary per language within one run."""
+
+from typing import Optional
+
+import pytest
+
+from rbx.box import solutions
+
+
+@pytest.mark.parametrize(
+    ('override', 'lang', 'expected'),
+    [
+        (None, 'cpp', None),
+        (1000, 'cpp', 1000),
+        (1000, None, 1000),
+        ({'cpp': 1500, 'py': 4000}, 'cpp', 1500),
+        ({'cpp': 1500, 'py': 4000}, 'py', 4000),
+        # A language the mapping does not mention keeps the profile's own limit.
+        ({'cpp': 1500}, 'java', None),
+        # A mapping cannot be resolved without knowing the language.
+        ({'cpp': 1500}, None, None),
+    ],
+)
+def test_resolve_timelimit_override(override, lang: Optional[str], expected):
+    assert solutions.resolve_timelimit_override(override, lang) == expected
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_solutions_timelimit_override.py -v`
+Expected: FAIL, `AttributeError: module 'rbx.box.solutions' has no attribute 'resolve_timelimit_override'`
+
+**Step 3: Write minimal implementation**
+
+In `rbx/box/solutions.py`, near the top-level type aliases:
+
+```python
+# The enforced time limit for a run: one limit for every language, or one per
+# language. The per-language form exists because a time-limit estimate assigns a
+# different limit to each language group (see `rbx/box/timing.py`).
+TimelimitOverride = Union[int, Mapping[str, int]]
+
+
+def resolve_timelimit_override(
+    override: Optional[TimelimitOverride],
+    lang: Optional[str],
+) -> Optional[int]:
+    """The limit this language runs under, or None to keep the profile's own.
+
+    A mapping that does not mention the language -- or a language that could not
+    be identified at all -- resolves to None rather than to some other language's
+    limit.
+    """
+    if override is None or isinstance(override, int):
+        return override
+    if lang is None:
+        return None
+    return override.get(lang)
+```
+
+Add `Mapping` and `Union` to the `typing` import if absent.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_solutions_timelimit_override.py -v`
+Expected: PASS
+
+**Step 5: Thread the wider type through**
+
+Change the annotation `timelimit_override: Optional[int]` to `timelimit_override: Optional[TimelimitOverride]` in `run_solutions`, `_get_report_skeleton`, `_produce_solution_items`, and `_run_solution`. Then resolve at the two sites that know the language:
+
+In `_get_report_skeleton` (around `solutions.py:728`):
+
+```python
+    limits = {
+        lang: get_limits_for_language(
+            lang, verification, resolve_timelimit_override(timelimit_override, lang)
+        )
+        for lang in langs
+        if lang is not None
+    }
+```
+
+In `_run_solution`, resolve once before the entry loop and pass the scalar down, since `run_solution_on_testcase` takes an `int`:
+
+```python
+    groups_by_name = {group.name: group for group in groups}
+    # Resolved once per solution: the language cannot change between its testcases.
+    solution_timelimit = resolve_timelimit_override(
+        timelimit_override, find_language_name(solution)
+    )
+```
+
+and inside `run_fn`, pass `timelimit_override=solution_timelimit`.
+
+**Step 6: Verify nothing regressed**
+
+Run: `uv run pytest tests/rbx/box -k 'solutions or timing' -v`
+Expected: PASS (no behavior change — every existing caller passes an `int` or `None`)
+
+**Step 7: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/solutions.py tests/rbx/box/test_solutions_timelimit_override.py
+git commit  # feat(solutions): allow a per-language time limit override
+```
+
+---
+
+### Task 2: Record the upper-bound validation outcome in the profile
+
+`TimingGroupReport.droppedUpper` means "expected to be too slow but still running at `inferenceTimeout`, so it bounds nothing". After the split, a slow solution that hits its probe limit is *confirmed* rather than dropped, and one that finishes is a *violation*. Replace the field, keeping the old name parseable so profiles already on disk still load (`TimingGroupReport` is `extra='forbid'`).
+
+**Files:**
+- Modify: `rbx/box/schema.py:963-995`
+- Test: `tests/rbx/box/test_timing_upper_validation.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+"""The limits profile records what phase 2 learned about each slow solution."""
+
+from rbx.box import schema
+
+
+def test_upper_validation_defaults_to_absent():
+    report = schema.TimingGroupReport(
+        languages=['cpp'], timeLimit=1000, origin=schema.TimingGroupOrigin.ESTIMATED
+    )
+    assert report.upperValidation is None
+
+
+def test_upper_validation_round_trips():
+    validation = schema.TimingGroupUpperValidation(
+        confirmed=['sols/slow.cpp'],
+        violating=[schema.TimingBound(value=1200, solution='sols/nearly.cpp')],
+        skipped=['sols/unrun.cpp'],
+    )
+    report = schema.TimingGroupReport(
+        languages=['cpp'],
+        timeLimit=1000,
+        origin=schema.TimingGroupOrigin.ESTIMATED,
+        upperValidation=validation,
+    )
+    assert (
+        schema.TimingGroupReport.model_validate(report.model_dump()).upperValidation
+        == validation
+    )
+
+
+def test_a_profile_written_before_the_split_still_parses():
+    # `droppedUpper` is deprecated but must not make an existing
+    # `.limits/<profile>.yml` unparseable.
+    report = schema.TimingGroupReport.model_validate(
+        {
+            'languages': ['cpp'],
+            'timeLimit': 1000,
+            'origin': 'estimated',
+            'droppedUpper': ['sols/slow.cpp'],
+        }
+    )
+    assert report.upperValidation is None
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_upper_validation.py -v`
+Expected: FAIL, `AttributeError: module 'rbx.box.schema' has no attribute 'TimingGroupUpperValidation'`
+
+**Step 3: Write minimal implementation**
+
+In `rbx/box/schema.py`, after `TimingBound`:
+
+```python
+class TimingGroupUpperValidation(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    confirmed: List[str] = Field(
+        default=[],
+        description="""Solutions of this group expected to be too slow that were
+confirmed to be so: they were still running when the estimated time limit times
+`timeLimitToTle` elapsed. Presentation-only.""",
+    )
+
+    violating: List[TimingBound] = Field(
+        default=[],
+        description="""Solutions of this group expected to be too slow that finished
+within the estimated time limit times `timeLimitToTle`, so they do not respect the
+upper bound. `value` is the time the solution actually took. Presentation-only.""",
+    )
+
+    skipped: List[str] = Field(
+        default=[],
+        description="""Solutions of this group expected to be too slow that were not
+run, either because `timeLimitToTle` is unset or because the validation phase was
+skipped. Presentation-only.""",
+    )
+```
+
+Then on `TimingGroupReport`, replace `droppedUpper` with:
+
+```python
+    upperValidation: Optional[TimingGroupUpperValidation] = Field(
+        default=None,
+        description="""What checking this group's slow solutions against its estimated
+time limit found. Absent when the group has no slow solutions. Presentation-only.""",
+    )
+
+    droppedUpper: List[str] = Field(
+        default=[],
+        deprecated=True,
+        exclude=True,
+        description="""Deprecated: replaced by `upperValidation`. Accepted so that a
+limits profile written before the estimation was split into two phases still parses;
+never written.""",
+    )
+```
+
+`exclude=True` keeps it out of every profile rbx writes while `extra='forbid'` still accepts it on the way in.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_upper_validation.py -v`
+Expected: PASS
+
+**Step 5: Update the readers**
+
+`droppedUpper` is read in three places. Point them at `upperValidation`, keeping the rendering shape (`limits_info._LimitsRow.dropped_upper` and the warning at `limits_info.py:427-433`) but rewording it: the warning currently tells the setter to raise `inferenceTimeout`, which is no longer the reason a slow solution goes unmeasured.
+
+- `rbx/box/timing_groups.py:203-208` — writes the field from `measured.upper.dropped_upper`. Task 7 revisits this; for now write `upperValidation=TimingGroupUpperValidation(confirmed=list(measured.upper.dropped_upper))`.
+- `rbx/box/limits_info.py:319-345` — read `report.upperValidation.confirmed` (guarding `None`).
+- `rbx/box/limits_info.py:427-433` — reword: these solutions are confirmed too slow, which is the desired outcome, so this should read as information rather than a warning.
+- `rbx/box/timing.py:932-941` — the preview key includes `report.droppedUpper`; use the confirmed list.
+
+**Step 6: Run the affected suites**
+
+Run: `uv run pytest tests/rbx/box -k 'timing or limits' -v`
+Expected: PASS. Fix any test asserting on `droppedUpper` by moving it to `upperValidation.confirmed`.
+
+**Step 7: Regenerate schemas and commit**
+
+Schemas under `docs/schemas` are generated at import (see `rbx/box/dump_schemas.py`) and are not checked in — no action needed, but confirm `uv run rbx --help` still starts.
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/schema.py rbx/box/limits_info.py rbx/box/timing_groups.py rbx/box/timing.py tests/
+git commit  # feat(timing): record upper-bound validation in the limits profile
+```
+
+---
+
+### Task 3: Probe limits and the slow-solution knowledge cache
+
+Pure arithmetic and bookkeeping, with no I/O, so it is worth pinning precisely before anything runs it. Two pieces:
+
+- the probe limit for a language: `ceil(TL_lang * timeLimitToTle)` in exact `Fraction` arithmetic, matching how `compute_bounds` reads the ratio the setter typed;
+- a per-solution record of what is already known, so the picker loop re-runs only what it must.
+
+**Files:**
+- Create: `rbx/box/timing_validation.py`
+- Test: `tests/rbx/box/test_timing_validation.py`
+
+**Step 1: Write the failing test**
+
+```python
+"""Probe limits and the knowledge that lets the picker loop skip re-runs."""
+
+import pytest
+
+from rbx.box import timing_validation
+
+
+@pytest.mark.parametrize(
+    ('time_limit', 'ratio', 'expected'),
+    [
+        (1000, 1.5, 1500),
+        # 1.1 is not exactly representable in binary floating point; the ratio the
+        # setter typed is what must be used, as in `timing.compute_bounds`.
+        (1000, 1.1, 1100),
+        # Rounded up: a solution that finishes at exactly the rounded-down value
+        # would be under the real bound.
+        (333, 1.5, 500),
+        (1, 1.5, 2),
+    ],
+)
+def test_probe_limit_is_the_bound_rounded_up_exactly(time_limit, ratio, expected):
+    assert timing_validation.probe_limit(time_limit, ratio) == expected
+
+
+def test_an_unmeasured_solution_must_run():
+    knowledge = timing_validation.SlowKnowledge()
+    assert knowledge.needs_run('sols/slow.cpp', 1500)
+
+
+def test_a_solution_that_timed_out_covers_any_lower_probe():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 1500)
+    assert not knowledge.needs_run('sols/slow.cpp', 1500)
+    assert not knowledge.needs_run('sols/slow.cpp', 900)
+    # A higher probe demands more than what is known.
+    assert knowledge.needs_run('sols/slow.cpp', 1600)
+
+
+def test_a_measured_solution_never_runs_again():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_time('sols/slow.cpp', 1200)
+    assert not knowledge.needs_run('sols/slow.cpp', 99999)
+    assert knowledge.measured_time('sols/slow.cpp') == 1200
+
+
+def test_a_measurement_supersedes_an_earlier_timeout():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 900)
+    knowledge.record_time('sols/slow.cpp', 1200)
+    assert not knowledge.needs_run('sols/slow.cpp', 99999)
+    assert knowledge.measured_time('sols/slow.cpp') == 1200
+
+
+def test_a_timeout_never_weakens_what_is_known():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 1500)
+    knowledge.record_timeout('sols/slow.cpp', 900)
+    assert not knowledge.needs_run('sols/slow.cpp', 1500)
+
+
+def test_a_confirmed_solution_reports_no_measurement():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 1500)
+    assert knowledge.measured_time('sols/slow.cpp') is None
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_validation.py -v`
+Expected: FAIL, `ModuleNotFoundError: No module named 'rbx.box.timing_validation'`
+
+**Step 3: Write minimal implementation**
+
+```python
+"""What is known about the solutions expected to be too slow.
+
+Validating an estimated time limit asks one question per slow solution: does it
+take at least ``timeLimit * timeLimitToTle``? Running it under exactly that limit
+answers the question without measuring it -- a solution killed at the limit
+cleared the bound, and one that finished did not, and hands us its real time on
+the way out.
+
+The answer is monotone, which is what makes the picker loop cheap: a solution
+killed at ``L`` is also killed at any lower limit, and a solution that finished
+is answered by arithmetic forever after.
+"""
+
+import dataclasses
+import math
+from fractions import Fraction
+from typing import Dict, Optional
+
+
+def probe_limit(time_limit: int, time_limit_to_tle: float) -> int:
+    """The limit a slow solution must survive for ``time_limit`` to hold.
+
+    Rounded up, and computed from the ratio the setter typed rather than from its
+    binary approximation, so it agrees with `timing.compute_bounds` on the
+    boundary case where a solution takes exactly ``time_limit * ratio``.
+    """
+    return math.ceil(time_limit * Fraction(str(time_limit_to_tle)))
+
+
+@dataclasses.dataclass
+class _SolutionKnowledge:
+    # Its real time, once it finished under some probe limit.
+    time: Optional[int] = None
+    # The highest limit it was killed at, so its time exceeds this.
+    survived: Optional[int] = None
+
+
+@dataclasses.dataclass
+class SlowKnowledge:
+    """What each slow solution has already told us, across probe limits."""
+
+    _per_solution: Dict[str, _SolutionKnowledge] = dataclasses.field(
+        default_factory=dict
+    )
+
+    def _entry(self, solution: str) -> _SolutionKnowledge:
+        return self._per_solution.setdefault(solution, _SolutionKnowledge())
+
+    def record_time(self, solution: str, time: int) -> None:
+        """It finished under its probe limit, in ``time`` ms."""
+        self._entry(solution).time = time
+
+    def record_timeout(self, solution: str, limit: int) -> None:
+        """It was still running at ``limit`` ms."""
+        entry = self._entry(solution)
+        entry.survived = max(entry.survived or 0, limit)
+
+    def measured_time(self, solution: str) -> Optional[int]:
+        """Its real time, or None if it has only ever been killed."""
+        return self._per_solution.get(solution, _SolutionKnowledge()).time
+
+    def needs_run(self, solution: str, limit: int) -> bool:
+        """Whether answering the question at ``limit`` requires running it."""
+        entry = self._per_solution.get(solution)
+        if entry is None:
+            return True
+        if entry.time is not None:
+            # A real measurement answers every limit by arithmetic.
+            return False
+        return entry.survived is None or entry.survived < limit
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_validation.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing_validation.py tests/rbx/box/test_timing_validation.py
+git commit  # feat(timing): add probe limits and slow-solution knowledge
+```
+
+---
+
+### Task 4: Phase 1 runs only the lower-bound solutions
+
+`_run_for_inference` (`timing.py:1036`) already runs only the lower solutions when `timeLimitToTle` is unset. Make that the only behavior, and delete the machinery whose sole purpose was to explain the cap's effect on the upper side.
+
+**Files:**
+- Modify: `rbx/box/timing.py:791-1122` (`_InferenceCap`, `_diagnose_inference_run`, `_report_inference_diagnosis`, `_warn_if_the_cap_bounded_the_estimate`, `_InferenceRun`, `_run_for_inference`)
+- Test: `tests/rbx/box/test_timing_inference_run.py`
+
+**Step 1: Update the tests to describe one phase-1 run**
+
+`test_timing_inference_run.py` asserts against `run_solutions.call_args`. Rewrite the affected cases so they pin phase 1's contract:
+
+- `test_multipliers_with_tle_ratio_runs_both_capped` becomes `test_the_estimation_run_only_runs_lower_solutions`: with `timeLimitToTle` set, `tracked_solutions` still contains only the lower solutions, and `timelimit_override` is `inferenceTimeout`.
+- `test_an_upper_solution_at_the_cap_is_dropped_with_a_warning` is deleted; no upper solution runs in phase 1. Its replacement lands in Task 7.
+- `test_formula_mode_runs_only_lower_solutions_under_the_cap`, `test_multipliers_without_tle_ratio_runs_only_lower_solutions`, `test_the_estimation_run_never_doubles_the_time_limit`, and `test_only_lower_solutions_gate_the_run_report` stay as they are — they already describe the new behavior.
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_timing_inference_run.py -v`
+Expected: FAIL — the run still tracks the upper solutions.
+
+**Step 3: Make phase 1 lower-only**
+
+In `_run_for_inference`, delete the `upper_solutions` block (`timing.py:1053-1058`) and every use of it: `tracked_solutions` becomes the lower solutions, the status message is always `'Running ACCEPTED solutions...'`, and `gating_solutions` covers every solution that ran.
+
+`_InferenceCap` loses `time_limit_to_tle` and `largest_bounded_limit`; it is now just the timeout, so collapse it into a plain `int` on `_InferenceRun` and delete the dataclass. `_diagnose_inference_run` loses `dropped_upper` and `failed_upper` — with no upper solution in the run, only `truncated_lower` remains, which is the fatal case. Delete `_warn_if_the_cap_bounded_the_estimate` (`timing.py:957-995`), `_failed_upper_message` (`:868`), and `_InferenceRun.dropped_upper_per_language` (`:1009`), along with their call sites in `compute_time_limits` (`:1148-1158`).
+
+**Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_inference_run.py tests/rbx/box/test_timing.py -v`
+Expected: PASS. `estimate_time_limit` already tolerates an empty upper side — `_upper_timings` returns `None`, `compute_bounds` leaves `upper=None`, and `TimingBounds.fits` is then trivially true — so at this point `rbx time` produces an unvalidated estimate. That is the intended intermediate state.
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing.py tests/rbx/box/test_timing_inference_run.py
+git commit  # refactor(timing): run only accepted solutions while estimating
+```
+
+---
+
+### Task 5: Let the profile record a violated upper bound instead of raising
+
+`_check_bounds` (`timing.py:226`) raises `TimingRangeError` when the quantized limit exceeds the upper bound. The "proceed anyway" exit and the no-picker path both need to build that profile regardless, with the violation recorded.
+
+**Files:**
+- Modify: `rbx/box/timing.py:226-303` (`_check_bounds`, `make_multipliers_eval`, `make_multipliers_derive`), `rbx/box/timing.py:349-415` (`build_timing_profile`)
+- Test: `tests/rbx/box/test_timing_bounds.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/rbx/box/test_timing_bounds.py`:
+
+```python
+def test_a_forced_estimate_keeps_the_limit_that_violates_the_upper_bound():
+    multipliers = schema.TimingMultipliers(
+        acToTimeLimit=2.0, timeLimitToTle=1.5, timeResolution=100
+    )
+    measured = timing_groups.GroupMeasurements(
+        lower=timing_groups.GroupTimings(
+            fastest=500, slowest=500, solution_count=1, slowest_solution='sols/ac.cpp'
+        ),
+        upper=timing_groups.UpperTimings(
+            fastest_slow=1100, fastest_slow_solution='sols/slow.cpp'
+        ),
+    )
+    # acToTimeLimit puts the limit at 1000 ms; timeLimitToTle caps it at 733 ms.
+    with pytest.raises(timing_groups.TimingRangeError):
+        timing.make_multipliers_eval(multipliers)(measured)
+
+    forced = timing.make_multipliers_eval(multipliers, force=True)(measured)
+    assert forced.time_limit == 1000
+    assert forced.upper_bound == schema.TimingBound(
+        value=733, solution='sols/slow.cpp'
+    )
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_timing_bounds.py -k forced -v`
+Expected: FAIL, `TypeError: make_multipliers_eval() got an unexpected keyword argument 'force'`
+
+**Step 3: Write minimal implementation**
+
+Give `_check_bounds` a `force` parameter that returns the limit instead of raising, and thread it through both factories and `build_timing_profile`:
+
+```python
+def _check_bounds(
+    bounds: TimingBounds,
+    multipliers: schema.TimingMultipliers,
+    measured: timing_groups.GroupMeasurements,
+    force: bool = False,
+) -> int:
+    """Return the quantized limit if the group's slow solutions allow it, else
+    raise naming the binding solution on each side and the knob to turn.
+
+    ``force`` keeps the limit anyway. The violation is not swallowed: it stays
+    visible in the group's recorded bounds, and the caller is responsible for
+    telling the setter about it.
+    """
+    if bounds.fits or force:
+        return bounds.time_limit
+```
+
+The rest of the function is unchanged. `make_multipliers_eval(multipliers, force=False)` and `make_multipliers_derive(multipliers, force=False)` pass it on, and `build_timing_profile(..., force: bool = False)` passes it to both factories.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_timing_bounds.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing.py tests/rbx/box/test_timing_bounds.py
+git commit  # feat(timing): allow forcing a limit past a violated upper bound
+```
+
+---
+
+### Task 6: Extract an estimation context so the picker can be re-entered
+
+The picker currently runs inside `estimate_time_limit` (`timing.py:739-754`), which measures, prompts, and builds in one pass. The loop needs to prompt and build repeatedly against measurements that change between iterations. Split the function without changing behavior yet.
+
+**Files:**
+- Modify: `rbx/box/timing.py:654-788`
+- Test: `tests/rbx/box/test_timing.py`, `tests/rbx/box/test_timing_estimation.py`
+
+**Step 1: Introduce the context**
+
+Extract everything `estimate_time_limit` does *before* the picker into a dataclass built by a new coroutine:
+
+```python
+@dataclasses.dataclass
+class _EstimationContext:
+    """Phase 1's measurements, ready to be estimated from repeatedly.
+
+    The picker may be re-entered once phase 2 has something to say, so the parts
+    that do not change between iterations are computed once.
+    """
+
+    strategy: timing_config.TimingStrategy
+    env_groups: List[environment.LanguageGroup]
+    all_languages: List[str]
+    lower_timings: Dict[str, Dict[str, int]]
+    upper_solutions: List[Solution]
+
+    @property
+    def can_prompt(self) -> bool:
+        """Whether there is a grouping decision for the setter to make."""
+        return len(self.all_languages) > 1
+```
+
+`build_estimation_context(console, result, strategy)` performs the current work of `timing.py:663-736`: keying the evaluations, splitting by `inference_role_of`, measuring the lower side with `_timings_per_language`, printing the "Time report" rule and the headline measurements, resolving the strategy and `all_languages`. Note that `relevant_languages_for_estimation` currently pools the slow and dropped languages into `timing_languages` (`:730-737`); keep that, sourcing the slow languages from `upper_solutions` via `find_language_name`, so a language present only on the slow side still gets a group.
+
+`estimate_time_limit` keeps its signature and becomes: build the context, prompt once if `not auto and ctx.can_prompt`, build the profile. Every existing test of it must still pass untouched.
+
+**Step 2: Run the tests**
+
+Run: `uv run pytest tests/rbx/box/test_timing.py tests/rbx/box/test_timing_estimation.py -v`
+Expected: PASS with no test changes. This task is a pure refactor; if a test needs changing, the extraction changed behavior and is wrong.
+
+**Step 3: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing.py
+git commit  # refactor(timing): extract the estimation context from the estimate
+```
+
+---
+
+### Task 7: Phase 2 — validate the estimate against the slow solutions
+
+**Files:**
+- Modify: `rbx/box/timing.py`, `rbx/box/timing_validation.py`
+- Test: `tests/rbx/box/test_timing_phase_two.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+"""Phase 2 checks the estimated limit against the solutions expected to be slow."""
+
+# Follow the mocking setup of `tests/rbx/box/test_timing_inference_run.py::_compute`:
+# patch `rbx.box.timing.run_solutions`, `print_run_report`,
+# `consume_and_key_evaluation_items`, `find_language_name` and
+# `rbx.box.environment.get_environment`.
+
+
+async def test_each_language_is_probed_at_its_own_limit(...):
+    # profile: timeLimit 1000, timeLimitPerLanguage {'cpp': 1000, 'py': 4000},
+    # timeLimitToTle 1.5
+    # -> run_solutions gets timelimit_override={'cpp': 1500, 'py': 6000}
+    ...
+
+
+async def test_a_slow_solution_that_times_out_is_confirmed(...):
+    # TLE at the probe limit -> confirmed, contributes no measurement,
+    # the profile validates
+    ...
+
+
+async def test_a_slow_solution_that_finishes_violates_the_bound(...):
+    # finished at 1200 ms under a 1500 ms probe -> violation carrying 1200 ms
+    ...
+
+
+async def test_only_the_solutions_whose_probe_grew_are_re_run(...):
+    # knowledge already holds a timeout at 1500; re-validating at 1200 runs nothing,
+    # re-validating at 1600 runs it again
+    ...
+
+
+async def test_the_validation_run_never_doubles_the_time_limit(...):
+    # verification stays ALL_SOLUTIONS, so isDoubleTL is off and the probe limit
+    # is enforced as computed
+    ...
+```
+
+Fill these in against the real signatures as you implement; the assertions above are the contract.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_timing_phase_two.py -v`
+Expected: FAIL — the driver does not exist.
+
+**Step 3: Write the driver**
+
+In `rbx/box/timing.py`:
+
+```python
+@dataclasses.dataclass
+class _ValidationOutcome:
+    """What checking a candidate profile's upper bound found."""
+
+    # Slow solutions confirmed too slow, keyed by language.
+    confirmed_per_language: Dict[str, List[str]]
+    # Slow solutions that finished, with their real time, keyed by language.
+    violating_per_language: Dict[str, Dict[str, int]]
+
+    @property
+    def ok(self) -> bool:
+        return not any(self.violating_per_language.values())
+
+
+async def _validate_upper_bound(
+    profile: TimingProfile,
+    upper_solutions: List[Solution],
+    knowledge: timing_validation.SlowKnowledge,
+    check: bool,
+    detailed: bool,
+    runs: int,
+) -> _ValidationOutcome:
+    """Run each slow solution at its language's probe limit and say what it proved.
+
+    Only the solutions whose answer is not already known are run: `knowledge`
+    carries what earlier iterations of the picker loop established, and a lower
+    limit never needs re-asking.
+    """
+```
+
+The body:
+
+1. `multipliers = profile.multipliers`; assert `multipliers.timeLimitToTle is not None` (the caller checks).
+2. Per solution, `lang = find_language_name(solution)`, `tl = profile.timeLimitPerLanguage.get(lang, profile.timeLimit)`, `limit = timing_validation.probe_limit(tl, multipliers.timeLimitToTle)`.
+3. Partition into solutions that `knowledge.needs_run(path, limit)` and those that do not.
+4. If any need running, call `run_solutions` with `tracked_solutions` set to just those, `timelimit_override={lang: limit}` built from step 2, `verification=_INFERENCE_VERIFICATION`, `nruns=runs`, `check=check`, and `abort_on=lambda ctx: ctx.evaluation.result.outcome.is_slow()` — the first TLE settles that solution, so the remaining testcases only cost wall clock.
+5. Print the run report under a `'Run report (upper-bound validation)'` rule with `gating_solutions` set to the slow solutions: here a TLE is the expected verdict, so the ordinary report machinery already flags a solution that finished.
+6. Feed the outcome into `knowledge`: a solution whose evaluations contain a slow outcome gets `record_timeout(path, limit)`; otherwise `record_time(path, max_time)` using `_timings_per_language`.
+7. Build `_ValidationOutcome` from `knowledge` over *all* the slow solutions, not just the ones that ran this round.
+
+The violating measurements are exactly what `build_timing_profile` already takes as `slow_timing_per_solution_per_language`, and the confirmed list is what `dropped_upper_per_language` used to carry — so the existing plumbing into `timing_groups` and `TimingGroupReport` works unchanged, with `timing_groups.py:203-208` writing `upperValidation` from Task 2.
+
+**Step 4: Run the tests**
+
+Run: `uv run pytest tests/rbx/box/test_timing_phase_two.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing.py rbx/box/timing_validation.py tests/rbx/box/test_timing_phase_two.py
+git commit  # feat(timing): validate the estimated limit against slow solutions
+```
+
+---
+
+### Task 8: A "proceed anyway" exit in the group picker
+
+**Files:**
+- Modify: `rbx/box/timing_group_picker.py:10-24` (`GroupAssignment`, `LEGEND_LINES`), `:300-478` (`prompt_group_assignment`)
+- Test: `tests/rbx/box/test_timing_group_picker.py`
+
+**Step 1: Write the failing test**
+
+Follow the existing `create_pipe_input` + `DummyOutput` harness in that file:
+
+```python
+async def test_f_accepts_the_current_assignment_despite_a_violation():
+    with create_pipe_input() as inp:
+        inp.send_text('f')
+        result = await timing_group_picker.prompt_group_assignment(
+            ['cpp', 'py'], {'cpp': 0, 'py': 0}, allow_force=True,
+            input=inp, output=DummyOutput(),
+        )
+    assert result is not None
+    assert result.force
+
+
+async def test_f_does_nothing_when_there_is_nothing_to_override():
+    # Without a violation the key is inert, so the picker is still open and the
+    # following enter is what confirms it.
+    with create_pipe_input() as inp:
+        inp.send_text('f\r')
+        result = await timing_group_picker.prompt_group_assignment(
+            ['cpp', 'py'], {'cpp': 0, 'py': 0}, input=inp, output=DummyOutput(),
+        )
+    assert result is not None
+    assert not result.force
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -k force -v`
+Expected: FAIL, `TypeError: prompt_group_assignment() got an unexpected keyword argument 'allow_force'`
+
+**Step 3: Write minimal implementation**
+
+Add `force: bool = False` to `GroupAssignment`. Give `prompt_group_assignment` an `allow_force: bool = False` parameter, and bind the key behind a `Condition`:
+
+```python
+    forcing = Condition(lambda: allow_force)
+
+    @kb.add('f', filter=not_editing & forcing)
+    def _(event):
+        state.done = True
+        event.app.exit(
+            result=GroupAssignment(
+                numbers=state.assignment(),
+                relatives=state.prune_relatives(),
+                force=True,
+            )
+        )
+```
+
+`LEGEND_LINES` is a module constant, so make the hint line depend on `allow_force`: turn the last line into a function of the flag, or append `' · f keep this limit anyway'` to it when the flag is set. Keep the legend's existing width discipline.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing_group_picker.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing_group_picker.py tests/rbx/box/test_timing_group_picker.py
+git commit  # feat(timing): let the group picker keep a violating limit
+```
+
+---
+
+### Task 9: The loop, and `--skip-slow`
+
+**Files:**
+- Modify: `rbx/box/timing.py` (`estimate_time_limit`, `compute_time_limits`), `rbx/box/cli.py:549-709`
+- Test: `tests/rbx/box/test_timing.py`, `tests/rbx/box/test_timing_cli.py`
+
+**Step 1: Write the failing tests**
+
+In `tests/rbx/box/test_timing.py`:
+
+```python
+async def test_a_violation_reopens_the_picker_and_the_repick_is_written(...):
+    # phase 2 finds a violation; the picker returns a new assignment; phase 2
+    # revalidates and passes; exactly one profile is written, carrying the
+    # re-picked limits
+    ...
+
+
+async def test_forcing_past_a_violation_writes_the_violating_limit(...):
+    # picker returns force=True; no further validation runs; the profile is
+    # written with `upperValidation.violating` recording the offending solution
+    ...
+
+
+async def test_cancelling_the_picker_writes_nothing(...):
+    # picker returns None -> compute_time_limits returns None, no file on disk
+    ...
+
+
+async def test_a_violation_with_no_picker_warns_and_writes(...):
+    # auto=True -> the profile is written, the violation is recorded, and
+    # compute_time_limits returns the profile rather than None
+    ...
+
+
+async def test_skip_slow_stops_after_the_estimate(...):
+    # run_solutions is called exactly once; the slow solutions are recorded as
+    # skipped in the profile
+    ...
+```
+
+In `tests/rbx/box/test_timing_cli.py`, assert `--skip-slow` reaches `compute_time_limits`.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/test_timing.py tests/rbx/box/test_timing_cli.py -v`
+Expected: FAIL
+
+**Step 3: Write the loop**
+
+`compute_time_limits` gains `skip_slow: bool = False` and becomes:
+
+```python
+    run = await _run_for_inference(check=check, detailed=detailed, runs=runs, formula=formula)
+    if run is None:
+        return None
+
+    ctx = await build_estimation_context(console.console, run.result, run.strategy)
+    knowledge = timing_validation.SlowKnowledge()
+
+    multipliers = ctx.strategy.multipliers
+    validates = (
+        not skip_slow
+        and multipliers is not None
+        and multipliers.timeLimitToTle is not None
+        and bool(ctx.upper_solutions)
+    )
+
+    violation: Optional[_ValidationOutcome] = None
+    while True:
+        picked = await ctx.prompt(
+            auto=auto,
+            knowledge=knowledge,
+            allow_force=violation is not None,
+        )
+        if picked is None:
+            console.console.print('[error]Time limit estimation cancelled.[/error]')
+            return None
+
+        profile = ctx.build(picked, knowledge=knowledge, force=picked.force)
+        if profile is None:
+            return None
+
+        if not validates or picked.force:
+            break
+
+        outcome = await _validate_upper_bound(
+            profile, ctx.upper_solutions, knowledge,
+            check=check, detailed=detailed, runs=runs,
+        )
+        if outcome.ok:
+            break
+
+        violation = outcome
+        _report_violation(outcome)
+        if auto or not ctx.can_prompt:
+            # Nothing to re-pick: record it, say so loudly, and write anyway.
+            profile = ctx.build(picked, knowledge=knowledge, force=True)
+            break
+```
+
+then the existing write-the-profile block, unchanged.
+
+`ctx.prompt(auto, knowledge, allow_force)` returns a default `GroupAssignment` without prompting when `auto or not self.can_prompt`, and otherwise calls `_prompt_repartition`, passing `allow_force` down to the picker and the knowledge-derived slow measurements into `build_preview_renderer`. Build a fresh preview renderer each call: its `lru_cache` closes over the measurements, which change between iterations.
+
+`ctx.build(picked, knowledge, force)` calls `build_timing_profile` with `slow_timing_per_solution_per_language` and the confirmed/skipped lists derived from `knowledge`, catching `TimingRangeError` only when `force` is false — an un-forced range error at this point means the *preview* was infeasible, which the picker already showed, so print it and return `None`.
+
+`_report_violation` prints, per offending solution, its measured time, the limit its group got, and the bound `timeLimitToTle` implies — reusing the wording of `_check_bounds`.
+
+**Step 4: Add the CLI flag**
+
+In `rbx/box/cli.py`, add to the `time` command:
+
+```python
+    skip_slow: bool = typer.Option(
+        False,
+        '--skip-slow',
+        help='Skip the phase that checks the estimated limit against the solutions '
+        'expected to be too slow. The limit is estimated and written with its upper '
+        'bound unchecked.',
+    ),
+```
+
+and pass `skip_slow=skip_slow` to `compute_time_limits`.
+
+**Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/test_timing.py tests/rbx/box/test_timing_cli.py -v`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/timing.py rbx/box/cli.py tests/
+git commit  # feat(timing): split rbx time into estimation and validation phases
+```
+
+---
+
+### Task 10: Docs, CLI spec, and the full sweep
+
+**Files:**
+- Modify: `docs/` (wherever `inferenceTimeout` and `timeLimitToTle` are documented), `rbx/box/completion/_spec.py` if the new flag must be registered
+- Verify: the whole suite
+
+**Step 1: Find the docs that describe the old one-step behavior**
+
+Run: `grep -rn 'inferenceTimeout\|timeLimitToTle' docs/`
+Update the prose: slow solutions are no longer run under `inferenceTimeout`, so raising it no longer helps them, and `inferenceTimeout` now caps only the accepted solutions. Document `--skip-slow` and the two phases.
+
+**Step 2: Check the completion spec**
+
+Run: `uv run pytest tests/rbx/box/completion -v`
+If a drift test fails on the new `--skip-slow` flag, regenerate the spec as that test's message directs. Note the pre-existing drift recorded for the `tut`/`tutorials` command — do not "fix" that here.
+
+**Step 3: Run the full suite**
+
+Run: `uv run pytest --ignore=tests/rbx/box/cli -n auto`
+Expected: PASS except the pre-existing local failures (C++/sandbox-dependent tests, `test_compute_walltime_uses_active_environment`, the completion drift). Compare against `git stash`-free baseline on `main` if anything looks new.
+
+Run: `uv run pytest tests/rbx/box/cli -v`
+Expected: PASS
+
+**Step 4: Exercise it for real**
+
+Build a fixture package that has both an accepted solution and one expected to be too slow, and run `uv run rbx time` in it. Confirm the console shows two run reports, that the second enforces the probe limit, and that `.limits/local.yml` carries `upperValidation`.
+
+**Step 5: Lint, then commit**
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+git add docs/ rbx/
+git commit  # docs(timing): document the two-phase time limit estimation
+```
+
+---
+
+### Task 11: Open the PR
+
+```bash
+git push -u origin worktree-time-two-phase
+gh pr create --draft --title 'feat(timing): split rbx time into estimation and validation phases' --body '...'
+```
+
+The body should explain the two phases, the picker loop and its three exits, `--skip-slow`, the `upperValidation` profile field replacing `droppedUpper`, and that `--auto` warns rather than fails on a violated upper bound. Close with `Closes #693`.
+
+Note: `gh pr edit`/`gh pr view` fail against this repo with a classic-Projects GraphQL error; use `gh api -X PATCH repos/rsalesc/rbx/pulls/N` to amend the PR afterwards.

--- a/docs/setters/packaging-walkthrough.md
+++ b/docs/setters/packaging-walkthrough.md
@@ -68,10 +68,11 @@ When prompted, you'll see four strategies:
 | **Custom time limit**            | You already know the exact time limit you want.                             |
 
 By default, {{rbx}} estimates from ratios: the limit is at least `acToTimeLimit`
-times the slowest accepted solution, small enough that `timeLimitToTle` times the
-limit still fits within the fastest solution expected to be too slow, and rounded
-up to a multiple of `timeResolution`. If no limit satisfies them, the estimation
-fails and says which solution binds each side. You can tune the ratios (or switch
+times the slowest accepted solution, and rounded up to a multiple of
+`timeResolution`. Once it is decided, each solution expected to be too slow is run
+at `timeLimitToTle` times that limit to confirm it really is too slow. If one of
+them finishes, {{rbx}} says so and lets you regroup the languages, keep the limit
+anyway, or start over. You can tune the ratios (or switch
 to a formula) in `env.rbx.yml` -- see the
 [Profiling](/setters/profiling#time-limit-ratios) docs for details.
 

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -40,13 +40,14 @@ solutions and applying the estimation strategy configured in the environment: ei
 
 1. **Displays current profile** -- If a profile already exists for the given name, its current limits are shown.
 2. **Strategy selection** -- You are prompted to choose how to define the time limit (unless `--auto` or `--strategy` is used).
-3. **Solution execution** -- For estimating strategies, the solutions the limit is inferred from are run against all testcases, so that their true execution times can be measured. Every one of them is capped at [`inferenceTimeout`](#the-estimation-cap); solutions expected to be too slow only run at all when the ratios bound the limit from above.
+3. **Solution execution** -- For estimating strategies, the accepted solutions are run against all testcases, so that their true execution times can be measured. Every one of them is capped at [`inferenceTimeout`](#the-estimation-cap). The solutions expected to be too slow are *not* run here; see [Checking the upper bound](#checking-the-upper-bound).
 4. **Time report** -- The fastest and slowest solution times are shown, along with per-language breakdowns if solutions in multiple languages exist.
 5. **Estimation** -- The ratios (or the formula) are applied to compute the estimated time limit.
 6. **Language groups** -- You are shown every environment language and can place each one into a group, so related languages (e.g. `c`/`cpp`, or `java`/`kotlin`) share a single estimated limit and unrepresented languages inherit a sensible limit instead of falling back to the base. See [Language groups](#language-groups).
-7. **Profile persistence** -- The result is written to `.limits/<profile>.yml`, together with the chosen grouping as metadata.
+7. **Upper-bound check** -- Each solution expected to be too slow is run at the limit the estimate demands of it, to confirm it really is too slow. See [Checking the upper bound](#checking-the-upper-bound).
+8. **Profile persistence** -- The result is written to `.limits/<profile>.yml`, together with the chosen grouping and what the check found.
 
-All seven steps in one run, taking the recommended **Estimate** strategy and the default
+All the steps in one run, taking the recommended **Estimate** strategy and the default
 grouping — note the preview table updating as the languages are bucketed, and the strategy
 printed just above the limits that get written:
 
@@ -140,23 +141,22 @@ timing:
 ## The estimation cap
 
 While the limit is being estimated there is no limit to enforce yet, so a solution left to run
-freely could run forever. `timing.inferenceTimeout` is the cap every solution runs under during
-`rbx time`, in milliseconds, whichever strategy estimates the limit -- ratios or formula:
+freely could run forever. `timing.inferenceTimeout` is the cap the accepted solutions run under
+during `rbx time`, in milliseconds, whichever strategy estimates the limit -- ratios or formula:
 
 ```yaml
 timing:
   inferenceTimeout: 10000   # ms; defaults to 10s
 ```
 
-- A solution expected to be **too slow** that hits the cap is dropped from the upper bound,
-  with a warning: it did not finish, so how long it would have taken is unknown. If the limit
-  then resolves above what the cap alone allows (`inferenceTimeout / timeLimitToTle`), `rbx`
-  says so -- the cap, not the solutions, bounded the estimate.
-- An **accepted** solution that hits it is an error: its measured time is truncated, so it
-  cannot bound the limit from below. Raise the cap, or speed the solution up.
+An accepted solution that hits the cap is an error: its measured time is truncated, so it
+cannot bound the limit from below. Raise the cap, or speed the solution up. Either way the
+solution stops there -- its remaining testcases are skipped, since they would measure nothing
+usable.
 
-Either way, the solution stops there: its remaining testcases are skipped, since they would
-measure nothing usable.
+The cap does not apply to the solutions expected to be too slow. They are not measured at all;
+they are checked against the estimated limit instead, at a limit derived from it. Raising
+`inferenceTimeout` therefore does nothing for them.
 
 A single problem can raise it in its `problem.rbx.yml`:
 
@@ -191,6 +191,43 @@ solutions:
 
 `inference: lower` on a solution expected to be too slow is rejected: a solution meant to
 time out cannot bound the limit from below.
+
+## Checking the upper bound
+
+A solution expected to be too slow does not need to be measured. It needs to answer one
+question: does it take at least `timeLimitToTle` times the estimated limit? Running it at
+exactly that bound answers it, without waiting to find out how slow it really is.
+
+So once the limit is decided, `rbx time` runs each of those solutions at
+`timeLimitToTle × <the limit for its language>`, and reads the verdict:
+
+- It **runs out of time** -- confirmed. It respects the upper bound, and its remaining
+  testcases are skipped: one timeout settles the question.
+- It **finishes** -- the upper bound is violated, and now there is a real time to report it
+  with. `rbx` names the solution, what it took, and what the limit demands of it.
+- It **fails some other way** (a crash, a wrong answer) -- evidence of nothing either way, and
+  an error. Fix it, or set `inference: false` to leave it out.
+
+A violation is not the end of the run. The language-group picker re-opens, this time knowing
+what the check found, so its preview shows which groupings cannot work. From there you can
+regroup to satisfy the bound, press ++f++ to keep the limits anyway, or cancel. Nothing is
+written until you settle on one of the three.
+
+Where there is no picker to re-open -- `--auto`, or a problem with a single language -- the
+violation is reported, recorded in the profile under `upperValidation`, and the limit is
+written anyway.
+
+Re-checking after a regroup is cheap: a solution that already ran out of time at some limit
+also runs out of time at any lower one, and a solution that finished is answered by arithmetic.
+Only the solutions whose bound went up are run again.
+
+Pass `--skip-slow` to stop after the estimate, leaving the upper bound unchecked:
+
+```console
+$ rbx time --skip-slow
+```
+
+Without `timeLimitToTle` there is no upper bound to check, so this phase does not run at all.
 
 ## Time limit formulas
 

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -192,7 +192,7 @@ the file at load time.
 
 ### The estimation cap
 
-`timing.inferenceTimeout` caps how long any solution may run while the limit is being
+`timing.inferenceTimeout` caps how long an accepted solution may run while the limit is being
 estimated, whichever strategy estimates it:
 
 ```yaml
@@ -200,9 +200,11 @@ timing:
   inferenceTimeout: 10000   # ms; defaults to 10s
 ```
 
-A solution expected to be too slow that hits the cap is dropped from the upper bound, with a
-warning; an accepted one that hits it is an error, since its measurement is truncated and
+An accepted solution that hits the cap is an error, since its measurement is truncated and
 bounds nothing. Raise it for an environment whose solutions are legitimately slow.
+
+It does not apply to the solutions expected to be too slow: those are never measured, only
+checked against the estimated limit.
 
 !!! note "The old spelling"
 
@@ -223,12 +225,14 @@ timing:
 ```
 
 - `acToTimeLimit`: the limit is at least this multiple of the slowest accepted solution.
-- `timeLimitToTle`: the limit times this must still fit within the fastest solution expected
-  to be too slow. When it is unset, those solutions are not run at all.
+- `timeLimitToTle`: every solution expected to be too slow must take at least the limit times
+  this. It is checked after the limit is estimated, by running each of those solutions at that
+  bound. When it is unset, they are not run at all.
 - `timeResolution`: the limit is rounded up to a multiple of this.
 
-If no limit satisfies the ratios, the estimation fails naming the solution that binds each
-side, and nothing is written to the limits profile. A problem may override any subset of the
+If no limit satisfies the ratios, the estimation reports the solution that binds each side and
+re-opens the language-group picker, so the ratios can be satisfied by regrouping — or the limit
+kept anyway. A problem may override any subset of the
 ratios under `timing.multipliers` in its `problem.rbx.yml`, and a solution may opt into (or
 out of) either side with its `inference` field — see the
 [Profiling](/setters/profiling#time-limit-ratios) guide.

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -598,6 +598,12 @@ async def time(
         help='Capture the time report (run report + limits table) and copy it '
         'to the clipboard. Pass a format: --share png or --share text.',
     ),
+    skip_slow: bool = typer.Option(
+        False,
+        '--skip-slow',
+        help='Skip checking the estimated limit against the solutions expected to '
+        'be too slow. The limit is written with its upper bound unchecked.',
+    ),
 ):
     if share is not None and share not in ('png', 'text'):
         console.console.print(
@@ -698,7 +704,14 @@ async def time(
         raise typer.Exit(1)
 
     estimated = await timing.compute_time_limits(
-        check, detailed, runs, formula=formula, profile=profile, auto=auto, share=share
+        check,
+        detailed,
+        runs,
+        formula=formula,
+        profile=profile,
+        auto=auto,
+        share=share,
+        skip_slow=skip_slow,
     )
     if estimated is None:
         # Every failure of the estimation -- an unsatisfiable range, a solution

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -335,6 +335,16 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': 'Skip checking the estimated limit against the solutions '
+                    'expected to be too slow. The limit is written with its upper '
+                    'bound unchecked.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--skip-slow'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -259,8 +259,11 @@ class LimitsTableRow(BaseModel):
     source: str
     defaulted: bool = False
     is_leftover: bool = False
-    # Slow solutions of this group that bound nothing from above.
-    dropped_upper: List[str] = []
+    # Slow solutions of this group confirmed to be too slow for its limit.
+    confirmed_upper: List[str] = []
+    # Slow solutions of this group that finished within its limit times
+    # `timeLimitToTle`, so they do not respect the upper bound.
+    violating_upper: List[str] = []
 
 
 def _bounds_note(report: TimingGroupReport) -> str:
@@ -312,17 +315,24 @@ def _base_row(profile: LimitsProfile) -> LimitsTableRow:
     """
     source = 'base'
     solutions = None
-    dropped: List[str] = []
+    confirmed: List[str] = []
+    violating: List[str] = []
     if profile.baseEstimate is not None:
         source = _report_source(profile.baseEstimate)
         solutions = profile.baseEstimate.solutionCount
-        dropped = list(profile.baseEstimate.droppedUpper)
+        validation = profile.baseEstimate.upperValidation
+        if validation is not None:
+            confirmed = list(validation.confirmed)
+            violating = [
+                bound.solution for bound in validation.violating if bound.solution
+            ]
     return LimitsTableRow(
         languages='(base)',
         solutions=solutions,
         time_limit_ms=profile.timeLimit or 0,
         source=source,
-        dropped_upper=dropped,
+        confirmed_upper=confirmed,
+        violating_upper=violating,
     )
 
 
@@ -342,7 +352,20 @@ def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
                     source=source,
                     defaulted=report.origin == TimingGroupOrigin.DEFAULTED,
                     is_leftover=report.isLeftover,
-                    dropped_upper=list(report.droppedUpper),
+                    confirmed_upper=(
+                        list(report.upperValidation.confirmed)
+                        if report.upperValidation is not None
+                        else []
+                    ),
+                    violating_upper=(
+                        [
+                            bound.solution
+                            for bound in report.upperValidation.violating
+                            if bound.solution
+                        ]
+                        if report.upperValidation is not None
+                        else []
+                    ),
                 )
             )
         # Leftover group is shown first; stable sort keeps the rest in order.
@@ -421,16 +444,24 @@ def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
             '[warning]⚠ DEFAULTED: no accepted solutions and no whenEmpty rule; '
             'fell back to the base time limit.[/warning]'
         )
-    # Terse on purpose: the estimation run already warned about each dropped
+    # Terse on purpose: the validation run already reported each offending
     # solution by name, with what to do about it. This only says the table's
-    # upper bounds are missing some evidence, and where to find which.
-    dropped = {solution for row in rows for solution in row.dropped_upper}
-    if dropped:
-        plural = 's' if len(dropped) > 1 else ''
+    # limits were checked, and where to find against what.
+    violating = {solution for row in rows for solution in row.violating_upper}
+    if violating:
+        plural = 's' if len(violating) > 1 else ''
         caption_lines.append(
-            f'[warning]⚠ {len(dropped)} slow solution{plural} hit the inference '
-            f'timeout and bound{"" if plural else "s"} nothing from above; named '
-            f'under droppedUpper in the limits profile.[/warning]'
+            f'[error]⚠ {len(violating)} solution{plural} expected to be too slow '
+            f'finished within the estimated limit, so the upper bound is not '
+            f'respected; named under upperValidation in the limits profile.[/error]'
+        )
+    confirmed = {solution for row in rows for solution in row.confirmed_upper}
+    if confirmed:
+        plural = 's' if len(confirmed) > 1 else ''
+        caption_lines.append(
+            f'[success]✓ {len(confirmed)} solution{plural} expected to be too slow '
+            f'{"were" if plural else "was"} confirmed too slow for the estimated '
+            f'limit.[/success]'
         )
     caption = '\n'.join(caption_lines) if caption_lines else None
     table = rich.table.Table(

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -960,6 +960,33 @@ solution of the group. Absent when the bound was derived from another group's li
     )
 
 
+class TimingGroupUpperValidation(BaseModel):
+    """What checking a group's slow solutions against its time limit found."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    confirmed: List[str] = Field(
+        default=[],
+        description="""Solutions of this group expected to be too slow that were
+confirmed to be so: they were still running once the estimated time limit times
+`timeLimitToTle` had elapsed. Presentation-only.""",
+    )
+
+    violating: List[TimingBound] = Field(
+        default=[],
+        description="""Solutions of this group expected to be too slow that finished
+within the estimated time limit times `timeLimitToTle`, so they do not respect the
+upper bound. `value` is the time the solution actually took. Presentation-only.""",
+    )
+
+    skipped: List[str] = Field(
+        default=[],
+        description="""Solutions of this group expected to be too slow that were not
+run, either because `timeLimitToTle` is unset or because the validation phase was
+skipped. Presentation-only.""",
+    )
+
+
 class TimingGroupReport(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
@@ -987,11 +1014,19 @@ was estimated from multipliers and some slow solution of the group bounded it.
 Presentation-only.""",
     )
 
+    upperValidation: Optional[TimingGroupUpperValidation] = Field(
+        default=None,
+        description="""What checking this group's slow solutions against its estimated
+time limit found. Absent when the group has no slow solutions. Presentation-only.""",
+    )
+
     droppedUpper: List[str] = Field(
         default=[],
-        description="""Solutions of this group that were expected to be too slow but
-were still running at `inferenceTimeout`, so they bound nothing from above.
-Presentation-only.""",
+        deprecated=True,
+        exclude=True,
+        description="""Deprecated: replaced by `upperValidation`. Accepted so that a
+limits profile written before the estimation was split into two phases still parses;
+never written.""",
     )
 
 

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -7,7 +7,18 @@ import shutil
 import typing
 from collections.abc import AsyncIterator
 from enum import Enum
-from typing import Callable, Collection, Dict, Iterable, List, Optional, Set, Tuple
+from typing import (
+    Callable,
+    Collection,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import rich
 import rich.live
@@ -96,6 +107,28 @@ from rbx.grading.steps import (
 from rbx.utils import StatusProgress
 
 StructuredEvaluation = Dict[str, Dict[str, List[Optional[Deferred[Evaluation]]]]]
+
+# The enforced time limit for a run: one limit for every language, or one per
+# language. The per-language form exists because a time-limit estimate assigns a
+# different limit to each language group (see `rbx/box/timing.py`).
+TimelimitOverride = Union[int, Mapping[str, int]]
+
+
+def resolve_timelimit_override(
+    override: Optional[TimelimitOverride],
+    lang: Optional[str],
+) -> Optional[int]:
+    """The limit this language runs under, or None to keep the profile's own.
+
+    A mapping that does not mention the language -- or a language that could not
+    be identified at all -- resolves to None rather than to some other language's
+    limit.
+    """
+    if override is None or isinstance(override, int):
+        return override
+    if lang is None:
+        return None
+    return override.get(lang)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -570,13 +603,17 @@ def _run_solution(
     interactor_digest: Optional[str] = None,
     progress: Optional[StatusProgress] = None,
     verification: VerificationLevel = VerificationLevel.NONE,
-    timelimit_override: Optional[int] = None,
+    timelimit_override: Optional[TimelimitOverride] = None,
     nruns: int = 0,
     capture_pipes: bool = False,
     gate: Optional['_AbortGate'] = None,
     abort_on: Optional[AbortPredicate] = None,
 ) -> List[Deferred[Evaluation]]:
     groups_by_name = {group.name: group for group in groups}
+    # Resolved once per solution: its language cannot change between testcases.
+    solution_timelimit = resolve_timelimit_override(
+        timelimit_override, find_language_name(solution)
+    )
 
     res: List[Deferred[Evaluation]] = []
     for i, entry in enumerate(entries):
@@ -604,7 +641,7 @@ def _run_solution(
                 interactor_digest=interactor_digest,
                 testcase_index=i,
                 verification=verification,
-                timelimit_override=timelimit_override,
+                timelimit_override=solution_timelimit,
                 nruns=nruns,
                 capture_pipes=capture_pipes,
             )
@@ -706,7 +743,7 @@ async def _get_compiled_solutions_for_skeleton(
 async def _get_report_skeleton(
     tracked_solutions: Optional[Iterable[str]] = None,
     verification: VerificationLevel = VerificationLevel.NONE,
-    timelimit_override: Optional[int] = None,
+    timelimit_override: Optional[TimelimitOverride] = None,
     progress: Optional[StatusProgress] = None,
     sanitized: bool = False,
 ) -> SolutionReportSkeleton:
@@ -726,7 +763,9 @@ async def _get_report_skeleton(
 
     langs = set(find_language_name(solution) for solution in solutions)
     limits = {
-        lang: get_limits_for_language(lang, verification, timelimit_override)
+        lang: get_limits_for_language(
+            lang, verification, resolve_timelimit_override(timelimit_override, lang)
+        )
         for lang in langs
         if lang is not None
     }
@@ -798,7 +837,7 @@ async def _produce_solution_items(
     progress: Optional[StatusProgress] = None,
     verification: VerificationLevel = VerificationLevel.NONE,
     check: bool = True,
-    timelimit_override: Optional[int] = None,
+    timelimit_override: Optional[TimelimitOverride] = None,
     nruns: int = 0,
     abort_on: Optional[AbortPredicate] = None,
 ) -> List[EvaluationItem]:
@@ -874,7 +913,7 @@ async def run_solutions(
     tracked_solutions: Optional[Iterable[str]] = None,
     verification: VerificationLevel = VerificationLevel.NONE,
     check: bool = True,
-    timelimit_override: Optional[int] = None,
+    timelimit_override: Optional[TimelimitOverride] = None,
     sanitized: bool = False,
     nruns: int = 0,
     abort_on: Optional[AbortPredicate] = None,

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -1169,6 +1169,9 @@ class _ValidationOutcome:
 
     # Confirmed too slow: still running when the limit they had to clear elapsed.
     confirmed: List[Solution] = dataclasses.field(default_factory=list)
+    # Ran, or should have, and produced no verdict at all -- a solution that
+    # failed to compile, say. It answers nothing, so the bound is not checked.
+    unmeasured: List[Solution] = dataclasses.field(default_factory=list)
     # Fast enough to break the upper bound, with the time they actually took.
     violating: List[Tuple[Solution, int]] = dataclasses.field(default_factory=list)
     # Broke for a reason other than running out of time, so they are evidence of
@@ -1177,7 +1180,7 @@ class _ValidationOutcome:
 
     @property
     def ok(self) -> bool:
-        return not self.violating and not self.failed
+        return not self.violating and not self.failed and not self.unmeasured
 
 
 def _probe_limits(
@@ -1202,13 +1205,17 @@ async def _record_validation_run(
     solutions_run: List[Solution],
     limits: Dict[str, int],
     knowledge: timing_validation.SlowKnowledge,
-) -> List[Tuple[Solution, Outcome]]:
-    """Fold what the run said into ``knowledge``; return the solutions that broke
-    for a reason other than running out of time."""
+) -> Tuple[List[Tuple[Solution, Outcome]], List[Solution]]:
+    """Fold what the run said into ``knowledge``.
+
+    Returns the solutions that broke for a reason other than running out of time,
+    and the ones that produced no verdict at all.
+    """
     structured_evaluations = consume_and_key_evaluation_items(
         result.items, result.skeleton
     )
     failed: List[Tuple[Solution, Outcome]] = []
+    unmeasured: List[Solution] = []
     for solution in solutions_run:
         path = str(solution.path)
         outcomes: List[Outcome] = []
@@ -1241,7 +1248,10 @@ async def _record_validation_run(
             # Its time is the slowest testcase, as everywhere else: that is the
             # one the limit has to accommodate.
             knowledge.record_time(path, max(timings))
-    return failed
+        else:
+            # It was asked and said nothing -- it did not compile, or never ran.
+            unmeasured.append(solution)
+    return failed, unmeasured
 
 
 def _classify_slow_solutions(
@@ -1249,13 +1259,16 @@ def _classify_slow_solutions(
     upper_solutions: List[Solution],
     knowledge: timing_validation.SlowKnowledge,
     failed: List[Tuple[Solution, Outcome]],
+    unmeasured: Optional[List[Solution]] = None,
 ) -> _ValidationOutcome:
     """What is now known about every slow solution, not only the ones that just
     ran: an earlier iteration may already have settled some of them."""
     multipliers = profile.multipliers
     assert multipliers is not None and multipliers.timeLimitToTle is not None
+    unmeasured = unmeasured or []
     broken = {str(solution.path) for solution, _ in failed}
-    outcome = _ValidationOutcome(failed=list(failed))
+    broken.update(str(solution.path) for solution in unmeasured)
+    outcome = _ValidationOutcome(failed=list(failed), unmeasured=list(unmeasured))
     for solution in upper_solutions:
         path = str(solution.path)
         if path in broken:
@@ -1333,8 +1346,10 @@ async def _validate_upper_bound(
         gating_solutions=set(tracked_solutions),
     )
 
-    failed = await _record_validation_run(result, to_run, limits, knowledge)
-    return _classify_slow_solutions(profile, upper_solutions, knowledge, failed)
+    failed, unmeasured = await _record_validation_run(result, to_run, limits, knowledge)
+    return _classify_slow_solutions(
+        profile, upper_solutions, knowledge, failed, unmeasured
+    )
 
 
 def _report_validation_outcome(
@@ -1351,6 +1366,11 @@ def _report_validation_outcome(
         )
     for solution, outcome_value in outcome.failed:
         console.console.print(_failed_upper_message(solution, outcome_value))
+    for solution in outcome.unmeasured:
+        console.console.print(
+            f'[error]✗ {solution.href()} produced no verdict at all, so nothing '
+            f'checks that it is too slow for the estimated time limit.[/error]'
+        )
     for solution, time in outcome.violating:
         lang = find_language_name(solution)
         time_limit = profile.timeLimitPerLanguage.get(lang, profile.timeLimit)
@@ -1394,7 +1414,13 @@ async def _estimate_and_validate(
             picked, knowledge=knowledge, force=violated and picked.force
         )
         if profile is None:
-            return None
+            # No limit fits this grouping. Every reason for that is a property of
+            # the grouping, so ask again rather than giving up -- the setter can
+            # still cancel. With nothing to ask, there is nothing to do but stop.
+            if auto or not ctx.can_prompt:
+                return None
+            violated = True
+            continue
 
         if skip_slow or picked.force:
             return profile

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -599,7 +599,7 @@ def _describe_strategy(strategy: timing_config.TimingStrategy) -> str:
     instead of merely omitted.
     """
     cap_line = (
-        f'  every solution runs capped at {strategy.inferenceTimeout} ms '
+        f'  the accepted solutions run capped at {strategy.inferenceTimeout} ms '
         f'(inferenceTimeout)'
     )
     if not strategy.uses_multipliers:
@@ -612,8 +612,9 @@ def _describe_strategy(strategy: timing_config.TimingStrategy) -> str:
     ]
     if multipliers.timeLimitToTle is not None:
         lines.append(
-            f'  and at most 1/{multipliers.timeLimitToTle} of the fastest solution '
-            f'expected to be too slow (timeLimitToTle)'
+            f'  and every solution expected to be too slow must take at least '
+            f'{multipliers.timeLimitToTle}x the limit, checked afterwards '
+            f'(timeLimitToTle)'
         )
     else:
         lines.append(
@@ -1410,7 +1411,11 @@ async def _estimate_and_validate(
         )
         _report_validation_outcome(outcome, profile)
         if outcome.ok:
-            return profile
+            # Rebuilt so the profile records what the check found rather than
+            # what was known before it ran. The limits cannot move: a confirmed
+            # solution contributes no measurement, and a measured one that
+            # respects the bound only widens the range the limit already fits.
+            return ctx.build(picked, knowledge=knowledge, announce=False)
 
         violated = True
         if auto or not ctx.can_prompt:

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -1363,6 +1363,73 @@ def _report_validation_outcome(
         )
 
 
+async def _estimate_and_validate(
+    ctx: _EstimationContext,
+    knowledge: timing_validation.SlowKnowledge,
+    auto: bool,
+    skip_slow: bool,
+    check: bool,
+    detailed: bool,
+    runs: int,
+) -> Optional[TimingProfile]:
+    """Estimate a limit and check it against the solutions expected to be too
+    slow, letting the setter re-decide until the two agree.
+
+    A violation is not fatal: it is new evidence. Carrying it back into the
+    picker is what makes the second pass better informed than the first -- the
+    preview can now show which groupings are impossible -- and the setter either
+    picks one that works, keeps the limit anyway, or gives up. Where there is no
+    picker to go back to, the violation is recorded and reported instead, and the
+    profile is written with it.
+    """
+    violated = False
+    while True:
+        picked = await ctx.prompt(auto=auto, knowledge=knowledge, allow_force=violated)
+        if picked is None:
+            ctx.console.print('[error]Time limit estimation cancelled.[/error]')
+            return None
+
+        profile = ctx.build(
+            picked, knowledge=knowledge, force=violated and picked.force
+        )
+        if profile is None:
+            return None
+
+        if skip_slow or picked.force:
+            return profile
+        if not can_validate_upper_bound(profile, ctx.upper_solutions):
+            return profile
+
+        outcome = await _validate_upper_bound(
+            profile,
+            ctx.upper_solutions,
+            knowledge,
+            check=check,
+            detailed=detailed,
+            runs=runs,
+        )
+        _report_validation_outcome(outcome, profile)
+        if outcome.ok:
+            return profile
+
+        violated = True
+        if auto or not ctx.can_prompt:
+            # Nothing to go back to: record what was found and write it anyway,
+            # so the profile carries the violation rather than hiding it.
+            ctx.console.print(
+                '[warning]⚠ The estimated time limit does not respect its upper '
+                'bound, and there is no grouping to re-pick. Writing it anyway; '
+                'the offending solutions are named under upperValidation in the '
+                'limits profile.[/warning]'
+            )
+            return ctx.build(picked, knowledge=knowledge, force=True, announce=False)
+
+        ctx.console.print(
+            '[warning]⚠ Re-opening the picker with what the check found. Regroup '
+            'to satisfy the bound, keep these limits anyway, or cancel.[/warning]'
+        )
+
+
 async def compute_time_limits(
     check: bool,
     detailed: bool,
@@ -1371,6 +1438,7 @@ async def compute_time_limits(
     formula: Optional[str] = None,
     auto: bool = False,
     share: Optional[str] = None,
+    skip_slow: bool = False,
 ):
     if package.get_main_solution() is None:
         # An error, not a warning: with no accepted solution nothing bounds the
@@ -1386,11 +1454,25 @@ async def compute_time_limits(
     if run is None:
         return None
 
-    estimated_tl = await estimate_time_limit(
+    knowledge = timing_validation.SlowKnowledge()
+    ctx = await build_estimation_context(
         console.console,
         run.result,
         run.strategy,
+        upper_solutions=get_inference_solutions(InferenceRole.UPPER),
+        knowledge=knowledge,
+    )
+    if ctx is None:
+        return None
+
+    estimated_tl = await _estimate_and_validate(
+        ctx,
+        knowledge,
         auto=auto,
+        skip_slow=skip_slow,
+        check=check,
+        detailed=detailed,
+        runs=runs,
     )
     if estimated_tl is None:
         return None

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -227,10 +227,16 @@ def _check_bounds(
     bounds: TimingBounds,
     multipliers: schema.TimingMultipliers,
     measured: timing_groups.GroupMeasurements,
+    force: bool = False,
 ) -> int:
     """Return the quantized limit if the group's slow solutions allow it, else
-    raise naming the binding solution on each side and the knob to turn."""
-    if bounds.fits:
+    raise naming the binding solution on each side and the knob to turn.
+
+    ``force`` keeps the limit anyway, for a setter who has seen the violation and
+    decided to accept it. The violation is not swallowed: the bounds it breaks
+    stay on the group report, so the profile records what was overridden.
+    """
+    if bounds.fits or force:
         return bounds.time_limit
     assert bounds.upper is not None
 
@@ -274,20 +280,25 @@ def _check_bounds(
 
 def make_multipliers_eval(
     multipliers: schema.TimingMultipliers,
+    force: bool = False,
 ) -> timing_groups.EvalFn:
     """Estimator that bounds the limit from below by the group's accepted
     solutions, quantizes it to ``timeResolution``, and checks it against the
-    upper bound its slow solutions impose."""
+    upper bound its slow solutions impose. ``force`` keeps a limit that fails
+    that check."""
 
     def _eval(measured: timing_groups.GroupMeasurements) -> timing_groups.EvalResult:
         bounds = compute_bounds(multipliers, measured)
-        return _as_eval_result(bounds, _check_bounds(bounds, multipliers, measured))
+        return _as_eval_result(
+            bounds, _check_bounds(bounds, multipliers, measured, force=force)
+        )
 
     return _eval
 
 
 def make_multipliers_derive(
     multipliers: schema.TimingMultipliers,
+    force: bool = False,
 ) -> timing_groups.DeriveFn:
     """Post-processor for a limit that did NOT come from the group's own accepted
     solutions: it is quantized to ``timeResolution`` and still checked against
@@ -297,7 +308,9 @@ def make_multipliers_derive(
         tl: int, measured: timing_groups.GroupMeasurements
     ) -> timing_groups.EvalResult:
         bounds = compute_bounds(multipliers, measured, derived_from=tl)
-        return _as_eval_result(bounds, _check_bounds(bounds, multipliers, measured))
+        return _as_eval_result(
+            bounds, _check_bounds(bounds, multipliers, measured, force=force)
+        )
 
     return _derive
 
@@ -367,12 +380,13 @@ def build_timing_profile(
     confirmed_upper_per_language: Optional[Dict[str, List[str]]] = None,
     repartition: Optional[Dict[str, int]] = None,
     relatives: Optional[Dict[str, environment.LanguageGroupFallback]] = None,
+    force: bool = False,
 ) -> TimingProfile:
     multipliers = strategy.multipliers
     if multipliers is not None:
-        eval_fn = make_multipliers_eval(multipliers)
+        eval_fn = make_multipliers_eval(multipliers, force=force)
         derive_fn: Optional[timing_groups.DeriveFn] = make_multipliers_derive(
-            multipliers
+            multipliers, force=force
         )
     else:
         eval_fn = make_formula_eval(strategy.formula_or_die())

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -2,7 +2,7 @@ import dataclasses
 import functools
 import math
 from fractions import Fraction
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set
 
 import rich
 import rich.console
@@ -800,39 +800,10 @@ async def estimate_time_limit(
     return profile
 
 
-@dataclasses.dataclass(frozen=True)
-class _InferenceCap:
-    """The cap an estimation run enforced, with the ratio that justifies it.
-
-    Every estimation run is capped -- the cap is a property of the estimation,
-    not of the multipliers -- but only a run that bounds the limit from above has
-    a `timeLimitToTle` to weigh a dropped solution against.
-    """
-
-    timeout: int
-    time_limit_to_tle: Optional[float] = None
-
-    @property
-    def largest_bounded_limit(self) -> int:
-        """The largest limit a solution stopped at the cap could still justify.
-        Above it, the cap -- not the solution -- is what bounded the estimate."""
-        assert self.time_limit_to_tle is not None, (
-            'Only a run bounded from above can drop a solution at the cap.'
-        )
-        return math.floor(self.timeout / _exact(self.time_limit_to_tle))
-
-
 @dataclasses.dataclass
 class _InferenceDiagnosis:
     """What the capped estimation run says about the solutions it measured."""
 
-    # Slow solutions killed at the cap: measured, but bounding nothing.
-    dropped_upper: List[Solution] = dataclasses.field(default_factory=list)
-    # Slow solutions that failed for a reason other than running out of time,
-    # with the verdict that says so. Their timings are meaningless.
-    failed_upper: List[Tuple[Solution, Outcome]] = dataclasses.field(
-        default_factory=list
-    )
     # Accepted solutions killed at the cap: the estimate would rest on a
     # truncated measurement.
     truncated_lower: List[Solution] = dataclasses.field(default_factory=list)
@@ -844,8 +815,7 @@ async def _diagnose_inference_run(result: RunSolutionResult) -> _InferenceDiagno
     )
     diagnosis = _InferenceDiagnosis()
     for solution in result.skeleton.solutions:
-        role = inference_role_of(solution)
-        if role is None:
+        if inference_role_of(solution) != InferenceRole.LOWER:
             continue
         outcomes: List[Outcome] = []
         for evals in structured_evaluations.get(str(solution.path), {}).values():
@@ -861,18 +831,7 @@ async def _diagnose_inference_run(result: RunSolutionResult) -> _InferenceDiagno
                 if outcome == Outcome.SKIPPED:
                     continue
                 outcomes.append(outcome)
-        timed_out = any(outcome.is_slow() for outcome in outcomes)
-        broken = [
-            outcome
-            for outcome in outcomes
-            if outcome != Outcome.ACCEPTED and not outcome.is_slow()
-        ]
-        if role == InferenceRole.UPPER:
-            if broken:
-                diagnosis.failed_upper.append((solution, broken[0]))
-            elif timed_out:
-                diagnosis.dropped_upper.append(solution)
-        elif timed_out:
+        if any(outcome.is_slow() for outcome in outcomes):
             diagnosis.truncated_lower.append(solution)
     return diagnosis
 
@@ -905,106 +864,17 @@ def _failed_upper_message(solution: Solution, outcome: Outcome) -> str:
     )
 
 
-def _report_inference_diagnosis(
-    diagnosis: _InferenceDiagnosis, cap: _InferenceCap
-) -> bool:
+def _report_inference_diagnosis(diagnosis: _InferenceDiagnosis, timeout: int) -> bool:
     """Print what the run says about each solution; return whether the estimate
     may proceed."""
-    for solution in diagnosis.dropped_upper:
-        console.console.print(
-            f'[warning]⚠ {solution.href()} was still running at the inference '
-            f'timeout of {cap.timeout} ms, so it does not bound the time limit '
-            f'from above.[/warning]'
-        )
-    for solution, outcome in diagnosis.failed_upper:
-        console.console.print(_failed_upper_message(solution, outcome))
     for solution in diagnosis.truncated_lower:
         console.console.print(
             f'[error]✗ {solution.href()} was still running at the inference '
-            f'timeout of {cap.timeout} ms, so its measured time is truncated and '
+            f'timeout of {timeout} ms, so its measured time is truncated and '
             f'cannot bound the time limit from below. Raise '
             f'[item]inferenceTimeout[/item], or speed the solution up.[/error]'
         )
-    return not diagnosis.failed_upper and not diagnosis.truncated_lower
-
-
-def _bounded_scopes(
-    estimated: TimingProfile, dropped: List[Solution]
-) -> List[Tuple[str, int, List[str]]]:
-    """Every (name, resolved limit, solutions dropped inside it) an estimate
-    resolved: one per language group, plus the pooled base limit.
-
-    Scopes resolving to the same limit from the same drops are reported once --
-    a single-group problem would otherwise say the same thing twice, as its
-    group and its base limit are the same estimate seen from two sides.
-    """
-    scopes: List[Tuple[str, int, List[str]]] = []
-    for report in estimated.groups or []:
-        scopes.append(
-            (', '.join(report.languages), report.timeLimit, report.droppedUpper)
-        )
-    base = estimated.baseEstimate
-    scopes.append(
-        (
-            'the base time limit',
-            estimated.timeLimit,
-            # Without a base report there is no record of what the pooled
-            # estimate saw, and every drop reached it by definition.
-            list(base.droppedUpper)
-            if base is not None
-            else [str(solution.path) for solution in dropped],
-        )
-    )
-    seen = set()
-    unique: List[Tuple[str, int, List[str]]] = []
-    for name, time_limit, dropped_paths in scopes:
-        key = (time_limit, tuple(sorted(dropped_paths)))
-        if key in seen:
-            continue
-        seen.add(key)
-        unique.append((name, time_limit, dropped_paths))
-    return unique
-
-
-def _warn_if_the_cap_bounded_the_estimate(
-    estimated: TimingProfile,
-    cap: _InferenceCap,
-    dropped: List[Solution],
-) -> None:
-    """Diagnostic (2): something was dropped at the cap AND the resolved limit is
-    above what the cap alone allows, so the cap -- not the slow solutions -- is
-    what bounded the estimate.
-
-    Checked per language group, because that is the scope a drop bounds: a slow
-    C++ solution stopped at the cap says nothing about the limit resolved for
-    Python, and blaming the cap for it would send the setter after a solution
-    that bounds a different group entirely. The pooled base limit is one more
-    such scope -- it is what DEFAULTED languages and the packagers run under,
-    and it pools every drop.
-
-    The drops themselves were reported before the run report and the estimation
-    tables, far enough up to have scrolled away, so they are named again here.
-    """
-    if not dropped:
-        return
-    by_path = {str(solution.path): solution for solution in dropped}
-    for languages, time_limit, dropped_paths in _bounded_scopes(estimated, dropped):
-        if not dropped_paths:
-            continue
-        if time_limit <= cap.largest_bounded_limit:
-            continue
-        names = ', '.join(
-            by_path[path].href() if path in by_path else path for path in dropped_paths
-        )
-        console.console.print(
-            f'[warning]⚠ The upper bound of this estimate is not trustworthy for '
-            f'[item]{languages}[/item]: {names} stopped at the inference timeout '
-            f'of {cap.timeout} ms, and the limit of {time_limit} ms resolved '
-            f'for it is above the {cap.largest_bounded_limit} ms that '
-            f'timeout allows on its own (inferenceTimeout / timeLimitToTle). The '
-            f'cap, not the slow solutions, is what bounded the estimate -- raise '
-            f'[item]inferenceTimeout[/item] to measure them for real.[/warning]'
-        )
+    return not diagnosis.truncated_lower
 
 
 @dataclasses.dataclass
@@ -1014,17 +884,7 @@ class _InferenceRun:
     result: RunSolutionResult
     strategy: timing_config.TimingStrategy
     # The cap this run enforced. Always present: every run is capped.
-    cap: _InferenceCap
-    # Slow solutions the cap stopped, so they measure nothing usable.
-    dropped_upper: List[Solution] = dataclasses.field(default_factory=list)
-
-    def dropped_upper_per_language(self) -> Dict[str, List[str]]:
-        per_language: Dict[str, List[str]] = {}
-        for solution in self.dropped_upper:
-            per_language.setdefault(find_language_name(solution), []).append(
-                str(solution.path)
-            )
-        return per_language
+    timeout: int
 
 
 def _resolve_inference_strategy(
@@ -1054,7 +914,6 @@ async def _run_for_inference(
     """Run the solutions the time limit is inferred from, report them, and say
     what their verdicts mean. ``None`` when the estimate must not proceed."""
     strategy = _resolve_inference_strategy(formula)
-    multipliers = strategy.multipliers
 
     lower_solutions = get_inference_solutions(InferenceRole.LOWER)
     if not lower_solutions:
@@ -1062,28 +921,16 @@ async def _run_for_inference(
         # anything: no run and no grouping could rescue the estimate.
         raise MissingLowerBoundError(_NO_LOWER_BOUND_MESSAGE)
 
-    upper_solutions: List[Solution] = []
-    time_limit_to_tle = multipliers.timeLimitToTle if multipliers is not None else None
-    if time_limit_to_tle is not None:
-        # The slow solutions are only worth running when their timings bound
-        # something -- and they only terminate because of the cap below.
-        upper_solutions = get_inference_solutions(InferenceRole.UPPER)
-    # Every estimation run is capped, whatever it estimates with: a solution that
-    # outruns the cap measures nothing usable, and waiting on it forever measures
-    # nothing either.
-    cap = _InferenceCap(
-        timeout=strategy.inferenceTimeout,
-        time_limit_to_tle=time_limit_to_tle if upper_solutions else None,
-    )
+    # The solutions expected to be too slow are NOT run here. Nothing bounds how
+    # long they take, so the only limit that could terminate them is the cap --
+    # which is set for the accepted solutions and says nothing about the limit
+    # they are meant to bound. They are checked in the validation phase instead,
+    # against the limit this run estimates.
+    timeout = strategy.inferenceTimeout
 
-    status = (
-        'Running solutions for time estimation...'
-        if upper_solutions
-        else 'Running ACCEPTED solutions...'
-    )
-    with utils.StatusProgress(status) as s:
+    with utils.StatusProgress('Running ACCEPTED solutions...') as s:
         tracked_solutions = OrderedSet(
-            str(solution.path) for solution in [*lower_solutions, *upper_solutions]
+            str(solution.path) for solution in lower_solutions
         )
         result = await run_solutions(
             progress=s,
@@ -1093,12 +940,10 @@ async def _run_for_inference(
             # doubling the limit here would double the very cap that exists to
             # bound the solutions running under it.
             verification=_INFERENCE_VERIFICATION,
-            timelimit_override=cap.timeout,
+            timelimit_override=timeout,
             nruns=runs,
-            # A solution killed at the cap has its measurement dropped either
-            # way -- an upper-bound one bounds nothing, a lower-bound one fails
-            # the estimate outright -- so its remaining tests only cost wall
-            # clock.
+            # An accepted solution killed at the cap fails the estimate outright,
+            # so its remaining tests only cost wall clock.
             abort_on=lambda ctx: ctx.evaluation.result.outcome.is_slow(),
         )
 
@@ -1112,16 +957,12 @@ async def _run_for_inference(
         _INFERENCE_VERIFICATION,
         detailed=detailed,
         skip_printing_limits=True,
-        # An upper-bound solution is *supposed* to hit the cap, so only the
-        # solutions that bound the limit from below decide whether the run
-        # succeeded.
         gating_solutions={str(solution.path) for solution in lower_solutions},
     )
 
     diagnosis = await _diagnose_inference_run(result)
-    if not _report_inference_diagnosis(diagnosis, cap):
+    if not _report_inference_diagnosis(diagnosis, timeout):
         return None
-    dropped_upper = diagnosis.dropped_upper
 
     if not ok:
         console.console.print(
@@ -1129,9 +970,7 @@ async def _run_for_inference(
         )
         return None
 
-    return _InferenceRun(
-        result=result, strategy=strategy, cap=cap, dropped_upper=dropped_upper
-    )
+    return _InferenceRun(result=result, strategy=strategy, timeout=timeout)
 
 
 async def compute_time_limits(
@@ -1162,12 +1001,9 @@ async def compute_time_limits(
         run.result,
         run.strategy,
         auto=auto,
-        confirmed_upper_per_language=run.dropped_upper_per_language(),
     )
     if estimated_tl is None:
         return None
-
-    _warn_if_the_cap_bounded_the_estimate(estimated_tl, run.cap, run.dropped_upper)
 
     limits_path = package.get_limits_file(profile)
     console.console.print(

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -22,6 +22,7 @@ from rbx.box import (
     timing_config,
     timing_group_picker,
     timing_groups,
+    timing_validation,
 )
 from rbx.box.code import find_language_name
 from rbx.box.environment import VerificationLevel
@@ -378,6 +379,7 @@ def build_timing_profile(
     all_languages: List[str],
     slow_timing_per_solution_per_language: Optional[Dict[str, Dict[str, int]]] = None,
     confirmed_upper_per_language: Optional[Dict[str, List[str]]] = None,
+    skipped_upper_per_language: Optional[Dict[str, List[str]]] = None,
     repartition: Optional[Dict[str, int]] = None,
     relatives: Optional[Dict[str, environment.LanguageGroupFallback]] = None,
     force: bool = False,
@@ -394,6 +396,7 @@ def build_timing_profile(
 
     slow_per_language = slow_timing_per_solution_per_language or {}
     confirmed_per_language = confirmed_upper_per_language or {}
+    skipped_per_language = skipped_upper_per_language or {}
 
     if repartition is not None:
         groups = timing_groups.partition_from_assignment(repartition, relatives)
@@ -405,30 +408,37 @@ def build_timing_profile(
     all_values: List[timing_groups.Measurement] = []
     all_slow_values: List[timing_groups.Measurement] = []
     all_confirmed: List[str] = []
+    all_skipped: List[str] = []
     for idx, group in enumerate(groups):
         values = _pooled(timing_per_solution_per_language, group.languages)
         slow_values = _pooled(slow_per_language, group.languages)
-        dropped = [
+        confirmed = [
             path
             for lang in group.languages
             for path in (confirmed_per_language.get(lang) or [])
         ]
-        if not values and not slow_values and not dropped:
+        skipped = [
+            path
+            for lang in group.languages
+            for path in (skipped_per_language.get(lang) or [])
+        ]
+        if not values and not slow_values and not confirmed and not skipped:
             continue
         measured[idx] = timing_groups.GroupMeasurements(
             lower=_lower_timings(values),
-            upper=_upper_timings(slow_values, dropped),
+            upper=_upper_timings(slow_values, confirmed, skipped),
         )
         all_values.extend(values)
         all_slow_values.extend(slow_values)
-        all_confirmed.extend(dropped)
+        all_confirmed.extend(confirmed)
+        all_skipped.extend(skipped)
 
     if not all_values:
         raise MissingLowerBoundError(_NO_LOWER_BOUND_MESSAGE)
 
     base = timing_groups.GroupMeasurements(
         lower=_lower_timings(all_values),
-        upper=_upper_timings(all_slow_values, all_confirmed),
+        upper=_upper_timings(all_slow_values, all_confirmed, all_skipped),
     )
     result = timing_groups.resolve_groups(groups, measured, base, eval_fn, derive_fn)
     return TimingProfile(
@@ -483,6 +493,7 @@ def build_preview_renderer(
     all_languages: List[str],
     slow_timing_per_solution_per_language: Optional[Dict[str, Dict[str, int]]] = None,
     confirmed_upper_per_language: Optional[Dict[str, List[str]]] = None,
+    skipped_upper_per_language: Optional[Dict[str, List[str]]] = None,
     width: Optional[int] = None,
 ) -> Callable[..., ANSI]:
     """Return a memoized callback mapping a picker assignment (and optional
@@ -502,6 +513,7 @@ def build_preview_renderer(
                 all_languages=all_languages,
                 slow_timing_per_solution_per_language=slow_timing_per_solution_per_language,
                 confirmed_upper_per_language=confirmed_upper_per_language,
+                skipped_upper_per_language=skipped_upper_per_language,
                 repartition=assignment,
                 relatives=relatives,
             )
@@ -538,6 +550,8 @@ async def _prompt_repartition(
     strategy: timing_config.TimingStrategy,
     slow_timing_per_solution_per_language: Optional[Dict[str, Dict[str, int]]] = None,
     confirmed_upper_per_language: Optional[Dict[str, List[str]]] = None,
+    skipped_upper_per_language: Optional[Dict[str, List[str]]] = None,
+    allow_force: bool = False,
 ) -> Optional[timing_group_picker.GroupAssignment]:
     preview = build_preview_renderer(
         timing_per_solution_per_language=timing_per_solution_per_language,
@@ -546,6 +560,7 @@ async def _prompt_repartition(
         all_languages=all_languages,
         slow_timing_per_solution_per_language=slow_timing_per_solution_per_language,
         confirmed_upper_per_language=confirmed_upper_per_language,
+        skipped_upper_per_language=skipped_upper_per_language,
         width=console.console.size.width,
     )
     langs_with_solutions = {
@@ -556,6 +571,7 @@ async def _prompt_repartition(
         default_assignment(all_languages, env_groups),
         relatives=default_relatives(env_groups, langs_with_solutions),
         preview=preview,
+        allow_force=allow_force,
     )
 
 
@@ -677,13 +693,169 @@ def _flatten(per_language: Dict[str, Dict[str, int]]) -> List[int]:
     ]
 
 
-async def estimate_time_limit(
+@dataclasses.dataclass(frozen=True)
+class _SlowEvidence:
+    """What is known about the slow solutions, pooled by language.
+
+    Three disjoint buckets, because they mean three different things to the
+    estimate: a measured solution bounds the limit from above, a confirmed one
+    respects whatever bound it was checked against, and a skipped one was never
+    asked.
+    """
+
+    measured: Dict[str, Dict[str, int]]
+    confirmed: Dict[str, List[str]]
+    skipped: Dict[str, List[str]]
+
+    @property
+    def languages(self) -> List[str]:
+        return list(OrderedSet([*self.measured, *self.confirmed, *self.skipped]))
+
+
+@dataclasses.dataclass(frozen=True)
+class _Picked:
+    """How the setter answered the grouping question.
+
+    ``assignment`` is None when nothing was asked -- ``--auto``, or a problem
+    with a single language -- and the environment's own partition stands.
+    """
+
+    assignment: Optional[timing_group_picker.GroupAssignment]
+    force: bool = False
+
+    @property
+    def numbers(self) -> Optional[Dict[str, int]]:
+        return self.assignment.numbers if self.assignment is not None else None
+
+    @property
+    def relatives(self) -> Optional[Dict[str, environment.LanguageGroupFallback]]:
+        return self.assignment.relatives if self.assignment is not None else None
+
+
+@dataclasses.dataclass
+class _EstimationContext:
+    """Phase 1's measurements, ready to be estimated from repeatedly.
+
+    The picker may be re-entered once the validation phase has something to say,
+    so everything that does not change between iterations is computed once. What
+    does change is the evidence about the slow solutions, which is read out of
+    the knowledge passed in at each call.
+    """
+
+    console: rich.console.Console
+    strategy: timing_config.TimingStrategy
+    env_groups: List[environment.LanguageGroup]
+    all_languages: List[str]
+    lower_timings: Dict[str, Dict[str, int]]
+    upper_solutions: List[Solution]
+
+    @property
+    def can_prompt(self) -> bool:
+        """Whether there is a grouping decision for the setter to make."""
+        return len(self.all_languages) > 1
+
+    def slow_evidence(self, knowledge: timing_validation.SlowKnowledge):
+        measured: Dict[str, Dict[str, int]] = {}
+        confirmed: Dict[str, List[str]] = {}
+        skipped: Dict[str, List[str]] = {}
+        for solution in self.upper_solutions:
+            lang = find_language_name(solution)
+            path = str(solution.path)
+            time = knowledge.measured_time(path)
+            if time is not None:
+                measured.setdefault(lang, {})[path] = time
+            elif knowledge.is_confirmed(path):
+                confirmed.setdefault(lang, []).append(path)
+            else:
+                skipped.setdefault(lang, []).append(path)
+        return _SlowEvidence(measured=measured, confirmed=confirmed, skipped=skipped)
+
+    async def prompt(
+        self,
+        auto: bool,
+        knowledge: timing_validation.SlowKnowledge,
+        allow_force: bool = False,
+    ) -> Optional[_Picked]:
+        """Ask how to group the languages, or answer for the setter when there
+        is nothing to ask. ``None`` when the setter cancelled."""
+        if auto or not self.can_prompt:
+            # Nothing was picked, so the environment's own partition stands.
+            return _Picked(assignment=None)
+        evidence = self.slow_evidence(knowledge)
+        assignment = await _prompt_repartition(
+            self.all_languages,
+            self.env_groups,
+            self.lower_timings,
+            self.strategy,
+            slow_timing_per_solution_per_language=evidence.measured,
+            confirmed_upper_per_language=evidence.confirmed,
+            skipped_upper_per_language=evidence.skipped,
+            allow_force=allow_force,
+        )
+        if assignment is None:
+            return None
+        return _Picked(assignment=assignment, force=assignment.force)
+
+    def build(
+        self,
+        picked: _Picked,
+        knowledge: timing_validation.SlowKnowledge,
+        force: bool = False,
+        announce: bool = True,
+    ) -> Optional[TimingProfile]:
+        """The profile this grouping produces, or ``None`` when no limit fits."""
+        evidence = self.slow_evidence(knowledge)
+        if announce:
+            self.console.print()
+            self.console.rule('[status]Time estimation[/status]', style='status')
+            self.console.print(_describe_strategy(self.strategy))
+
+        try:
+            profile = build_timing_profile(
+                timing_per_solution_per_language=self.lower_timings,
+                strategy=self.strategy,
+                env_groups=self.env_groups,
+                all_languages=self.all_languages,
+                slow_timing_per_solution_per_language=evidence.measured,
+                confirmed_upper_per_language=evidence.confirmed,
+                skipped_upper_per_language=evidence.skipped,
+                repartition=picked.numbers,
+                relatives=picked.relatives,
+                force=force or picked.force,
+            )
+        except timing_groups.GroupValidationError as e:
+            self.console.print(f'[error]Invalid language groups: {e}[/error]')
+            return None
+
+        defaulted = [
+            lang
+            for report in (profile.groups or [])
+            if report.origin == schema.TimingGroupOrigin.DEFAULTED
+            for lang in report.languages
+        ]
+        if defaulted:
+            self.console.print(
+                '[warning]⚠ The following languages have no solution and no whenEmpty '
+                f'rule, so they fall back to the base time limit of {profile.timeLimit} '
+                f'ms: {", ".join(defaulted)}.[/warning]'
+            )
+        return profile
+
+
+async def build_estimation_context(
     console: rich.console.Console,
     result: RunSolutionResult,
     strategy: Optional[timing_config.TimingStrategy] = None,
-    auto: bool = False,
-    confirmed_upper_per_language: Optional[Dict[str, List[str]]] = None,
-) -> Optional[TimingProfile]:
+    upper_solutions: Optional[List[Solution]] = None,
+    knowledge: Optional[timing_validation.SlowKnowledge] = None,
+) -> Optional[_EstimationContext]:
+    """Measure what the estimation run produced and report it.
+
+    ``upper_solutions`` names the solutions expected to be too slow, which the
+    estimation run does not include; it defaults to any the result happens to
+    carry. Measurements the result holds for them seed ``knowledge``, so a caller
+    that already ran them does not run them again.
+    """
     if not result.skeleton.solutions:
         console.print('[error]No solutions to estimate time limit from.[/error]')
         return None
@@ -692,126 +864,105 @@ async def estimate_time_limit(
         result.items, result.skeleton
     )
 
-    # The run may carry both roles; each bounds a different side of the limit.
     lower_solutions = [
         solution
         for solution in result.skeleton.solutions
         if inference_role_of(solution) == InferenceRole.LOWER
-    ]
-    upper_solutions = [
-        solution
-        for solution in result.skeleton.solutions
-        if inference_role_of(solution) == InferenceRole.UPPER
     ]
     if not lower_solutions:
         # Knowable from `problem.rbx.yml` alone and fixable only there, so fail
         # before the setter navigates a picker in which no grouping can succeed.
         raise MissingLowerBoundError(_NO_LOWER_BOUND_MESSAGE)
 
-    confirmed_upper_per_language = confirmed_upper_per_language or {}
-    dropped_paths = {
-        path for paths in confirmed_upper_per_language.values() for path in paths
-    }
+    if upper_solutions is None:
+        upper_solutions = [
+            solution
+            for solution in result.skeleton.solutions
+            if inference_role_of(solution) == InferenceRole.UPPER
+        ]
 
-    timing_per_solution_per_language = await _timings_per_language(
+    lower_timings = await _timings_per_language(
         console, structured_evaluations, lower_solutions
     )
-    slow_timing_per_solution_per_language = await _timings_per_language(
-        console, structured_evaluations, upper_solutions, skip=dropped_paths
+
+    # Anything the result already measured for a slow solution is knowledge, so
+    # the validation phase does not ask a question it can already answer.
+    seeded = await _timings_per_language(
+        console,
+        structured_evaluations,
+        [
+            solution
+            for solution in upper_solutions
+            if str(solution.path) in structured_evaluations
+        ],
     )
+    if knowledge is not None:
+        for per_solution in seeded.values():
+            for path, time in per_solution.items():
+                knowledge.record_time(path, time)
 
     console.rule('[status]Time report[/status]', style='status')
 
     # Only the lower-bound measurements: the limit is computed from them, so
-    # pooling the slow ones in here would headline a number -- typically a slow
-    # solution sitting at the cap -- that no limit on screen derives from.
-    lower_timings = _flatten(timing_per_solution_per_language)
-    slow_timings = _flatten(slow_timing_per_solution_per_language)
-    if not lower_timings:
+    # pooling the slow ones in here would headline a number that no limit on
+    # screen derives from.
+    lower_flat = _flatten(lower_timings)
+    if not lower_flat:
         console.print('[error]No timings collected from solutions.[/error]')
         return None
 
-    fastest_time = min(lower_timings)
-    slowest_time = max(lower_timings)
-    console.print(f'Fastest solution: {fastest_time} ms')
-    console.print(f'Slowest solution: {slowest_time} ms')
-    if slow_timings:
-        console.print(
-            f'Fastest solution expected to be too slow: {min(slow_timings)} ms'
-        )
+    console.print(f'Fastest solution: {min(lower_flat)} ms')
+    console.print(f'Slowest solution: {max(lower_flat)} ms')
+    slow_flat = _flatten(seeded)
+    if slow_flat:
+        console.print(f'Fastest solution expected to be too slow: {min(slow_flat)} ms')
 
     env = environment.get_environment()
     if strategy is None:
         strategy = timing_config.resolve_strategy(
             env.timing, package.find_problem_package_or_die().timing
         )
-    env_groups = env.timing.groups
 
     all_languages = relevant_languages_for_estimation(
         env_languages=[lang.name for lang in env.languages],
-        # A language may show up on the slow side only (or only as a drop); it
-        # still needs a group, or its cap would be pooled nowhere.
+        # A language may show up on the slow side only; it still needs a group,
+        # or its solutions would be pooled nowhere.
         timing_languages=list(
             OrderedSet(
                 [
-                    *timing_per_solution_per_language,
-                    *slow_timing_per_solution_per_language,
-                    *confirmed_upper_per_language,
+                    *lower_timings,
+                    *(find_language_name(solution) for solution in upper_solutions),
                 ]
             )
         ),
     )
 
-    repartition = None
-    relatives = None
-    if not auto and len(all_languages) > 1:
-        picked = await _prompt_repartition(
-            all_languages,
-            env_groups,
-            timing_per_solution_per_language,
-            strategy,
-            slow_timing_per_solution_per_language=slow_timing_per_solution_per_language,
-            confirmed_upper_per_language=confirmed_upper_per_language,
-        )
-        if picked is None:
-            console.print('[error]Time limit estimation cancelled.[/error]')
-            return None
-        repartition = picked.numbers
-        relatives = picked.relatives
+    return _EstimationContext(
+        console=console,
+        strategy=strategy,
+        env_groups=env.timing.groups,
+        all_languages=all_languages,
+        lower_timings=lower_timings,
+        upper_solutions=upper_solutions,
+    )
 
-    console.print()
-    console.rule('[status]Time estimation[/status]', style='status')
-    console.print(_describe_strategy(strategy))
 
-    try:
-        profile = build_timing_profile(
-            timing_per_solution_per_language=timing_per_solution_per_language,
-            strategy=strategy,
-            env_groups=env_groups,
-            all_languages=all_languages,
-            slow_timing_per_solution_per_language=slow_timing_per_solution_per_language,
-            confirmed_upper_per_language=confirmed_upper_per_language,
-            repartition=repartition,
-            relatives=relatives,
-        )
-    except timing_groups.GroupValidationError as e:
-        console.print(f'[error]Invalid language groups: {e}[/error]')
+async def estimate_time_limit(
+    console: rich.console.Console,
+    result: RunSolutionResult,
+    strategy: Optional[timing_config.TimingStrategy] = None,
+    auto: bool = False,
+) -> Optional[TimingProfile]:
+    """One estimate from one run, with no validation phase behind it."""
+    knowledge = timing_validation.SlowKnowledge()
+    ctx = await build_estimation_context(console, result, strategy, knowledge=knowledge)
+    if ctx is None:
         return None
-
-    defaulted = [
-        lang
-        for report in (profile.groups or [])
-        if report.origin == schema.TimingGroupOrigin.DEFAULTED
-        for lang in report.languages
-    ]
-    if defaulted:
-        console.print(
-            '[warning]⚠ The following languages have no solution and no whenEmpty '
-            f'rule, so they fall back to the base time limit of {profile.timeLimit} '
-            f'ms: {", ".join(defaulted)}.[/warning]'
-        )
-
-    return profile
+    picked = await ctx.prompt(auto=auto, knowledge=knowledge)
+    if picked is None:
+        console.print('[error]Time limit estimation cancelled.[/error]')
+        return None
+    return ctx.build(picked, knowledge=knowledge)
 
 
 @dataclasses.dataclass

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -330,19 +330,31 @@ def _lower_timings(
 
 def _upper_timings(
     pooled: List[timing_groups.Measurement],
-    dropped: List[str],
+    confirmed: List[str],
+    skipped: Optional[List[str]] = None,
 ) -> Optional[timing_groups.UpperTimings]:
-    if not pooled and not dropped:
+    """The upper-bound evidence for one group.
+
+    ``pooled`` holds the slow solutions that finished under the limit they were
+    probed at, so every one of them violates the bound; ``confirmed`` holds the
+    ones that did not finish, which is the outcome the estimate needs.
+    """
+    skipped = skipped or []
+    if not pooled and not confirmed and not skipped:
         return None
     if not pooled:
-        # Every slow solution of the group was dropped: it bounds nothing from
-        # above, but the drop still belongs to this group.
-        return timing_groups.UpperTimings(dropped_upper=dropped)
+        # No slow solution of the group was measured: it bounds nothing from
+        # above, but the outcome still belongs to this group.
+        return timing_groups.UpperTimings(
+            confirmed_upper=confirmed, skipped_upper=skipped
+        )
     fastest_slow, fastest_slow_solution = min(pooled)
     return timing_groups.UpperTimings(
         fastest_slow=fastest_slow,
         fastest_slow_solution=fastest_slow_solution,
-        dropped_upper=dropped,
+        confirmed_upper=confirmed,
+        violating_upper=sorted(pooled),
+        skipped_upper=skipped,
     )
 
 
@@ -352,7 +364,7 @@ def build_timing_profile(
     env_groups: List[environment.LanguageGroup],
     all_languages: List[str],
     slow_timing_per_solution_per_language: Optional[Dict[str, Dict[str, int]]] = None,
-    dropped_upper_per_language: Optional[Dict[str, List[str]]] = None,
+    confirmed_upper_per_language: Optional[Dict[str, List[str]]] = None,
     repartition: Optional[Dict[str, int]] = None,
     relatives: Optional[Dict[str, environment.LanguageGroupFallback]] = None,
 ) -> TimingProfile:
@@ -367,7 +379,7 @@ def build_timing_profile(
         derive_fn = None
 
     slow_per_language = slow_timing_per_solution_per_language or {}
-    dropped_per_language = dropped_upper_per_language or {}
+    confirmed_per_language = confirmed_upper_per_language or {}
 
     if repartition is not None:
         groups = timing_groups.partition_from_assignment(repartition, relatives)
@@ -378,14 +390,14 @@ def build_timing_profile(
     measured: Dict[int, timing_groups.GroupMeasurements] = {}
     all_values: List[timing_groups.Measurement] = []
     all_slow_values: List[timing_groups.Measurement] = []
-    all_dropped: List[str] = []
+    all_confirmed: List[str] = []
     for idx, group in enumerate(groups):
         values = _pooled(timing_per_solution_per_language, group.languages)
         slow_values = _pooled(slow_per_language, group.languages)
         dropped = [
             path
             for lang in group.languages
-            for path in (dropped_per_language.get(lang) or [])
+            for path in (confirmed_per_language.get(lang) or [])
         ]
         if not values and not slow_values and not dropped:
             continue
@@ -395,14 +407,14 @@ def build_timing_profile(
         )
         all_values.extend(values)
         all_slow_values.extend(slow_values)
-        all_dropped.extend(dropped)
+        all_confirmed.extend(dropped)
 
     if not all_values:
         raise MissingLowerBoundError(_NO_LOWER_BOUND_MESSAGE)
 
     base = timing_groups.GroupMeasurements(
         lower=_lower_timings(all_values),
-        upper=_upper_timings(all_slow_values, all_dropped),
+        upper=_upper_timings(all_slow_values, all_confirmed),
     )
     result = timing_groups.resolve_groups(groups, measured, base, eval_fn, derive_fn)
     return TimingProfile(
@@ -456,7 +468,7 @@ def build_preview_renderer(
     env_groups: List[environment.LanguageGroup],
     all_languages: List[str],
     slow_timing_per_solution_per_language: Optional[Dict[str, Dict[str, int]]] = None,
-    dropped_upper_per_language: Optional[Dict[str, List[str]]] = None,
+    confirmed_upper_per_language: Optional[Dict[str, List[str]]] = None,
     width: Optional[int] = None,
 ) -> Callable[..., ANSI]:
     """Return a memoized callback mapping a picker assignment (and optional
@@ -475,7 +487,7 @@ def build_preview_renderer(
                 env_groups=env_groups,
                 all_languages=all_languages,
                 slow_timing_per_solution_per_language=slow_timing_per_solution_per_language,
-                dropped_upper_per_language=dropped_upper_per_language,
+                confirmed_upper_per_language=confirmed_upper_per_language,
                 repartition=assignment,
                 relatives=relatives,
             )
@@ -511,7 +523,7 @@ async def _prompt_repartition(
     timing_per_solution_per_language: Dict[str, Dict[str, int]],
     strategy: timing_config.TimingStrategy,
     slow_timing_per_solution_per_language: Optional[Dict[str, Dict[str, int]]] = None,
-    dropped_upper_per_language: Optional[Dict[str, List[str]]] = None,
+    confirmed_upper_per_language: Optional[Dict[str, List[str]]] = None,
 ) -> Optional[timing_group_picker.GroupAssignment]:
     preview = build_preview_renderer(
         timing_per_solution_per_language=timing_per_solution_per_language,
@@ -519,7 +531,7 @@ async def _prompt_repartition(
         env_groups=env_groups,
         all_languages=all_languages,
         slow_timing_per_solution_per_language=slow_timing_per_solution_per_language,
-        dropped_upper_per_language=dropped_upper_per_language,
+        confirmed_upper_per_language=confirmed_upper_per_language,
         width=console.console.size.width,
     )
     langs_with_solutions = {
@@ -656,7 +668,7 @@ async def estimate_time_limit(
     result: RunSolutionResult,
     strategy: Optional[timing_config.TimingStrategy] = None,
     auto: bool = False,
-    dropped_upper_per_language: Optional[Dict[str, List[str]]] = None,
+    confirmed_upper_per_language: Optional[Dict[str, List[str]]] = None,
 ) -> Optional[TimingProfile]:
     if not result.skeleton.solutions:
         console.print('[error]No solutions to estimate time limit from.[/error]')
@@ -682,9 +694,9 @@ async def estimate_time_limit(
         # before the setter navigates a picker in which no grouping can succeed.
         raise MissingLowerBoundError(_NO_LOWER_BOUND_MESSAGE)
 
-    dropped_upper_per_language = dropped_upper_per_language or {}
+    confirmed_upper_per_language = confirmed_upper_per_language or {}
     dropped_paths = {
-        path for paths in dropped_upper_per_language.values() for path in paths
+        path for paths in confirmed_upper_per_language.values() for path in paths
     }
 
     timing_per_solution_per_language = await _timings_per_language(
@@ -730,7 +742,7 @@ async def estimate_time_limit(
                 [
                     *timing_per_solution_per_language,
                     *slow_timing_per_solution_per_language,
-                    *dropped_upper_per_language,
+                    *confirmed_upper_per_language,
                 ]
             )
         ),
@@ -745,7 +757,7 @@ async def estimate_time_limit(
             timing_per_solution_per_language,
             strategy,
             slow_timing_per_solution_per_language=slow_timing_per_solution_per_language,
-            dropped_upper_per_language=dropped_upper_per_language,
+            confirmed_upper_per_language=confirmed_upper_per_language,
         )
         if picked is None:
             console.print('[error]Time limit estimation cancelled.[/error]')
@@ -764,7 +776,7 @@ async def estimate_time_limit(
             env_groups=env_groups,
             all_languages=all_languages,
             slow_timing_per_solution_per_language=slow_timing_per_solution_per_language,
-            dropped_upper_per_language=dropped_upper_per_language,
+            confirmed_upper_per_language=confirmed_upper_per_language,
             repartition=repartition,
             relatives=relatives,
         )
@@ -1150,7 +1162,7 @@ async def compute_time_limits(
         run.result,
         run.strategy,
         auto=auto,
-        dropped_upper_per_language=run.dropped_upper_per_language(),
+        confirmed_upper_per_language=run.dropped_upper_per_language(),
     )
     if estimated_tl is None:
         return None

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -2,7 +2,7 @@ import dataclasses
 import functools
 import math
 from fractions import Fraction
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import rich
 import rich.console
@@ -1136,6 +1136,231 @@ async def _run_for_inference(
         return None
 
     return _InferenceRun(result=result, strategy=strategy, timeout=timeout)
+
+
+def violates_upper_bound(time: int, time_limit: int, time_limit_to_tle: float) -> bool:
+    """Whether a slow solution taking ``time`` is too fast for ``time_limit``.
+
+    The same comparison `compute_bounds` makes, in the same exact arithmetic:
+    the limit may be at most ``time / timeLimitToTle``, so the solution must take
+    at least ``time_limit * timeLimitToTle``.
+    """
+    return time < time_limit * _exact(time_limit_to_tle)
+
+
+def can_validate_upper_bound(
+    profile: TimingProfile, upper_solutions: List[Solution]
+) -> bool:
+    """Whether this estimate has an upper bound to check, and something to check
+    it against. Without ``timeLimitToTle`` the limit is not bounded from above at
+    all, so the slow solutions are not run."""
+    multipliers = profile.multipliers
+    return (
+        multipliers is not None
+        and multipliers.timeLimitToTle is not None
+        and bool(upper_solutions)
+    )
+
+
+@dataclasses.dataclass
+class _ValidationOutcome:
+    """What checking an estimate against its slow solutions found."""
+
+    # Confirmed too slow: still running when the limit they had to clear elapsed.
+    confirmed: List[Solution] = dataclasses.field(default_factory=list)
+    # Fast enough to break the upper bound, with the time they actually took.
+    violating: List[Tuple[Solution, int]] = dataclasses.field(default_factory=list)
+    # Broke for a reason other than running out of time, so they are evidence of
+    # nothing either way.
+    failed: List[Tuple[Solution, Outcome]] = dataclasses.field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.violating and not self.failed
+
+
+def _probe_limits(
+    profile: TimingProfile,
+    upper_solutions: List[Solution],
+) -> Dict[str, int]:
+    """The limit each language's slow solutions have to survive."""
+    multipliers = profile.multipliers
+    assert multipliers is not None and multipliers.timeLimitToTle is not None
+    limits: Dict[str, int] = {}
+    for solution in upper_solutions:
+        lang = find_language_name(solution)
+        time_limit = profile.timeLimitPerLanguage.get(lang, profile.timeLimit)
+        limits[lang] = timing_validation.probe_limit(
+            time_limit, multipliers.timeLimitToTle
+        )
+    return limits
+
+
+async def _record_validation_run(
+    result: RunSolutionResult,
+    solutions_run: List[Solution],
+    limits: Dict[str, int],
+    knowledge: timing_validation.SlowKnowledge,
+) -> List[Tuple[Solution, Outcome]]:
+    """Fold what the run said into ``knowledge``; return the solutions that broke
+    for a reason other than running out of time."""
+    structured_evaluations = consume_and_key_evaluation_items(
+        result.items, result.skeleton
+    )
+    failed: List[Tuple[Solution, Outcome]] = []
+    for solution in solutions_run:
+        path = str(solution.path)
+        outcomes: List[Outcome] = []
+        timings: List[int] = []
+        for evals in structured_evaluations.get(path, {}).values():
+            for ev in evals:
+                if ev is None:
+                    continue
+                evaluation = await ev()
+                outcome = evaluation.result.outcome
+                # A skipped testcase is the CONSEQUENCE of an earlier verdict,
+                # never evidence of its own: counting it would read the abort
+                # that follows a timeout as a solution breaking outright.
+                if outcome == Outcome.SKIPPED:
+                    continue
+                outcomes.append(outcome)
+                if evaluation.log.time is not None:
+                    timings.append(int(evaluation.log.time * 1000))
+
+        broken = [
+            outcome
+            for outcome in outcomes
+            if outcome != Outcome.ACCEPTED and not outcome.is_slow()
+        ]
+        if broken:
+            failed.append((solution, broken[0]))
+        elif any(outcome.is_slow() for outcome in outcomes):
+            knowledge.record_timeout(path, limits[find_language_name(solution)])
+        elif timings:
+            # Its time is the slowest testcase, as everywhere else: that is the
+            # one the limit has to accommodate.
+            knowledge.record_time(path, max(timings))
+    return failed
+
+
+def _classify_slow_solutions(
+    profile: TimingProfile,
+    upper_solutions: List[Solution],
+    knowledge: timing_validation.SlowKnowledge,
+    failed: List[Tuple[Solution, Outcome]],
+) -> _ValidationOutcome:
+    """What is now known about every slow solution, not only the ones that just
+    ran: an earlier iteration may already have settled some of them."""
+    multipliers = profile.multipliers
+    assert multipliers is not None and multipliers.timeLimitToTle is not None
+    broken = {str(solution.path) for solution, _ in failed}
+    outcome = _ValidationOutcome(failed=list(failed))
+    for solution in upper_solutions:
+        path = str(solution.path)
+        if path in broken:
+            continue
+        time = knowledge.measured_time(path)
+        if time is None:
+            if knowledge.is_confirmed(path):
+                outcome.confirmed.append(solution)
+            continue
+        lang = find_language_name(solution)
+        time_limit = profile.timeLimitPerLanguage.get(lang, profile.timeLimit)
+        if violates_upper_bound(time, time_limit, multipliers.timeLimitToTle):
+            outcome.violating.append((solution, time))
+        else:
+            outcome.confirmed.append(solution)
+    return outcome
+
+
+async def _validate_upper_bound(
+    profile: TimingProfile,
+    upper_solutions: List[Solution],
+    knowledge: timing_validation.SlowKnowledge,
+    check: bool,
+    detailed: bool,
+    runs: int,
+) -> _ValidationOutcome:
+    """Run each slow solution at the limit this estimate demands of it, and say
+    whether it is genuinely too slow.
+
+    Only the solutions whose answer is not already known are run: ``knowledge``
+    carries what earlier iterations established, and a lower limit never needs
+    re-asking.
+    """
+    if not upper_solutions:
+        return _ValidationOutcome()
+
+    limits = _probe_limits(profile, upper_solutions)
+    to_run = [
+        solution
+        for solution in upper_solutions
+        if knowledge.needs_run(str(solution.path), limits[find_language_name(solution)])
+    ]
+    if not to_run:
+        return _classify_slow_solutions(profile, upper_solutions, knowledge, [])
+
+    tracked_solutions = OrderedSet(str(solution.path) for solution in to_run)
+    languages = {find_language_name(solution) for solution in to_run}
+    with utils.StatusProgress('Checking solutions expected to be too slow...') as s:
+        result = await run_solutions(
+            progress=s,
+            tracked_solutions=tracked_solutions,
+            check=check,
+            # ALL_SOLUTIONS keeps `isDoubleTL` off (only FULL turns it on):
+            # doubling here would double the very limit being probed at.
+            verification=_INFERENCE_VERIFICATION,
+            timelimit_override={
+                lang: limit for lang, limit in limits.items() if lang in languages
+            },
+            nruns=runs,
+            # One timeout settles the question, so the remaining testcases only
+            # cost wall clock.
+            abort_on=lambda ctx: ctx.evaluation.result.outcome.is_slow(),
+        )
+
+    console.console.print()
+    console.console.rule(
+        '[status]Run report (upper-bound validation)[/status]', style='status'
+    )
+    await print_run_report(
+        result,
+        console.console,
+        _INFERENCE_VERIFICATION,
+        detailed=detailed,
+        skip_printing_limits=True,
+        gating_solutions=set(tracked_solutions),
+    )
+
+    failed = await _record_validation_run(result, to_run, limits, knowledge)
+    return _classify_slow_solutions(profile, upper_solutions, knowledge, failed)
+
+
+def _report_validation_outcome(
+    outcome: _ValidationOutcome,
+    profile: TimingProfile,
+) -> None:
+    """Say what the check found, naming the solution and the bound it broke."""
+    multipliers = profile.multipliers
+    assert multipliers is not None and multipliers.timeLimitToTle is not None
+    for solution in outcome.confirmed:
+        console.console.print(
+            f'[success]✓ {solution.href()} is too slow for the estimated time '
+            f'limit, as expected.[/success]'
+        )
+    for solution, outcome_value in outcome.failed:
+        console.console.print(_failed_upper_message(solution, outcome_value))
+    for solution, time in outcome.violating:
+        lang = find_language_name(solution)
+        time_limit = profile.timeLimitPerLanguage.get(lang, profile.timeLimit)
+        required = timing_validation.probe_limit(time_limit, multipliers.timeLimitToTle)
+        console.console.print(
+            f'[error]✗ {solution.href()} runs in {time} ms, but the estimated '
+            f'limit of {time_limit} ms requires every solution expected to be too '
+            f'slow to take at least {required} ms (timeLimitToTle '
+            f'{multipliers.timeLimitToTle}). Speed up the accepted solutions, slow '
+            f'this one down, or relax the ratios.[/error]'
+        )
 
 
 async def compute_time_limits(

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -10,6 +10,9 @@ from rbx.box.environment import LanguageGroupFallback
 class GroupAssignment(BaseModel):
     numbers: Dict[str, int]
     relatives: Dict[str, LanguageGroupFallback] = {}
+    # Set when the setter chose to keep these limits despite a violated upper
+    # bound, rather than regrouping to satisfy it.
+    force: bool = False
 
 
 LEGEND_LINES = [
@@ -305,6 +308,7 @@ async def prompt_group_assignment(
     input=None,
     output=None,
     preview: Optional[Callable[..., AnyFormattedText]] = None,
+    allow_force: bool = False,
 ) -> Optional[GroupAssignment]:
     """Interactive single-screen group picker. Returns a ``GroupAssignment``
     whose ``numbers`` maps {language: group_number} (N>=1 shared group, 0

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -26,6 +26,18 @@ LEGEND_LINES = [
     ' · r derive limit from a group · R reset to env · enter confirm · q cancel',
 ]
 
+
+def legend_lines(allow_force: bool = False) -> List[str]:
+    """The legend to draw. The override is offered only when there is a violated
+    upper bound to override -- otherwise the key does nothing, and advertising it
+    would promise an action the picker will not take."""
+    if not allow_force:
+        return list(LEGEND_LINES)
+    lines = list(LEGEND_LINES)
+    lines[-1] += ' · f keep these limits anyway'
+    return lines
+
+
 # Number of extra lines the inline relative editor draws under the cursor row.
 EDITOR_HEIGHT = 3
 
@@ -325,11 +337,12 @@ async def prompt_group_assignment(
     from prompt_toolkit.styles import Style
 
     state = GroupPickerState(languages, default_number, relatives=relatives)
+    legend = legend_lines(allow_force)
 
     def _header_fragments():
         fragments = []
-        last = len(LEGEND_LINES) - 1
-        for i, line in enumerate(LEGEND_LINES):
+        last = len(legend) - 1
+        for i, line in enumerate(legend):
             if i == 0:
                 style = 'class:header'
             elif i == last:
@@ -400,6 +413,19 @@ async def prompt_group_assignment(
     def _(event):
         event.app.exit(result=None)
 
+    # Offered only when the caller has a violated upper bound to override: with
+    # nothing to override the key is inert rather than a second confirm.
+    @kb.add('f', filter=not_editing & Condition(lambda: allow_force))
+    def _(event):
+        state.done = True
+        event.app.exit(
+            result=GroupAssignment(
+                numbers=state.assignment(),
+                relatives=state.prune_relatives(),
+                force=True,
+            )
+        )
+
     # Edit-mode bindings: active only while the inline relative editor is open.
     @kb.add('tab', filter=editing)
     def _(event):
@@ -439,7 +465,7 @@ async def prompt_group_assignment(
         return len(state.languages) + (state.editor_height() if state.editing else 0)
 
     windows = [
-        Window(content=header, height=len(LEGEND_LINES), always_hide_cursor=True),
+        Window(content=header, height=len(legend), always_hide_cursor=True),
         Window(content=body, height=_body_height, always_hide_cursor=True),
     ]
     if preview is not None:

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -3,7 +3,12 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 from pydantic import BaseModel
 
 from rbx.box.environment import LanguageGroup, LanguageGroupFallback
-from rbx.box.schema import TimingBound, TimingGroupOrigin, TimingGroupReport
+from rbx.box.schema import (
+    TimingBound,
+    TimingGroupOrigin,
+    TimingGroupReport,
+    TimingGroupUpperValidation,
+)
 
 
 class ResolvedGroup(BaseModel):
@@ -115,14 +120,21 @@ class UpperTimings(BaseModel):
     checked against this bound.
     """
 
-    # Absent when every slow solution of the group was dropped: the group then
-    # bounds nothing from above, but still has to carry ``dropped_upper`` so the
-    # drop is reported against the group it happened in.
+    # Absent when no slow solution of the group was measured: every one of them
+    # was confirmed too slow (or none ran), so the group bounds nothing from
+    # above, but it still has to carry the outcome so it is reported against the
+    # group it belongs to.
     fastest_slow: Optional[int] = None
     fastest_slow_solution: Optional[str] = None
-    # Slow solutions that were measured but cannot bound the limit (e.g. they
-    # hit the inference timeout).
-    dropped_upper: List[str] = []
+    # Slow solutions confirmed too slow: they were still running when the limit
+    # they were probed at elapsed, so they respect the upper bound and there is
+    # no time to bound it with.
+    confirmed_upper: List[str] = []
+    # Slow solutions that finished under the limit they were probed at, so they
+    # violate the upper bound. Each carries the time it actually took.
+    violating_upper: List[Measurement] = []
+    # Slow solutions that were not run at all.
+    skipped_upper: List[str] = []
 
 
 class GroupMeasurements(BaseModel):
@@ -194,18 +206,28 @@ def _record_provenance(
     measured: GroupMeasurements,
 ) -> None:
     """Stamp onto a report what decided its limit: the bounds the estimator
-    computed and the slow solutions that were measured but bound nothing.
+    computed and what checking its slow solutions against that limit found.
     Presentation-only -- nothing here feeds limit resolution."""
     if result is None:
         return
     report.lowerBound = result.lower_bound
     report.upperBound = result.upper_bound
-    if measured.upper is not None and measured.upper.dropped_upper:
+    upper = measured.upper
+    if upper is not None and (
+        upper.confirmed_upper or upper.violating_upper or upper.skipped_upper
+    ):
         # Set only when there is something to record. The profile is serialized
-        # with `exclude_unset`, so assigning an empty list would make an
-        # estimated group emit `droppedUpper: []` while a derived one omits the
+        # with `exclude_unset`, so assigning an empty record would make an
+        # estimated group emit `upperValidation` while a derived one omits the
         # key -- a distinction that means nothing to whoever reads the file.
-        report.droppedUpper = list(measured.upper.dropped_upper)
+        report.upperValidation = TimingGroupUpperValidation(
+            confirmed=list(upper.confirmed_upper),
+            violating=[
+                TimingBound(value=time, solution=solution)
+                for time, solution in upper.violating_upper
+            ],
+            skipped=list(upper.skipped_upper),
+        )
 
 
 class GroupValidationError(ValueError):

--- a/rbx/box/timing_validation.py
+++ b/rbx/box/timing_validation.py
@@ -1,0 +1,75 @@
+"""What is known about the solutions expected to be too slow.
+
+Validating an estimated time limit asks one question per slow solution: does it
+take at least ``timeLimit * timeLimitToTle``? Running it under exactly that limit
+answers the question without measuring it -- a solution killed at the limit
+cleared the bound, and one that finished did not, and hands us its real time on
+the way out.
+
+The answer is monotone, which is what makes the picker loop cheap: a solution
+killed at ``L`` is also killed at any lower limit, and a solution that finished
+is answered by arithmetic forever after.
+"""
+
+import dataclasses
+import math
+from fractions import Fraction
+from typing import Dict, Optional
+
+
+def probe_limit(time_limit: int, time_limit_to_tle: float) -> int:
+    """The limit a slow solution must survive for ``time_limit`` to hold.
+
+    Rounded up, and computed from the ratio the setter typed rather than from its
+    binary approximation, so it agrees with `timing.compute_bounds` on the
+    boundary case where a solution takes exactly ``time_limit * ratio``.
+    """
+    return math.ceil(time_limit * Fraction(str(time_limit_to_tle)))
+
+
+@dataclasses.dataclass
+class _SolutionKnowledge:
+    # Its real time, once it finished under some probe limit.
+    time: Optional[int] = None
+    # The highest limit it was killed at, so its time exceeds this.
+    survived: Optional[int] = None
+
+
+@dataclasses.dataclass
+class SlowKnowledge:
+    """What each slow solution has already told us, across probe limits."""
+
+    _per_solution: Dict[str, _SolutionKnowledge] = dataclasses.field(
+        default_factory=dict
+    )
+
+    def _entry(self, solution: str) -> _SolutionKnowledge:
+        return self._per_solution.setdefault(solution, _SolutionKnowledge())
+
+    def record_time(self, solution: str, time: int) -> None:
+        """It finished under its probe limit, in ``time`` ms."""
+        self._entry(solution).time = time
+
+    def record_timeout(self, solution: str, limit: int) -> None:
+        """It was still running at ``limit`` ms."""
+        entry = self._entry(solution)
+        entry.survived = max(entry.survived or 0, limit)
+
+    def measured_time(self, solution: str) -> Optional[int]:
+        """Its real time, or None if it has only ever been killed."""
+        return self._per_solution.get(solution, _SolutionKnowledge()).time
+
+    def is_confirmed(self, solution: str) -> bool:
+        """Whether it is known to be too slow rather than merely unmeasured."""
+        entry = self._per_solution.get(solution)
+        return entry is not None and entry.time is None and entry.survived is not None
+
+    def needs_run(self, solution: str, limit: int) -> bool:
+        """Whether answering the question at ``limit`` requires running it."""
+        entry = self._per_solution.get(solution)
+        if entry is None:
+            return True
+        if entry.time is not None:
+            # A real measurement answers every limit by arithmetic.
+            return False
+        return entry.survived is None or entry.survived < limit

--- a/tests/e2e/testdata/inference-abort/e2e.rbx.yml
+++ b/tests/e2e/testdata/inference-abort/e2e.rbx.yml
@@ -1,32 +1,31 @@
-# One accepted solution and one hopeless one, under a 500 ms `inferenceTimeout`
-# the hopeless solution cannot possibly meet. It is dropped from the upper
-# bound the moment it hits the cap, so the testcases after that are pure wasted
-# wall clock -- the run stops instead, and the estimate is the same one the
-# accepted solution alone bounds.
+# One accepted solution and one hopeless one. The hopeless solution is not
+# measured at all: once the limit is estimated it is run at the bound that limit
+# demands of it, and the first testcase it fails to finish settles the question
+# -- so the testcases after that are pure wasted wall clock, and the run stops
+# instead.
 scenarios:
-  - name: abort-at-inference-timeout
+  - name: abort-at-upper-bound-check
     description: >
-      `rbx time --auto` stops running a solution once it hits the inference
-      timeout. The first testcase is measured and killed at the cap; every
-      later one resolves to a skipped evaluation without entering the sandbox,
-      and the written limit still comes from the accepted solution.
+      `rbx time --auto` stops running a solution expected to be too slow once it
+      runs out of time at the limit it is checked against. The first testcase is
+      killed at that limit; every later one resolves to a skipped evaluation
+      without entering the sandbox, and the profile records it as confirmed.
     steps:
       - cmd: time --auto
         expect:
           stdout_contains:
-            - 'inference timeout of 500 ms'
-            - 'bounds nothing from above'
+            - 'Run report (upper-bound validation)'
+            - 'is too slow for the estimated time limit, as expected'
           files_exist:
             - '.limits/local.yml'
           file_contains:
             # A multiple of 100ms (timeResolution), bounded from below by the
-            # accepted solution, with the hopeless one dropped from the bound.
-            .limits/local.yml: '/(?ms)^timeLimit: [0-9]*00$.*solution: sols/main\.cpp$.*droppedUpper:.*hopeless\.cpp/'
-            # `.rbx/runs/1` is the second declared solution, sols/hopeless.cpp.
-            # It is killed at the cap on the first testcase...
-            .rbx/runs/1/main/1-gen-000.eval: 'outcome: time-limit-exceeded'
+            # accepted solution, with the hopeless one confirmed rather than
+            # measured -- so it bounds nothing and no upperBound is recorded.
+            .limits/local.yml: '/(?ms)^timeLimit: [0-9]*00$.*solution: sols/main\.cpp$.*confirmed:\s*\n\s*- sols/hopeless\.cpp/'
+            # `.rbx/runs/0` is the only solution of the validation run,
+            # sols/hopeless.cpp. It is killed on the first testcase...
+            .rbx/runs/0/main/1-gen-000.eval: 'outcome: time-limit-exceeded'
             # ...and never runs again: the rest are skipped, not measured.
-            .rbx/runs/1/main/1-gen-001.eval: 'outcome: skipped'
-            .rbx/runs/1/main/1-gen-002.eval: 'outcome: skipped'
-            # The accepted solution is untouched by the other one's abort.
-            .rbx/runs/0/main/1-gen-002.eval: 'outcome: accepted'
+            .rbx/runs/0/main/1-gen-001.eval: 'outcome: skipped'
+            .rbx/runs/0/main/1-gen-002.eval: 'outcome: skipped'

--- a/tests/e2e/testdata/inference-abort/problem.rbx.yml
+++ b/tests/e2e/testdata/inference-abort/problem.rbx.yml
@@ -5,9 +5,8 @@ timeLimit: 300
 memoryLimit: 256
 
 timing:
-  # Small enough to keep the scenario quick: the hopeless solution is killed at
-  # the cap on the very first testcase, and the ones after it are skipped
-  # instead of costing another cap each.
+  # Only the accepted solution runs under this; the hopeless one is checked
+  # against the estimated limit instead, which is what keeps the scenario quick.
   inferenceTimeout: 500
 
 generators:

--- a/tests/e2e/testdata/timing-multipliers/e2e.rbx.yml
+++ b/tests/e2e/testdata/timing-multipliers/e2e.rbx.yml
@@ -7,36 +7,45 @@ scenarios:
     description: >
       `rbx time --auto` with an accepted solution and a solution expected to be
       too slow that are comfortably apart. The estimate resolves, the written
-      limit is a multiple of the time resolution (100ms), and the profile
-      records the solution that bounds it on each side.
+      limit is a multiple of the time resolution (100ms), the accepted solution
+      is recorded as bounding it from below, and the slow one is confirmed too
+      slow for it.
     steps:
       - cmd: time --auto
         cwd: range-ok
         expect:
+          stdout_contains:
+            - 'is too slow for the estimated time limit, as expected'
           files_exist:
             - 'range-ok/.limits/local.yml'
           file_contains:
-            # A multiple of 100ms, with both bounds and their solutions recorded.
-            range-ok/.limits/local.yml: '/(?ms)^timeLimit: [0-9]*00$.*solution: sols/main\.cpp$.*solution: sols/slow\.cpp$/'
+            # A multiple of 100ms, bounded from below by the accepted solution.
+            # The slow one is confirmed rather than measured, so it bounds
+            # nothing and no upper bound is recorded.
+            range-ok/.limits/local.yml: '/(?ms)\A(?!.*upperBound).*^timeLimit: [0-9]*00$.*solution: sols/main\.cpp$.*confirmed:\s*\n\s*- sols/slow\.cpp/'
 
   - name: empty-range
     description: >
       Same setup, but the solution declared too slow returns immediately, so it
-      caps the limit below what the accepted solution requires. No limit is
-      valid: the estimate is refused and nothing is written to the profile.
+      finishes well within the limit the estimate demands of it. `--auto` has no
+      language-group picker to go back to, so the violation is reported and
+      recorded rather than re-decided, and the limit is written anyway.
     steps:
       - cmd: time --auto
         cwd: empty-range
-        # The estimation is refused: `rbx time` reports the range, leaves the
-        # profile untouched, and fails -- a limit was asked for and none was
-        # produced, which a pipeline running `rbx time` has to see.
-        expect_exit: 1
         expect:
           stdout_contains:
-            - 'no valid time limit exists'
+            # The offending solution is named, with what it took and what the
+            # limit requires of it.
             - 'sols/not_slow.cpp'
-          files_absent:
+            - 'does not respect its upper bound'
+            - 'upperValidation'
+          files_exist:
             - 'empty-range/.limits/local.yml'
+          file_contains:
+            # The measurement that broke the bound is what makes the violation
+            # reportable, so it is recorded against the solution that took it.
+            empty-range/.limits/local.yml: '/(?ms)violating:\s*\n\s*- value: [0-9]+\s*\n\s*solution: sols/not_slow\.cpp/'
 
   - name: inference-off
     description: >

--- a/tests/rbx/box/test_limits_table.py
+++ b/tests/rbx/box/test_limits_table.py
@@ -5,6 +5,7 @@ from rbx.box.schema import (
     TimingBound,
     TimingGroupOrigin,
     TimingGroupReport,
+    TimingGroupUpperValidation,
 )
 
 
@@ -579,7 +580,7 @@ def test_a_derived_lower_bound_is_not_restated():
     assert 'sols/tle.py' in source
 
 
-def test_caption_notes_the_dropped_slow_solutions():
+def test_caption_notes_the_solutions_that_violate_the_upper_bound():
     from rbx.box.limits_info import build_limits_table
 
     profile = LimitsProfile(
@@ -592,18 +593,45 @@ def test_caption_notes_the_dropped_slow_solutions():
                 solutionCount=1,
                 fastest=630,
                 slowest=630,
-                droppedUpper=['sols/hopeless.cpp'],
+                upperValidation=TimingGroupUpperValidation(
+                    violating=[TimingBound(value=1400, solution='sols/nearly.cpp')],
+                ),
             ),
         ],
     )
     caption = build_limits_table(profile).caption or ''
-    # Terse: the run already warned about each dropped solution by name.
-    assert 'droppedUpper' in caption
+    # Terse: the validation run already reported each offender by name.
+    assert 'upperValidation' in caption
+    assert 'sols/nearly.cpp' not in caption
+    assert '[error]' in caption
+
+
+def test_caption_notes_the_confirmed_slow_solutions():
+    from rbx.box.limits_info import build_limits_table
+
+    profile = LimitsProfile(
+        timeLimit=1300,
+        groups=[
+            TimingGroupReport(
+                languages=['cpp'],
+                timeLimit=1300,
+                origin=TimingGroupOrigin.ESTIMATED,
+                solutionCount=1,
+                fastest=630,
+                slowest=630,
+                upperValidation=TimingGroupUpperValidation(
+                    confirmed=['sols/hopeless.cpp'],
+                ),
+            ),
+        ],
+    )
+    caption = build_limits_table(profile).caption or ''
+    assert '1 solution' in caption
     assert 'sols/hopeless.cpp' not in caption
-    assert '[warning]' in caption
+    assert '[success]' in caption
 
 
-def test_no_dropped_caption_without_dropped_solutions():
+def test_no_upper_validation_caption_without_slow_solutions():
     from rbx.box.limits_info import build_limits_table
 
     profile = LimitsProfile(
@@ -619,4 +647,6 @@ def test_no_dropped_caption_without_dropped_solutions():
             ),
         ],
     )
-    assert 'droppedUpper' not in (build_limits_table(profile).caption or '')
+    caption = build_limits_table(profile).caption or ''
+    assert 'upperValidation' not in caption
+    assert 'too slow' not in caption

--- a/tests/rbx/box/test_solutions_timelimit_override.py
+++ b/tests/rbx/box/test_solutions_timelimit_override.py
@@ -1,0 +1,25 @@
+"""The enforced time limit may vary per language within one run."""
+
+from typing import Optional
+
+import pytest
+
+from rbx.box import solutions
+
+
+@pytest.mark.parametrize(
+    ('override', 'lang', 'expected'),
+    [
+        (None, 'cpp', None),
+        (1000, 'cpp', 1000),
+        (1000, None, 1000),
+        ({'cpp': 1500, 'py': 4000}, 'cpp', 1500),
+        ({'cpp': 1500, 'py': 4000}, 'py', 4000),
+        # A language the mapping does not mention keeps the profile's own limit.
+        ({'cpp': 1500}, 'java', None),
+        # A mapping cannot be resolved without knowing the language.
+        ({'cpp': 1500}, None, None),
+    ],
+)
+def test_resolve_timelimit_override(override, lang: Optional[str], expected):
+    assert solutions.resolve_timelimit_override(override, lang) == expected

--- a/tests/rbx/box/test_timing.py
+++ b/tests/rbx/box/test_timing.py
@@ -410,12 +410,14 @@ class TestComputeTimeLimits:
     @mock.patch('rbx.box.timing.get_inference_solutions')
     @mock.patch('rbx.box.timing.run_solutions')
     @mock.patch('rbx.box.timing.print_run_report')
-    @mock.patch('rbx.box.timing.estimate_time_limit')
+    @mock.patch('rbx.box.timing.build_estimation_context')
+    @mock.patch('rbx.box.timing._estimate_and_validate')
     @mock.patch('rbx.box.timing.consume_and_key_evaluation_items', return_value={})
     async def test_compute_time_limits_success(
         self,
         mock_consume_evaluations,
-        mock_estimate_time_limit,
+        mock_estimate_and_validate,
+        mock_build_context,
         mock_print_run_report,
         mock_run_solutions,
         mock_get_inference_solutions,
@@ -439,9 +441,11 @@ class TestComputeTimeLimits:
         # Mock print_run_report
         mock_print_run_report.return_value = True
 
-        # Mock estimate_time_limit
+        # Mock the estimation itself: this test is about what
+        # `compute_time_limits` does with the profile it gets back.
         mock_profile = timing.TimingProfile(timeLimit=1000)
-        mock_estimate_time_limit.return_value = mock_profile
+        mock_build_context.return_value = mock.Mock()
+        mock_estimate_and_validate.return_value = mock_profile
 
         result = await timing.compute_time_limits(
             check=True, detailed=False, runs=0, profile='local'
@@ -527,12 +531,14 @@ class TestTimingIntegration:
     @mock.patch('rbx.box.timing.get_inference_solutions')
     @mock.patch('rbx.box.timing.run_solutions')
     @mock.patch('rbx.box.timing.print_run_report')
-    @mock.patch('rbx.box.timing.estimate_time_limit')
+    @mock.patch('rbx.box.timing.build_estimation_context')
+    @mock.patch('rbx.box.timing._estimate_and_validate')
     @mock.patch('rbx.box.timing.consume_and_key_evaluation_items', return_value={})
     async def test_timing_with_real_problem(
         self,
         mock_consume_evaluations,
-        mock_estimate_time_limit,
+        mock_estimate_and_validate,
+        mock_build_context,
         mock_print_run_report,
         mock_run_solutions,
         mock_get_inference_solutions,
@@ -562,7 +568,8 @@ class TestTimingIntegration:
 
         # Mock a successful timing profile
         mock_profile = timing.TimingProfile(timeLimit=1000)
-        mock_estimate_time_limit.return_value = mock_profile
+        mock_build_context.return_value = mock.Mock()
+        mock_estimate_and_validate.return_value = mock_profile
 
         mock_limits_path = pkg_from_testdata / '.limits' / 'test.yml'
         mock_limits_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/rbx/box/test_timing_cli.py
+++ b/tests/rbx/box/test_timing_cli.py
@@ -49,12 +49,12 @@ async def _build_ok(*args, **kwargs):
     return True
 
 
-def _invoke_time(runner: CliRunner, result):
+def _invoke_time(runner: CliRunner, result, extra_args=None):
     with (
         mock.patch('rbx.box.builder.build', _build_ok),
         mock.patch('rbx.box.timing.compute_time_limits', _mock_compute(result)),
     ):
-        return runner.invoke(cli.app, ['time', '--auto'])
+        return runner.invoke(cli.app, ['time', '--auto', *(extra_args or [])])
 
 
 def test_time_exits_nonzero_when_no_limit_was_estimated(
@@ -92,3 +92,43 @@ def test_time_exits_nonzero_when_nothing_bounds_the_limit_from_below(
     result = _invoke_time(runner, timing.MissingLowerBoundError('nope'))
 
     assert result.exit_code != 0
+
+
+def test_skip_slow_reaches_the_estimation(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    seen = {}
+
+    async def compute_time_limits(*args, **kwargs):
+        seen.update(kwargs)
+        return timing.TimingProfile(timeLimit=1000)
+
+    with (
+        mock.patch('rbx.box.builder.build', _build_ok),
+        mock.patch('rbx.box.timing.compute_time_limits', compute_time_limits),
+    ):
+        result = runner.invoke(cli.app, ['time', '--auto', '--skip-slow'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['skip_slow'] is True
+
+
+def test_the_slow_check_runs_unless_it_is_skipped(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    seen = {}
+
+    async def compute_time_limits(*args, **kwargs):
+        seen.update(kwargs)
+        return timing.TimingProfile(timeLimit=1000)
+
+    with (
+        mock.patch('rbx.box.builder.build', _build_ok),
+        mock.patch('rbx.box.timing.compute_time_limits', compute_time_limits),
+    ):
+        result = runner.invoke(cli.app, ['time', '--auto'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['skip_slow'] is False

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -269,27 +269,27 @@ def test_slowest_and_fastest_slow_solutions_are_recorded():
     assert 'sols/hopeless.cpp' not in message
 
 
-def test_dropped_upper_solutions_do_not_bound_the_limit():
+def test_confirmed_slow_solutions_do_not_bound_the_limit():
     profile = build_timing_profile(
         timing_per_solution_per_language={'cpp': {'sols/ac.cpp': 400}},
         strategy=_multipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
         slow_timing_per_solution_per_language={'cpp': {'sols/tle.cpp': 6000}},
-        dropped_upper_per_language={'cpp': ['sols/hopeless.cpp']},
+        confirmed_upper_per_language={'cpp': ['sols/hopeless.cpp']},
         env_groups=[],
         all_languages=['cpp'],
     )
     assert profile.timeLimit == 800
 
 
-def test_a_group_whose_slow_solutions_were_all_dropped_keeps_the_dropped_list():
-    # The group bounds nothing from above, but the drop still has to be
+def test_a_group_whose_slow_solutions_were_all_confirmed_keeps_them_listed():
+    # The group bounds nothing from above, but the outcome still has to be
     # attributable to it -- reconstructing that later from the per-language map
     # would duplicate the pooling this layer exists to do.
     profile_kwargs = dict(
         timing_per_solution_per_language={'cpp': {'sols/ac.cpp': 400}},
         strategy=_multipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
         slow_timing_per_solution_per_language={},
-        dropped_upper_per_language={'cpp': ['sols/hopeless.cpp']},
+        confirmed_upper_per_language={'cpp': ['sols/hopeless.cpp']},
         env_groups=[],
         all_languages=['cpp'],
     )
@@ -298,17 +298,17 @@ def test_a_group_whose_slow_solutions_were_all_dropped_keeps_the_dropped_list():
     upper = _measured_groups(profile_kwargs)[0].upper
     assert upper is not None
     assert upper.fastest_slow is None
-    assert upper.dropped_upper == ['sols/hopeless.cpp']
+    assert upper.confirmed_upper == ['sols/hopeless.cpp']
 
 
-def test_a_language_with_only_dropped_slow_solutions_still_forms_a_group():
-    # python has no measurement at all, only a dropped slow solution: its group
-    # must not be skipped, or the drop would be lost.
+def test_a_language_with_only_confirmed_slow_solutions_still_forms_a_group():
+    # python has no measurement at all, only a confirmed slow solution: its group
+    # must not be skipped, or the outcome would be lost.
     measured = _measured_groups(
         dict(
             timing_per_solution_per_language={'cpp': {'sols/ac.cpp': 400}},
             strategy=_multipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
-            dropped_upper_per_language={'python': ['sols/hopeless.py']},
+            confirmed_upper_per_language={'python': ['sols/hopeless.py']},
             env_groups=[],
             all_languages=['cpp', 'python'],
             repartition={'cpp': 1, 'python': 2},
@@ -316,7 +316,7 @@ def test_a_language_with_only_dropped_slow_solutions_still_forms_a_group():
     )
     python_upper = measured[1].upper
     assert python_upper is not None
-    assert python_upper.dropped_upper == ['sols/hopeless.py']
+    assert python_upper.confirmed_upper == ['sols/hopeless.py']
 
 
 def test_the_upper_bound_pools_every_language_of_a_single_group():
@@ -352,7 +352,7 @@ def test_formula_mode_ignores_slow_measurements():
     with_slow = build_timing_profile(
         **kwargs,
         slow_timing_per_solution_per_language={'cpp': {'sols/tle.cpp': 500}},
-        dropped_upper_per_language={'cpp': ['sols/hopeless.cpp']},
+        confirmed_upper_per_language={'cpp': ['sols/hopeless.cpp']},
     )
     assert with_slow == plain
     assert with_slow.timeLimit == 800
@@ -455,7 +455,7 @@ def test_the_profile_records_the_bounds_and_the_solutions_that_set_them():
         },
         strategy=_multipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
         slow_timing_per_solution_per_language={'cpp': {'sols/tle.cpp': 6100}},
-        dropped_upper_per_language={'cpp': ['sols/hopeless.cpp']},
+        confirmed_upper_per_language={'cpp': ['sols/hopeless.cpp']},
         env_groups=[],
         all_languages=['cpp'],
     )
@@ -466,7 +466,8 @@ def test_the_profile_records_the_bounds_and_the_solutions_that_set_them():
     assert group.lowerBound == TimingBound(value=1260, solution='sols/slow_ac.cpp')
     # floor(6100 / 1.5) = 4066: the LARGEST limit the slow solution still allows.
     assert group.upperBound == TimingBound(value=4066, solution='sols/tle.cpp')
-    assert group.droppedUpper == ['sols/hopeless.cpp']
+    assert group.upperValidation is not None
+    assert group.upperValidation.confirmed == ['sols/hopeless.cpp']
 
 
 def test_a_group_with_no_upper_bound_records_only_its_drops():
@@ -475,14 +476,15 @@ def test_a_group_with_no_upper_bound_records_only_its_drops():
     profile = build_timing_profile(
         timing_per_solution_per_language={'cpp': {'sols/ac.cpp': 400}},
         strategy=_multipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
-        dropped_upper_per_language={'cpp': ['sols/hopeless.cpp']},
+        confirmed_upper_per_language={'cpp': ['sols/hopeless.cpp']},
         env_groups=[],
         all_languages=['cpp'],
     )
     assert profile.groups is not None
     (group,) = profile.groups
     assert group.upperBound is None
-    assert group.droppedUpper == ['sols/hopeless.cpp']
+    assert group.upperValidation is not None
+    assert group.upperValidation.confirmed == ['sols/hopeless.cpp']
 
 
 def test_formula_mode_records_no_bounds():
@@ -496,7 +498,7 @@ def test_formula_mode_records_no_bounds():
     (group,) = profile.groups
     assert group.lowerBound is None
     assert group.upperBound is None
-    assert group.droppedUpper == []
+    assert group.upperValidation is None
 
 
 def test_the_recorded_bounds_are_computed_exactly_once_per_group():
@@ -547,7 +549,7 @@ def test_the_limits_profile_round_trips_the_multipliers_and_the_bounds():
         timing_per_solution_per_language={'cpp': {'sols/slow_ac.cpp': 630}},
         strategy=_multipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
         slow_timing_per_solution_per_language={'cpp': {'sols/tle.cpp': 6100}},
-        dropped_upper_per_language={'cpp': ['sols/hopeless.cpp']},
+        confirmed_upper_per_language={'cpp': ['sols/hopeless.cpp']},
         env_groups=[],
         all_languages=['cpp'],
     )

--- a/tests/rbx/box/test_timing_estimation.py
+++ b/tests/rbx/box/test_timing_estimation.py
@@ -403,7 +403,7 @@ def test_strategy_is_described_as_a_formula_or_as_ratios():
     # Every number in effect is spelled out as the relation it imposes, with the
     # YAML key it comes from in parentheses.
     assert '2.0x the slowest accepted solution (acToTimeLimit)' in described
-    assert '1/1.5 of the fastest solution expected to be too slow' in described
+    assert '1.5x the limit, checked afterwards (timeLimitToTle)' in described
     assert 'capped at 8000 ms (inferenceTimeout)' in described
     assert 'multiple of 100 ms (timeResolution)' in described
 

--- a/tests/rbx/box/test_timing_group_picker.py
+++ b/tests/rbx/box/test_timing_group_picker.py
@@ -5,6 +5,7 @@ from rbx.box.environment import LanguageGroupFallback
 from rbx.box.timing_group_picker import (
     GroupAssignment,
     GroupPickerState,
+    legend_lines,
     prompt_group_assignment,
 )
 
@@ -598,3 +599,52 @@ async def test_prompt_seeds_relatives_into_state():
             output=DummyOutput(),
         )
     assert result.relatives['g2'].multiplier == 2.0
+
+
+async def test_f_accepts_the_current_assignment_despite_a_violation():
+    with create_pipe_input() as inp:
+        inp.send_text('1')  # cpp -> group 1
+        inp.send_text('f')  # keep these limits anyway
+        result = await prompt_group_assignment(
+            ['cpp', 'java'],
+            {'cpp': 0, 'java': 0},
+            allow_force=True,
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert result is not None
+    assert result.force
+    # It accepts what is on screen, so the assignment survives the override.
+    assert result.numbers == {'cpp': 1, 'java': 0}
+
+
+async def test_f_does_nothing_when_there_is_nothing_to_override():
+    # Without a violation the key is inert, so the picker is still open and the
+    # following enter is what confirms it.
+    with create_pipe_input() as inp:
+        inp.send_text('f')
+        inp.send_text('\r')
+        result = await prompt_group_assignment(
+            ['cpp', 'java'], {'cpp': 0, 'java': 0}, input=inp, output=DummyOutput()
+        )
+    assert result is not None
+    assert not result.force
+
+
+async def test_confirming_normally_never_forces():
+    with create_pipe_input() as inp:
+        inp.send_text('\r')
+        result = await prompt_group_assignment(
+            ['cpp', 'java'],
+            {'cpp': 0, 'java': 0},
+            allow_force=True,
+            input=inp,
+            output=DummyOutput(),
+        )
+    assert result is not None
+    assert not result.force
+
+
+def test_the_legend_offers_the_override_only_when_it_applies():
+    assert 'anyway' not in ' '.join(legend_lines(False))
+    assert 'anyway' in ' '.join(legend_lines(True))

--- a/tests/rbx/box/test_timing_inference_run.py
+++ b/tests/rbx/box/test_timing_inference_run.py
@@ -75,6 +75,11 @@ class _Run:
         self.run_solutions = None
         self.print_run_report = None
         self.estimate = None
+        self.build_context = None
+
+    @property
+    def strategy(self):
+        return self.build_context.call_args.args[2]
 
     @property
     def tracked(self) -> List[str]:
@@ -122,7 +127,10 @@ async def _compute(
             return_value=structured or {},
         ),
         mock.patch(
-            'rbx.box.timing.estimate_time_limit',
+            'rbx.box.timing.build_estimation_context', return_value=mock.Mock()
+        ) as mock_context,
+        mock.patch(
+            'rbx.box.timing._estimate_and_validate',
             return_value=estimated or timing.TimingProfile(timeLimit=1000),
         ) as mock_estimate,
         mock.patch(
@@ -134,6 +142,7 @@ async def _compute(
         run.run_solutions = mock_run
         run.print_run_report = mock_report
         run.estimate = mock_estimate
+        run.build_context = mock_context
         result = await timing.compute_time_limits(
             check=True, detailed=False, formula=formula, auto=True
         )
@@ -256,7 +265,7 @@ async def test_custom_formula_forces_formula_mode_over_multipliers(pkg):
     # The custom formula overrides how the limit is derived, not the cap the
     # solutions are measured under -- that still comes from the configuration.
     assert run.timelimit_override == 6000
-    assert run.estimate.call_args.args[2].formula == 'slowest * 3'
+    assert run.strategy.formula == 'slowest * 3'
 
 
 async def test_the_estimation_run_never_doubles_the_time_limit(pkg):

--- a/tests/rbx/box/test_timing_inference_run.py
+++ b/tests/rbx/box/test_timing_inference_run.py
@@ -198,7 +198,7 @@ async def test_multipliers_without_tle_ratio_runs_only_lower_solutions(pkg):
     # Nothing about the run differs from the formula path: every solution that
     # ran still gates the report, and nothing was dropped.
     assert run.print_run_report.call_args.kwargs['gating_solutions'] == set(run.tracked)
-    assert run.estimate.call_args.kwargs['dropped_upper_per_language'] == {}
+    assert run.estimate.call_args.kwargs['confirmed_upper_per_language'] == {}
 
 
 async def test_multipliers_with_tle_ratio_runs_both_capped(pkg):
@@ -243,7 +243,7 @@ async def test_multipliers_with_tle_ratio_but_no_slow_solutions_still_cap(pkg):
     assert run.timelimit_override == 7000
     # With no slow solution there is nothing to drop from the upper bound.
     assert result is not None
-    assert run.estimate.call_args.kwargs['dropped_upper_per_language'] == {}
+    assert run.estimate.call_args.kwargs['confirmed_upper_per_language'] == {}
 
 
 async def test_custom_formula_forces_formula_mode_over_multipliers(pkg):
@@ -312,7 +312,7 @@ async def test_an_upper_solution_at_the_cap_is_dropped_with_a_warning(pkg, capsy
         ),
     )
     assert result is not None
-    assert run.estimate.call_args.kwargs['dropped_upper_per_language'] == {
+    assert run.estimate.call_args.kwargs['confirmed_upper_per_language'] == {
         'cpp': [str(tle.path)]
     }
     printed = _printed(capsys)

--- a/tests/rbx/box/test_timing_inference_run.py
+++ b/tests/rbx/box/test_timing_inference_run.py
@@ -5,7 +5,6 @@ The whole behavior of the inference run lives in the arguments handed to
 diagnostics derived from their verdicts, so that is what these tests assert on.
 """
 
-import dataclasses
 import pathlib
 import re
 from typing import Dict, List, Optional
@@ -14,10 +13,9 @@ from unittest import mock
 import pytest
 import rich.console
 
-from rbx.box import environment, limits_info, solutions, timing
+from rbx.box import limits_info, timing
 from rbx.box.deferred import Deferred
 from rbx.box.environment import TimingConfig, VerificationLevel
-from rbx.box.generators import generate_outputs_for_testcases, generate_testcases
 from rbx.box.schema import (
     ExpectedOutcome,
     Solution,
@@ -26,13 +24,11 @@ from rbx.box.schema import (
     TimingMultipliers,
 )
 from rbx.box.solutions import _gates_report  # noqa: SLF001
-from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
 from rbx.box.testing import testing_package
 from rbx.box.timing import (
     _diagnose_inference_run,  # noqa: SLF001
     _timings_per_language,  # noqa: SLF001
 )
-from rbx.grading import grading_context, steps
 from rbx.grading.steps import Outcome
 
 
@@ -196,12 +192,16 @@ async def test_multipliers_without_tle_ratio_runs_only_lower_solutions(pkg):
     assert run.tracked == [str(ac.path)]
     assert run.timelimit_override == 7000
     # Nothing about the run differs from the formula path: every solution that
-    # ran still gates the report, and nothing was dropped.
+    # ran still gates the report.
     assert run.print_run_report.call_args.kwargs['gating_solutions'] == set(run.tracked)
-    assert run.estimate.call_args.kwargs['confirmed_upper_per_language'] == {}
 
 
-async def test_multipliers_with_tle_ratio_runs_both_capped(pkg):
+async def test_the_estimation_run_leaves_the_slow_solutions_alone(pkg):
+    # Even with an upper bound to respect, the slow solutions do not run here:
+    # nothing bounds how long they take, so the only limit that could stop them
+    # is the cap -- which is set for the accepted solutions and says nothing
+    # about the limit they are meant to bound. They are checked afterwards,
+    # against the limit this run estimates.
     ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
     tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
     run, _ = await _compute(
@@ -213,14 +213,9 @@ async def test_multipliers_with_tle_ratio_runs_both_capped(pkg):
         ),
         lower=[ac],
         upper=[tle],
-        structured=_structured(
-            {
-                ac: [_evaluation(400, Outcome.ACCEPTED)],
-                tle: [_evaluation(6000, Outcome.ACCEPTED)],
-            }
-        ),
+        structured=_structured({ac: [_evaluation(400, Outcome.ACCEPTED)]}),
     )
-    assert run.tracked == [str(ac.path), str(tle.path)]
+    assert run.tracked == [str(ac.path)]
     assert run.timelimit_override == 7000
 
 
@@ -241,9 +236,7 @@ async def test_multipliers_with_tle_ratio_but_no_slow_solutions_still_cap(pkg):
     )
     assert run.tracked == [str(ac.path)]
     assert run.timelimit_override == 7000
-    # With no slow solution there is nothing to drop from the upper bound.
     assert result is not None
-    assert run.estimate.call_args.kwargs['confirmed_upper_per_language'] == {}
 
 
 async def test_custom_formula_forces_formula_mode_over_multipliers(pkg):
@@ -290,100 +283,6 @@ async def test_only_lower_solutions_gate_the_run_report(pkg):
         ),
     )
     assert run.print_run_report.call_args.kwargs['gating_solutions'] == {str(ac.path)}
-
-
-async def test_an_upper_solution_at_the_cap_is_dropped_with_a_warning(pkg, capsys):
-    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    run, result = await _compute(
-        pkg,
-        timing_config=TimingConfig(
-            multipliers=TimingMultipliers(
-                acToTimeLimit=2.0, timeLimitToTle=1.5, inferenceTimeout=7000
-            )
-        ),
-        lower=[ac],
-        upper=[tle],
-        structured=_structured(
-            {
-                ac: [_evaluation(400, Outcome.ACCEPTED)],
-                tle: [_evaluation(7000, Outcome.TIME_LIMIT_EXCEEDED)],
-            }
-        ),
-    )
-    assert result is not None
-    assert run.estimate.call_args.kwargs['confirmed_upper_per_language'] == {
-        'cpp': [str(tle.path)]
-    }
-    printed = _printed(capsys)
-    # A warning, not an error: the estimate goes on without this solution.
-    assert '⚠' in printed
-    assert '✗' not in printed
-    assert 'tle.cpp' in printed
-    assert 'does not bound the time limit from above' in printed
-
-
-async def test_an_upper_solution_crashing_as_declared_is_an_error_without_blame(
-    pkg, capsys
-):
-    # `tle-or-rte` declares the crash, so the message must not accuse the setter
-    # of a bug -- but a solution that stopped early still measures nothing, so
-    # it stays an error the setter has to resolve deliberately.
-    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TLE_OR_RTE)
-    run, result = await _compute(
-        pkg,
-        timing_config=TimingConfig(
-            multipliers=TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5)
-        ),
-        lower=[ac],
-        upper=[tle],
-        structured=_structured(
-            {
-                ac: [_evaluation(400, Outcome.ACCEPTED)],
-                tle: [_evaluation(120, Outcome.RUNTIME_ERROR)],
-            }
-        ),
-    )
-    assert result is None
-    run.estimate.assert_not_called()
-    printed = _printed(capsys)
-    assert '✗' in printed
-    assert 'tle.cpp' in printed
-    assert 'which is what its expectation declares' in printed
-    assert 'inference: false' in printed
-    # Nothing here says the solution is broken or asks for it to be fixed.
-    assert 'instead of running out of time' not in printed
-    assert 'Fix the solution' not in printed
-
-
-async def test_an_upper_solution_failing_for_an_undeclared_reason_is_an_error(
-    pkg, capsys
-):
-    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    run, result = await _compute(
-        pkg,
-        timing_config=TimingConfig(
-            multipliers=TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5)
-        ),
-        lower=[ac],
-        upper=[tle],
-        structured=_structured(
-            {
-                ac: [_evaluation(400, Outcome.ACCEPTED)],
-                tle: [_evaluation(120, Outcome.WRONG_ANSWER)],
-            }
-        ),
-        run_report_ok=False,
-    )
-    assert result is None
-    run.estimate.assert_not_called()
-    printed = _printed(capsys)
-    assert '✗' in printed
-    assert 'tle.cpp' in printed
-    assert 'instead of running out of time' in printed
-    assert 'inference: false' in printed
 
 
 async def test_a_lower_solution_at_the_cap_is_an_error(pkg, capsys):
@@ -467,210 +366,6 @@ async def test_a_lower_solution_failing_for_a_non_timing_reason_uses_the_plain_g
     assert 'Failed to run ACCEPTED solutions' in printed
 
 
-async def test_a_cap_bounded_estimate_warns_that_the_upper_bound_is_untrustworthy(
-    pkg, capsys
-):
-    # inferenceTimeout 7000 / timeLimitToTle 1.5 = 4666 ms; the resolved limit of
-    # 5000 ms is above it, so the cap -- not the slow solutions -- bounded it.
-    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    _, result = await _compute(
-        pkg,
-        timing_config=TimingConfig(
-            multipliers=TimingMultipliers(
-                acToTimeLimit=2.0, timeLimitToTle=1.5, inferenceTimeout=7000
-            )
-        ),
-        lower=[ac],
-        upper=[tle],
-        structured=_structured(
-            {
-                ac: [_evaluation(2500, Outcome.ACCEPTED)],
-                tle: [_evaluation(7000, Outcome.TIME_LIMIT_EXCEEDED)],
-            }
-        ),
-        estimated=timing.TimingProfile(
-            timeLimit=5000, groups=[_group(5000, dropped=[tle])]
-        ),
-    )
-    assert result is not None
-    printed = _printed(capsys)
-    assert '⚠' in printed
-    assert 'upper bound' in printed
-    # The drop warning has scrolled past by now, so the solution is named again.
-    assert printed.count('tle.cpp') >= 2
-
-
-@pytest.mark.parametrize(
-    ('limit', 'warns'),
-    [
-        # floor(7000 / 1.5) = 4666 is exactly what the cap still justifies.
-        (4666, False),
-        (4667, True),
-    ],
-)
-async def test_the_cap_bounded_warning_fires_just_above_the_bound(
-    pkg, capsys, limit, warns
-):
-    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    await _compute(
-        pkg,
-        timing_config=TimingConfig(
-            multipliers=TimingMultipliers(
-                acToTimeLimit=2.0, timeLimitToTle=1.5, inferenceTimeout=7000
-            )
-        ),
-        lower=[ac],
-        upper=[tle],
-        structured=_structured(
-            {
-                ac: [_evaluation(2333, Outcome.ACCEPTED)],
-                tle: [_evaluation(7000, Outcome.TIME_LIMIT_EXCEEDED)],
-            }
-        ),
-        estimated=timing.TimingProfile(
-            timeLimit=limit, groups=[_group(limit, dropped=[tle])]
-        ),
-    )
-    assert ('upper bound' in _printed(capsys)) is warns
-
-
-async def test_a_per_language_limit_can_trip_the_cap_bounded_warning(pkg, capsys):
-    # The base limit is under the bound but one language's is not, and that is
-    # the limit a solution would actually run under.
-    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    tle_py = Solution(
-        path=pkg.path('tle.py'),
-        language='py',
-        outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED,
-    )
-    await _compute(
-        pkg,
-        timing_config=TimingConfig(
-            multipliers=TimingMultipliers(
-                acToTimeLimit=2.0, timeLimitToTle=1.5, inferenceTimeout=7000
-            )
-        ),
-        lower=[ac],
-        upper=[tle, tle_py],
-        structured=_structured(
-            {
-                ac: [_evaluation(2000, Outcome.ACCEPTED)],
-                tle: [_evaluation(7000, Outcome.TIME_LIMIT_EXCEEDED)],
-                tle_py: [_evaluation(7000, Outcome.TIME_LIMIT_EXCEEDED)],
-            }
-        ),
-        estimated=timing.TimingProfile(
-            timeLimit=4000,
-            timeLimitPerLanguage={'py': 9000},
-            groups=[
-                _group(4000, dropped=[tle]),
-                _group(9000, languages=['py'], dropped=[tle_py]),
-            ],
-        ),
-    )
-    printed = _printed(capsys)
-    assert 'upper bound' in printed
-    # The py group is the untrustworthy one; the cpp group sits under the bound.
-    assert 'tle.py' in printed
-
-
-async def test_the_pooled_base_limit_is_checked_too(pkg, capsys):
-    # No single group is both above the bound and short of evidence, but the
-    # base limit -- the one DEFAULTED languages and the packagers run under --
-    # pools every drop, so it is checked in its own right.
-    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    await _compute(
-        pkg,
-        timing_config=TimingConfig(
-            multipliers=TimingMultipliers(
-                acToTimeLimit=2.0, timeLimitToTle=1.5, inferenceTimeout=7000
-            )
-        ),
-        lower=[ac],
-        upper=[tle],
-        structured=_structured(
-            {
-                ac: [_evaluation(3000, Outcome.ACCEPTED)],
-                tle: [_evaluation(7000, Outcome.TIME_LIMIT_EXCEEDED)],
-            }
-        ),
-        estimated=timing.TimingProfile(
-            timeLimit=6000,
-            groups=[_group(1000, dropped=[tle]), _group(6000, languages=['java'])],
-            baseEstimate=TimingGroupReport(
-                languages=[],
-                timeLimit=6000,
-                origin=TimingGroupOrigin.ESTIMATED,
-                droppedUpper=[str(tle.path)],
-            ),
-        ),
-    )
-    assert 'upper bound' in _printed(capsys)
-
-
-async def test_a_drop_does_not_taint_another_groups_limit(pkg, capsys):
-    # The cpp group had the drop and its limit is under what the cap justifies;
-    # the python group is above it but nothing of its own was dropped. Blaming
-    # the cap for python's limit would send the setter after a solution that
-    # bounds a different group entirely.
-    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    await _compute(
-        pkg,
-        timing_config=TimingConfig(
-            multipliers=TimingMultipliers(
-                acToTimeLimit=2.0, timeLimitToTle=1.5, inferenceTimeout=7000
-            )
-        ),
-        lower=[ac],
-        upper=[tle],
-        structured=_structured(
-            {
-                ac: [_evaluation(2000, Outcome.ACCEPTED)],
-                tle: [_evaluation(7000, Outcome.TIME_LIMIT_EXCEEDED)],
-            }
-        ),
-        estimated=timing.TimingProfile(
-            timeLimit=4000,
-            timeLimitPerLanguage={'py': 9000},
-            groups=[
-                _group(4000, dropped=[tle]),
-                _group(9000, languages=['py']),
-            ],
-        ),
-    )
-    assert 'upper bound' not in _printed(capsys)
-
-
-async def test_nothing_dropped_means_no_cap_bounded_warning(pkg, capsys):
-    # A high limit alone is not suspicious; only a drop makes the cap the
-    # suspect.
-    ac = _solution(pkg, 'ac.cpp', ExpectedOutcome.ACCEPTED)
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    await _compute(
-        pkg,
-        timing_config=TimingConfig(
-            multipliers=TimingMultipliers(
-                acToTimeLimit=2.0, timeLimitToTle=1.5, inferenceTimeout=7000
-            )
-        ),
-        lower=[ac],
-        upper=[tle],
-        structured=_structured(
-            {
-                ac: [_evaluation(2500, Outcome.ACCEPTED)],
-                tle: [_evaluation(6900, Outcome.ACCEPTED)],
-            }
-        ),
-        estimated=timing.TimingProfile(timeLimit=5000, groups=[_group(5000)]),
-    )
-    assert 'upper bound' not in _printed(capsys)
-
-
 async def test_a_package_with_no_lower_bound_solution_fails_before_running(pkg):
     tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
     with pytest.raises(timing.MissingLowerBoundError):
@@ -693,41 +388,6 @@ async def _diagnose(structured: Dict) -> timing._InferenceDiagnosis:  # noqa: SL
         return_value=_structured(structured),
     ):
         return await _diagnose_inference_run(result)
-
-
-async def test_skipped_evaluations_do_not_fail_an_upper_bound_solution(pkg):
-    # A solution stopped at the cap has every later testcase skipped. SKIPPED is
-    # both non-accepted and non-slow, so without a guard it reads as a solution
-    # that broke for a non-timing reason -- a fatal error -- when it is only the
-    # consequence of the timeout that was already diagnosed.
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    diagnosis = await _diagnose(
-        {
-            tle: [
-                _evaluation(400, Outcome.ACCEPTED),
-                _evaluation(7000, Outcome.TIME_LIMIT_EXCEEDED),
-                _evaluation(None, Outcome.SKIPPED),
-                _evaluation(None, Outcome.SKIPPED),
-            ]
-        }
-    )
-    assert diagnosis.failed_upper == []
-    assert diagnosis.dropped_upper == [tle]
-
-
-async def test_a_real_failure_is_still_diagnosed_next_to_skipped_evaluations(pkg):
-    # Ignoring skipped evaluations must not swallow the verdict that caused them.
-    tle = _solution(pkg, 'tle.cpp', ExpectedOutcome.TIME_LIMIT_EXCEEDED)
-    diagnosis = await _diagnose(
-        {
-            tle: [
-                _evaluation(120, Outcome.WRONG_ANSWER),
-                _evaluation(None, Outcome.SKIPPED),
-            ]
-        }
-    )
-    assert diagnosis.failed_upper == [(tle, Outcome.WRONG_ANSWER)]
-    assert diagnosis.dropped_upper == []
 
 
 async def test_skipped_evaluations_do_not_truncate_a_lower_bound_solution(pkg):
@@ -777,113 +437,6 @@ async def test_skipped_evaluations_contribute_no_timing(pkg, capsys):
             rich.console.Console(), structured, [ac]
         )
     assert per_language == {'cpp': {str(ac.path): 400}}
-
-
-@dataclasses.dataclass(frozen=True)
-class _RealRun:
-    """What one real estimation run produced, and how much it actually ran."""
-
-    estimate: Optional[timing.TimingProfile]
-    slow_runs: int  # testcases dispatched for `slow.cpp`
-    executions: int  # sandbox executions, cached ones excluded
-
-
-async def _time_a_real_package(*, abort: bool, profile: str) -> _RealRun:
-    """One real ``compute_time_limits`` over the package in the cwd, under a
-    500 ms inference timeout. With ``abort`` off, the abort predicate is dropped
-    on its way to the runner, reproducing the pre-abort behavior exactly.
-
-    The estimation run itself is executed under ``CACHE_COMPILATION``, so no run
-    is served from the grading cache: two arms of the same test would otherwise
-    share one dependency cache (it is keyed by content, not by directory, and
-    the fixtures share it session-wide), and the second arm would replay the
-    first arm's measurements instead of producing its own. Compilation stays
-    cached -- it is not what is being compared."""
-    await generate_testcases()
-    entries = [
-        entry.group_entry for entry in await extract_generation_testcases_from_groups()
-    ]
-    await generate_outputs_for_testcases(entries)
-
-    env = environment.get_environment()
-    capped = env.timing.model_copy(
-        update={
-            'inferenceTimeout': 500,
-            'multipliers': TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
-            'formula': None,
-        }
-    )
-
-    real_run_solutions = timing.run_solutions
-
-    async def without_abort(*args, **kwargs):
-        kwargs['abort_on'] = None
-        return await real_run_solutions(*args, **kwargs)
-
-    real_run_on_testcase = solutions.run_solution_on_testcase
-
-    real_steps_run = steps.run
-    executions = 0
-
-    async def counting_run(*args, **kwargs):
-        nonlocal executions
-        executions += 1
-        return await real_steps_run(*args, **kwargs)
-
-    with (
-        mock.patch.object(env, 'timing', capped),
-        mock.patch.object(steps, 'run', counting_run),
-        mock.patch.object(
-            solutions, 'run_solution_on_testcase', wraps=real_run_on_testcase
-        ) as spy,
-        grading_context.cache_level(grading_context.CacheLevel.CACHE_COMPILATION),
-    ):
-        if abort:
-            estimated = await timing.compute_time_limits(
-                check=False, detailed=False, auto=True, profile=profile
-            )
-        else:
-            with mock.patch('rbx.box.timing.run_solutions', without_abort):
-                estimated = await timing.compute_time_limits(
-                    check=False, detailed=False, auto=True, profile=profile
-                )
-
-    slow_runs = sum(
-        1 for call in spy.call_args_list if call.args[0].path.name == 'slow.cpp'
-    )
-    return _RealRun(estimate=estimated, slow_runs=slow_runs, executions=executions)
-
-
-@pytest.mark.test_pkg('problems/inference-abort')
-async def test_a_solution_that_hits_the_inference_timeout_stops_running(
-    pkg_from_testdata: pathlib.Path,
-):
-    # `inference-abort` has three testcases and one hopeless solution that burns
-    # far more than the 500 ms cap on each of them. Its measurement is dropped
-    # from the upper bound either way, so the runs after the first one only cost
-    # wall clock.
-    aborted = await _time_a_real_package(abort=True, profile='aborted')
-    full = await _time_a_real_package(abort=False, profile='full')
-
-    assert full.slow_runs == 3
-    assert aborted.slow_runs == 1
-
-    # Both arms measured what they report. The no-abort arm runs strictly more
-    # of them, so if it were replaying the first arm's cached evaluations --
-    # which would make the comparison below vacuous -- it would execute fewer,
-    # not more.
-    assert full.executions > aborted.executions
-
-    # The property the whole feature rests on: stopping early is a pure speedup.
-    # Compared on the limits, not on the whole profile: now that each arm
-    # measures for itself, the millisecond of jitter between two real runs of
-    # the same solution shows up verbatim in the profile's bookkeeping
-    # (`fastest`, `slowest`, `lowerBound`), and that is not what "aborting does
-    # not change the estimate" means. What must not move is what rbx writes.
-    assert aborted.estimate is not None
-    assert full.estimate is not None
-    assert aborted.estimate.timeLimit == full.estimate.timeLimit
-    assert aborted.estimate.timeLimitPerLanguage == full.estimate.timeLimitPerLanguage
 
 
 def test_the_report_gate_ignores_solutions_outside_gating_solutions():

--- a/tests/rbx/box/test_timing_loop.py
+++ b/tests/rbx/box/test_timing_loop.py
@@ -1,0 +1,172 @@
+"""How a violated upper bound sends the setter back to the picker.
+
+A violation is evidence, not a verdict: the picker re-opens knowing what the
+check found, and the setter regroups, keeps the limits anyway, or gives up. What
+matters is which of those ends the loop, and what is left on disk afterwards.
+"""
+
+from typing import List, Optional
+from unittest import mock
+
+from rbx.box import timing, timing_group_picker, timing_validation
+
+
+def _context(languages: List[str], upper: Optional[List] = None) -> mock.Mock:
+    ctx = mock.Mock()
+    ctx.console = mock.Mock()
+    ctx.all_languages = languages
+    ctx.can_prompt = len(languages) > 1
+    ctx.upper_solutions = upper if upper is not None else [mock.Mock()]
+    return ctx
+
+
+def _assignment(force: bool = False) -> timing_group_picker.GroupAssignment:
+    return timing_group_picker.GroupAssignment(numbers={'cpp': 1}, force=force)
+
+
+def _picked(force: bool = False) -> timing._Picked:  # noqa: SLF001
+    return timing._Picked(assignment=_assignment(force), force=force)  # noqa: SLF001
+
+
+def _profile(time_limit: int = 1000) -> timing.TimingProfile:
+    from rbx.box.schema import TimingMultipliers
+
+    return timing.TimingProfile(
+        timeLimit=time_limit,
+        multipliers=TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
+    )
+
+
+def _outcome(ok: bool) -> timing._ValidationOutcome:  # noqa: SLF001
+    if ok:
+        return timing._ValidationOutcome()  # noqa: SLF001
+    return timing._ValidationOutcome(  # noqa: SLF001
+        violating=[(mock.Mock(), 1200)]
+    )
+
+
+async def _run_loop(
+    ctx,
+    picks: List[Optional[timing._Picked]],  # noqa: SLF001
+    outcomes: List[bool],
+    auto: bool = False,
+    skip_slow: bool = False,
+):
+    """Drive the loop with a scripted sequence of picks and check outcomes."""
+    ctx.prompt = mock.AsyncMock(side_effect=picks)
+    ctx.build = mock.Mock(side_effect=lambda *a, **kw: _profile())
+    validated = []
+
+    async def _validate(*args, **kwargs):
+        return _outcome(
+            outcomes[len(validated)] if len(validated) < len(outcomes) else True
+        )
+
+    async def _counting_validate(*args, **kwargs):
+        outcome = await _validate(*args, **kwargs)
+        validated.append(outcome)
+        return outcome
+
+    with (
+        mock.patch('rbx.box.timing._validate_upper_bound', _counting_validate),
+        mock.patch('rbx.box.timing._report_validation_outcome'),
+    ):
+        profile = await timing._estimate_and_validate(  # noqa: SLF001
+            ctx,
+            timing_validation.SlowKnowledge(),
+            auto=auto,
+            skip_slow=skip_slow,
+            check=False,
+            detailed=False,
+            runs=0,
+        )
+    return profile, validated
+
+
+async def test_a_passing_check_ends_the_loop_at_once():
+    ctx = _context(['cpp', 'py'])
+    profile, validated = await _run_loop(ctx, [_picked()], [True])
+    assert profile is not None
+    assert ctx.prompt.await_count == 1
+    assert len(validated) == 1
+
+
+async def test_a_violation_reopens_the_picker_and_the_repick_is_returned():
+    ctx = _context(['cpp', 'py'])
+    profile, validated = await _run_loop(ctx, [_picked(), _picked()], [False, True])
+    assert profile is not None
+    # Asked twice: the second time with the violation to override.
+    assert ctx.prompt.await_count == 2
+    assert ctx.prompt.await_args_list[0].kwargs['allow_force'] is False
+    assert ctx.prompt.await_args_list[1].kwargs['allow_force'] is True
+    assert len(validated) == 2
+
+
+async def test_forcing_past_a_violation_stops_validating():
+    ctx = _context(['cpp', 'py'])
+    profile, validated = await _run_loop(
+        ctx, [_picked(), _picked(force=True)], [False, True]
+    )
+    assert profile is not None
+    assert ctx.prompt.await_count == 2
+    # The second pick was an override, so nothing was checked again.
+    assert len(validated) == 1
+    assert ctx.build.call_args.kwargs['force'] is True
+
+
+async def test_cancelling_the_picker_returns_nothing():
+    ctx = _context(['cpp', 'py'])
+    profile, _ = await _run_loop(ctx, [_picked(), None], [False])
+    assert profile is None
+    printed = ' '.join(str(call) for call in ctx.console.print.call_args_list)
+    assert 'cancelled' in printed
+
+
+async def test_a_violation_with_no_picker_warns_and_still_produces_a_profile():
+    # --auto has no picker to go back to, so the violation is recorded and the
+    # profile is written with it rather than lost.
+    ctx = _context(['cpp', 'py'])
+    profile, validated = await _run_loop(ctx, [_picked()], [False], auto=True)
+    assert profile is not None
+    assert len(validated) == 1
+    assert ctx.build.call_args.kwargs['force'] is True
+    printed = ' '.join(str(call) for call in ctx.console.print.call_args_list)
+    assert 'upperValidation' in printed
+
+
+async def test_a_single_language_problem_has_no_picker_either():
+    ctx = _context(['cpp'])
+    profile, _ = await _run_loop(ctx, [_picked()], [False])
+    assert profile is not None
+    assert ctx.build.call_args.kwargs['force'] is True
+
+
+async def test_skip_slow_never_validates():
+    ctx = _context(['cpp', 'py'])
+    profile, validated = await _run_loop(ctx, [_picked()], [False], skip_slow=True)
+    assert profile is not None
+    assert validated == []
+
+
+async def test_a_profile_with_nothing_to_check_is_returned_as_is():
+    # No slow solutions, so there is no upper bound to validate against.
+    ctx = _context(['cpp', 'py'], upper=[])
+    profile, validated = await _run_loop(ctx, [_picked()], [False])
+    assert profile is not None
+    assert validated == []
+
+
+async def test_an_unbuildable_grouping_ends_the_loop():
+    ctx = _context(['cpp', 'py'])
+    ctx.prompt = mock.AsyncMock(return_value=_picked())
+    ctx.build = mock.Mock(return_value=None)
+    profile = await timing._estimate_and_validate(  # noqa: SLF001
+        ctx,
+        timing_validation.SlowKnowledge(),
+        auto=False,
+        skip_slow=False,
+        check=False,
+        detailed=False,
+        runs=0,
+    )
+    assert profile is None

--- a/tests/rbx/box/test_timing_loop.py
+++ b/tests/rbx/box/test_timing_loop.py
@@ -156,17 +156,34 @@ async def test_a_profile_with_nothing_to_check_is_returned_as_is():
     assert validated == []
 
 
-async def test_an_unbuildable_grouping_ends_the_loop():
-    ctx = _context(['cpp', 'py'])
-    ctx.prompt = mock.AsyncMock(return_value=_picked())
-    ctx.build = mock.Mock(return_value=None)
-    profile = await timing._estimate_and_validate(  # noqa: SLF001
+async def _drive(ctx, picks, auto=False):
+    return await timing._estimate_and_validate(  # noqa: SLF001
         ctx,
         timing_validation.SlowKnowledge(),
-        auto=False,
+        auto=auto,
         skip_slow=False,
         check=False,
         detailed=False,
         runs=0,
     )
+
+
+async def test_an_unbuildable_grouping_is_asked_about_again():
+    # Nothing but the grouping can make a limit impossible, so the setter gets
+    # to pick another one rather than being dropped out of the command.
+    ctx = _context(['cpp', 'py'])
+    ctx.prompt = mock.AsyncMock(side_effect=[_picked(), None])
+    ctx.build = mock.Mock(return_value=None)
+    profile = await _drive(ctx, None)
+    assert profile is None
+    assert ctx.prompt.await_count == 2
+    # The second prompt offers the override, since the first grouping failed.
+    assert ctx.prompt.await_args_list[1].kwargs['allow_force'] is True
+
+
+async def test_an_unbuildable_grouping_with_no_picker_ends_the_loop():
+    ctx = _context(['cpp', 'py'])
+    ctx.prompt = mock.AsyncMock(return_value=_picked())
+    ctx.build = mock.Mock(return_value=None)
+    profile = await _drive(ctx, None, auto=True)
     assert profile is None

--- a/tests/rbx/box/test_timing_multipliers.py
+++ b/tests/rbx/box/test_timing_multipliers.py
@@ -310,3 +310,52 @@ def test_compute_bounds_distinguishes_a_grid_miss_from_an_empty_range():
     empty = compute_bounds(multipliers, _measurements(slowest=610, fastest_slow=550))
     assert not empty.fits
     assert not empty.quantization_is_binding
+
+
+def test_a_forced_estimate_keeps_the_limit_that_violates_the_upper_bound():
+    # Accepting a violated upper bound is a decision the setter makes, so the
+    # limit survives -- but the bound it violates is still reported, not
+    # swallowed, so the profile records what was overridden.
+    multipliers = TimingMultipliers(
+        acToTimeLimit=2.0, timeLimitToTle=1.5, timeResolution=100
+    )
+    measured = _measurements(
+        slowest=500,
+        slowest_solution='sols/ac.cpp',
+        fastest_slow=1100,
+        fastest_slow_solution='sols/slow.cpp',
+    )
+    # acToTimeLimit puts the limit at 1000 ms; timeLimitToTle caps it at 733 ms.
+    with pytest.raises(TimingRangeError):
+        make_multipliers_eval(multipliers)(measured)
+
+    forced = make_multipliers_eval(multipliers, force=True)(measured)
+    assert forced.time_limit == 1000
+    assert forced.upper_bound is not None
+    assert forced.upper_bound.value == 733
+    assert forced.upper_bound.solution == 'sols/slow.cpp'
+
+
+def test_a_forced_derive_keeps_a_relative_limit_that_violates_the_bound():
+    multipliers = TimingMultipliers(
+        acToTimeLimit=2.0, timeLimitToTle=1.5, timeResolution=100
+    )
+    measured = _measurements(fastest_slow=1100, fastest_slow_solution='sols/slow.cpp')
+    with pytest.raises(TimingRangeError):
+        make_multipliers_derive(multipliers)(1000, measured)
+
+    forced = make_multipliers_derive(multipliers, force=True)(1000, measured)
+    assert forced.time_limit == 1000
+    assert forced.upper_bound is not None
+    assert forced.upper_bound.value == 733
+
+
+def test_forcing_changes_nothing_when_the_bound_is_respected():
+    multipliers = TimingMultipliers(
+        acToTimeLimit=2.0, timeLimitToTle=1.5, timeResolution=100
+    )
+    measured = _measurements(slowest=500, fastest_slow=3000)
+    assert (
+        make_multipliers_eval(multipliers, force=True)(measured).time_limit
+        == make_multipliers_eval(multipliers)(measured).time_limit
+    )

--- a/tests/rbx/box/test_timing_phase_two.py
+++ b/tests/rbx/box/test_timing_phase_two.py
@@ -333,3 +333,14 @@ def test_violation_matches_the_bound_the_estimate_enforces(
     time, time_limit, ratio, violates
 ):
     assert timing.violates_upper_bound(time, time_limit, ratio) is violates
+
+
+async def test_a_slow_solution_that_says_nothing_validates_nothing():
+    # It was asked and produced no verdict at all -- it did not compile, say.
+    # Silence is not confirmation.
+    slow = _solution('sols/slow.cpp')
+    validation = await _validate(_profile(), [slow], structured={})
+    assert not validation.outcome.ok
+    assert validation.outcome.unmeasured == [slow]
+    assert validation.outcome.confirmed == []
+    assert validation.outcome.violating == []

--- a/tests/rbx/box/test_timing_phase_two.py
+++ b/tests/rbx/box/test_timing_phase_two.py
@@ -1,0 +1,335 @@
+"""How the validation phase checks an estimate against the slow solutions.
+
+The whole behavior lives in the limits each slow solution is probed at, in which
+of them are probed at all, and in what their verdicts are taken to mean, so that
+is what these tests assert on.
+"""
+
+import pathlib
+from typing import Dict, List, Optional
+from unittest import mock
+
+import pytest
+
+from rbx.box import timing, timing_validation
+from rbx.box.deferred import Deferred
+from rbx.box.schema import ExpectedOutcome, Solution, TimingMultipliers
+from rbx.grading.steps import Outcome
+
+
+def _solution(name: str, language: str = 'cpp') -> Solution:
+    return Solution(
+        path=pathlib.Path(name),
+        language=language,
+        outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED,
+    )
+
+
+def _evaluation(time_ms: Optional[int], outcome: Outcome):
+    log = mock.Mock()
+    log.time = None if time_ms is None else time_ms / 1000
+    return mock.Mock(log=log, result=mock.Mock(outcome=outcome))
+
+
+def _structured(evals: Dict[Solution, List]):
+    def _make(ev):
+        async def _get():
+            return ev
+
+        return _get
+
+    return {
+        str(solution.path): {'main': [Deferred(_make(ev)) for ev in evaluations]}
+        for solution, evaluations in evals.items()
+    }
+
+
+def _profile(
+    time_limit: int = 1000,
+    per_language: Optional[Dict[str, int]] = None,
+    time_limit_to_tle: Optional[float] = 1.5,
+) -> timing.TimingProfile:
+    return timing.TimingProfile(
+        timeLimit=time_limit,
+        timeLimitPerLanguage=per_language or {},
+        multipliers=TimingMultipliers(
+            acToTimeLimit=2.0, timeLimitToTle=time_limit_to_tle
+        ),
+    )
+
+
+class _Validation:
+    """One mocked validation run."""
+
+    def __init__(self):
+        self.run_solutions = None
+        self.outcome = None
+
+    @property
+    def tracked(self) -> List[str]:
+        return list(self.run_solutions.call_args.kwargs['tracked_solutions'])
+
+    @property
+    def timelimit_override(self):
+        return self.run_solutions.call_args.kwargs['timelimit_override']
+
+    @property
+    def ran(self) -> bool:
+        return self.run_solutions.called
+
+
+async def _validate(
+    profile: timing.TimingProfile,
+    upper: List[Solution],
+    knowledge: Optional[timing_validation.SlowKnowledge] = None,
+    structured: Optional[Dict] = None,
+) -> _Validation:
+    validation = _Validation()
+    result = mock.Mock()
+    result.skeleton.solutions = list(upper)
+    with (
+        mock.patch(
+            'rbx.box.timing.run_solutions', return_value=result
+        ) as mock_run_solutions,
+        mock.patch('rbx.box.timing.print_run_report', return_value=True),
+        mock.patch(
+            'rbx.box.timing.consume_and_key_evaluation_items',
+            return_value=structured or {},
+        ),
+        mock.patch(
+            'rbx.box.timing.find_language_name', side_effect=lambda sol: sol.language
+        ),
+    ):
+        validation.run_solutions = mock_run_solutions
+        validation.outcome = await timing._validate_upper_bound(  # noqa: SLF001
+            profile,
+            upper,
+            knowledge if knowledge is not None else timing_validation.SlowKnowledge(),
+            check=False,
+            detailed=False,
+            runs=0,
+        )
+    return validation
+
+
+async def test_each_language_is_probed_at_its_own_limit():
+    # Every language group gets its own estimated limit, so the bound each slow
+    # solution has to clear differs by language.
+    slow_cpp = _solution('sols/slow.cpp', language='cpp')
+    slow_py = _solution('sols/slow.py', language='py')
+    validation = await _validate(
+        _profile(time_limit=1000, per_language={'cpp': 1000, 'py': 4000}),
+        [slow_cpp, slow_py],
+        structured=_structured(
+            {
+                slow_cpp: [_evaluation(None, Outcome.TIME_LIMIT_EXCEEDED)],
+                slow_py: [_evaluation(None, Outcome.TIME_LIMIT_EXCEEDED)],
+            }
+        ),
+    )
+    assert validation.timelimit_override == {'cpp': 1500, 'py': 6000}
+
+
+async def test_a_language_without_its_own_limit_uses_the_base_one():
+    slow = _solution('sols/slow.cpp')
+    validation = await _validate(
+        _profile(time_limit=1000, per_language={}),
+        [slow],
+        structured=_structured(
+            {slow: [_evaluation(None, Outcome.TIME_LIMIT_EXCEEDED)]}
+        ),
+    )
+    assert validation.timelimit_override == {'cpp': 1500}
+
+
+async def test_a_slow_solution_that_times_out_is_confirmed():
+    slow = _solution('sols/slow.cpp')
+    knowledge = timing_validation.SlowKnowledge()
+    validation = await _validate(
+        _profile(),
+        [slow],
+        knowledge=knowledge,
+        structured=_structured(
+            {slow: [_evaluation(None, Outcome.TIME_LIMIT_EXCEEDED)]}
+        ),
+    )
+    assert validation.outcome.ok
+    assert validation.outcome.confirmed == [slow]
+    assert validation.outcome.violating == []
+    # It cleared the bound without being measured, so it bounds nothing.
+    assert knowledge.measured_time('sols/slow.cpp') is None
+    assert knowledge.is_confirmed('sols/slow.cpp')
+
+
+async def test_a_slow_solution_that_finishes_violates_the_bound():
+    slow = _solution('sols/slow.cpp')
+    knowledge = timing_validation.SlowKnowledge()
+    validation = await _validate(
+        _profile(time_limit=1000),
+        [slow],
+        knowledge=knowledge,
+        # Probed at 1500 ms and finished in 1200, which is under the 1500 ms the
+        # limit of 1000 ms demands of it.
+        structured=_structured({slow: [_evaluation(1200, Outcome.ACCEPTED)]}),
+    )
+    assert not validation.outcome.ok
+    assert validation.outcome.violating == [(slow, 1200)]
+    assert validation.outcome.confirmed == []
+    # The real time is what makes the violation reportable and re-usable.
+    assert knowledge.measured_time('sols/slow.cpp') == 1200
+
+
+async def test_a_solution_exactly_on_the_bound_respects_it():
+    # 1000 * 1.5 = 1500 exactly: taking 1500 ms is enough, and `compute_bounds`
+    # agrees -- floor(1500 / 1.5) is 1000, which the limit does not exceed.
+    slow = _solution('sols/slow.cpp')
+    validation = await _validate(
+        _profile(time_limit=1000),
+        [slow],
+        structured=_structured({slow: [_evaluation(1500, Outcome.ACCEPTED)]}),
+    )
+    assert validation.outcome.ok
+    assert validation.outcome.violating == []
+
+
+async def test_a_solution_that_breaks_for_another_reason_fails_the_validation():
+    # A crash leaves no evidence about how long it would have run, so it can
+    # neither confirm the bound nor violate it.
+    slow = _solution('sols/slow.cpp')
+    validation = await _validate(
+        _profile(),
+        [slow],
+        structured=_structured({slow: [_evaluation(200, Outcome.RUNTIME_ERROR)]}),
+    )
+    assert not validation.outcome.ok
+    assert validation.outcome.failed == [(slow, Outcome.RUNTIME_ERROR)]
+
+
+async def test_skipped_evaluations_are_not_evidence():
+    # A skipped testcase is the consequence of an earlier verdict, never
+    # evidence of its own: counting it would read the abort as a crash.
+    slow = _solution('sols/slow.cpp')
+    validation = await _validate(
+        _profile(),
+        [slow],
+        structured=_structured(
+            {
+                slow: [
+                    _evaluation(None, Outcome.TIME_LIMIT_EXCEEDED),
+                    _evaluation(None, Outcome.SKIPPED),
+                ]
+            }
+        ),
+    )
+    assert validation.outcome.ok
+    assert validation.outcome.confirmed == [slow]
+
+
+async def test_only_the_solutions_whose_probe_grew_are_re_run():
+    slow = _solution('sols/slow.cpp')
+    knowledge = timing_validation.SlowKnowledge()
+    # It already survived 1500 ms, which is what a 1000 ms limit demands.
+    knowledge.record_timeout('sols/slow.cpp', 1500)
+
+    unchanged = await _validate(_profile(time_limit=1000), [slow], knowledge=knowledge)
+    assert not unchanged.ran
+    assert unchanged.outcome.ok
+
+    lower = await _validate(_profile(time_limit=600), [slow], knowledge=knowledge)
+    assert not lower.ran
+    assert lower.outcome.ok
+
+    higher = await _validate(
+        _profile(time_limit=1200),
+        [slow],
+        knowledge=knowledge,
+        structured=_structured(
+            {slow: [_evaluation(None, Outcome.TIME_LIMIT_EXCEEDED)]}
+        ),
+    )
+    assert higher.ran
+    assert higher.timelimit_override == {'cpp': 1800}
+
+
+async def test_a_measured_solution_is_never_re_run():
+    slow = _solution('sols/slow.cpp')
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_time('sols/slow.cpp', 1200)
+
+    validation = await _validate(_profile(time_limit=1000), [slow], knowledge=knowledge)
+    assert not validation.ran
+    # 1200 ms is under the 1500 ms a 1000 ms limit demands, so it still violates.
+    assert validation.outcome.violating == [(slow, 1200)]
+
+    # ...but a lower limit is a weaker demand, which the same measurement meets.
+    relaxed = await _validate(_profile(time_limit=700), [slow], knowledge=knowledge)
+    assert not relaxed.ran
+    assert relaxed.outcome.ok
+
+
+async def test_the_validation_run_never_doubles_the_time_limit():
+    # FULL is the only verification level that turns `isDoubleTL` on, which
+    # would double the very limit being probed at.
+    slow = _solution('sols/slow.cpp')
+    validation = await _validate(
+        _profile(),
+        [slow],
+        structured=_structured(
+            {slow: [_evaluation(None, Outcome.TIME_LIMIT_EXCEEDED)]}
+        ),
+    )
+    kwargs = validation.run_solutions.call_args.kwargs
+    assert kwargs['verification'] == timing._INFERENCE_VERIFICATION  # noqa: SLF001
+    assert kwargs['verification'].value < 4  # FULL
+
+
+async def test_the_validation_run_stops_a_solution_at_its_first_timeout():
+    # One timeout settles the question; the remaining testcases only cost wall
+    # clock.
+    slow = _solution('sols/slow.cpp')
+    validation = await _validate(
+        _profile(),
+        [slow],
+        structured=_structured(
+            {slow: [_evaluation(None, Outcome.TIME_LIMIT_EXCEEDED)]}
+        ),
+    )
+    abort_on = validation.run_solutions.call_args.kwargs['abort_on']
+    assert abort_on is not None
+    ctx = mock.Mock()
+    ctx.evaluation.result.outcome = Outcome.TIME_LIMIT_EXCEEDED
+    assert abort_on(ctx)
+    ctx.evaluation.result.outcome = Outcome.ACCEPTED
+    assert not abort_on(ctx)
+
+
+async def test_nothing_runs_when_there_are_no_slow_solutions():
+    validation = await _validate(_profile(), [])
+    assert not validation.ran
+    assert validation.outcome.ok
+
+
+def test_a_profile_without_a_tle_ratio_cannot_be_validated():
+    assert not timing.can_validate_upper_bound(
+        _profile(time_limit_to_tle=None), [_solution('sols/slow.cpp')]
+    )
+    assert not timing.can_validate_upper_bound(_profile(), [])
+    assert timing.can_validate_upper_bound(_profile(), [_solution('sols/slow.cpp')])
+
+
+@pytest.mark.parametrize(
+    ('time', 'time_limit', 'ratio', 'violates'),
+    [
+        (1200, 1000, 1.5, True),
+        (1500, 1000, 1.5, False),
+        (1501, 1000, 1.5, False),
+        (1499, 1000, 1.5, True),
+        # The ratio the setter typed, not its binary approximation.
+        (1100, 1000, 1.1, False),
+        (1099, 1000, 1.1, True),
+    ],
+)
+def test_violation_matches_the_bound_the_estimate_enforces(
+    time, time_limit, ratio, violates
+):
+    assert timing.violates_upper_bound(time, time_limit, ratio) is violates

--- a/tests/rbx/box/test_timing_upper_validation.py
+++ b/tests/rbx/box/test_timing_upper_validation.py
@@ -1,0 +1,54 @@
+"""The limits profile records what phase 2 learned about each slow solution."""
+
+from rbx.box import schema
+
+
+def test_upper_validation_defaults_to_absent():
+    report = schema.TimingGroupReport(
+        languages=['cpp'], timeLimit=1000, origin=schema.TimingGroupOrigin.ESTIMATED
+    )
+    assert report.upperValidation is None
+
+
+def test_upper_validation_round_trips():
+    validation = schema.TimingGroupUpperValidation(
+        confirmed=['sols/slow.cpp'],
+        violating=[schema.TimingBound(value=1200, solution='sols/nearly.cpp')],
+        skipped=['sols/unrun.cpp'],
+    )
+    report = schema.TimingGroupReport(
+        languages=['cpp'],
+        timeLimit=1000,
+        origin=schema.TimingGroupOrigin.ESTIMATED,
+        upperValidation=validation,
+    )
+    assert (
+        schema.TimingGroupReport.model_validate(report.model_dump()).upperValidation
+        == validation
+    )
+
+
+def test_a_profile_written_before_the_split_still_parses():
+    # `droppedUpper` is deprecated but must not make an existing
+    # `.limits/<profile>.yml` unparseable.
+    report = schema.TimingGroupReport.model_validate(
+        {
+            'languages': ['cpp'],
+            'timeLimit': 1000,
+            'origin': 'estimated',
+            'droppedUpper': ['sols/slow.cpp'],
+        }
+    )
+    assert report.upperValidation is None
+
+
+def test_the_deprecated_field_is_never_written_back():
+    report = schema.TimingGroupReport.model_validate(
+        {
+            'languages': ['cpp'],
+            'timeLimit': 1000,
+            'origin': 'estimated',
+            'droppedUpper': ['sols/slow.cpp'],
+        }
+    )
+    assert 'droppedUpper' not in report.model_dump()

--- a/tests/rbx/box/test_timing_validation.py
+++ b/tests/rbx/box/test_timing_validation.py
@@ -1,0 +1,83 @@
+"""Probe limits and the knowledge that lets the picker loop skip re-runs."""
+
+import pytest
+
+from rbx.box import timing_validation
+
+
+@pytest.mark.parametrize(
+    ('time_limit', 'ratio', 'expected'),
+    [
+        (1000, 1.5, 1500),
+        # 1.1 is not exactly representable in binary floating point; the ratio the
+        # setter typed is what must be used, as in `timing.compute_bounds`.
+        (1000, 1.1, 1100),
+        # Rounded up: a solution that finished at exactly the rounded-down value
+        # would still be under the real bound.
+        (333, 1.5, 500),
+        (1, 1.5, 2),
+        (1000, 2.0, 2000),
+    ],
+)
+def test_probe_limit_is_the_bound_rounded_up_exactly(time_limit, ratio, expected):
+    assert timing_validation.probe_limit(time_limit, ratio) == expected
+
+
+def test_an_unmeasured_solution_must_run():
+    knowledge = timing_validation.SlowKnowledge()
+    assert knowledge.needs_run('sols/slow.cpp', 1500)
+
+
+def test_a_solution_that_timed_out_covers_any_lower_probe():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 1500)
+    assert not knowledge.needs_run('sols/slow.cpp', 1500)
+    assert not knowledge.needs_run('sols/slow.cpp', 900)
+    # A higher probe demands more than what is known.
+    assert knowledge.needs_run('sols/slow.cpp', 1600)
+
+
+def test_a_measured_solution_never_runs_again():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_time('sols/slow.cpp', 1200)
+    assert not knowledge.needs_run('sols/slow.cpp', 99999)
+    assert knowledge.measured_time('sols/slow.cpp') == 1200
+
+
+def test_a_measurement_supersedes_an_earlier_timeout():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 900)
+    knowledge.record_time('sols/slow.cpp', 1200)
+    assert not knowledge.needs_run('sols/slow.cpp', 99999)
+    assert knowledge.measured_time('sols/slow.cpp') == 1200
+
+
+def test_a_timeout_never_weakens_what_is_known():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 1500)
+    knowledge.record_timeout('sols/slow.cpp', 900)
+    assert not knowledge.needs_run('sols/slow.cpp', 1500)
+
+
+def test_a_confirmed_solution_reports_no_measurement():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 1500)
+    assert knowledge.measured_time('sols/slow.cpp') is None
+
+
+def test_a_solution_that_never_ran_is_neither_confirmed_nor_violating():
+    knowledge = timing_validation.SlowKnowledge()
+    assert knowledge.measured_time('sols/slow.cpp') is None
+    assert not knowledge.is_confirmed('sols/slow.cpp')
+
+
+def test_a_solution_that_timed_out_is_confirmed():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 1500)
+    assert knowledge.is_confirmed('sols/slow.cpp')
+
+
+def test_a_measured_solution_is_not_confirmed():
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_time('sols/slow.cpp', 1200)
+    assert not knowledge.is_confirmed('sols/slow.cpp')


### PR DESCRIPTION
Splits `rbx time` into an estimation phase and a validation phase, as described in #693.

## Why

`inferenceTimeout` served two incompatible purposes. For the accepted solutions it is a safety net; for the solutions expected to be too slow it was the only thing that made the run terminate at all, and it distorted the very measurement it was supposed to produce. A slow solution killed at the cap bounded nothing; one that survived it was measured under a limit unrelated to the real one. `_warn_if_the_cap_bounded_the_estimate` existed only to say that the cap, rather than the setter's slow solutions, had decided the estimate.

The upper side never needed to be measured. It needs to be *checked*: given a limit `TL`, does every slow solution take at least `TL × timeLimitToTle`? That question can only be asked once `TL` is known, and running the solution at exactly that bound answers it.

## What changed

**Phase 1** runs only the accepted solutions, capped at `inferenceTimeout`, and produces a candidate profile. **Phase 2** runs each slow solution at `ceil(TL_lang × timeLimitToTle)`, aborting it at its first timeout. A solution killed there is *confirmed* too slow; one that finishes *violates* the bound and hands over the real time that makes the violation reportable.

A violation is not fatal. The picker re-opens knowing what the check found — so its preview now shows which groupings are impossible — and the setter regroups, presses <kbd>f</kbd> to keep the limits anyway, or cancels. The profile is written once the loop settles. Re-checking after a regroup is cheap: a solution that timed out at some limit also times out at any lower one, and a measured one is answered by arithmetic, so only the solutions whose bound went up run again.

Where there is no picker to re-open — `--auto`, or a single-language problem — the violation is reported, recorded in the profile, and the limit written anyway. Note this means `rbx time --auto` does not fail on a violated upper bound; the violation is visible in the output and in the profile instead.

`--skip-slow` stops after the estimate.

## Notes for review

- `TimingGroupReport.droppedUpper` is replaced by `upperValidation` (confirmed / violating / skipped). The old key stays parseable and is never written, so profiles from before this change still load.
- `run_solutions` gained a per-language time limit override; phase 2 needs one limit per language group.
- `upperBound` is now recorded only when a violation supplied a real measurement — in the happy path there is nothing to measure.
- Two bugs found while exercising this against a real package, fixed in their own commits: the profile was being built before the check ran (so it reported confirmed solutions as skipped), and a slow solution that produced no verdict at all was being read as confirmed.

## Testing

`uv run pytest --ignore=tests/e2e -n auto` — 4719 passed. 35 failures remain, all pre-existing on this machine (local C++ toolchain / sandbox), none under `tests/rbx/box/test_timing*` or `test_limits*`.

The `inference-abort` and `timing-multipliers` e2e scenarios were rewritten for the two phases and pass. The remaining 7 e2e failures are the same pre-existing local set (checker compilation, double-TL flakiness).

Also exercised by hand on the `inference-abort` fixture: phase 1 estimated 100 ms, phase 2 probed at 150 ms, the hopeless solution timed out on the first testcase and the other two were skipped, and the profile recorded it as confirmed.

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNVt8pxDmTNL8Cwvk49RA1
