### PR TITLE
feat(timing): warn when a derived limit denies a group's own solutions

### DIFF
--- a/docs/plans/2026-08-23-timing-lower-violation-design.md
+++ b/docs/plans/2026-08-23-timing-lower-violation-design.md
@@ -1,0 +1,67 @@
+# Surfacing invalid-by-nature time limits in the timing table
+
+## Problem
+
+A timing group whose limit is *derived* -- from a reference group (`whenEmpty`
+or a picker-forced relative) or from the base estimate -- is never checked
+against its own accepted solutions. `timing.compute_bounds` takes the derived
+limit as the lower bound and discards `measured.lower` entirely, so the group's
+own evidence bounds nothing.
+
+The result is a limit that no good solution of the group can meet, rendered in
+the table as an ordinary row:
+
+    java | 1 | 200 ms | x1.0 of cpp
+
+with `sol.java` taking 900 ms. Nothing in the table says the row is impossible.
+
+Two further gaps share the root cause:
+
+* In **formula mode** `build_timing_profile` passes `derive_fn=None`, so a
+  derived group is checked from neither side -- not even the upper bound.
+* The invariant is not specific to derived groups. A formula is arbitrary, so an
+  `ESTIMATED` row can also land below its own slowest accepted solution.
+
+## The invariant
+
+Every group carries the smallest limit its own accepted solutions allow:
+
+* multipliers mode: `ceil(slowest_ac * acToTimeLimit)` -- the setter's own margin;
+* formula mode: `slowest_ac` -- a solution taking `T` ms passes at a limit of `T`.
+
+A group violates it when its resolved limit is below that value. On the
+estimated path the limit is *built* from this bound and rounded up, so the
+invariant holds by construction; only derived limits can break it.
+
+## Design
+
+`TimingGroupReport` gains `lowerViolation: Optional[TimingBound]`, recorded only
+when the invariant is broken -- `value` is the smallest limit the group's own
+accepted solutions allow and `solution` is the one that sets it. Following
+`upperValidation`, the field stays unset when there is nothing to record, so an
+untroubled group does not emit a meaningless key.
+
+`compute_bounds` computes that bound from `measured.lower` on every path,
+derived or not, and `_as_eval_result` stamps the violation. Formula mode gains
+`make_formula_derive`, which runs the same check without inventing bounds a
+formula does not have.
+
+Severity is a **warning, not an error**. The upper-bound path raises
+`TimingRangeError`, which the interactive picker renders *instead of* the table
+-- acceptable for a grouping that is wholly unsatisfiable, wrong here: the
+setter cycling groupings needs to see which row is broken, in the table, beside
+the rows that are fine.
+
+`limits_info` renders a violating row in the error style and appends the bound
+to its Source cell, with a caption distinguishing the two severities:
+
+* `slowest_ac > timeLimit` -- the accepted solutions do not pass at all;
+* otherwise -- they pass, but below the margin `acToTimeLimit` asks for.
+
+Because `build_limits_table` is the single rendering path, this reaches
+`rbx time`, the group picker preview and shared reports alike.
+
+## Out of scope
+
+Deliberately not surfaced (raised, considered, dropped): skipped upper
+validation, zero-evidence multiplier rows, and reference-chain provenance.

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -404,6 +404,24 @@ group instead of from its own measured timings:
 Unlike the env `whenEmpty` fallback (which only applies to groups that have **no** solutions),
 a forced relative **always overrides** the group's measured estimate.
 
+!!! warning "A derived limit can be one the group's own solutions cannot meet"
+
+    Because the override is total, a group can end up with a limit **below** what its own
+    accepted solutions need -- deriving `java` from `cpp` at `×1.0` gives it `cpp`'s limit
+    however slow the Java solutions actually are. {{rbx}} checks every derived limit against
+    the group's own measurements and flags the row in the table, in the picker preview as
+    well as in the final report:
+
+    ```
+    java  1  200 ms  ×1.0 of cpp ⚠ needs ≥ 1800 ms (sol.java takes 900 ms)
+    ```
+
+    The row is red when the group's accepted solutions do not pass at the limit at all, and
+    yellow when they pass but without the margin `acToTimeLimit` asks for. The bound is
+    recorded in the profile under `lowerViolation`. This is a warning, not an error: the
+    limit is written as asked, so regroup or drop the reference if it was not what you
+    meant.
+
 Press <kbd>Enter</kbd> to confirm, or pass `--auto` to skip the prompt and use the configured
 env groups as-is.
 

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -17,7 +17,7 @@ The central Pydantic model hierarchy defining `problem.rbx.yml`:
 - **`CodeItem`** -- `path`, `language`, `compilationArgs` (reference to any code file)
 - **`LimitsProfile`** -- Per-packager limit overrides with `modifiers` per language, `formula` support; also carries optional `groups` metadata (a `TimingGroupReport` list, presentation-only) recording how languages were grouped during estimation
 - **`LimitModifiers`** -- `time`, `timeMultiplier`, `memory` per language
