### PR TITLE
fix(ui): size hidden command panes so their output is not mangled

### DIFF
--- a/rbx/box/ui/CLAUDE.md
+++ b/rbx/box/ui/CLAUDE.md
@@ -87,6 +87,30 @@ Helper functions that load run results from disk:
 - **Surfacing exceptions** -- `rbxBaseApp.show_error(exc)` (`main.py`) pushes an `ErrorModal` rendering `exc.from_ansi()` (formatting preserved, scrollable, not truncated). Use it instead of `notify(e.plain(), severity='error')` for `RbxException`s that may carry long output; the visualizer actions in `test_explorer.py`/`run_test_explorer.py` do (#380). Short one-line validation messages ("No test selected") stay toasts. Screens call it as `self.app.show_error(e)  # type: ignore[attr-defined]`.
 - **YAML/config error safety net** -- `rbxBaseApp._handle_exception` (`main.py`) intercepts `RbxException` (e.g. invalid `problem.rbx.yml`/`env.rbx.yml` from `load_yaml_model`): if the app is running it shows the error via `show_error` (ErrorModal) and keeps the TUI alive; otherwise it exits cleanly via `exit(return_code=1, message=exc.from_ansi())` (no Rich traceback, not re-raised, so the top-level CLI handler in `rbx/box/main.py` can't double-print). This recovers screen-entry crashes (`compose`/`on_mount` of a pushed screen — e.g. `RunScreen.compose`, `TestExplorerScreen.on_mount`). The explorer screens need no per-call guard: their loads run at mount and `find_problem_package` is `@functools.cache`d (later action loads hit the cache; a failed first load re-parses on retry since exceptions aren't cached). Loads whose *first* execution is in an action/watcher body cannot recover from `_handle_exception` (verified: the app goes half-dead), so they catch `RbxException` at the call site and call `self.app.show_error(e)` directly — currently only `limits_editor._load_profile_detail_from`.
 
+## Command app pane sizing (`command_app.py`)
+
+`rbxCommandApp` stacks one `_AppCommandPane` per (problem, sub-command) in
+`#command-pane-container` and shows exactly one at a time via `display`. A hidden Textual
+widget has a **zero-sized region**, which used to mean two things at once: its child
+process ran on a `0x0` pty (so rich, and anything else that measures its terminal, fell
+back to 80 columns), and the pane's own emulator sat at the `Terminal` default of 80x24.
+Switching to that problem then showed output hard-wrapped at 80 inside a much wider pane
+-- stray line breaks, and tables rendered at half the available width.
+
+All panes share the container's geometry, so the fix is to let the laid-out one speak for
+the hidden ones: `_AppCommandPane.on_resize` reports its size to
+`rbxCommandApp.sync_hidden_pane_sizes`, which caches it in `_pane_size` and calls
+`refresh_terminal_size()` on every other pane (re-applying `TIOCSWINSZ`, so a *running*
+command gets a `SIGWINCH` and adapts mid-run). Panes are built through `_make_pane`, which
+wires `get_fallback_dimensions=self._pane_dimensions` -- consulted by `CommandPane` only
+when its own region is degenerate, so a visible pane always measures itself.
+
+The other half of the same symptom lived in the vendored `Terminal`: a resize reflows the
+buffer but upstream only refreshes `virtual_size` on a write, so a resize after the command
+finished left the scroll extents stale and the anchored view scrolled past the real end of
+the output -- the tail (e.g. a time-limits table) looked eaten. `update_size()` now calls
+`_update_virtual_size()`. Both are covered by `tests/rbx/box/ui/test_command_pane.py`.
+
 ## Keybindings
 
 Vim navigation lives in `vim_nav.py` (`VimNavMixin`, mixed into `rbxBaseApp` in `main.py`, ahead of `App` in the MRO). It registers app-level `h/j/k/l` bindings that dispatch to the focused widget's existing `cursor_*` action, falling back to `scroll_*`: `j`/`k` move down/up everywhere; `h`/`l` move left/right only where horizontal movement exists (e.g. `DataTable` cells, scroll viewers). `check_action` disables the keys while an `Input`/`TextArea` is focused, so typing is never hijacked. The mixin subclasses `DOMNode` so Textual merges its `BINDINGS`.

--- a/rbx/box/ui/_vendor/toad/README.md
+++ b/rbx/box/ui/_vendor/toad/README.md
@@ -24,3 +24,14 @@ Only the files required for the `CommandPane` terminal widget are included:
 - PEP 695 type parameter syntax converted to `TypeVar`/`Generic` for Python 3.10 compatibility
 - Removed Toad-specific `Conversation` widget reference from `terminal.py`
 - Removed unused `MenuItem` import from `terminal.py`
+- `terminal.py`: `update_size()` now recomputes the scrollable extents (extracted as
+  `_update_virtual_size()`, shared with `_update_from_state()`). Upstream only sets
+  `virtual_size` on a write, so a resize that reflows the buffer with nothing written
+  afterwards -- a command that already finished -- leaves the extents describing the old
+  fold count and an anchored terminal scrolls past the end of its own output.
+- `command_pane.py`: `CommandPane` takes an optional `get_fallback_dimensions` callable,
+  used when its own region is zero-sized (a hidden pane), and exposes
+  `refresh_terminal_size()` so an owner can re-apply the size to a pane that gets no
+  `Resize` of its own. `_size_changed()` no longer bails before the process starts (it
+  just skips the ioctl), and `_execute()` sizes the pty *before* forking, so a program
+  reading its width on the first write does not see the 0x0 a fresh pty starts with.

--- a/rbx/box/ui/_vendor/toad/widgets/command_pane.py
+++ b/rbx/box/ui/_vendor/toad/widgets/command_pane.py
@@ -1,6 +1,7 @@
 import asyncio
 import codecs
 from dataclasses import dataclass
+from typing import Callable
 
 import os
 import fcntl
@@ -33,10 +34,12 @@ class CommandPane(Terminal):
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
+        get_fallback_dimensions: Callable[[], tuple[int, int]] | None = None,
     ):
         self._execute_task: asyncio.Task | None = None
         self._return_code: int | None = None
         self._master: int | None = None
