### PR TITLE
fix(ui): reserve the command pane's scrollbar gutter

### DIFF
--- a/rbx/box/ui/CLAUDE.md
+++ b/rbx/box/ui/CLAUDE.md
@@ -105,6 +105,17 @@ command gets a `SIGWINCH` and adapts mid-run). Panes are built through `_make_pa
 wires `get_fallback_dimensions=self._pane_dimensions` -- consulted by `CommandPane` only
 when its own region is degenerate, so a visible pane always measures itself.
 
+The pane CSS sets **`scrollbar-gutter: stable`**, and that is load-bearing rather than
+cosmetic. Textual posts `Resize` only when a widget's *own* size changes, so the vertical
+scrollbar appearing once the output overflows narrows `scrollable_content_region` by one
+column **without any event**: the pty and the emulator keep the pre-scrollbar width, and
+everything the command prints from then on is one column wider than the pane can draw. The
+next genuine resize (the window, a new pane mounting, a relayout) then re-folds that
+backlog one column short, spilling a trailing character of each full-width line onto a line
+of its own -- the `...byte-for-byte th` / `e` shape from #707. Reserving the gutter keeps
+the width constant for the whole command instead. The invariant a test pins is
+`pane.width == pane.scrollable_content_region.width`.
+
 The other half of the same symptom lived in the vendored `Terminal`: a resize reflows the
 buffer but upstream only refreshes `virtual_size` on a write, so a resize after the command
 finished left the scroll extents stale and the anchored view scrolled past the real end of

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -339,6 +339,14 @@ class rbxCommandApp(rbxBaseApp):
         border: solid $accent;
         padding: 0 1;
         scrollbar-size-vertical: 1;
+        /* Reserve the scrollbar column up front. Textual only posts `Resize`
+           when the widget's own size changes, so a scrollbar appearing once
+           the output overflows silently narrows the content region by one
+           column -- the emulator and the pty keep the old width until some
+           unrelated relayout corrects them, and everything printed until then
+           is re-folded one column short (a trailing character per line spills
+           onto a line of its own). */
+        scrollbar-gutter: stable;
     }
     #command-pane-container CommandPane:focus {
         border: solid dodgerblue;

--- a/tests/rbx/box/ui/test_command_pane.py
+++ b/tests/rbx/box/ui/test_command_pane.py
@@ -96,3 +96,47 @@ async def test_resize_keeps_scroll_extents_in_sync():
             for y in range(terminal.scrollable_content_region.height)
         ]
         assert any(rendered)
+
+
+# A line exactly as wide as the terminal says it is -- what rich emits when it
+# hard-wraps a paragraph -- followed by enough output to bring up the scrollbar.
+_OVERFLOW = [
+    sys.executable,
+    '-c',
+    'import os\n'
+    'print("A" * os.get_terminal_size().columns, flush=True)\n'
+    'for i in range(60): print(f"line {i}", flush=True)\n',
+]
+
+
+async def test_scrollbar_does_not_narrow_the_terminal_mid_command():
+    # Textual posts `Resize` only when a widget's own size changes, so the
+    # vertical scrollbar appearing once the output overflows would otherwise
+    # take a column out of the content region without telling the pty. Anything
+    # printed until the next genuine resize is then one column too wide, and
+    # that resize re-folds it one short -- spilling a trailing character onto a
+    # line of its own. Reserving the gutter keeps the width constant instead.
+    app = rbxCommandApp([CommandEntry(argv=_OVERFLOW, name='a')])
+    async with app.run_test(size=(150, 40)) as pilot:
+        await _wait_for_commands(app, pilot, panes_expected=1)
+        pane = app.query_one(CommandPane)
+        assert pane.show_vertical_scrollbar
+
+        # What the command was told matches what the pane can actually draw.
+        assert pane.width == pane.scrollable_content_region.width
+
+        # A height-only resize re-folds the buffer at the width measured now.
+        await pilot.resize_terminal(150, 30)
+        await pilot.pause()
+        await asyncio.sleep(0.1)
+        await pilot.pause()
+
+        full_width_line = next(
+            record
+            for record in pane.state.scrollback_buffer.lines
+            if record.content.plain.startswith('A')
+        )
+        assert len(full_width_line.folds) == 1, (
+            'a line the command wrapped at its own terminal width spilled onto '
+            'a second line'
+        )


### PR DESCRIPTION
Follow-up to #706. That PR fixed the *gross* width error (hidden panes running on a `0x0` pty and falling back to 80 columns), but a one-column error survived it — visible as a single character spilling onto a line of its own:

```
... the probe package and the submitted source are byte-for-byte th
e
ones that run measured, so nothing was submitted to the judge.
```

## Root cause

Textual posts `Resize` only when a widget's **own** size changes. The vertical scrollbar appearing once the output overflows narrows `scrollable_content_region` by one column **without any event**, so the pty and the emulator keep the pre-scrollbar width:

```
content region width: 105     <- what the pane can actually draw
emulator fold width : 106     <- what the pty was told, and what folding uses
```

Everything the command prints in that window is therefore one column wider than the pane can draw. The next *genuine* resize (the window, a new pane mounting, any relayout) re-applies the width the pane now measures and re-folds the whole backlog one column short — spilling a trailing character of each full-width line onto its own line.

Reproduced exactly, printing a line as wide as the child's own terminal and then forcing a height-only resize:

```
=== merged main ===
the AAA line: 106 chars -> 2 fold(s)
  SPILL: tail rendered on its own line -> ['A']

=== with this fix ===
the AAA line: 105 chars -> 1 fold(s)
```

That lone `'A'` is the lone `e` in the report.

Note this also explains why only the *first* paragraph in the screenshot is broken and the later ones are fine: the first was printed before the width correction, the rest after.

## The fix

`scrollbar-gutter: stable` on the pane, so the column is reserved from the start and the content width never changes mid-command. (The vendored toad demo app uses the same setting.)

## Verification

New test `test_scrollbar_does_not_narrow_the_terminal_mid_command`, which pins the invariant `pane.width == pane.scrollable_content_region.width` and then asserts a full-width line does not fold after a resize. It fails on merged main with `AssertionError: assert 106 == 105` and passes here.

All 99 UI tests pass; ruff clean. Rationale recorded in `rbx/box/ui/CLAUDE.md` next to the #706 notes, since `scrollbar-gutter` reads as cosmetic and would otherwise be an easy thing to drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBVnonLqmgwU4x6d6tf9Cw
