### PR TITLE
feat(contest): queue several commands per problem in `each` and `on`

### DIFF
--- a/docs/setters/reference/cli_explanations.yaml
+++ b/docs/setters/reference/cli_explanations.yaml
@@ -21,3 +21,29 @@ rbx stress: |
   Stress testing allows you to find counter-examples where your solution fails (or where two solutions differ).
   
   You usually provide a generator command (with random seed) and a reference solution (or validator/checker).
+
+rbx each: |
+  Runs a command for each problem in the contest, in a TUI with one tab per problem.
+
+  Chain several commands with `::` to queue them all at once, in order:
+
+  ```bash
+  rbx each build :: package build
+  ```
+
+  Each problem runs its whole chain before the next problem starts. If a command in a chain fails, the rest of that problem's chain is skipped -- pass `-k`/`--keep-going` to run it anyway. Other problems are unaffected either way.
+
+  Commands you type into the TUI later are queued too, but they always run, even after a failure.
+
+rbx on: |
+  Runs a command in the context of one problem (or a set of problems) of a contest.
+
+  Problems can be selected by short name, alias, a comma-separated list (`A,C`), a range (`A-C`) or `*`.
+
+  Like [`rbx each`](#each), commands can be chained with `::`:
+
+  ```bash
+  rbx on A-C build :: run -s
+  ```
+
+  A single command on a single problem runs directly in your terminal; anything else opens the TUI. Since flags after the problem selector belong to the chained commands, `-k`/`--keep-going` has to come first: `rbx on -k A build :: run`.

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -273,8 +273,15 @@ def ui():
 
 @app.command(
     'on',
-    help='Run a command in the context of a problem (or a set of problems) of a contest.',
-    context_settings={'allow_extra_args': True, 'ignore_unknown_options': True},
+    help=(
+        'Run a command in the context of a problem (or a set of problems) of a '
+        'contest. Chain commands with `::` to queue them.'
+    ),
+    context_settings={
+        'allow_extra_args': True,
+        'ignore_unknown_options': True,
+        'allow_interspersed_args': False,
+    },
 )
 def on(
     ctx: typer.Context,
@@ -282,17 +289,25 @@ def on(
         str,
         typer.Argument(autocompletion=annotations._adapt('problem')),  # noqa: SLF001
     ],
+    keep_going: bool = contest.KEEP_GOING_OPTION,
 ) -> None:
-    contest.on(ctx, problems)
+    contest.on(ctx, problems, keep_going=keep_going)
 
 
 @app.command(
     'each',
-    help='Run a command for each problem in the contest.',
-    context_settings={'allow_extra_args': True, 'ignore_unknown_options': True},
+    help=(
+        'Run a command for each problem in the contest. '
+        'Chain commands with `::` to queue them.'
+    ),
+    context_settings={
+        'allow_extra_args': True,
+        'ignore_unknown_options': True,
+        'allow_interspersed_args': False,
+    },
 )
-def each(ctx: typer.Context) -> None:
-    contest.each(ctx)
+def each(ctx: typer.Context, keep_going: bool = contest.KEEP_GOING_OPTION) -> None:
+    contest.each(ctx, keep_going=keep_going)
 
 
 @app.command('diff', hidden=True)

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -34,6 +34,16 @@ SPEC = {
                     'value': {'completer': 'problem', 'kind': 'completer'},
                 },
                 {
+                    'help': 'Keep running the rest of a chain in a problem even after a '
+                    'command fails. Must come before the problem selector in `rbx '
+                    'on`.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--keep-going', '-k'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,
@@ -50,13 +60,23 @@ SPEC = {
             'panel': None,
             'params': [
                 {
+                    'help': 'Keep running the rest of a chain in a problem even after a '
+                    'command fails. Must come before the problem selector in `rbx '
+                    'on`.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--keep-going', '-k'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,
                     'names': ['--help'],
                     'takes_value': False,
                     'value': {'kind': 'none'},
-                }
+                },
             ],
         },
         {
@@ -2156,13 +2176,23 @@ SPEC = {
                     'panel': None,
                     'params': [
                         {
+                            'help': 'Keep running the rest of a chain in a problem '
+                            'even after a command fails. Must come before the '
+                            'problem selector in `rbx on`.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--keep-going', '-k'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        },
+                        {
                             'help': 'Show this message and exit.',
                             'kind': 'option',
                             'multiple': False,
                             'names': ['--help'],
                             'takes_value': False,
                             'value': {'kind': 'none'},
-                        }
+                        },
                     ],
                 },
                 {
@@ -2178,6 +2208,16 @@ SPEC = {
                             'names': [],
                             'takes_value': True,
                             'value': {'completer': 'problem', 'kind': 'completer'},
+                        },
+                        {
+                            'help': 'Keep running the rest of a chain in a problem '
+                            'even after a command fails. Must come before the '
+                            'problem selector in `rbx on`.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--keep-going', '-k'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
                         },
                         {
                             'help': 'Show this message and exit.',

--- a/rbx/box/contest/contest_utils.py
+++ b/rbx/box/contest/contest_utils.py
@@ -6,6 +6,16 @@ from rbx.box.contest.schema import ContestProblem
 
 SHELL_NAMES = frozenset({'bash', 'zsh', 'fish', 'sh', 'dash', 'ksh', 'csh', 'tcsh'})
 
+# Token that separates chained commands in `rbx each` / `rbx on`.
+COMMAND_SEPARATOR = '::'
+
+
+class EmptyCommandError(ValueError):
+    """Raised when a command chain has an empty group around a `::`."""
+
+    def __init__(self):
+        super().__init__(f'empty command in chain around `{COMMAND_SEPARATOR}`')
+
 
 def is_shell_command(command: str) -> bool:
     """Check if a command name refers to a known shell."""
@@ -33,6 +43,45 @@ def build_command_argv(args: List[str]) -> Tuple[List[str], Optional[str]]:
     if executable is not None and is_shell_command(executable):
         return list(args), None
     return ['rbx'] + list(args), 'rbx'
+
+
+def split_commands(args: List[str]) -> List[List[str]]:
+    """Split extra args into command groups on bare `::` tokens.
+
+    A group with no args is a typo (a doubled, leading or trailing separator),
+    so it raises instead of being silently dropped.
+    """
+    groups: List[List[str]] = []
+    current: List[str] = []
+    for arg in args:
+        if arg == COMMAND_SEPARATOR:
+            if not current:
+                raise EmptyCommandError()
+            groups.append(current)
+            current = []
+            continue
+        current.append(arg)
+    if not current and groups:
+        raise EmptyCommandError()
+    if current:
+        groups.append(current)
+    return groups
+
+
+def build_command_argvs(
+    args: List[str],
+) -> Tuple[List[List[str]], Optional[str]]:
+    """Build the argvs and placeholder_prefix for a chain of commands.
+
+    Each group is prefixed independently, so a shell group in the chain keeps
+    running as-is. The placeholder_prefix only feeds the interactive input
+    hint, so it follows the first group.
+    """
+    groups = split_commands(args)
+    if not groups:
+        return [], 'rbx'
+    built = [build_command_argv(group) for group in groups]
+    return [argv for argv, _ in built], built[0][1]
 
 
 def match_problem(problems: str, contest_problem: ContestProblem) -> bool:

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -2,7 +2,7 @@ import pathlib
 import shutil
 import subprocess
 import tempfile
-from typing import Annotated, Optional
+from typing import Annotated, List, Optional, Tuple
 
 import rich.prompt
 import ruyaml
@@ -371,21 +371,48 @@ def remove(path_or_short_name: str):
     )
 
 
+KEEP_GOING_OPTION = typer.Option(
+    False,
+    '--keep-going',
+    '-k',
+    help=(
+        'Keep running the rest of a chain in a problem even after a command '
+        'fails. Must come before the problem selector in `rbx on`.'
+    ),
+)
+
+
+def _build_command_argvs_or_die(
+    args: List[str],
+) -> Tuple[List[List[str]], Optional[str]]:
+    try:
+        return contest_utils.build_command_argvs(args)
+    except contest_utils.EmptyCommandError as e:
+        console.console.print(f'[error]{e}[/error]')
+        raise typer.Exit(1) from e
+
+
 @app.command(
     'each',
-    help='Run a command for each problem in the contest.',
-    context_settings={'allow_extra_args': True, 'ignore_unknown_options': True},
+    help=(
+        'Run a command for each problem in the contest. '
+        f'Chain commands with `{contest_utils.COMMAND_SEPARATOR}` to queue them.'
+    ),
+    context_settings={
+        'allow_extra_args': True,
+        'ignore_unknown_options': True,
+        # Stop parsing at the first positional, otherwise click would steal a
+        # `-k` meant for one of the chained commands.
+        'allow_interspersed_args': False,
+    },
 )
 @within_contest
-def each(ctx: typer.Context) -> None:
+def each(ctx: typer.Context, keep_going: bool = KEEP_GOING_OPTION) -> None:
     contest = find_contest_package_or_die()
-    if ctx.args:
-        argv, placeholder_prefix = contest_utils.build_command_argv(ctx.args)
-    else:
-        argv, placeholder_prefix = [], 'rbx'
+    argvs, placeholder_prefix = _build_command_argvs_or_die(ctx.args)
     commands = [
         CommandEntry(
-            argv=argv,
+            argvs=argvs,
             placeholder_prefix=placeholder_prefix,
             name=naming.get_contest_problem_label(problem),
             labels=naming.get_contest_problem_labels(problem),
@@ -393,13 +420,22 @@ def each(ctx: typer.Context) -> None:
         )
         for problem in contest.problems
     ]
-    start_command_app(commands)
+    start_command_app(commands, keep_going=keep_going)
 
 
 @app.command(
     'on',
-    help='Run a command in the problem (or in a set of problems) of a context.',
-    context_settings={'allow_extra_args': True, 'ignore_unknown_options': True},
+    help=(
+        'Run a command in the problem (or in a set of problems) of a context. '
+        f'Chain commands with `{contest_utils.COMMAND_SEPARATOR}` to queue them.'
+    ),
+    context_settings={
+        'allow_extra_args': True,
+        'ignore_unknown_options': True,
+        # See `each`: keeps a chained command's own flags out of click's hands.
+        # As a result, `-k` has to come before the problem selector.
+        'allow_interspersed_args': False,
+    },
 )
 @within_contest
 def on(
@@ -408,6 +444,7 @@ def on(
         str,
         typer.Argument(autocompletion=annotations._adapt('problem')),  # noqa: SLF001
     ],
+    keep_going: bool = KEEP_GOING_OPTION,
 ) -> None:
     problems_of_interest = contest_utils.get_problems_of_interest(problems)
 
@@ -417,7 +454,11 @@ def on(
         )
         raise typer.Exit(1)
 
-    if len(problems_of_interest) == 1:
+    argvs, placeholder_prefix = _build_command_argvs_or_die(ctx.args)
+
+    # A single command on a single problem keeps the plain-terminal fast path;
+    # a chain needs the queue, so it opens the app with one tab.
+    if len(problems_of_interest) == 1 and len(argvs) <= 1:
         command = ' '.join(['rbx'] + ctx.args)
         console.console.print(
             f'[status]Running [item]{command}[/item] for [item]{naming.get_contest_problem_label(problems_of_interest[0])}[/item]...[/status]'
@@ -425,10 +466,9 @@ def on(
         subprocess.call(command, cwd=problems_of_interest[0].get_path(), shell=True)
         return
 
-    argv, placeholder_prefix = contest_utils.build_command_argv(ctx.args)
     commands = [
         CommandEntry(
-            argv=argv,
+            argvs=argvs,
             placeholder_prefix=placeholder_prefix,
             name=naming.get_contest_problem_label(p),
             labels=naming.get_contest_problem_labels(p),
@@ -436,7 +476,7 @@ def on(
         )
         for p in problems_of_interest
     ]
-    start_command_app(commands)
+    start_command_app(commands, keep_going=keep_going)
 
 
 @app.command(

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -183,6 +183,12 @@ class HelpModal(ModalScreen[None]):
                 markup=True,
             )
             yield Label(
+                '[b]Status[/b]\n'
+                '  \u25cb queued   \u25cf running   \u2713 done   \u2717 failed\n'
+                '  \u2298 skipped (an earlier command in the chain failed)',
+                markup=True,
+            )
+            yield Label(
                 '[b]esc[/b] or [b]?[/b] to close',
                 id='help-hints',
             )
@@ -193,6 +199,7 @@ class CommandStatus(enum.Enum):
     RUNNING = 'running'
     SUCCESS = 'success'
     FAILED = 'failed'
+    SKIPPED = 'skipped'
 
 
 _STATUS_MARKUP = {
@@ -200,6 +207,7 @@ _STATUS_MARKUP = {
     CommandStatus.RUNNING: '[yellow]●[/yellow]',
     CommandStatus.SUCCESS: '[green]✓[/green]',
     CommandStatus.FAILED: '[red]✗[/red]',
+    CommandStatus.SKIPPED: '[dim]⊘[/dim]',
 }
 
 _STATUS_ICON = {
@@ -207,12 +215,20 @@ _STATUS_ICON = {
     CommandStatus.RUNNING: '●',
     CommandStatus.SUCCESS: '✓',
     CommandStatus.FAILED: '✗',
+    CommandStatus.SKIPPED: '⊘',
 }
+
+_FINISHED_STATUSES = (
+    CommandStatus.SUCCESS,
+    CommandStatus.FAILED,
+    CommandStatus.SKIPPED,
+)
 
 
 @dataclasses.dataclass
 class CommandEntry:
-    argv: List[str]
+    # One argv per command in the chain; they are queued in order in the tab.
+    argvs: List[List[str]]
     name: Optional[str] = None
     cwd: Optional[str] = None
     prefix: Optional[str] = None
@@ -223,7 +239,9 @@ class CommandEntry:
 
     @property
     def display_name(self) -> str:
-        return self.name if self.name else ' '.join(self.argv)
+        if self.name:
+            return self.name
+        return ' '.join(self.argvs[0]) if self.argvs else ''
 
     def make_raw_shell_command(self, cmd: str) -> str:
         if self.prefix is not None:
@@ -236,8 +254,8 @@ class CommandEntry:
         return self.make_raw_shell_command(shlex.join(argv))
 
     @property
-    def shell_command(self) -> str:
-        return self.make_shell_command(self.argv)
+    def shell_commands(self) -> List[str]:
+        return [self.make_shell_command(argv) for argv in self.argvs]
 
 
 @dataclasses.dataclass
@@ -247,6 +265,10 @@ class SubCommand:
     pane_id: str
     status: CommandStatus = CommandStatus.PENDING
     task_id: Optional[int] = None
+    # Seeded from the CLI as part of a `::` chain. Only chained commands are
+    # skipped when an earlier one fails; commands queued interactively always
+    # run, so a typo in one does not silently swallow the next.
+    chained: bool = False
 
 
 class TabState:
@@ -256,20 +278,25 @@ class TabState:
         self.sub_commands: List[SubCommand] = []
         self._next_sub_id = 0
 
-    def _append_sub_command(self, name: str, shell_command: str) -> SubCommand:
+    def _append_sub_command(
+        self, name: str, shell_command: str, chained: bool = False
+    ) -> SubCommand:
         pane_id = f'cmd-pane-{self.tab_index}-{self._next_sub_id}'
         sub = SubCommand(
             name=name,
             shell_command=shell_command,
             pane_id=pane_id,
+            chained=chained,
         )
         self._next_sub_id += 1
         self.sub_commands.append(sub)
         return sub
 
-    def add_sub_command(self, name: str, argv: List[str]) -> SubCommand:
+    def add_sub_command(
+        self, name: str, argv: List[str], chained: bool = False
+    ) -> SubCommand:
         shell_command = self.entry.make_shell_command(argv)
-        return self._append_sub_command(name, shell_command)
+        return self._append_sub_command(name, shell_command, chained=chained)
 
     def add_sub_command_raw(self, name: str, raw_command: str) -> SubCommand:
         shell_command = self.entry.make_raw_shell_command(raw_command)
@@ -279,10 +306,7 @@ class TabState:
     def is_idle(self) -> bool:
         if not self.sub_commands:
             return True
-        return all(
-            s.status in (CommandStatus.SUCCESS, CommandStatus.FAILED)
-            for s in self.sub_commands
-        )
+        return all(s.status in _FINISHED_STATUSES for s in self.sub_commands)
 
     @property
     def aggregate_status(self) -> CommandStatus:
@@ -291,6 +315,7 @@ class TabState:
         statuses = {s.status for s in self.sub_commands}
         for status in (
             CommandStatus.FAILED,
+            CommandStatus.SKIPPED,
             CommandStatus.RUNNING,
             CommandStatus.PENDING,
         ):
@@ -369,10 +394,16 @@ class rbxCommandApp(rbxBaseApp):
         ('q', 'quit', 'Quit'),
     ]
 
-    def __init__(self, commands: List[CommandEntry], parallel: bool = False):
+    def __init__(
+        self,
+        commands: List[CommandEntry],
+        parallel: bool = False,
+        keep_going: bool = False,
+    ):
         super().__init__()
         self.commands = commands
         self.parallel = parallel
+        self.keep_going = keep_going
         self._tabs: List[TabState] = []
         self._active_tab: int = 0
         self._label_mode: ProblemLabelMode = get_setter_config().ui.problem_label
@@ -387,8 +418,11 @@ class rbxCommandApp(rbxBaseApp):
         # Initialize tab states and add initial sub-commands.
         for i, cmd in enumerate(commands):
             tab = TabState(entry=cmd, tab_index=i)
-            if cmd.argv:
-                tab.add_sub_command(name=' '.join(cmd.argv), argv=cmd.argv)
+            chained = len(cmd.argvs) > 1
+            for argv in cmd.argvs:
+                if not argv:
+                    continue
+                tab.add_sub_command(name=' '.join(argv), argv=argv, chained=chained)
             self._tabs.append(tab)
 
     def compose(self) -> ComposeResult:
@@ -726,11 +760,37 @@ class rbxCommandApp(rbxBaseApp):
                     sub.status = CommandStatus.FAILED
                     pane.border_subtitle = f'Exit code: {pane.return_code}'
 
+                if sub.status == CommandStatus.FAILED:
+                    self._skip_rest_of_chain(tab_index, sub)
+
                 self._update_sidebar(tab_index)
                 self._refresh_select_if_active(tab_index)
                 if sub.task_id is not None:
                     self._task_queue.notify_complete(sub.task_id)
                 return
+
+    def _skip_rest_of_chain(self, tab_index: int, failed: SubCommand) -> None:
+        """Cancel the rest of a failed CLI chain in this tab.
+
+        Runs before `notify_complete` releases the terminal, otherwise the
+        queue would drain the next command before it is cancelled. Commands
+        queued interactively are left alone -- they keep going by design.
+        """
+        if self.keep_going or not failed.chained:
+            return
+        tab = self._tabs[tab_index]
+        for later in tab.sub_commands[tab.sub_commands.index(failed) + 1 :]:
+            if later.status != CommandStatus.PENDING or not later.chained:
+                continue
+            if later.task_id is None or not self._task_queue.cancel(later.task_id):
+                continue
+            later.status = CommandStatus.SKIPPED
+            later.task_id = None
+            try:
+                pane = self.query_one(f'#{later.pane_id}', CommandPane)
+            except NoMatches:
+                continue
+            pane.border_subtitle = 'Skipped'
 
     def _queue_command_in_tab(self, tab_index: int, raw_command: str) -> SubCommand:
         tab = self._tabs[tab_index]
@@ -866,16 +926,20 @@ class rbxCommandApp(rbxBaseApp):
             self.notify(f'Command queued in {queued} tab(s)')
 
 
-def start_command_app(commands: List[CommandEntry], parallel: bool = False) -> None:
-    app = rbxCommandApp(commands, parallel=parallel)
+def start_command_app(
+    commands: List[CommandEntry],
+    parallel: bool = False,
+    keep_going: bool = False,
+) -> None:
+    app = rbxCommandApp(commands, parallel=parallel, keep_going=keep_going)
     app.run()
 
 
 if __name__ == '__main__':
     start_command_app(
         [
-            CommandEntry(argv=['echo', 'hello'], name='echo1'),
-            CommandEntry(argv=['echo', 'world'], name='echo2'),
-            CommandEntry(argv=['echo', 'foo'], name='echo3'),
+            CommandEntry(argvs=[['echo', 'hello']], name='echo1'),
+            CommandEntry(argvs=[['echo', 'world']], name='echo2'),
+            CommandEntry(argvs=[['echo', 'foo']], name='echo3'),
         ]
     )

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -303,6 +303,22 @@ class TabState:
         return self._append_sub_command(name, shell_command)
 
     @property
+    def active_sub_command_index(self) -> Optional[int]:
+        """The sub-command worth showing when this tab is opened.
+
+        The one that is running, or the next one up if the tab is between
+        commands. Falls back to the last one once the whole queue is done --
+        with nothing left to watch, its output is what you came to read.
+        """
+        if not self.sub_commands:
+            return None
+        for status in (CommandStatus.RUNNING, CommandStatus.PENDING):
+            for i, sub_command in enumerate(self.sub_commands):
+                if sub_command.status is status:
+                    return i
+        return len(self.sub_commands) - 1
+
+    @property
     def is_idle(self) -> bool:
         if not self.sub_commands:
             return True
@@ -618,8 +634,30 @@ class rbxCommandApp(rbxBaseApp):
         sub.status = CommandStatus.RUNNING
         self._update_sidebar(task.terminal_id)
         self._refresh_select_if_active(task.terminal_id)
+        self._follow_running_sub_command(task.terminal_id, sub)
         pane = self.query_one(f'#{sub.pane_id}', CommandPane)
         pane.execute(task.command)
+
+    def _follow_running_sub_command(self, tab_index: int, started: SubCommand) -> None:
+        """Move the view onto a command that just started.
+
+        Only when the view is parked on a command that already finished --
+        typically the previous link of the same chain. A pending selection is
+        someone looking ahead on purpose, so it is left alone.
+        """
+        if tab_index != self._active_tab:
+            return
+        tab = self._tabs[tab_index]
+        select = self.query_one('#command-select', Select)
+        if select.value is Select.BLANK:
+            return
+        current: int = select.value  # type: ignore[assignment]
+        if not 0 <= current < len(tab.sub_commands):
+            return
+        if tab.sub_commands[current].status not in _FINISHED_STATUSES:
+            return
+        select.value = tab.sub_commands.index(started)
+        self._show_pane(started.pane_id)
 
     def _on_tab_selected(self, index: Optional[int]):
         if index is None:
@@ -630,12 +668,14 @@ class rbxCommandApp(rbxBaseApp):
         self._active_tab = index
         self._refresh_select()
 
-        # Select the latest sub-command by default.
+        # Land on the command that is actually executing, not on the tail of
+        # the queue -- with a chain, the last one has not started yet.
         tab = self._tabs[index]
         select = self.query_one('#command-select', Select)
-        if tab.sub_commands:
-            select.value = len(tab.sub_commands) - 1
-            self._show_pane(tab.sub_commands[-1].pane_id)
+        active = tab.active_sub_command_index
+        if active is not None:
+            select.value = active
+            self._show_pane(tab.sub_commands[active].pane_id)
         else:
             # Hide all panes for this tab.
             container = self.query_one('#command-pane-container', Vertical)

--- a/rbx/box/ui/task_queue.py
+++ b/rbx/box/ui/task_queue.py
@@ -55,6 +55,19 @@ class TaskQueue:
         self._drain()
         return task
 
+    def cancel(self, task_id: int) -> bool:
+        """Drop a still-pending task from the queue.
+
+        A running task owns its terminal, so cancelling it would leave the
+        terminal marked busy forever -- those must go through
+        `notify_complete` instead, and this returns False for them.
+        """
+        task = self._find_task(task_id)
+        if task is None or task.status != TaskStatus.PENDING:
+            return False
+        self._queue.remove(task)
+        return True
+
     def notify_complete(self, task_id: int) -> None:
         task = self._find_task(task_id)
         if task is None:

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 from typer.testing import CliRunner
 
+from rbx.box.contest import contest_utils
 from rbx.box.contest import main as contest_main
 
 
@@ -16,6 +17,16 @@ def runner() -> CliRunner:
 
 def _write_single_contest(root: pathlib.Path) -> None:
     (root / 'contest.rbx.yml').write_text('name: ctt\nproblems: []\n')
+
+
+@pytest.fixture
+def clear_package_caches():
+    # `find_contest_package` and friends are lru_cached on the resolved paths,
+    # so a test that runs a command inside a temporary contest would otherwise
+    # leave that contest visible to whatever runs next.
+    contest_utils.clear_all_caches()
+    yield
+    contest_utils.clear_all_caches()
 
 
 def _write_minimal_problem(dest: pathlib.Path, name: str) -> None:
@@ -361,7 +372,10 @@ class TestContestOn:
 
     @pytest.fixture
     def contest_dir(
-        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        clear_package_caches,
     ) -> pathlib.Path:
         monkeypatch.chdir(tmp_path)
         (tmp_path / 'contest.rbx.yml').write_text(
@@ -439,7 +453,10 @@ class TestContestOn:
 class TestContestEach:
     @pytest.fixture
     def contest_dir(
-        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        clear_package_caches,
     ) -> pathlib.Path:
         monkeypatch.chdir(tmp_path)
         (tmp_path / 'contest.rbx.yml').write_text(

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -1,6 +1,7 @@
 """Tests for `rbx contest` Typer commands."""
 
 import pathlib
+from unittest import mock
 
 import pytest
 from typer.testing import CliRunner
@@ -15,6 +16,13 @@ def runner() -> CliRunner:
 
 def _write_single_contest(root: pathlib.Path) -> None:
     (root / 'contest.rbx.yml').write_text('name: ctt\nproblems: []\n')
+
+
+def _write_minimal_problem(dest: pathlib.Path, name: str) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / 'problem.rbx.yml').write_text(
+        f'name: {name}\ntimeLimit: 1000\nmemoryLimit: 256\n'
+    )
 
 
 def _write_dispatcher(root: pathlib.Path, *variant_ids: str) -> None:
@@ -346,3 +354,125 @@ class TestContestAddVariant:
         contest_package.find_contest_yaml.cache_clear()
         variants = contest_package.discover_contest_variants(tmp_path)
         assert 'extra' in variants
+
+
+class TestContestOn:
+    """`rbx on` dispatch: inline fast path vs. the queued command app."""
+
+    @pytest.fixture
+    def contest_dir(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> pathlib.Path:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'contest.rbx.yml').write_text(
+            'name: ctt\nproblems:\n  - short_name: A\n    path: probs/a\n'
+        )
+        _write_minimal_problem(tmp_path / 'probs' / 'a', 'prob-a')
+        return tmp_path
+
+    def test_single_command_on_single_problem_runs_inline(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with (
+            mock.patch.object(contest_main.subprocess, 'call') as call,
+            mock.patch.object(contest_main, 'start_command_app') as start_app,
+        ):
+            result = runner.invoke(contest_main.app, ['on', 'A', 'build'])
+
+        assert result.exit_code == 0, result.output
+        start_app.assert_not_called()
+        assert call.call_args.args[0] == 'rbx build'
+
+    def test_chained_commands_on_single_problem_open_the_app(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with (
+            mock.patch.object(contest_main.subprocess, 'call') as call,
+            mock.patch.object(contest_main, 'start_command_app') as start_app,
+        ):
+            result = runner.invoke(
+                contest_main.app, ['on', 'A', 'build', '::', 'run', '-s']
+            )
+
+        assert result.exit_code == 0, result.output
+        call.assert_not_called()
+        (commands,), kwargs = start_app.call_args
+        assert len(commands) == 1
+        assert commands[0].argvs == [['rbx', 'build'], ['rbx', 'run', '-s']]
+        assert kwargs['keep_going'] is False
+
+    def test_keep_going_flag_precedes_the_problem_selector(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+            result = runner.invoke(
+                contest_main.app, ['on', '-k', 'A', 'build', '::', 'run']
+            )
+
+        assert result.exit_code == 0, result.output
+        assert start_app.call_args.kwargs['keep_going'] is True
+
+    def test_flags_after_the_selector_belong_to_the_chained_command(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        # `-k` here is `rbx run`'s business, not `rbx on`'s.
+        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+            result = runner.invoke(
+                contest_main.app, ['on', 'A', 'build', '::', 'run', '-k']
+            )
+
+        assert result.exit_code == 0, result.output
+        (commands,), kwargs = start_app.call_args
+        assert commands[0].argvs == [['rbx', 'build'], ['rbx', 'run', '-k']]
+        assert kwargs['keep_going'] is False
+
+    def test_empty_command_in_chain_is_an_error(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+            result = runner.invoke(contest_main.app, ['on', 'A', 'build', '::'])
+
+        assert result.exit_code == 1
+        start_app.assert_not_called()
+
+
+class TestContestEach:
+    @pytest.fixture
+    def contest_dir(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> pathlib.Path:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'contest.rbx.yml').write_text(
+            'name: ctt\n'
+            'problems:\n'
+            '  - short_name: A\n    path: probs/a\n'
+            '  - short_name: B\n    path: probs/b\n'
+        )
+        for name in ('a', 'b'):
+            _write_minimal_problem(tmp_path / 'probs' / name, f'prob-{name}')
+        return tmp_path
+
+    def test_each_queues_the_chain_in_every_problem(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+            result = runner.invoke(
+                contest_main.app, ['each', 'build', '::', 'package', 'build']
+            )
+
+        assert result.exit_code == 0, result.output
+        (commands,), _ = start_app.call_args
+        assert len(commands) == 2
+        for command in commands:
+            assert command.argvs == [['rbx', 'build'], ['rbx', 'package', 'build']]
+
+    def test_each_without_args_opens_an_empty_app(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+            result = runner.invoke(contest_main.app, ['each'])
+
+        assert result.exit_code == 0, result.output
+        (commands,), _ = start_app.call_args
+        assert all(command.argvs == [] for command in commands)
+        assert all(command.placeholder_prefix == 'rbx' for command in commands)

--- a/tests/rbx/box/contest/test_contest_utils.py
+++ b/tests/rbx/box/contest/test_contest_utils.py
@@ -3,7 +3,15 @@
 from typing import Optional
 from unittest.mock import patch
 
-from rbx.box.contest.contest_utils import get_problems_of_interest, match_problem
+import pytest
+
+from rbx.box.contest.contest_utils import (
+    EmptyCommandError,
+    build_command_argvs,
+    get_problems_of_interest,
+    match_problem,
+    split_commands,
+)
 from rbx.box.contest.schema import Contest, ContestProblem
 
 
@@ -73,3 +81,59 @@ class TestGetProblemsOfInterest:
 
         all_three = get_problems_of_interest('*')
         assert len(all_three) == 3
+
+
+class TestSplitCommands:
+    def test_no_separator_yields_single_group(self):
+        assert split_commands(['build', '-v']) == [['build', '-v']]
+
+    def test_empty_args_yield_no_groups(self):
+        assert split_commands([]) == []
+
+    def test_splits_on_separator_keeping_per_command_flags(self):
+        assert split_commands(
+            ['build', '::', 'run', '-s', '::', 'package', 'build']
+        ) == [
+            ['build'],
+            ['run', '-s'],
+            ['package', 'build'],
+        ]
+
+    def test_separator_only_matches_a_bare_token(self):
+        # A `::` glued to something else is a normal argument.
+        assert split_commands(['run', '--filter', 'a::b']) == [
+            ['run', '--filter', 'a::b']
+        ]
+
+    @pytest.mark.parametrize(
+        'args',
+        [
+            ['::'],
+            ['::', 'build'],
+            ['build', '::'],
+            ['build', '::', '::', 'run'],
+        ],
+    )
+    def test_empty_group_is_an_error(self, args):
+        with pytest.raises(EmptyCommandError):
+            split_commands(args)
+
+
+class TestBuildCommandArgvs:
+    def test_prefixes_each_command_with_rbx(self):
+        argvs, prefix = build_command_argvs(['build', '::', 'run', '-s'])
+        assert argvs == [['rbx', 'build'], ['rbx', 'run', '-s']]
+        assert prefix == 'rbx'
+
+    def test_shell_group_keeps_its_own_argv(self):
+        argvs, _ = build_command_argvs(['build', '::', 'bash', '-c', 'ls'])
+        assert argvs == [['rbx', 'build'], ['bash', '-c', 'ls']]
+
+    def test_placeholder_prefix_follows_the_first_command(self):
+        _, prefix = build_command_argvs(['bash', '-c', 'ls', '::', 'build'])
+        assert prefix is None
+
+    def test_no_args_still_gives_the_rbx_placeholder(self):
+        argvs, prefix = build_command_argvs([])
+        assert argvs == []
+        assert prefix == 'rbx'

--- a/tests/rbx/box/ui/test_command_app.py
+++ b/tests/rbx/box/ui/test_command_app.py
@@ -20,8 +20,8 @@ def _reset_label_mode():
 
 def _labeled_entry() -> CommandEntry:
     return CommandEntry(
-        # Empty argv => no sub-command is enqueued, so no subprocess is spawned.
-        argv=[],
+        # Empty argvs => no sub-command is enqueued, so no subprocess is spawned.
+        argvs=[],
         name='A. two-sum',
         labels={
             ProblemLabelMode.NAME: 'A. two-sum',
@@ -81,7 +81,7 @@ async def test_l_cycles_and_persists_problem_label():
 
 
 async def test_l_is_inert_without_labels():
-    app = rbxCommandApp([CommandEntry(argv=[], name='echo')])
+    app = rbxCommandApp([CommandEntry(argvs=[], name='echo')])
     async with app.run_test() as pilot:
         await pilot.press('shift+tab')
         await pilot.pause()

--- a/tests/rbx/box/ui/test_command_chain.py
+++ b/tests/rbx/box/ui/test_command_chain.py
@@ -1,12 +1,32 @@
 """Tests for chained commands (`rbx each build :: run`) in the command app."""
 
 import asyncio
+import pathlib
+import shlex
 from typing import List
 
-from textual.widgets import Input
+from textual.widgets import Input, Select
 
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
 from rbx.box.ui.command_app import CommandEntry, rbxCommandApp
+
+
+def _gate(path: pathlib.Path, exit_code: int = 0) -> List[str]:
+    """A command that blocks until the test creates ``path``.
+
+    Sleeping for a fixed time instead makes these tests race the scheduler on a
+    loaded machine, so every command whose lifetime matters is gated explicitly.
+    """
+    quoted = shlex.quote(str(path))
+    return [
+        'sh',
+        '-c',
+        f'while [ ! -f {quoted} ]; do sleep 0.02; done; exit {exit_code}',
+    ]
+
+
+def _release(path: pathlib.Path) -> None:
+    path.write_text('')
 
 
 def _panes(app) -> List[CommandPane]:
@@ -19,24 +39,37 @@ def _settled(panes: List[CommandPane]) -> bool:
     )
 
 
-async def _wait_until_settled(app, pilot, panes_expected: int) -> List[CommandPane]:
+async def _wait_until(pilot, predicate, what: str) -> None:
     for _ in range(200):
         await pilot.pause()
         await asyncio.sleep(0.05)
-        panes = _panes(app)
-        if len(panes) == panes_expected and _settled(panes):
-            return panes
-    raise AssertionError('commands did not settle in time')
+        if predicate():
+            return
+    raise AssertionError(f'timed out waiting for {what}')
+
+
+async def _wait_until_settled(app, pilot, panes_expected: int) -> List[CommandPane]:
+    await _wait_until(
+        pilot,
+        lambda: len(_panes(app)) == panes_expected and _settled(_panes(app)),
+        'commands to settle',
+    )
+    return _panes(app)
+
+
+def _selected_index(app) -> int:
+    return app.query_one('#command-select', Select).value
+
+
+def _visible_pane(app) -> CommandPane:
+    visible = [p for p in _panes(app) if p.display]
+    assert len(visible) == 1
+    return visible[0]
 
 
 async def test_chain_queues_one_pane_per_command_in_order():
     app = rbxCommandApp(
-        [
-            CommandEntry(
-                argvs=[['echo', 'first'], ['echo', 'second']],
-                name='A',
-            )
-        ]
+        [CommandEntry(argvs=[['echo', 'first'], ['echo', 'second']], name='A')]
     )
     async with app.run_test(size=(100, 30)) as pilot:
         panes = await _wait_until_settled(app, pilot, panes_expected=2)
@@ -46,12 +79,7 @@ async def test_chain_queues_one_pane_per_command_in_order():
 
 async def test_failed_chain_skips_the_rest_of_the_chain():
     app = rbxCommandApp(
-        [
-            CommandEntry(
-                argvs=[['sh', '-c', 'exit 3'], ['echo', 'never']],
-                name='A',
-            )
-        ]
+        [CommandEntry(argvs=[['sh', '-c', 'exit 3'], ['echo', 'never']], name='A')]
     )
     async with app.run_test(size=(100, 30)) as pilot:
         failed, skipped = await _wait_until_settled(app, pilot, panes_expected=2)
@@ -66,8 +94,7 @@ async def test_keep_going_runs_the_whole_chain():
     app = rbxCommandApp(
         [
             CommandEntry(
-                argvs=[['sh', '-c', 'exit 3'], ['echo', 'still runs']],
-                name='A',
+                argvs=[['sh', '-c', 'exit 3'], ['echo', 'still runs']], name='A'
             )
         ],
         keep_going=True,
@@ -78,21 +105,19 @@ async def test_keep_going_runs_the_whole_chain():
         assert after.return_code == 0
 
 
-async def test_failure_does_not_skip_interactively_queued_commands():
+async def test_failure_does_not_skip_interactively_queued_commands(
+    tmp_path: pathlib.Path,
+):
     # Commands typed into the app are never part of a chain, so a failing chain
     # must not swallow them -- they keep going by design.
+    gate = tmp_path / 'gate'
     app = rbxCommandApp(
-        [
-            CommandEntry(
-                argvs=[['sh', '-c', 'sleep 0.6; exit 3'], ['echo', 'never']],
-                name='A',
-            )
-        ]
+        [CommandEntry(argvs=[_gate(gate, exit_code=3), ['echo', 'never']], name='A')]
     )
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.press('shift+tab')
         await pilot.pause()
-        # Queue an extra command while the first one is still sleeping.
+        # Queue an extra command while the chain is still on its first command.
         await pilot.press('!')
         await pilot.pause()
         app.query_one('#command-input', Input).value = 'echo interactive'
@@ -100,10 +125,98 @@ async def test_failure_does_not_skip_interactively_queued_commands():
         await pilot.pause()
         # Menu: "Run in this tab".
         await pilot.press('1')
+        await pilot.pause()
 
+        _release(gate)
         failed, skipped, interactive = await _wait_until_settled(
             app, pilot, panes_expected=3
         )
         assert failed.return_code == 3
         assert skipped.border_subtitle == 'Skipped'
         assert interactive.return_code == 0
+
+
+async def test_view_opens_on_the_running_command_not_the_last_queued(
+    tmp_path: pathlib.Path,
+):
+    # The tail of a chain has not started yet; the useful pane is the one
+    # actually executing.
+    gate = tmp_path / 'gate'
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[_gate(gate), ['echo', 'later']], name='A')]
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert _selected_index(app) == 0
+        assert _visible_pane(app) is _panes(app)[0]
+
+        _release(gate)
+        await _wait_until_settled(app, pilot, panes_expected=2)
+
+
+async def test_switching_tabs_lands_on_that_tab_s_running_command(
+    tmp_path: pathlib.Path,
+):
+    gate = tmp_path / 'gate'
+    app = rbxCommandApp(
+        [
+            CommandEntry(argvs=[['echo', 'a1'], ['echo', 'a2']], name='A'),
+            CommandEntry(argvs=[_gate(gate), ['echo', 'b2']], name='B'),
+        ],
+        parallel=True,
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # The sidebar is focused at mount, so `down` moves to tab B.
+        await pilot.press('down')
+        await pilot.pause()
+
+        assert _selected_index(app) == 0
+        assert _visible_pane(app).border_title.startswith('sh -c')
+
+        _release(gate)
+        await _wait_until_settled(app, pilot, panes_expected=4)
+
+
+async def test_view_follows_the_chain_as_it_advances(tmp_path: pathlib.Path):
+    first, second = tmp_path / 'first', tmp_path / 'second'
+    app = rbxCommandApp([CommandEntry(argvs=[_gate(first), _gate(second)], name='A')])
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert _selected_index(app) == 0
+
+        # Once the first command finishes, the view moves onto the second.
+        _release(first)
+        await _wait_until(
+            pilot, lambda: _selected_index(app) == 1, 'the view to follow the chain'
+        )
+        assert _visible_pane(app) is _panes(app)[1]
+
+        _release(second)
+        await _wait_until_settled(app, pilot, panes_expected=2)
+
+
+async def test_view_stays_put_when_parked_on_a_pending_command(
+    tmp_path: pathlib.Path,
+):
+    # Looking ahead at a queued command is deliberate; the app must not yank
+    # the view away when the next one starts.
+    first, second = tmp_path / 'first', tmp_path / 'second'
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[_gate(first), _gate(second), ['echo', 'third']], name='A')]
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one('#command-select', Select).value = 2
+        await pilot.pause()
+
+        _release(first)
+        await _wait_until(
+            pilot,
+            lambda: _panes(app)[0].return_code is not None,
+            'the first command to finish',
+        )
+        assert _selected_index(app) == 2
+
+        _release(second)
+        await _wait_until_settled(app, pilot, panes_expected=3)

--- a/tests/rbx/box/ui/test_command_chain.py
+++ b/tests/rbx/box/ui/test_command_chain.py
@@ -1,0 +1,109 @@
+"""Tests for chained commands (`rbx each build :: run`) in the command app."""
+
+import asyncio
+from typing import List
+
+from textual.widgets import Input
+
+from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
+from rbx.box.ui.command_app import CommandEntry, rbxCommandApp
+
+
+def _panes(app) -> List[CommandPane]:
+    return list(app.query(CommandPane))
+
+
+def _settled(panes: List[CommandPane]) -> bool:
+    return all(
+        p.return_code is not None or p.border_subtitle == 'Skipped' for p in panes
+    )
+
+
+async def _wait_until_settled(app, pilot, panes_expected: int) -> List[CommandPane]:
+    for _ in range(200):
+        await pilot.pause()
+        await asyncio.sleep(0.05)
+        panes = _panes(app)
+        if len(panes) == panes_expected and _settled(panes):
+            return panes
+    raise AssertionError('commands did not settle in time')
+
+
+async def test_chain_queues_one_pane_per_command_in_order():
+    app = rbxCommandApp(
+        [
+            CommandEntry(
+                argvs=[['echo', 'first'], ['echo', 'second']],
+                name='A',
+            )
+        ]
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        panes = await _wait_until_settled(app, pilot, panes_expected=2)
+        assert [p.border_title for p in panes] == ['echo first', 'echo second']
+        assert [p.return_code for p in panes] == [0, 0]
+
+
+async def test_failed_chain_skips_the_rest_of_the_chain():
+    app = rbxCommandApp(
+        [
+            CommandEntry(
+                argvs=[['sh', '-c', 'exit 3'], ['echo', 'never']],
+                name='A',
+            )
+        ]
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        failed, skipped = await _wait_until_settled(app, pilot, panes_expected=2)
+        assert failed.return_code == 3
+        assert failed.border_subtitle == 'Exit code: 3'
+        # The skipped command must never have been spawned at all.
+        assert skipped.return_code is None
+        assert skipped.border_subtitle == 'Skipped'
+
+
+async def test_keep_going_runs_the_whole_chain():
+    app = rbxCommandApp(
+        [
+            CommandEntry(
+                argvs=[['sh', '-c', 'exit 3'], ['echo', 'still runs']],
+                name='A',
+            )
+        ],
+        keep_going=True,
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        failed, after = await _wait_until_settled(app, pilot, panes_expected=2)
+        assert failed.return_code == 3
+        assert after.return_code == 0
+
+
+async def test_failure_does_not_skip_interactively_queued_commands():
+    # Commands typed into the app are never part of a chain, so a failing chain
+    # must not swallow them -- they keep going by design.
+    app = rbxCommandApp(
+        [
+            CommandEntry(
+                argvs=[['sh', '-c', 'sleep 0.6; exit 3'], ['echo', 'never']],
+                name='A',
+            )
+        ]
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.press('shift+tab')
+        await pilot.pause()
+        # Queue an extra command while the first one is still sleeping.
+        await pilot.press('!')
+        await pilot.pause()
+        app.query_one('#command-input', Input).value = 'echo interactive'
+        await pilot.press('enter')
+        await pilot.pause()
+        # Menu: "Run in this tab".
+        await pilot.press('1')
+
+        failed, skipped, interactive = await _wait_until_settled(
+            app, pilot, panes_expected=3
+        )
+        assert failed.return_code == 3
+        assert skipped.border_subtitle == 'Skipped'
+        assert interactive.return_code == 0

--- a/tests/rbx/box/ui/test_command_pane.py
+++ b/tests/rbx/box/ui/test_command_pane.py
@@ -46,9 +46,9 @@ async def test_hidden_panes_run_at_the_visible_pane_width():
     # at the 80-column fallback and look hard-wrapped once shown.
     app = rbxCommandApp(
         [
-            CommandEntry(argv=_PRINT_WIDTH, name='a'),
-            CommandEntry(argv=_PRINT_WIDTH, name='b'),
-            CommandEntry(argv=_PRINT_WIDTH, name='c'),
+            CommandEntry(argvs=[_PRINT_WIDTH], name='a'),
+            CommandEntry(argvs=[_PRINT_WIDTH], name='b'),
+            CommandEntry(argvs=[_PRINT_WIDTH], name='c'),
         ],
         parallel=True,
     )

--- a/tests/rbx/box/ui/test_task_queue.py
+++ b/tests/rbx/box/ui/test_task_queue.py
@@ -216,3 +216,51 @@ class TestTaskQueue:
         q.notify_complete(t1.task_id)
         assert t2.status == TaskStatus.RUNNING
         assert t4.status == TaskStatus.PENDING
+
+
+class TestTaskQueueCancel:
+    def _make_queue(self, num_terminals=2, parallel=True):
+        self.ready_tasks = []
+        return TaskQueue(
+            num_terminals=num_terminals,
+            parallel=parallel,
+            on_task_ready=lambda t: self.ready_tasks.append(t),
+        )
+
+    def test_cancel_drops_pending_task(self):
+        q = self._make_queue()
+        running = q.enqueue('echo first', terminal_id=0)
+        pending = q.enqueue('echo second', terminal_id=0)
+        assert pending.status == TaskStatus.PENDING
+
+        assert q.cancel(pending.task_id) is True
+
+        # The cancelled task never runs, even once the terminal frees up.
+        q.notify_complete(running.task_id)
+        assert len(self.ready_tasks) == 1
+        assert len(q) == 0
+
+    def test_cancel_refuses_running_task(self):
+        q = self._make_queue()
+        running = q.enqueue('echo first', terminal_id=0)
+
+        # A running task owns its terminal; cancelling it would leak that flag.
+        assert q.cancel(running.task_id) is False
+        assert running.status == TaskStatus.RUNNING
+
+    def test_cancel_unknown_task_is_noop(self):
+        q = self._make_queue()
+        assert q.cancel(1234) is False
+
+    def test_cancel_leaves_other_terminals_alone(self):
+        q = self._make_queue()
+        first = q.enqueue('echo a1', terminal_id=0)
+        cancelled = q.enqueue('echo a2', terminal_id=0)
+        q.enqueue('echo b1', terminal_id=1)
+        other_pending = q.enqueue('echo b2', terminal_id=1)
+
+        assert q.cancel(cancelled.task_id) is True
+        q.notify_complete(first.task_id)
+
+        assert other_pending.status == TaskStatus.PENDING
+        assert [t.command for t in self.ready_tasks] == ['echo a1', 'echo b1']


### PR DESCRIPTION
## What

`rbx each` and `rbx on` accept a chain of commands, separated by a bare `::`, and queue them per problem:

```bash
rbx each build :: package build
rbx on A-C build :: run -s
```

Each problem runs its whole chain before the next problem starts. The command app already modelled a queue per tab (`TabState.sub_commands` + `TaskQueue`) and let you add to it interactively with `!` — only the CLI surface was limited to one command, so most of this is plumbing.

## Failure semantics

A failing command skips the rest of that problem's chain (new `⊘` status, pane subtitle `Skipped`); other problems are unaffected. `-k` / `--keep-going` runs the chain anyway.

Commands typed into the app are never part of a chain and always run, even after a failure — a chain failure must not silently swallow what you queued by hand. This keeps today's interactive behaviour unchanged.

## Parsing

Both commands now set `allow_interspersed_args: False`. Without it click parses known options anywhere, so `rbx each run -k` would hand `-k` to `each` instead of to `rbx run`. The consequence is that `rbx on` takes the flag **before** the problem selector: `rbx on -k A build :: run`.

A `::` with nothing on one side is an error rather than being silently dropped — it is almost always a typo. There is no escape for a literal `::` reaching a sub-command; `bash -c '...'` is the workaround.

## Also

- `TaskQueue.cancel()` drops a still-pending task; it refuses running tasks, which own their terminal and must go through `notify_complete`.
- `CommandEntry.argv` → `argvs: List[List[str]]`.
- Status legend added to the app's help modal, since `⊘` is new.
- `rbx on` keeps its plain-terminal fast path only for a single command on a single problem; a chain opens the app.

## Which pane you land on

Opening a tab used to select its last sub-command, which with a chain is the one that has not started yet. It now lands on the command that is actually running (or the next one up between commands), falling back to the tail once the queue is done and its output is all there is to read.

The view also follows the chain as it advances, but only when it is parked on a command that already finished -- sitting on a pending command is someone looking ahead on purpose.

## Testing

`split_commands` / `build_command_argvs` unit tests, `TaskQueue.cancel` tests, CLI dispatch tests for `each`/`on` (including that a flag after the selector reaches the chained command), and integration tests driving the real app: chain ordering, skip-on-failure, `-k`, and an interactively queued command surviving a chain failure.

Full suite: 5200 passed. The 42 failures are the pre-existing local g++/clang toolchain and sandbox set — none touch the code changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANaZtqjgfF8jykZoFx8vWr