+        self._get_fallback_dimensions = get_fallback_dimensions
         super().__init__(name=name, id=id, classes=classes)
 
     @property
@@ -54,21 +57,36 @@ class CommandPane(Terminal):
 
     def on_resize(self, event: events.Resize):
         event.prevent_default()
-        if self._master is None:
-            return
         self._size_changed()
 
-    def _size_changed(self):
-        if self._master is None:
-            return
+    def refresh_terminal_size(self) -> None:
+        """Re-apply the terminal size.
+
+        Useful for panes that are currently hidden: they get no `Resize` event
+        of their own, yet their child process is still running and must be told
+        the size it will be shown at.
+        """
+        self._size_changed()
+
+    def _terminal_dimensions(self) -> tuple[int, int]:
         width, height = self.scrollable_content_region.size
+        if (width <= 0 or height <= 0) and self._get_fallback_dimensions is not None:
+            # A hidden pane has a zero-sized region. Falling back keeps its
+            # child process on a sane winsize instead of a 0x0 pty (which makes
+            # every size-aware program render at its 80 column default).
+            width, height = self._get_fallback_dimensions()
+        return width, height
+
+    def _size_changed(self):
+        width, height = self._terminal_dimensions()
         if width <= 0 or height <= 0:
             return
-        try:
-            size = struct.pack("HHHH", height, width, 0, 0)
-            fcntl.ioctl(self._master, termios.TIOCSWINSZ, size)
-        except OSError:
-            pass
+        if self._master is not None:
+            try:
+                size = struct.pack("HHHH", height, width, 0, 0)
+                fcntl.ioctl(self._master, termios.TIOCSWINSZ, size)
+            except OSError:
+                pass
         self.update_size(width, height)
 
     @property
@@ -96,6 +114,10 @@ class CommandPane(Terminal):
 
         master, slave = pty.openpty()
         self._master = master
+
+        # Size the pty *before* forking: a program that reads its width on the
+        # very first write would otherwise see the 0x0 the pty starts with.
+        self._size_changed()
 
         flags = fcntl.fcntl(master, fcntl.F_GETFL)
         fcntl.fcntl(master, fcntl.F_SETFL, flags | os.O_NONBLOCK)

--- a/rbx/box/ui/_vendor/toad/widgets/terminal.py
+++ b/rbx/box/ui/_vendor/toad/widgets/terminal.py
@@ -224,6 +224,12 @@ Tap escape *twice* to exit.
         self._width = max(self._width, self.minimum_terminal_width)
 
         self.state.update_size(self._width, self._height)
+        # Reflowing changes how many folded lines the buffer has, so the
+        # scrollable extents have to follow. Without this, a resize that is not
+        # followed by a write (e.g. the command already finished) leaves
+        # `virtual_size` describing the *old* fold count, and an anchored
+        # terminal scrolls to a `max_scroll_y` past the real end of the output.
+        self._update_virtual_size()
         self._terminal_render_cache.clear()
         self.refresh()
 
@@ -272,12 +278,12 @@ Tap escape *twice* to exit.
         self.focus()
         event.stop()
 
-    def _update_from_state(
-        self, scrollback_delta: set[int] | None, alternate_delta: set[int] | None
-    ) -> None:
-        if self.state.current_directory:
-            self.current_directory = self.state.current_directory
-            self.finalize()
+    def _update_virtual_size(self) -> int:
+        """Recompute the scrollable extents from the current terminal state.
+
+        Returns:
+            The buffer height used for the virtual size.
+        """
         width = self.state.width
         height = self.state.scrollback_buffer.height
 
@@ -286,6 +292,15 @@ Tap escape *twice* to exit.
         self.virtual_size = Size(min(self.state.buffer.max_line_width, width), height)
         if self._anchored and not self._anchor_released:
             self.scroll_y = self.max_scroll_y
+        return height
+
+    def _update_from_state(
+        self, scrollback_delta: set[int] | None, alternate_delta: set[int] | None
+    ) -> None:
+        if self.state.current_directory:
+            self.current_directory = self.state.current_directory
+            self.finalize()
+        height = self._update_virtual_size()
 
         scroll_y = int(self.scroll_y)
         visible_lines = frozenset(range(scroll_y, scroll_y + height))

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -32,6 +32,13 @@ _ESCAPE_TAP_DURATION = 0.4
 class _AppCommandPane(CommandPane):
     """CommandPane that redirects focus to sidebar on blur (double-escape)."""
 
+    def on_resize(self, event: events.Resize) -> None:
+        super().on_resize(event)
+        # All panes share the container's geometry, so whatever this one just
+        # got is exactly what the hidden ones will get once shown. Tell them,
+        # otherwise their commands keep rendering at the 80-column fallback.
+        self.app.sync_hidden_pane_sizes(self)  # type: ignore[attr-defined]
+
     def blur(self):
         try:
             sidebar = self.screen.query_one('#command-list', ListView)
@@ -375,6 +382,7 @@ class rbxCommandApp(rbxBaseApp):
             on_task_ready=lambda t: self.post_message(self.TaskReady(t)),
         )
         self._pending_command: Optional[str] = None
+        self._pane_size: Tuple[int, int] = (0, 0)
 
         # Initialize tab states and add initial sub-commands.
         for i, cmd in enumerate(commands):
@@ -488,6 +496,32 @@ class rbxCommandApp(rbxBaseApp):
         elif options:
             select.value = options[-1][1]
 
+    def _pane_dimensions(self) -> Tuple[int, int]:
+        """Size a hidden pane should pretend to have."""
+        return self._pane_size
+
+    def sync_hidden_pane_sizes(self, source: CommandPane) -> None:
+        """Propagate a laid-out pane's geometry to the hidden ones.
+
+        Only one pane is displayed at a time, and a hidden widget has a
+        zero-sized region -- so a hidden pane never learns the terminal size and
+        its command runs on a 0x0 pty, which every size-aware program (rich,
+        included) reads as the 80-column fallback. Switching to that tab then
+        shows output hard-wrapped at 80 inside a much wider pane.
+        """
+        width, height = source.scrollable_content_region.size
+        if width <= 0 or height <= 0 or (width, height) == self._pane_size:
+            return
+        self._pane_size = (width, height)
+        for pane in self.query(_AppCommandPane):
+            if pane is not source:
+                pane.refresh_terminal_size()
+
+    def _make_pane(self, pane_id: str) -> '_AppCommandPane':
+        return _AppCommandPane(
+            id=pane_id, get_fallback_dimensions=self._pane_dimensions
+        )
+
     def _show_pane(self, pane_id: str):
         container = self.query_one('#command-pane-container', Vertical)
         for child in container.query(CommandPane):
@@ -515,7 +549,7 @@ class rbxCommandApp(rbxBaseApp):
         container = self.query_one('#command-pane-container', Vertical)
         for tab in self._tabs:
             for sub in tab.sub_commands:
-                pane = _AppCommandPane(id=sub.pane_id)
+                pane = self._make_pane(sub.pane_id)
                 pane.border_title = sub.name
                 container.mount(pane)
 
@@ -709,7 +743,7 @@ class rbxCommandApp(rbxBaseApp):
 
         # Mount the new pane.
         container = self.query_one('#command-pane-container', Vertical)
-        pane = _AppCommandPane(id=sub.pane_id)
+        pane = self._make_pane(sub.pane_id)
         pane.border_title = sub.name
         pane.display = False
         container.mount(pane)

--- a/tests/rbx/box/ui/test_command_pane.py
+++ b/tests/rbx/box/ui/test_command_pane.py
@@ -1,0 +1,98 @@
+"""Tests for terminal sizing in the command app's panes.
+
+Regressions for the two bugs that made a background problem's output look
+mangled once you switched to its tab: it had been rendered at the 80-column
+fallback (hidden panes never got a pty winsize), and the reflow on reveal left
+the scroll extents stale, so the tail of the output was unreachable.
+"""
+
+import asyncio
+import sys
+
+from textual.app import App, ComposeResult
+
+from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
+from rbx.box.ui._vendor.toad.widgets.terminal import Terminal
+from rbx.box.ui.command_app import CommandEntry, rbxCommandApp
+
+_PRINT_WIDTH = [
+    sys.executable,
+    '-c',
+    'import os; print(os.get_terminal_size().columns)',
+]
+
+
+def _pane_text(pane: CommandPane) -> str:
+    return ' '.join(
+        line.content.plain.strip() for line in pane.state.scrollback_buffer.lines
+    ).strip()
+
+
+async def _wait_for_commands(app, pilot, panes_expected: int) -> None:
+    for _ in range(100):
+        await pilot.pause()
+        await asyncio.sleep(0.05)
+        panes = list(app.query(CommandPane))
+        if len(panes) == panes_expected and all(
+            p.return_code is not None for p in panes
+        ):
+            return
+    raise AssertionError('commands did not finish in time')
+
+
+async def test_hidden_panes_run_at_the_visible_pane_width():
+    # Only one pane is displayed at a time; the hidden ones have a zero-sized
+    # region. They must still get a real pty winsize, or their commands render
+    # at the 80-column fallback and look hard-wrapped once shown.
+    app = rbxCommandApp(
+        [
+            CommandEntry(argv=_PRINT_WIDTH, name='a'),
+            CommandEntry(argv=_PRINT_WIDTH, name='b'),
+            CommandEntry(argv=_PRINT_WIDTH, name='c'),
+        ],
+        parallel=True,
+    )
+    async with app.run_test(size=(150, 40)) as pilot:
+        await _wait_for_commands(app, pilot, panes_expected=3)
+
+        panes = list(app.query(CommandPane))
+        visible = [p for p in panes if p.display]
+        assert len(visible) == 1
+        expected_width = visible[0].scrollable_content_region.width
+        assert expected_width > 80
+
+        for pane in panes:
+            assert pane.width == expected_width
+            assert _pane_text(pane) == str(expected_width)
+
+
+class _TerminalApp(App):
+    CSS = 'Terminal { width: 1fr; height: 1fr; }'
+
+    def compose(self) -> ComposeResult:
+        yield Terminal()
+
+
+async def test_resize_keeps_scroll_extents_in_sync():
+    # A resize reflows the buffer, so the scrollable extents have to follow it.
+    # When nothing is written afterwards (the command already finished), a stale
+    # `virtual_size` scrolls an anchored terminal past the end of its output.
+    app = _TerminalApp()
+    async with app.run_test(size=(150, 20)) as pilot:
+        terminal = app.query_one(Terminal)
+        terminal.anchor()
+        terminal.update_size(80, 20)
+        await terminal.write('\r\n'.join('x' * 120 for _ in range(40)))
+        await pilot.pause()
+        assert terminal.virtual_size.height == terminal.state.scrollback_buffer.height
+
+        terminal.update_size(150, 20)
+        await pilot.pause()
+
+        assert terminal.virtual_size.height == terminal.state.scrollback_buffer.height
+        # The anchored view still ends on real content, not on blank space past it.
+        rendered = [
+            terminal.render_line(y).text.rstrip()
+            for y in range(terminal.scrollable_content_region.height)
+        ]
+        assert any(rendered)