-- **`TimingGroupOrigin` / `TimingGroupReport`** -- presentation-only types describing each language group's resolved time limit and its source (estimated / `whenEmpty` multiple / defaulted)
+- **`TimingGroupOrigin` / `TimingGroupReport`** -- presentation-only types describing each language group's resolved time limit and its source (estimated / `whenEmpty` multiple / defaulted). `lowerViolation` records the smallest limit the group's *own* accepted solutions allow, and is set only when the resolved limit is below it -- which only a **derived** limit can be, since an estimated one is built from that bound and rounded up. It is a warning, never an error: the limit is written as asked and the table flags the row (see `timing.make_formula_derive` / `make_multipliers_derive`)
 
 ### Vars and per-group overrides
 

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -264,6 +264,26 @@ class LimitsTableRow(BaseModel):
     # Slow solutions of this group that finished within its limit times
     # `timeLimitToTle`, so they do not respect the upper bound.
     violating_upper: List[str] = []
+    # Set when the group's own accepted solutions do not fit its time limit:
+    # the smallest limit they allow, and the one that takes the longest.
+    lower_violation_ms: Optional[int] = None
+    lower_violation_solution: Optional[str] = None
+    # The group's slowest accepted solution, to tell a limit its solutions
+    # outright fail from one they merely clear without the configured margin.
+    slowest_ms: Optional[int] = None
+
+    @property
+    def violates_lower(self) -> bool:
+        """Whether this row's limit is below what its own accepted solutions
+        allow -- a limit no good solution of the group can be judged under as
+        the setter intended."""
+        return self.lower_violation_ms is not None
+
+    @property
+    def rejects_own_solutions(self) -> bool:
+        """Whether the group's own accepted solutions do not pass at all, as
+        opposed to passing without the configured margin."""
+        return self.slowest_ms is not None and self.slowest_ms > self.time_limit_ms
 
 
 def _bounds_note(report: TimingGroupReport) -> str:
@@ -291,6 +311,23 @@ def _bounds_note(report: TimingGroupReport) -> str:
     return ' [' + ', '.join(parts) + ']'
 
 
+def _violation_note(report: TimingGroupReport) -> str:
+    """What the group's own accepted solutions need, when its limit denies it.
+
+    Spelled out beside the limit rather than left to the caption: the caption
+    counts the groups, this says which row and by how much.
+    """
+    violation = report.lowerViolation
+    if violation is None:
+        return ''
+    note = f'needs ≥ {violation.value} ms'
+    if violation.solution is not None and report.slowest is not None:
+        note += f' ({violation.solution} takes {report.slowest} ms)'
+    elif violation.solution is not None:
+        note += f' from {violation.solution}'
+    return f' ⚠ {note}'
+
+
 def _report_source(report: TimingGroupReport) -> str:
     if report.origin == TimingGroupOrigin.ESTIMATED:
         source = (
@@ -303,7 +340,7 @@ def _report_source(report: TimingGroupReport) -> str:
             source += f' + {report.increment} ms'
     else:
         source = 'DEFAULTED to base'
-    return source + _bounds_note(report)
+    return source + _bounds_note(report) + _violation_note(report)
 
 
 def _base_row(profile: LimitsProfile) -> LimitsTableRow:
@@ -317,9 +354,13 @@ def _base_row(profile: LimitsProfile) -> LimitsTableRow:
     solutions = None
     confirmed: List[str] = []
     violating: List[str] = []
+    lower_violation = None
+    slowest = None
     if profile.baseEstimate is not None:
         source = _report_source(profile.baseEstimate)
         solutions = profile.baseEstimate.solutionCount
+        lower_violation = profile.baseEstimate.lowerViolation
+        slowest = profile.baseEstimate.slowest
         validation = profile.baseEstimate.upperValidation
         if validation is not None:
             confirmed = list(validation.confirmed)
@@ -333,6 +374,11 @@ def _base_row(profile: LimitsProfile) -> LimitsTableRow:
         source=source,
         confirmed_upper=confirmed,
         violating_upper=violating,
+        lower_violation_ms=lower_violation.value if lower_violation else None,
+        lower_violation_solution=(
+            lower_violation.solution if lower_violation else None
+        ),
+        slowest_ms=slowest,
     )
 
 
