### PR TITLE
feat(runners): let a backend say what it is doing on the solution header

### DIFF
--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -92,6 +92,24 @@ flattened testset in group order, and returns one `Deferred[Evaluation]` per ent
 grain is deliberate -- a remote judge judges one submission against every test at once, so
 a per-testcase seam would force every batch backend to coalesce calls back into a batch.
 
+**Saying what it is doing.** `RunContext.progress_board` is a `RunProgress`: one slot per
+solution, holding the chips a backend wants on that solution's header while the report waits
+on it. The same object reaches the reporter as `RunSolutionResult.progress_board`, because
+the two ends cannot be wired directly -- the reporter does not exist until `run_solutions`
+has returned. Chips are text plus a style, never a typed state, so the backend owns its own
+vocabulary and the reporter knows nothing about judges.
+
+The board is what makes a **background task** able to say anything. The standing rule was
+that a polling task must stay silent: the console and the `StatusProgress` belong to the
+reporter, and a poll printing from one of ten in-flight solutions makes the display flip
+every few seconds. A board write is not a print -- it lands in that solution's own slot, and
+the reporter draws only the slot it is currently blocked on. So every in-flight solution
+keeps its slot current for the cost of a dict write, while the one being watched reports
+itself live. Reads and writes share one event loop, so there is no lock; chips come back as
+a tuple, so a reader holds a snapshot. `LocalRunner` writes nothing and reads back empty.
+Anything that must be said *durably* still goes through the console from
+`_evaluation_from_job`. The board is a status line -- overwritten, then gone.
+
 Two things stay with the orchestrator rather than the backend:
 
 - **Abort/skip policy.** `_gated_evaluation()` wraps each returned deferred when a run asks
@@ -277,9 +295,19 @@ off the packager that built the uploaded package: the live probe
 pairing by position would misattribute essentially every timing. That mapping is keyed on
 **`subgroup_entry`**, never `group_entry`: `group_entry.index` restarts at 0 per subgroup
 while its `group` is the top-level one, so `beta/one/0` and `beta/two/0` collide.
-Everything the runner says to the setter is said from `_evaluation_from_job`, on the
-consumer's own thread of control -- the polling tasks are silent, because the reporter owns
-the console and the `StatusProgress` while they run. `MAX_INFLIGHT_TESTRUNS` is **1**: MOJ allows one account only a few queued testruns
+Everything the runner *prints* is printed from `_evaluation_from_job`, on the
+consumer's own thread of control -- the polling tasks never touch the console, because the
+reporter owns it and the `StatusProgress` while they run. They are not silent, though: each
+poll repaints its own solution's slot on `RunContext.progress_board` (`_say`,
+`_poll_chips`), so the header of the solution the report is waiting on carries the remote
+problem, the testrun id, the judge's own state word, its host and how long the wait has
+been. Only what the judge actually answered with goes there -- a `0/0` on a run that has
+not started would read as a lost testset -- and the counts are `correct`, never "tests
+run", since a solution the validation phase *expects* to fail would otherwise look stuck at
+zero. The slot is cleared once the solution has a real verdict, so no stale `running` chip
+survives beside an outcome. This replaced a `ctx.progress.update(...)` that nobody ever
+saw: every caller exits its `StatusProgress` before `print_run_report` runs, so the
+`Status` being updated there was always already stopped. `MAX_INFLIGHT_TESTRUNS` is **1**: MOJ allows one account only a few queued testruns
 (three, observed) and answers 429 past that, `moj testrun` cannot pick a judge so two in
 flight may share a machine and inflate each other, and the park is shared with everyone
 else. A 429 is waited out rather than failed -- it cannot be cleared, since `moj` has no

--- a/rbx/box/runners/base.py
+++ b/rbx/box/runners/base.py
@@ -19,7 +19,7 @@ see `supports_abort` below for why that is a correctness rule, not an optimizati
 
 import dataclasses
 import typing
-from typing import TYPE_CHECKING, List, Optional, Protocol
+from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Tuple
 
 from rbx.box.deferred import Deferred
 from rbx.box.environment import VerificationLevel
@@ -82,6 +82,65 @@ class RunnerCapabilities:
     supports_sanitizers: bool = True
 
 
+@dataclasses.dataclass(frozen=True)
+class RunnerChip:
+    """One thing a backend wants said about a solution, right now.
+
+    Text and a style, not a typed state. A typed `RunnerStatus` would put MOJ's
+    vocabulary -- `queued`, `running`, `done` -- into the reporter, and the next
+    judge's vocabulary after that. The backend owns its own words; the reporter
+    owns the layout and knows nothing about judges.
+    """
+
+    text: str
+    style: str = 'bright_black'
+
+
+class RunProgress:
+    """What each backend wants said about each solution while the report waits.
+
+    A **board**, written by the backend and read by the reporter, rather than a
+    channel between them. The two cannot be wired together directly: the reporter
+    is built from a `RunSolutionResult`, so it does not exist yet when
+    `run_solutions` hands the backend its `RunContext`. The board is created
+    before either and handed to both.
+
+    **Pull, not push.** The reporter reads whichever solution it is currently
+    blocked on, every time it paints. A backend that dispatched ten solutions is
+    therefore free to keep all ten slots current -- the nine nobody is looking at
+    cost a dict write each -- which is what lets a poll say something without
+    fighting the reporter for the console. That was the standing objection to a
+    backend writing status lines at all (see `MojRunner._wait_for_testrun`), and
+    it is dissolved rather than worked around: a poll writes into its own slot,
+    and only the slot being waited on is ever drawn.
+
+    **No locking.** Backend and reporter run on the same event loop, so a write
+    is a plain dict assignment. Chips are stored as a tuple so a reader cannot be
+    handed a list that the next write mutates underneath it.
+
+    A backend that never writes -- `LocalRunner` -- costs nothing and reads back
+    empty.
+    """
+
+    def __init__(self) -> None:
+        self._chips: Dict[str, Tuple[RunnerChip, ...]] = {}
+
+    def set(self, solution_path: str, *chips: RunnerChip) -> None:
+        """Replace this solution's chips. Whole line at once, never appended.
+
+        A backend says what is true *now*; it does not accumulate. Half a
+        solution's state from one moment beside half from another is exactly the
+        kind of line that reads as a bug in whatever it describes.
+        """
+        self._chips[solution_path] = chips
+
+    def clear(self, solution_path: str) -> None:
+        self._chips.pop(solution_path, None)
+
+    def get(self, solution_path: str) -> Tuple[RunnerChip, ...]:
+        return self._chips.get(solution_path, ())
+
+
 @dataclasses.dataclass
 class RunContext:
     """Everything a runner needs that is fixed for a whole `run_solutions` call."""
@@ -100,6 +159,11 @@ class RunContext:
     nruns: int
     progress: Optional[StatusProgress]
     abort_on: Optional['AbortPredicate']
+    # Where a backend says what it is doing, per solution, while the report is
+    # waiting on it. Defaulted so a caller that does not care -- every test that
+    # builds a context by hand -- gets a working board rather than a `None` to
+    # guard against at every write site.
+    progress_board: RunProgress = dataclasses.field(default_factory=RunProgress)
 
 
 @typing.runtime_checkable

--- a/rbx/box/runners/moj/cli.py
+++ b/rbx/box/runners/moj/cli.py
@@ -155,6 +155,12 @@ class TestrunStatus(BaseModel):
     total_tests: Optional[int] = None
     duration_s: Optional[float] = None
     tl_used: Optional[float] = None
+    # Which machine of the park ran this. The 2026-08-21 probe came back
+    # `host: judge-sp1`; it is surfaced on the run reporter's solution header, so
+    # a timing can be read against the machine that produced it. Optional because
+    # nothing guarantees every response carries it -- and a park with one judge
+    # may well never send it.
+    host: Optional[str] = None
     # Absent while the run is still queued or running: the CLI's own formatter
     # falls back to `.filename` / `.problem_id` in that case, so a status without
     # tests is normal, not an error.

--- a/rbx/box/runners/moj/runner.py
+++ b/rbx/box/runners/moj/runner.py
@@ -42,7 +42,13 @@ from rbx.box.exception import RbxException
 from rbx.box.generation_schema import GenerationTestcaseEntry
 from rbx.box.packaging.moj.moj_language_utils import get_moj_language_from_rbx_language
 from rbx.box.packaging.moj.packager import MojPackager, ProbePackage, ProbePinned
-from rbx.box.runners.base import RunContext, RunnerCapabilities, SolutionRunner
+from rbx.box.runners.base import (
+    RunContext,
+    RunnerCapabilities,
+    RunnerChip,
+    RunProgress,
+    SolutionRunner,
+)
 from rbx.box.runners.moj import cli, problem_id
 from rbx.box.runners.moj.problem_id import ensure_moj_id, is_rbxt_id, moj_id_path
 from rbx.box.schema import CodeItem
@@ -486,6 +492,29 @@ class MojRunner:
             f'[item]{calibration_elapsed}[/item].[/status]'
         )
 
+    def _say(
+        self,
+        board: RunProgress,
+        solution: 'SolutionSkeleton',
+        *chips: RunnerChip,
+    ) -> None:
+        """Put this solution's current state on the board, as one whole line.
+
+        Always led by the remote problem, because on a park shared between the
+        two `rbx time` phases -- which upload to *different* problems -- knowing
+        which one a testrun belongs to is what makes the rest of the line mean
+        anything.
+
+        Writing here is safe from a polling task in a way that writing to the
+        console is not: the board is a per-solution slot, and the reporter draws
+        only the slot it is currently blocked on. See `RunProgress`.
+        """
+        board.set(
+            str(solution.path),
+            RunnerChip(f'moj {self._moj_id}' if self._moj_id else 'moj'),
+            *chips,
+        )
+
     def run_solution(
         self,
         solution: 'SolutionSkeleton',
@@ -521,7 +550,13 @@ class MojRunner:
         # judge starts working before anything awaits. The task is captured by
         # every deferred below and by `self._jobs`, so it is never
         # garbage-collected mid-flight.
-        job = asyncio.create_task(self._submit_and_poll(solution, names))
+        # Said before the task is even created, so a solution the report has not
+        # reached yet is already accounted for on the board rather than blank.
+        self._say(ctx.progress_board, solution, RunnerChip('waiting for a slot'))
+
+        job = asyncio.create_task(
+            self._submit_and_poll(solution, names, ctx.progress_board)
+        )
         job.add_done_callback(_retrieve_exception)
         self._jobs.append(job)
 
@@ -657,6 +692,7 @@ class MojRunner:
         self,
         solution: 'SolutionSkeleton',
         expected_names: List[str],
+        board: RunProgress,
     ) -> '_TestrunResult':
         """Submit one solution and wait for its verdicts, keyed by MOJ test name.
 
@@ -665,15 +701,21 @@ class MojRunner:
         occupies, and a run that has been dispatched is occupying it whether or
         not rbx is still talking to the server.
 
-        **Takes no `RunContext`, and says nothing to the setter.** This runs on a
-        background task -- up to `MAX_INFLIGHT_TESTRUNS` of them at once, on their
-        own schedule, long after the call that created them returned. The
+        **Writes to the board, never to the console.** This runs on a background
+        task -- up to `MAX_INFLIGHT_TESTRUNS` of them at once, on their own
+        schedule, long after the call that created them returned. The
         `StatusProgress` and the console belong to the reporter that is printing
-        results right now, so a poll writing a status line from here makes the
-        display flip between solutions and the reporter's own message every few
-        seconds. Everything this learns is handed back and said by
-        `_evaluation_from_job`, which runs on the consumer's own thread of
-        control.
+        results right now, so a poll *printing* from here would make the display
+        flip between solutions every few seconds. A board write does not: it
+        lands in this solution's own slot, and the reporter draws only the slot
+        it is currently blocked on (see `RunProgress`). So the solution the
+        report is waiting on reports itself, live, while the nine queued behind
+        it keep their slots current for free.
+
+        Anything that has to be said *durably* -- a cache hit, a short testset --
+        is still handed back and printed by `_evaluation_from_job`, on the
+        consumer's own thread of control. The board is a status line: it is
+        overwritten and then gone.
 
         **The cache is consulted before the semaphore, not inside it.** A hit
         costs one file read and no judge time at all, so making it queue behind
@@ -687,6 +729,12 @@ class MojRunner:
         cached = _load_cached_testrun(key)
         if cached is not None:
             run, status = cached
+            self._say(
+                board,
+                solution,
+                RunnerChip(f'testrun {run}'),
+                RunnerChip('cached', style='green'),
+            )
             # Deliberately put through the *same* derivation a fresh status goes
             # through, rather than storing the derived `_TestrunResult`. That is
             # what makes a hit and a miss provably identical: there is one place
@@ -698,10 +746,30 @@ class MojRunner:
             result.cached = True
             return result
 
+        # Started before the slot is taken, so what it counts is the whole wait
+        # a setter is actually enduring -- queueing behind other solutions
+        # included, which on `MAX_INFLIGHT_TESTRUNS = 1` is most of it.
+        since = _Elapsed()
+
         assert self._testrun_slots is not None
         async with self._testrun_slots:
             run = await self._submit(solution, content)
-            status = await self._wait_for_testrun(run, solution)
+            self._say(
+                board,
+                solution,
+                RunnerChip(f'testrun {run}'),
+                RunnerChip('submitted'),
+                RunnerChip(str(since)),
+            )
+            status = await self._wait_for_testrun(run, solution, board, since)
+
+        self._say(
+            board,
+            solution,
+            RunnerChip(f'testrun {run}'),
+            RunnerChip('done', style='green'),
+            RunnerChip(str(since)),
+        )
 
         result = self._result_from_status(solution, run, status, expected_names)
         # Written only once the status has survived every check above, which is
@@ -927,18 +995,31 @@ class MojRunner:
         return digest.hexdigest()
 
     async def _wait_for_testrun(
-        self, run: str, solution: 'SolutionSkeleton'
+        self,
+        run: str,
+        solution: 'SolutionSkeleton',
+        board: RunProgress,
+        since: '_Elapsed',
     ) -> cli.TestrunStatus:
-        """Poll until the judge is finished with `run`. Bounded, and silent.
+        """Poll until the judge is finished with `run`. Bounded, and on the board.
 
-        Silent because it is a background task: see `_submit_and_poll`. What the
-        setter sees while this runs is one line from `_evaluation_from_job`, for
-        the solution whose result the report is actually waiting on.
+        This is the slow half of a remote run and the half a setter most wants to
+        see moving, so every poll repaints this solution's slot. It writes to the
+        board rather than the console for the reason `_submit_and_poll` gives:
+        printing from a background task would make the display flip between
+        solutions, a board write cannot.
+
+        What it can say depends on what the judge chose to answer with. The state
+        word is always there; the counts and the host are reported by some
+        responses and not others, so they are added when present rather than
+        defaulted -- a `0/0` on a run that simply has not started would read as a
+        judge losing the testset.
         """
         for attempt in range(TESTRUN_POLL_ATTEMPTS):
             status = await cli.testrun_status(run)
             if status.done:
                 return status
+            self._say(board, solution, *self._poll_chips(run, status, since))
             if attempt + 1 < TESTRUN_POLL_ATTEMPTS:
                 await asyncio.sleep(TESTRUN_POLL_INTERVAL_SECONDS)
 
@@ -951,6 +1032,26 @@ class MojRunner:
             f'outside history and placar, so nothing on the server needs cleaning '
             f'up.'
         )
+
+    def _poll_chips(
+        self,
+        run: str,
+        status: cli.TestrunStatus,
+        since: '_Elapsed',
+    ) -> List[RunnerChip]:
+        """What one in-flight poll has to say. Only what the judge reported."""
+        chips = [RunnerChip(f'testrun {run}')]
+        if status.status:
+            chips.append(RunnerChip(status.status))
+        if status.host:
+            chips.append(RunnerChip(status.host))
+        # `correct`, not "tests run": MOJ reports how many *passed*, and calling
+        # that progress would show a solution expected to fail -- which is half
+        # of what the validation phase submits -- stuck at 0 while it works fine.
+        if status.total_tests:
+            chips.append(RunnerChip(f'{status.correct or 0}/{status.total_tests} ok'))
+        chips.append(RunnerChip(str(since)))
+        return chips
 
     async def _evaluation_from_job(
         self,
@@ -965,17 +1066,27 @@ class MojRunner:
         Awaiting a `Task` more than once is fine -- it hands every waiter the same
         result (or the same exception), and does not re-run the body.
 
-        This is where the runner talks to the setter, and the only place it does
-        during a run: it is reached from the deferred the reporter itself is
-        awaiting, so a status line or a warning written here lands on the
-        consumer's own thread of control rather than racing the live display from
-        a polling task.
-        """
-        if not job.done() and ctx.progress:
-            ctx.progress.update(
-                f'Waiting for MOJ to judge [item]{solution.path}[/item]...'
-            )
+        This is where the runner *prints* to the setter, and the only place it
+        does during a run: it is reached from the deferred the reporter itself is
+        awaiting, so a warning written here lands on the consumer's own thread of
+        control rather than racing the live display from a polling task.
 
+        Live status is not printed at all -- it goes on `ctx.progress_board`, from
+        whichever task owns the solution, and this method only *clears* the slot
+        once there is a real verdict to show instead.
+        """
+        # Nothing is said here on the way in, deliberately. This used to be
+        # `ctx.progress.update('Waiting for MOJ to judge ...')`, which nobody ever
+        # saw: every caller exits its `StatusProgress` context manager *before*
+        # `print_run_report` runs, so the `Status` being updated was always
+        # already stopped.
+        #
+        # It is not replaced by a board write either, and that is the more
+        # interesting half. This solution's slot is already being repainted by
+        # its own polling task, with the testrun id, the judge's state and how
+        # long the wait has been -- strictly more than "waiting" -- so writing
+        # here would overwrite a better line with a worse one, and leave it worse
+        # until the next poll came round to fix it.
         result = await job
 
         # Said out loud, and said here, for the same reason the missing-testcase
@@ -1007,6 +1118,11 @@ class MojRunner:
                 f'[warning]Those testcases are left unmeasured; the time limit is '
                 f'estimated from the rest.[/warning]'
             )
+
+        # Cleared once there is a real verdict to show: the header is about to
+        # carry the solution's outcome, and a stale `running` chip beside a
+        # finished verdict is worse than no chip at all.
+        ctx.progress_board.clear(str(solution.path))
 
         # `.get`, not `[]`: a name MOJ did not report is a case with an answer,
         # and it is not this one blowing up. See `_evaluation_for`.

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -67,6 +67,12 @@ from rbx.box.generators import (
 )
 from rbx.box.parallel import live_tasks
 from rbx.box.rendering import CellSlot, Throttling
+
+# Imported eagerly, unlike `runners.local` below: `runners.base` reaches back
+# into this module for type names only, under TYPE_CHECKING, so there is no cycle
+# to break -- and the board has to be a real class here, not a string, because a
+# dataclass default_factory is evaluated at runtime.
+from rbx.box.runners.base import RunProgress
 from rbx.box.sanitizers import compilation_warnings, issue_stack
 from rbx.box.schema import (
     ExpectedOutcome,
@@ -365,6 +371,11 @@ class RunSolutionResult:
     # all -- the reporting tests do exactly that -- and a result with no backend
     # has nothing to close.
     runner: Optional['SolutionRunner'] = None
+    # The board the backend writes what it is doing on, per solution, read by the
+    # reporter every time it paints a solution header. Defaulted so a result
+    # built without a run at all -- which every reporting test does -- reads back
+    # empty rather than needing a guard at the one place that reads it.
+    progress_board: 'RunProgress' = dataclasses.field(default_factory=RunProgress)
 
     def empty_structured_evaluation(self) -> StructuredEvaluation:
         return self.skeleton.empty_structured_evaluation()
@@ -1041,6 +1052,11 @@ async def run_solutions(
 
     checker_digest, interactor_digest = await _compile_checking_digests(check)
 
+    # One board for the whole run, handed to the backend here and to the reporter
+    # on the result below. It cannot be created by either of them: the reporter
+    # does not exist until this function has returned.
+    progress_board = RunProgress()
+
     ctx = RunContext(
         skeleton=skeleton,
         checker_digest=checker_digest,
@@ -1050,12 +1066,18 @@ async def run_solutions(
         nruns=nruns,
         progress=progress,
         abort_on=abort_on,
+        progress_board=progress_board,
     )
 
     await runner.prepare(ctx)
     items = _produce_solution_items(runner=runner, ctx=ctx)
 
-    return RunSolutionResult(skeleton=skeleton, items=items, runner=runner)
+    return RunSolutionResult(
+        skeleton=skeleton,
+        items=items,
+        runner=runner,
+        progress_board=progress_board,
+    )
 
 
 async def _generate_testcase_interactively(
@@ -3058,16 +3080,25 @@ class LiveRunReporter(TraditionalRunReporter):
             self.console.height
         )
 
-    def _header_chips(self) -> List[rich.text.Text]:
+    def _header_chips(self, solution: Solution) -> List[rich.text.Text]:
         """The live annotations on the solution header, left to right.
 
-        Wall-clock chips render on a terminal only. A shared report, an e2e
-        golden and an asciinema cast are all non-terminal consoles, and an
-        elapsed time in any of them turns every re-run into a diff.
+        The wall clock first, then whatever the backend running this solution has
+        put on the board -- a testrun id, a queue state, a cache hit. The
+        reporter renders those verbatim and knows nothing about what they mean;
+        see `runners.base.RunProgress`.
+
+        The clock renders on a terminal only. A shared report, an e2e golden and
+        an asciinema cast are all non-terminal consoles, and an elapsed time in
+        any of them turns every re-run into a diff. Backend chips are not
+        wall-clock and do render there: a setter reading a shared report wants to
+        know which testrun produced its numbers.
         """
         chips: List[rich.text.Text] = []
         if self._elapsed is not None and self.console.is_terminal:
             chips.append(rich.text.Text(str(self._elapsed), style='bright_black'))
+        for chip in self.result.progress_board.get(str(solution.path)):
+            chips.append(rich.text.Text(chip.text, style=chip.style))
         return chips
 
     def _header_line(self, solution: Solution) -> rich.text.Text:
@@ -3076,7 +3107,7 @@ class LiveRunReporter(TraditionalRunReporter):
         line = rich.text.Text.from_markup(
             f'{solution_skeleton.href()} ({solution_skeleton.runs_dir_href()})'
         )
-        for chip in self._header_chips():
+        for chip in self._header_chips(solution):
             line.append(rich.text.Text(' · ', style='bright_black'))
             line.append(chip)
         return line

--- a/tests/rbx/box/runners/moj/test_run_solution.py
+++ b/tests/rbx/box/runners/moj/test_run_solution.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional, Tuple
 
 import pytest
 
+from rbx import utils
 from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
 from rbx.box.runners.moj import cli
 from rbx.box.runners.moj import runner as runner_module
@@ -650,8 +651,13 @@ async def test_the_background_polling_never_writes_the_status_line(
 
     They share the `StatusProgress` the reporter is driving, so a poll writing to
     it makes the status line flip between two solutions -- and keep flipping after
-    the reporter has moved on to printing the first one's results. Nothing the
-    runner says may come from a task the consumer is not waiting on.
+    the reporter has moved on to printing the first one's results.
+
+    This is about the *console*, and stays true now that polls report themselves
+    on the board: a board write lands in the polled solution's own slot, and the
+    reporter draws only the slot it is blocked on, so nothing a non-awaited task
+    learns can reach the display. See
+    `test_a_poll_writes_to_its_own_slot_and_no_other` for that half.
     """
     progress = RecordingProgress()
     runner, fake, ctx = await _prepared(
@@ -1191,3 +1197,196 @@ async def test_a_queue_that_never_drains_says_it_cannot_be_cancelled(
     assert 'cannot be cancelled' in message
     assert 'moj status' in message
     assert '[item]' not in message
+
+
+# -- what the runner puts on the board -----------------------------------------
+
+
+def _chips(ctx, solution_path: str) -> List[str]:
+    return [chip.text for chip in ctx.progress_board.get(solution_path)]
+
+
+async def test_a_queued_solution_says_so_before_it_is_submitted(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """A solution the report has not reached is accounted for, not blank.
+
+    `run_solution` returns without awaiting -- that is the point of the seam --
+    so every solution is queued while the report is still printing the first. A
+    blank header for the other nine reads as nothing happening, which is the
+    opposite of the truth.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+
+    runner.run_solution(ctx.skeleton.solutions[0], ctx.skeleton.entries, ctx)
+
+    # Synchronously, before a single turn of the loop has run the task.
+    assert _chips(ctx, 'sol.cpp') == [f'moj {runner._moj_id}', 'waiting for a slot']  # noqa: SLF001
+
+
+async def test_the_board_names_the_testrun_once_it_is_submitted(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The testrun id is the one thing that makes the rest of the line
+    actionable: it is what `moj testrun-status <run>` takes."""
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+    fake.results['sol.cpp'] = [
+        _test(SAMPLE_NAMES[0], 'AC', 0.1),
+        _test(SAMPLE_NAMES[1], 'AC', 0.2),
+    ]
+    fake.polls_until_done = 3
+
+    seen: List[List[str]] = []
+    original = runner._wait_for_testrun  # noqa: SLF001
+
+    async def watching(run, solution, board, since):
+        status = await original(run, solution, board, since)
+        seen.append([chip.text for chip in board.get(str(solution.path))])
+        return status
+
+    monkeypatch.setattr(runner, '_wait_for_testrun', watching)
+    await _run(runner, ctx)
+
+    assert seen, 'the wait was never entered'
+    assert any(text.startswith('testrun ') for text in seen[0])
+
+
+async def test_every_poll_repaints_the_solution_it_is_waiting_on(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """This is the slow half of a remote run and the half a setter wants moving.
+
+    The judge's own state word goes on the board on each poll, so a run that is
+    queued behind the park looks different from one that is being judged.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+    fake.results['sol.cpp'] = [
+        _test(SAMPLE_NAMES[0], 'AC', 0.1),
+        _test(SAMPLE_NAMES[1], 'AC', 0.2),
+    ]
+    fake.polls_until_done = 3
+
+    seen: List[List[str]] = []
+    original = runner_module.cli.testrun_status
+
+    async def watching(run):
+        status = await original(run)
+        seen.append([chip.text for chip in ctx.progress_board.get('sol.cpp')])
+        return status
+
+    monkeypatch.setattr(runner_module.cli, 'testrun_status', watching)
+    await _run(runner, ctx)
+
+    # By the last poll the board is describing this testrun, not the queue.
+    assert any(any(text.startswith('testrun ') for text in chips) for chips in seen[1:])
+
+
+async def test_the_board_is_cleared_once_the_solution_has_a_verdict(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """A stale `running` chip beside a finished verdict is worse than no chip.
+
+    The header is about to carry the solution's outcome; whatever the judge was
+    doing a moment ago is no longer what the setter is being told.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+    fake.results['sol.cpp'] = [
+        _test(SAMPLE_NAMES[0], 'AC', 0.1),
+        _test(SAMPLE_NAMES[1], 'AC', 0.2),
+    ]
+
+    await _run(runner, ctx)
+
+    assert _chips(ctx, 'sol.cpp') == []
+
+
+async def test_a_poll_writes_to_its_own_slot_and_no_other(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The rule that lets a background task say anything at all.
+
+    Up to `MAX_INFLIGHT_TESTRUNS` tasks poll at once, long after the call that
+    created them returned. Printing from one would make the display flip between
+    solutions; a board write cannot, because the reporter draws only the slot it
+    is blocked on. Pinned here from the writing end: `other.cpp` being polled
+    throughout never touches `sol.cpp`'s slot.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg,
+        tmp_path,
+        monkeypatch,
+        groups=['samples'],
+        solutions=[
+            ('sol.cpp', ExpectedOutcome.ACCEPTED),
+            ('other.cpp', ExpectedOutcome.WRONG_ANSWER),
+        ],
+    )
+    for filename in ('sol.cpp', 'other.cpp'):
+        fake.results[filename] = [
+            _test(SAMPLE_NAMES[0], 'AC', 0.1),
+            _test(SAMPLE_NAMES[1], 'AC', 0.2),
+        ]
+    fake.polls_until_done = 5
+
+    first = runner.run_solution(ctx.skeleton.solutions[0], ctx.skeleton.entries, ctx)
+    runner.run_solution(ctx.skeleton.solutions[1], ctx.skeleton.entries, ctx)
+
+    await _gather(first)
+
+    # `sol.cpp` is finished and cleared; `other.cpp` kept its own slot the whole
+    # time, and never appeared in `sol.cpp`'s.
+    assert _chips(ctx, 'sol.cpp') == []
+    assert _chips(ctx, 'other.cpp')
+    assert not any('other' in text for text in _chips(ctx, 'sol.cpp'))
+
+
+def test_poll_chips_say_only_what_the_judge_reported(testing_pkg):
+    """A `0/0` on a run that has not started would read as a lost testset.
+
+    The state word is always answered; the counts and the host are reported by
+    some responses and not others, so they are added when present rather than
+    defaulted.
+    """
+    runner = MojRunner()
+    runner._moj_id = 'alice#rbxt-x'  # noqa: SLF001
+    since = utils.Elapsed()
+
+    bare = runner._poll_chips(  # noqa: SLF001
+        '4821', cli.TestrunStatus(status='queued'), since
+    )
+    texts = [chip.text for chip in bare]
+    assert 'queued' in texts
+    assert not any('/' in text and 'ok' in text for text in texts)
+
+    full = runner._poll_chips(  # noqa: SLF001
+        '4821',
+        cli.TestrunStatus(
+            status='running', correct=12, total_tests=72, host='judge-sp1'
+        ),
+        since,
+    )
+    texts = [chip.text for chip in full]
+    assert 'running' in texts
+    assert 'judge-sp1' in texts
+    # `correct`, not "tests run": MOJ reports how many passed, and calling that
+    # progress would show a solution expected to fail stuck at 0 while it works.
+    assert '12/72 ok' in texts
+
+
+def test_the_host_is_read_off_a_status_that_carries_one():
+    """The live probe came back `host: judge-sp1`.
+
+    Optional because nothing guarantees every response carries it -- a park with
+    one judge may well never send it -- and `extra='ignore'` means a missing field
+    is not an error.
+    """
+    assert cli.TestrunStatus(status='done', host='judge-sp1').host == 'judge-sp1'
+    assert cli.TestrunStatus(status='done').host is None

--- a/tests/rbx/box/runners/test_progress_board.py
+++ b/tests/rbx/box/runners/test_progress_board.py
@@ -1,0 +1,100 @@
+"""`RunProgress`: the slot each backend says what it is doing in.
+
+The board exists because the two ends cannot be wired together directly -- the
+reporter is built from a `RunSolutionResult`, so it does not exist yet when
+`run_solutions` hands the backend its `RunContext`. What is pinned here is the
+shape that makes a *pull* reader safe: whole-line writes, immutable reads, and an
+unwritten solution reading back empty rather than raising.
+"""
+
+from rbx.box.runners.base import RunnerChip, RunProgress
+
+
+def test_an_unwritten_solution_reads_back_empty():
+    """A backend that never writes -- `LocalRunner` -- costs the reader nothing.
+
+    Empty rather than `None`, so the reporter can iterate the result without a
+    guard at the one place that reads it.
+    """
+    board = RunProgress()
+
+    assert board.get('sols/never-written.cpp') == ()
+
+
+def test_set_replaces_the_whole_line_rather_than_appending():
+    """A backend says what is true *now*; it does not accumulate.
+
+    Half a solution's state from one moment beside half from another is exactly
+    the kind of line that reads as a bug in whatever it describes -- a `queued`
+    chip still sitting beside a `done` one.
+    """
+    board = RunProgress()
+
+    board.set('sol.cpp', RunnerChip('moj rbxt-a1b2'), RunnerChip('queued'))
+    board.set('sol.cpp', RunnerChip('moj rbxt-a1b2'), RunnerChip('done'))
+
+    assert [chip.text for chip in board.get('sol.cpp')] == ['moj rbxt-a1b2', 'done']
+
+
+def test_slots_are_per_solution():
+    """The point of the board: a poll writes where nobody else is reading.
+
+    Up to `MAX_INFLIGHT_TESTRUNS` background tasks write at once while the
+    reporter reads exactly one slot, so a write for a solution the report has not
+    reached must not disturb the one it is drawing.
+    """
+    board = RunProgress()
+
+    board.set('first.cpp', RunnerChip('running'))
+    board.set('second.cpp', RunnerChip('queued'))
+
+    assert [chip.text for chip in board.get('first.cpp')] == ['running']
+    assert [chip.text for chip in board.get('second.cpp')] == ['queued']
+
+
+def test_a_reader_cannot_be_handed_something_a_later_write_mutates():
+    """Chips come back as a tuple, so a read is a snapshot.
+
+    The reporter reads on one turn of the loop and renders on the same one, but a
+    list handed out here would still be a live reference into the board -- and the
+    backend writing between the two is the normal case, not a rare one.
+    """
+    board = RunProgress()
+    board.set('sol.cpp', RunnerChip('queued'))
+
+    held = board.get('sol.cpp')
+    board.set('sol.cpp', RunnerChip('done'))
+
+    assert [chip.text for chip in held] == ['queued']
+
+
+def test_clearing_a_solution_leaves_the_others_alone():
+    """A finished solution's slot is dropped once it has a real verdict to show.
+
+    A stale `running` chip beside a finished verdict is worse than no chip at
+    all -- but the solutions still in flight have to keep theirs.
+    """
+    board = RunProgress()
+    board.set('first.cpp', RunnerChip('done'))
+    board.set('second.cpp', RunnerChip('running'))
+
+    board.clear('first.cpp')
+
+    assert board.get('first.cpp') == ()
+    assert [chip.text for chip in board.get('second.cpp')] == ['running']
+
+
+def test_clearing_something_never_written_is_not_an_error():
+    """`clear` runs on a path the consumer reached; nothing promises a write."""
+    board = RunProgress()
+
+    board.clear('sols/never-written.cpp')
+
+    assert board.get('sols/never-written.cpp') == ()
+
+
+def test_a_chip_defaults_to_the_dim_style():
+    """Chips are annotations on a header, not the header. The backend opts in to
+    anything louder -- MOJ colours `cached` and `done` green, nothing else."""
+    assert RunnerChip('queued').style == 'bright_black'
+    assert RunnerChip('cached', style='green').style == 'green'

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -19,6 +19,7 @@ from rbx.box.generators import (
     generate_outputs_for_testcases,
     generate_testcases,
 )
+from rbx.box.runners.base import RunnerChip
 from rbx.box.sanitizers.issue_stack import IssueAccumulator, issue_stack_var
 from rbx.box.schema import (
     ExpectedOutcome,
@@ -2385,3 +2386,112 @@ def test_elapsed_reads_one_decimal_below_ten_seconds():
         assert str(elapsed) == '3.2s'
     with patch('rbx.utils.time.monotonic', return_value=elapsed._started + 41.9):  # noqa: SLF001
         assert str(elapsed) == '41s'
+
+
+# -- backend chips on the header ----------------------------------------------
+
+
+async def test_the_header_carries_what_the_backend_put_on_the_board(
+    mock_problem_root, mock_binary_scoring
+):
+    """The reporter renders the backend's chips verbatim, and knows nothing.
+
+    A typed status would put MOJ's vocabulary into the reporter, and the next
+    judge's after that. What arrives here is text and a style.
+    """
+    solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = make_reporter_skeleton(mock_problem_root, solution, {'group1': 1})
+    result = make_run_result(skeleton, {('group1', 0): Outcome.ACCEPTED})
+    result.progress_board.set(
+        'sol.cpp',
+        RunnerChip('moj rbxt-a1b2'),
+        RunnerChip('testrun 4821'),
+        RunnerChip('running'),
+    )
+    console = recording_console()
+
+    with fresh_issue_stack():
+        await drive_reporter(
+            LiveRunReporter(result, VerificationLevel.FULL, console), skeleton
+        )
+
+    header = next(
+        line for line in rendered_lines(console) if line.startswith('sol.cpp')
+    )
+    assert 'moj rbxt-a1b2' in header
+    assert 'testrun 4821' in header
+    assert 'running' in header
+
+
+async def test_backend_chips_survive_a_non_terminal_console(
+    mock_problem_root, mock_binary_scoring
+):
+    """Unlike the wall clock, backend chips do render into a shared report.
+
+    They are not wall-clock, so they do not turn every re-run into a diff -- and a
+    setter reading a `--share` report wants to know which testrun produced its
+    numbers.
+    """
+    solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = make_reporter_skeleton(mock_problem_root, solution, {'group1': 1})
+    result = make_run_result(skeleton, {('group1', 0): Outcome.ACCEPTED})
+    result.progress_board.set('sol.cpp', RunnerChip('testrun 4821'))
+    console = recording_console()
+    assert not console.is_terminal
+
+    with fresh_issue_stack():
+        await drive_reporter(
+            LiveRunReporter(result, VerificationLevel.FULL, console), skeleton
+        )
+
+    header = next(
+        line for line in rendered_lines(console) if line.startswith('sol.cpp')
+    )
+    assert 'testrun 4821' in header
+    # ...and still no clock.
+    assert not re.search(r'\d+(\.\d)?s', header)
+
+
+async def test_only_the_solution_being_drawn_reaches_the_header(
+    mock_problem_root, mock_binary_scoring
+):
+    """Every in-flight solution keeps its slot current; one of them is drawn.
+
+    That is what makes a background poll safe to write from at all: it lands in
+    its own slot, and the reporter never draws a slot it is not blocked on.
+    """
+    solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = make_reporter_skeleton(mock_problem_root, solution, {'group1': 1})
+    result = make_run_result(skeleton, {('group1', 0): Outcome.ACCEPTED})
+    result.progress_board.set('sol.cpp', RunnerChip('testrun 4821'))
+    result.progress_board.set('other.cpp', RunnerChip('testrun 4822'))
+    console = recording_console()
+
+    with fresh_issue_stack():
+        await drive_reporter(
+            LiveRunReporter(result, VerificationLevel.FULL, console), skeleton
+        )
+
+    text = console.export_text(clear=False)
+    assert 'testrun 4821' in text
+    assert 'testrun 4822' not in text
+
+
+async def test_a_run_with_no_backend_chips_renders_exactly_as_before(
+    mock_problem_root, mock_binary_scoring
+):
+    """`LocalRunner` writes nothing, and an empty board adds no separator."""
+    solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = make_reporter_skeleton(mock_problem_root, solution, {'group1': 1})
+    result = make_run_result(skeleton, {('group1', 0): Outcome.ACCEPTED})
+    console = recording_console()
+
+    with fresh_issue_stack():
+        await drive_reporter(
+            LiveRunReporter(result, VerificationLevel.FULL, console), skeleton
+        )
+
+    header = next(
+        line for line in rendered_lines(console) if line.startswith('sol.cpp')
+    )
+    assert '·' not in header

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import pathlib
 import re
@@ -19,7 +20,7 @@ from rbx.box.generators import (
     generate_outputs_for_testcases,
     generate_testcases,
 )
-from rbx.box.runners.base import RunnerChip
+from rbx.box.runners.base import RunnerChip, RunProgress
 from rbx.box.sanitizers.issue_stack import IssueAccumulator, issue_stack_var
 from rbx.box.schema import (
     ExpectedOutcome,
@@ -2585,3 +2586,63 @@ async def test_the_frozen_frame_still_carries_the_backend_chips(
     )
     assert 'testrun 4821' in header
     assert 'done' in header
+
+
+async def test_a_slow_testcase_repaints_the_header_while_it_waits(
+    mock_problem_root, mock_binary_scoring
+):
+    """The reported symptom, end to end, through the real refresh thread.
+
+    A backend that learns something while the report is blocked on an
+    unresolved deferred has to reach the screen *during* the wait. This drives
+    `rich`'s own auto-refresh rather than calling `refresh()` by hand: the
+    reporter is blocked in `await`, nothing calls `update()`, and the frames that
+    appear are the ones the refresh thread produced on its own.
+
+    Before the block rendered itself, this test saw only `waiting`, then the
+    finished report -- which is exactly what a `rbx time --runner moj` run looked
+    like.
+    """
+    solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = make_reporter_skeleton(mock_problem_root, solution, {'group1': 1})
+    board = RunProgress()
+    board.set('sol.cpp', RunnerChip('waiting for a slot'))
+
+    on_screen_during_the_wait: List[str] = []
+
+    async def slow() -> Evaluation:
+        # Stands in for a judge: the deferred the reporter is awaiting does not
+        # resolve for a while, and the backend learns something meanwhile.
+        await asyncio.sleep(0.1)
+        board.set('sol.cpp', RunnerChip('testrun 4821'), RunnerChip('running'))
+        await asyncio.sleep(0.6)
+        # Snapshotted from *inside* the unresolved deferred, which is the only
+        # place that can tell "reached the screen during the wait" from "reached
+        # it once the wait was over". Asserting on the finished transcript cannot:
+        # the frame drawn after this resolves carries the chip either way.
+        on_screen_during_the_wait.append(console.export_text(clear=False))
+        return make_evaluation(Outcome.ACCEPTED, time_ms=100, memory_bytes=1024)
+
+    result = RunSolutionResult(
+        skeleton=skeleton,
+        items=[
+            EvaluationItem(
+                solution=solution,
+                testcase_entry=TestcaseEntry(group='group1', index=0),
+                eval=Deferred(slow),
+            )
+        ],
+        progress_board=board,
+    )
+    console = terminal_console()
+
+    reporter = LiveRunReporter(result, VerificationLevel.FULL, console)
+    with fresh_issue_stack():
+        await drive_reporter(reporter, skeleton)
+    reporter.close()
+
+    (during,) = on_screen_during_the_wait
+    # The mid-flight state was on screen while the reporter was still in `await`,
+    # drawn by frames nothing in this reporter asked for.
+    assert 'testrun 4821' in during
+    assert 'running' in during


### PR DESCRIPTION
Stacked on #697 — review that one first; this PR's diff is against it.

Second of two. #697 gave the solution header a live region; this fills it with what the backend running the solution actually knows.

## The problem

`MojRunner.run_solution` dispatches **every** solution onto a background task immediately, so while the report is blocked on solution #1, solutions #2..#N are genuinely in flight on the judge. rbx knows their testrun ids, their queue state, whether a result came from cache — and had nowhere to say any of it.

It was not for lack of trying. `_evaluation_from_job` called `ctx.progress.update('Waiting for MOJ to judge …')`, but **every caller exits its `with utils.StatusProgress(...)` block before `print_run_report`** (`cli.py`, `timing.py`). The `Status` was always already stopped, so that line rendered nowhere. It has never been visible to a setter.

## The board

`RunProgress` — one slot per solution, holding `RunnerChip`s (text + style). Created by `run_solutions`, handed to the backend on `RunContext` and to the reporter on `RunSolutionResult`. The two ends cannot be wired directly: the reporter does not exist until `run_solutions` has returned.

```
sols/slow.cpp (runs/2) · 12.4s · moj alice#rbxt-a1b2 · testrun 4821 · running · judge-sp1 · 34/72 ok · 51s
```

**Chips, not a typed status.** A typed `RunnerStatus` would put MOJ's vocabulary — `queued`, `running`, `done` — into the reporter, and the next judge's after that. The backend owns its words; the reporter owns the layout.

**Pull, not push.** The reporter reads the slot it is blocked on, each time it paints.

This dissolves the standing objection to a backend saying anything from a polling task. `_submit_and_poll`'s docstring argued that a poll writing a status line "makes the display flip between solutions and the reporter's own message every few seconds" — true of a *print*, false of a board write, which lands in that solution's own slot and is drawn only if the reporter is waiting on it. So all ten in-flight solutions keep their slots current for a dict write each, and the one being watched reports itself live. Those docstrings are rewritten rather than bypassed.

Same event loop on both ends, so no locking; chips come back as a tuple so a reader holds a snapshot. `LocalRunner` writes nothing and reads back empty.

## What MOJ writes

| Where | Chips |
|---|---|
| `run_solution`, at dispatch | `moj <id>`, `waiting for a slot` |
| `_submit_and_poll`, cache hit | `testrun <id>`, `cached` |
| `_submit_and_poll`, after submit | `testrun <id>`, `submitted`, elapsed |
| `_wait_for_testrun`, each poll | `testrun <id>`, state, host, `N/M ok`, elapsed |
| `_submit_and_poll`, on done | `testrun <id>`, `done`, elapsed |
| failure | nothing — the exception speaks |

Two judgement calls worth checking:

- **Only what the judge answered with.** The state word is always present; counts and host are not, so they are added when reported rather than defaulted. A `0/0` on a run that has not started would read as a judge losing the testset.
- **`correct`, never "tests run".** MOJ reports how many *passed*. Calling that progress would show a solution the validation phase expects to fail sitting at `0/72` while working perfectly — so the chip is labelled `ok`.

The elapsed chip starts **before** the concurrency slot is taken, so it counts the whole wait the setter is enduring. On `MAX_INFLIGHT_TESTRUNS = 1` that queueing is most of it, and it is the part the reporter's own clock cannot see — that clock starts when the *report* reaches the solution, long after the judge did.

The slot is cleared once the solution has a real verdict: a stale `running` chip beside a finished outcome is worse than no chip.

`_evaluation_from_job` deliberately writes **nothing** on the way in. The obvious move — replacing the dead `progress.update` with a `waiting for the judge` chip — is wrong: that solution's own polling task is already repainting the slot with the testrun id, the judge's state and the elapsed wait, so a write here would overwrite a better line with a worse one and leave it worse until the next poll came round.

`TestrunStatus` gains `host` (the 2026-08-21 probe saw `judge-sp1`), so a timing can be read against the machine that produced it.

## Tests

- `tests/rbx/box/runners/test_progress_board.py` (new): whole-line writes, snapshot reads, per-solution slots, clear semantics, empty default.
- `tests/rbx/box/solutions_test.py`: chips reach the header; they survive a non-terminal console (unlike the clock); only the drawn solution's slot renders; an empty board adds no separator.
- `tests/rbx/box/runners/moj/test_run_solution.py`: each write point, plus `_poll_chips` saying only what the judge reported, plus `host` parsing.
- `test_the_background_polling_never_writes_the_status_line` keeps its assertion and gains a docstring saying why it still holds — it is about the *console*, and a board write is not a print.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jj1dDYMUJByG2yxLT1JQhq