### PR DESCRIPTION
Switching the command view to a background problem showed its output mangled: stray line breaks throughout, and a `Time Limits (moj)` table drawn at half the pane width with its body unreachable.

Two bugs, both rooted in the fact that `rbxCommandApp` mounts every problem's pane at once and shows one at a time — and **a hidden Textual widget has a zero-sized region**.

## 1. The stray line breaks and the half-width table

`CommandPane._size_changed()` bailed on `width <= 0`, so a hidden pane never issued `TIOCSWINSZ`. Its command ran on a `0x0` pty and rich fell back to 80 columns. Switching to that problem then showed 80-column-wrapped output inside a ~106-column pane.

Reproduced directly — a hidden pane's child reports:

```
VISIBLE region: Size(width=150, height=40) term width: 150
HIDDEN  region: Size(width=0, height=0)    term width: 80
--- visible output --- WINSZ os.terminal_size(columns=150, lines=40)
--- hidden output  --- WINSZ os.terminal_size(columns=0, lines=0)
```

This affected **every** background problem's output, not just `rbx time` — anything rich-rendered in a non-active tab was drawn at 80 columns.

## 2. The "eaten" table

`Terminal.update_size()` reflowed the buffer but never recomputed `virtual_size`; upstream only does that on a *write*. With the command already finished, the reveal-time reflow left the scroll extents describing the old fold count:

```
hidden pane pre-reveal:  term_width=80  folded=181 virtual_size=(80,181)  scroll_y=161
hidden pane post-reveal: term_width=150 folded=121 virtual_size=(80,181)  scroll_y=141
  (blank view)
```

Real content is 121 lines, `max_scroll_y` is 141, and the anchored view scrolls clean past the end of its own output — rendering **blank**. The table was never dropped; it was scrolled out of reach.

## The fix

- **`terminal.py`** — extracted `_update_virtual_size()` (shared with `_update_from_state`) and call it from `update_size()`, so a reflow always drags the scroll extents with it.
- **`command_pane.py`** — optional `get_fallback_dimensions`, consulted only when a pane's own region is degenerate; public `refresh_terminal_size()` for panes that get no `Resize` of their own; and the pty is now sized **before** the fork, so a program reading its width on the first write never sees the `0x0` a fresh pty starts with.
- **`command_app.py`** — `_AppCommandPane.on_resize` reports its geometry to `sync_hidden_pane_sizes`, which caches it and re-applies it to every hidden pane. A *running* background command therefore gets a `SIGWINCH` and adapts mid-run — which is what produced the mixed-width output in the original report.

## Verification

Two regression tests in `tests/rbx/box/ui/test_command_pane.py`, confirmed to fail on the unfixed code with exactly the reported symptoms (`assert 80 == 106` for the pty width, `assert 80 == 40` for the scroll extents) and pass after.

- All 98 UI tests pass.
- Full suite (`--ignore=tests/rbx/box/cli`, same ordering both sides): **42 failed / 5161 passed** with the fix vs **43 / 5158** on base. No new failures; the +3 are the 2 new tests plus flake variance. The remaining failures are the known pre-existing local C++/sandbox/e2e ones and vary run to run.

Docs updated in `rbx/box/ui/CLAUDE.md` and the vendor `README.md`'s "Modifications from upstream" (both touched files are vendored toad code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBVnonLqmgwU4x6d6tf9Cw