@@ -366,6 +412,17 @@ def build_limits_table_rows(profile: LimitsProfile) -> List[LimitsTableRow]:
                         if report.upperValidation is not None
                         else []
                     ),
+                    lower_violation_ms=(
+                        report.lowerViolation.value
+                        if report.lowerViolation is not None
+                        else None
+                    ),
+                    lower_violation_solution=(
+                        report.lowerViolation.solution
+                        if report.lowerViolation is not None
+                        else None
+                    ),
+                    slowest_ms=report.slowest,
                 )
             )
         # Leftover group is shown first; stable sort keeps the rest in order.
@@ -419,6 +476,20 @@ def _highlight_ms(text: str) -> str:
     return _MS_PATTERN.sub(r'[timelimit]\1[/timelimit] [dim]ms[/dim]', text)
 
 
+def _subject(rows: List[LimitsTableRow]) -> str:
+    """Name the solutions a caption is about, or count their groups when the
+    rows carry no name. Always phrased so a singular verb follows."""
+    named = [
+        row.lower_violation_solution for row in rows if row.lower_violation_solution
+    ]
+    if not named:
+        plural = 's' if len(rows) > 1 else ''
+        return f'The slowest accepted solution of {len(rows)} group{plural} is'
+    if len(named) == 1:
+        return f'{named[0]} is'
+    return f'Each of {", ".join(named)} is'
+
+
 def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
     """Build a styled rich Table of the resolved per-language/group limits.
 
@@ -443,6 +514,29 @@ def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
         caption_lines.append(
             '[warning]⚠ DEFAULTED: no accepted solutions and no whenEmpty rule; '
             'fell back to the base time limit.[/warning]'
+        )
+    # The grouping handed a group a limit its own good solutions cannot meet --
+    # the group's limit was derived from elsewhere and its own measurements were
+    # never consulted. Split by severity: a limit its solutions outright fail is
+    # a different problem from one they clear without the configured margin, and
+    # collapsing the two would understate the first.
+    rejecting = [
+        row for row in rows if row.violates_lower and row.rejects_own_solutions
+    ]
+    if rejecting:
+        caption_lines.append(
+            f'[error]⚠ {_subject(rejecting)} accepted, but does not pass at the '
+            f'time limit of its own group, which was derived from another group '
+            f'instead of estimated from it. Regroup, or drop the reference so the '
+            f'group is estimated from its own solutions.[/error]'
+        )
+    thin = [row for row in rows if row.violates_lower and not row.rejects_own_solutions]
+    if thin:
+        caption_lines.append(
+            f'[warning]⚠ {_subject(thin)} accepted and passes at the time limit of '
+            f'its own group, but without the margin acToTimeLimit asks for, because '
+            f'the limit was derived from another group. See the Source column for '
+            f'what each group needs.[/warning]'
         )
     # Terse on purpose: the validation run already reported each offending
     # solution by name, with what to do about it. This only says the table's
@@ -485,7 +579,17 @@ def build_limits_table(profile: LimitsProfile, title: str = 'Time limits'):
         # any other consumer -- and before the styling helpers, whose own markup
         # must survive.
         source = rich.markup.escape(row.source)
-        if row.defaulted:
+        if row.violates_lower:
+            # Red beats the defaulted yellow: a limit the group's own solutions
+            # cannot meet is a broken grouping, not a fallback.
+            style = 'error' if row.rejects_own_solutions else 'warning'
+            table.add_row(
+                f'[{style}]{row.languages}[/{style}]',
+                f'[{style}]{sols}[/{style}]',
+                f'[{style}]{tl}[/{style}]',
+                f'[{style}]{source}[/{style}]',
+            )
+        elif row.defaulted:
             # Defaulted rows are warnings: the yellow signals the fallback and
             # deliberately overrides the per-figure time highlight.
             table.add_row(

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -1020,6 +1020,16 @@ Presentation-only.""",
 time limit found. Absent when the group has no slow solutions. Presentation-only.""",
     )
 
+    lowerViolation: Optional[TimingBound] = Field(
+        default=None,
+        description="""The smallest time limit this group's own accepted solutions
+allow, recorded only when the group's time limit is below it -- that is, when the
+limit was derived from a reference group or the base estimate instead of being
+estimated from the group's own solutions, and the group's own solutions do not fit
+in it. `solution` is the accepted solution that sets the bound. Absent whenever the
+limit respects the group's own evidence. Presentation-only.""",
+    )
+
     droppedUpper: List[str] = Field(
         default=[],
         deprecated=True,

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -140,6 +140,17 @@ class TimingBounds(BaseModel):
     # Whether ``lower`` came from a reference group instead of this group's own
     # accepted solutions.
     derived: bool = False
+    # The smallest limit this group's own accepted solutions allow, whatever
+    # decided ``lower``. On the estimated path it *is* ``lower``; on a derived
+    # one it is the evidence the derivation ignored, which is the only way a
+    # limit can end up below what the group's own good solutions need.
+    own_lower: Optional[int] = None
+    own_lower_solution: Optional[str] = None
+
+    def violates_own_lower(self, time_limit: int) -> bool:
+        """Whether ``time_limit`` is below what this group's own accepted
+        solutions allow -- an invalid-by-nature limit for this group."""
+        return self.own_lower is not None and time_limit < self.own_lower
 
     @property
     def fits(self) -> bool:
@@ -165,13 +176,21 @@ def compute_bounds(
     estimate); otherwise the lower bound is this group's slowest accepted
     solution scaled by ``acToTimeLimit``.
     """
+    own_lower = None
+    own_lower_solution = None
+    if measured.lower is not None:
+        own_lower = math.ceil(
+            measured.lower.slowest * _exact(multipliers.acToTimeLimit)
+        )
+        own_lower_solution = measured.lower.slowest_solution
+
     lower_solution = None
     if derived_from is not None:
         lower = derived_from
     else:
-        assert measured.lower is not None
-        lower = math.ceil(measured.lower.slowest * _exact(multipliers.acToTimeLimit))
-        lower_solution = measured.lower.slowest_solution
+        assert own_lower is not None
+        lower = own_lower
+        lower_solution = own_lower_solution
 
     upper = None
     upper_solution = None
@@ -192,6 +211,8 @@ def compute_bounds(
         upper=upper,
         upper_solution=upper_solution,
         derived=derived_from is not None,
+        own_lower=own_lower,
+        own_lower_solution=own_lower_solution,
     )
 
 
@@ -209,6 +230,15 @@ def _as_eval_result(bounds: TimingBounds, time_limit: int) -> timing_groups.Eval
             None
             if bounds.upper is None
             else schema.TimingBound(value=bounds.upper, solution=bounds.upper_solution)
+        ),
+        # Recorded only when broken: a limit that respects the group's own
+        # solutions has nothing to say about them.
+        lower_violation=(
+            schema.TimingBound(
+                value=bounds.own_lower, solution=bounds.own_lower_solution
+            )
+            if bounds.own_lower is not None and bounds.violates_own_lower(time_limit)
+            else None
         ),
     )
 
@@ -228,6 +258,34 @@ def make_formula_eval(formula: str) -> timing_groups.EvalFn:
         )
 
     return _eval
+
+
+def make_formula_derive() -> timing_groups.DeriveFn:
+    """Post-processor for a formula-mode limit that did NOT come from the group's
+    own accepted solutions.
+
+    Takes no formula, because there is nothing to evaluate: the limit belongs to
+    the group this one derives from. A formula bounds nothing, so this invents no
+    bounds and never moves the limit; it exists so that a derived group is still
+    checked against the one thing its own measurements do say -- that a solution
+    taking ``T`` ms needs a limit of at least ``T`` ms. Without it a formula-mode
+    reference group is checked from neither side.
+    """
+
+    def _derive(
+        tl: int, measured: timing_groups.GroupMeasurements
+    ) -> timing_groups.EvalResult:
+        timings = measured.lower
+        if timings is None or timings.slowest <= tl:
+            return timing_groups.EvalResult(time_limit=tl)
+        return timing_groups.EvalResult(
+            time_limit=tl,
+            lower_violation=schema.TimingBound(
+                value=timings.slowest, solution=timings.slowest_solution
+            ),
+        )
+
+    return _derive
 
 
 def _check_bounds(
@@ -398,7 +456,7 @@ def build_timing_profile(
         )
     else:
         eval_fn = make_formula_eval(strategy.formula_or_die())
-        derive_fn = None
+        derive_fn = make_formula_derive()
 
     slow_per_language = slow_timing_per_solution_per_language or {}
     confirmed_per_language = confirmed_upper_per_language or {}

--- a/rbx/box/timing_groups.py
+++ b/rbx/box/timing_groups.py
@@ -166,6 +166,10 @@ class EvalResult(BaseModel):
     time_limit: int
     lower_bound: Optional[TimingBound] = None
     upper_bound: Optional[TimingBound] = None
+    # The smallest limit the group's own accepted solutions allow, set only when
+    # ``time_limit`` is below it. Only a limit that did not come from those
+    # solutions can break that -- an estimated one is built from this very bound.
+    lower_violation: Optional[TimingBound] = None
 
 
 # An estimator that derives no bounds at all (the formula path) may return the
@@ -212,9 +216,16 @@ def _record_provenance(
         return
     report.lowerBound = result.lower_bound
     report.upperBound = result.upper_bound
+    report.lowerViolation = result.lower_violation
     upper = measured.upper
-    if upper is not None and (
-        upper.confirmed_upper or upper.violating_upper or upper.skipped_upper
+    # Only an estimator that computes bounds says anything about the slow
+    # solutions -- the same rule ``_provenance_of`` states. The formula path
+    # reports a lower violation and nothing else, so a formula-mode group must
+    # not start emitting an upper record its estimated siblings never emit.
+    if (
+        result.lower_bound is not None
+        and upper is not None
+        and (upper.confirmed_upper or upper.violating_upper or upper.skipped_upper)
     ):
         # Set only when there is something to record. The profile is serialized
         # with `exclude_unset`, so assigning an empty record would make an

--- a/tests/rbx/box/test_timing_lower_violation.py
+++ b/tests/rbx/box/test_timing_lower_violation.py
@@ -1,0 +1,292 @@
+"""A group whose limit is derived from elsewhere is still checked against its own
+accepted solutions, and the table says so when the check fails."""
+
+import re
+from typing import Dict, List, Optional
+
+import pytest
+from prompt_toolkit.formatted_text import ANSI, to_formatted_text
+
+from rbx.box import limits_info
+from rbx.box.environment import LanguageGroup, LanguageGroupFallback
+from rbx.box.schema import TimingGroupOrigin, TimingMultipliers
+from rbx.box.timing import build_preview_renderer, build_timing_profile
+from rbx.box.timing_config import TimingStrategy
+
+
+def _multipliers(
+    ac_to_time_limit: float = 2.0,
+    time_resolution: int = 100,
+) -> TimingStrategy:
+    return TimingStrategy(
+        multipliers=TimingMultipliers(
+            acToTimeLimit=ac_to_time_limit,
+            timeLimitToTle=1.5,
+            timeResolution=time_resolution,
+        )
+    )
+
+
+def _profile(
+    strategy: TimingStrategy,
+    timings: Dict[str, Dict[str, int]],
+    repartition: Optional[Dict[str, int]] = None,
+    relatives: Optional[Dict[str, LanguageGroupFallback]] = None,
+    env_groups: Optional[List[LanguageGroup]] = None,
+    skipped_upper: Optional[Dict[str, List[str]]] = None,
+):
+    return build_timing_profile(
+        timing_per_solution_per_language=timings,
+        strategy=strategy,
+        env_groups=env_groups or [],
+        all_languages=sorted(timings),
+        repartition=repartition,
+        relatives=relatives,
+        skipped_upper_per_language=skipped_upper,
+    )
+
+
+def _group(profile, language: str):
+    assert profile.groups is not None
+    return next(g for g in profile.groups if language in g.languages)
+
+
+_ANSI = re.compile(r'\x1b\[[0-9;]*m')
+
+
+def _table_text(profile, width: int = 100) -> str:
+    """The table as plain text, with styling and rich's own word wrapping
+    normalized away -- a caption assertion is about the wording, not about where
+    a 100-column render happens to break the line."""
+    from rbx import console
+
+    rendered = console.capture_ansi(
+        limits_info.build_limits_table(profile.to_limits()), width=width
+    )
+    return ' '.join(_ANSI.sub('', rendered).split())
+
+
+# The grouping that started this: java is forced relative to cpp, so its own
+# 900 ms solution never bounds the 200 ms limit it ends up with.
+_REJECTING = dict(
+    timings={'cpp': {'sol.cpp': 100}, 'java': {'sol.java': 900}},
+    repartition={'cpp': 1, 'java': 2},
+    relatives={'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=1.0)},
+)
+
+
+def test_derived_limit_records_the_bound_its_own_solutions_need():
+    profile = _profile(_multipliers(), **_REJECTING)
+
+    java = _group(profile, 'java')
+    assert java.origin == TimingGroupOrigin.MULTIPLIER
+    assert java.timeLimit == 200
+    # 900 ms of accepted solution at acToTimeLimit 2.0 needs 1800 ms.
+    assert java.lowerViolation is not None
+    assert java.lowerViolation.value == 1800
+    assert java.lowerViolation.solution == 'sol.java'
+
+
+def test_estimated_group_never_violates_its_own_bound():
+    profile = _profile(_multipliers(), **_REJECTING)
+
+    # cpp is estimated from its own solutions, so the bound holds by construction.
+    assert _group(profile, 'cpp').lowerViolation is None
+    assert profile.baseEstimate is not None
+    assert profile.baseEstimate.lowerViolation is None
+
+
+def test_no_violation_when_the_derived_limit_clears_the_bound():
+    profile = _profile(
+        _multipliers(),
+        timings={'cpp': {'sol.cpp': 100}, 'java': {'sol.java': 900}},
+        repartition={'cpp': 1, 'java': 2},
+        relatives={'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=10.0)},
+    )
+
+    java = _group(profile, 'java')
+    assert java.timeLimit == 2000
+    assert java.lowerViolation is None
+
+
+def test_violation_is_flagged_when_only_the_margin_is_missing():
+    # java takes 150 ms and gets 200 ms: it passes, but acToTimeLimit 2.0 wants 300.
+    profile = _profile(
+        _multipliers(),
+        timings={'cpp': {'sol.cpp': 100}, 'java': {'sol.java': 150}},
+        repartition={'cpp': 1, 'java': 2},
+        relatives={'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=1.0)},
+    )
+
+    java = _group(profile, 'java')
+    assert java.timeLimit == 200
+    assert java.lowerViolation is not None
+    assert java.lowerViolation.value == 300
+
+
+def test_when_empty_group_with_no_solutions_has_nothing_to_violate():
+    profile = _profile(
+        _multipliers(),
+        timings={'cpp': {'sol.cpp': 100}, 'java': {}},
+        env_groups=[
+            LanguageGroup(
+                languages=['java'],
+                whenEmpty=LanguageGroupFallback(relativeTo='cpp', multiplier=1.0),
+            )
+        ],
+    )
+
+    assert _group(profile, 'java').lowerViolation is None
+
+
+def test_formula_mode_derived_group_is_checked():
+    # Formula mode used to pass derive_fn=None, leaving a derived group
+    # unchecked from both sides.
+    profile = _profile(
+        TimingStrategy(formula='fastest * 2'),
+        **_REJECTING,
+    )
+
+    java = _group(profile, 'java')
+    assert java.timeLimit == 200
+    # With no acToTimeLimit to apply, the bound is the raw measurement: a
+    # solution taking 900 ms needs a limit of at least 900 ms.
+    assert java.lowerViolation is not None
+    assert java.lowerViolation.value == 900
+    assert java.lowerViolation.solution == 'sol.java'
+
+
+def test_formula_mode_estimated_group_is_left_alone():
+    profile = _profile(
+        TimingStrategy(formula='slowest * 3'),
+        timings={'cpp': {'sol.cpp': 100}, 'java': {'sol.java': 900}},
+        repartition={'cpp': 1, 'java': 2},
+    )
+
+    assert _group(profile, 'java').lowerViolation is None
+    assert _group(profile, 'java').timeLimit == 2700
+
+
+def test_formula_mode_derive_reports_no_bounds_it_cannot_know():
+    profile = _profile(TimingStrategy(formula='fastest * 2'), **_REJECTING)
+
+    java = _group(profile, 'java')
+    # A formula bounds nothing, so the derived row must not claim bounds.
+    assert java.lowerBound is None
+    assert java.upperBound is None
+
+
+@pytest.mark.parametrize(
+    'strategy', [_multipliers(), TimingStrategy(formula='fastest * 2')]
+)
+def test_derived_limit_is_not_moved_by_the_check(strategy: TimingStrategy):
+    profile = _profile(strategy, **_REJECTING)
+
+    # The check warns; it never silently repairs the limit under the setter.
+    assert _group(profile, 'java').timeLimit == 200
+    assert profile.timeLimitPerLanguage['java'] == 200
+
+
+class TestTable:
+    def test_rejecting_group_is_named_in_the_caption(self):
+        text = _table_text(_profile(_multipliers(), **_REJECTING))
+
+        assert 'sol.java is accepted, but does not pass at the time limit' in text
+        assert 'needs ≥ 1800 ms' in text
+        assert 'sol.java takes 900 ms' in text
+
+    def test_missing_margin_gets_its_own_caption(self):
+        profile = _profile(
+            _multipliers(),
+            timings={'cpp': {'sol.cpp': 100}, 'java': {'sol.java': 150}},
+            repartition={'cpp': 1, 'java': 2},
+            relatives={'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=1.0)},
+        )
+        text = _table_text(profile)
+
+        assert 'without the margin acToTimeLimit asks for' in text
+        assert 'does not pass at the time limit' not in text
+
+    def test_healthy_grouping_says_nothing(self):
+        profile = _profile(
+            _multipliers(),
+            timings={'cpp': {'sol.cpp': 100}, 'java': {'sol.java': 900}},
+            repartition={'cpp': 1, 'java': 2},
+        )
+        text = _table_text(profile)
+
+        assert 'does not pass at the time limit' not in text
+        assert 'without the margin' not in text
+        assert '⚠' not in text
+
+    def test_several_violating_groups_are_all_named(self):
+        profile = _profile(
+            _multipliers(),
+            timings={
+                'cpp': {'sol.cpp': 100},
+                'java': {'sol.java': 900},
+                'python': {'sol.py': 800},
+            },
+            repartition={'cpp': 1, 'java': 2, 'python': 3},
+            relatives={
+                'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=1.0),
+                'g3': LanguageGroupFallback(relativeTo='cpp', multiplier=1.0),
+            },
+        )
+        text = _table_text(profile)
+
+        assert 'Each of' in text
+        assert 'sol.java' in text and 'sol.py' in text
+
+
+def test_formula_mode_does_not_start_reporting_on_slow_solutions():
+    """Checking the lower bound must not make formula mode emit an upper record.
+
+    A formula computes no bounds, so its estimated groups say nothing about the
+    slow solutions; a derived one gaining an `upperValidation` its siblings never
+    get would make the profile look like only some groups were validated.
+    """
+    profile = _profile(
+        TimingStrategy(formula='fastest * 2'),
+        timings={'cpp': {'sol.cpp': 100}, 'java': {'sol.java': 900}},
+        repartition={'cpp': 1, 'java': 2},
+        relatives={'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=1.0)},
+        skipped_upper={'java': ['slow.java']},
+    )
+
+    assert _group(profile, 'java').upperValidation is None
+    assert _group(profile, 'cpp').upperValidation is None
+    # The lower-bound check still fired.
+    assert _group(profile, 'java').lowerViolation is not None
+
+
+def test_multiplier_mode_still_reports_on_slow_solutions():
+    profile = _profile(
+        _multipliers(),
+        timings={'cpp': {'sol.cpp': 100}, 'java': {'sol.java': 900}},
+        repartition={'cpp': 1, 'java': 2},
+        relatives={'g2': LanguageGroupFallback(relativeTo='cpp', multiplier=1.0)},
+        skipped_upper={'java': ['slow.java']},
+    )
+
+    validation = _group(profile, 'java').upperValidation
+    assert validation is not None
+    assert validation.skipped == ['slow.java']
+
+
+def test_preview_surfaces_the_violation_instead_of_hiding_the_table():
+    """The picker must keep rendering the table -- the setter is choosing the
+    grouping and needs to see which row the warning is about."""
+    render = build_preview_renderer(
+        timing_per_solution_per_language=_REJECTING['timings'],
+        strategy=_multipliers(),
+        env_groups=[],
+        all_languages=['cpp', 'java'],
+        width=100,
+    )
+    ansi: ANSI = render(_REJECTING['repartition'], _REJECTING['relatives'])
+    text = ''.join(t for _, t in to_formatted_text(ansi))
+
+    assert 'Time Limit' in text  # the table itself, not an inline error
+    assert 'cpp' in text and 'java' in text
+    assert 'does not pass at the time limit' in text


### PR DESCRIPTION
## Problem

A timing group whose limit is **derived** -- from a reference group (`whenEmpty` or a picker-forced relative) or from the base estimate -- was never checked against its own accepted solutions. `timing.compute_bounds` took the derived limit as the lower bound and discarded `measured.lower` entirely, so the group's own evidence bounded nothing.

Forcing `java` relative to `cpp` at `×1.0` therefore handed java cpp's **200 ms** while java's own accepted solution took **900 ms** -- and the table rendered that row like any other:

```
java  1  200 ms  ×1.0 of cpp
```

Nothing said the row was impossible.

## The invariant

Every group carries the smallest limit its own accepted solutions allow:

- multipliers mode: `ceil(slowest_ac * acToTimeLimit)` -- the setter's own margin;
- formula mode: `slowest_ac` -- a solution taking `T` ms passes at a limit of `T`.

On the estimated path the limit is *built* from this bound and rounded up, so the invariant holds by construction. Only a derived limit can break it.

## What this adds

`TimingGroupReport.lowerViolation` records that bound, set only when it is broken. Violating rows are flagged in the table:

```
java  1  200 ms  ×1.0 of cpp ⚠ needs ≥ 1800 ms (sol.java takes 900 ms)
```

**red** when the group's accepted solutions do not pass at the limit at all, **yellow** when they pass but without the margin `acToTimeLimit` asks for, plus a caption naming the offending solutions and what to do about it.

A **warning, not an error**. The upper-bound path raises `TimingRangeError`, which the picker renders *instead of* the table -- right for a wholly unsatisfiable grouping, wrong here: a setter cycling groupings needs to see which row is broken beside the rows that are fine. Since `build_limits_table` is the single render path, this reaches `rbx time`, the group-picker preview and `--share` reports alike.

## Formula mode

`build_timing_profile` passed `derive_fn=None` in formula mode, leaving a derived group checked from **neither** side. It gains `make_formula_derive`, which invents no bounds a formula does not have and never moves the limit -- it only runs the lower check.

Because a formula computes no bounds, `_record_provenance` now emits `upperValidation` only for an estimator that does. Without that gate the change made formula-mode *derived* rows start emitting an upper record while their *estimated* siblings still emitted nothing, so the profile looked like only some groups had been validated. Pinned by two tests.

## Other scenarios considered

Raised during the investigation and deliberately left out of this PR (recorded under "Out of scope" in the design doc): skipped upper validation not shown in the caption, zero-evidence multiplier rows styled like well-evidenced ones, and reference-chain provenance (a row reading `×2.0 of java` does not reveal that java's own limit was itself a guess).

## Testing

- 17 new tests in `tests/rbx/box/test_timing_lower_violation.py` covering both severities, both estimation modes, the untouched healthy path, the profile field, and the picker preview.
- Full suite (`tests/rbx`, excluding `box/cli`) diffed against unmodified `main`: **no regressions**. The five apparent diffs are timing-sensitive tests that pass in isolation and failed only because two `-n auto` suites were running concurrently.
- `ruff check` and `ruff format --check` clean.

Design doc: `docs/plans/2026-08-23-timing-lower-violation-design.md`. User-facing docs updated under "Forcing a relative limit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDypomxysqfNUgnNZiBbke
