### PR TITLE
refactor(moj): stop announcing testrun cache hits

### DIFF
--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -351,11 +351,11 @@ verdict code are things the setter is about to fix, and a cached one would make 
 look like it did nothing. A **bad verdict is cached** -- a WA or a TLE is a real,
 reproducible measurement, and the validation phase exists to take exactly those. The cache lives beside
 the upload record in the disposable problem cache, is consulted *before* the concurrency
-slot (a hit costs no judge time and must not queue behind one that does), and is announced
-once per testrun from `_evaluation_from_job`, naming the directory to delete. There is no
-`--no-cache` flag: the key covers everything rbx can observe, and what it cannot observe --
-another machine's `moj upload`, a park that changed under the numbers -- is fixed by
-throwing the observations away.
+slot (a hit costs no judge time and must not queue behind one that does), and is not
+announced beyond the solution's `cached` board chip -- the explanatory paragraph it used to
+print per solution drowned the report. There is no `--no-cache` flag: the key covers
+everything rbx can observe, and what it cannot observe -- another machine's `moj upload`, a
+park that changed under the numbers -- is fixed by deleting the cache directory.
 
 Design: `docs/plans/2026-08-20-moj-remote-runner-design.md`.
 

--- a/rbx/box/runners/moj/runner.py
+++ b/rbx/box/runners/moj/runner.py
@@ -204,8 +204,6 @@ class _TestrunResult:
     # `run` is then the id of the testrun that was really measured, back when it
     # was measured -- which is the id the setter needs to look the run up.
     cached: bool = False
-    # Same idea as `warned`, for the cache-hit line.
-    announced: bool = False
 
 
 def _retrieve_exception(task: 'asyncio.Task') -> None:
@@ -1098,22 +1096,10 @@ class MojRunner:
         # until the next poll came round to fix it.
         result = await job
 
-        # Said out loud, and said here, for the same reason the missing-testcase
-        # warning is: a setter who expected a judge round-trip and got an answer
-        # instantly has to be told *why* it was instant, or the run reads as
-        # either magic or a bug. It also names the one way to force a real
-        # measurement -- see `_testrun_cache_dir` for why that is a directory to
-        # delete rather than a `--no-cache` flag.
-        if result.cached and not result.announced:
-            result.announced = True
-            console.console.print(
-                f'[status]Reused MOJ timings for [item]{solution.path}[/item] from '
-                f'testrun [item]{result.run}[/item]: the probe package and the '
-                f'submitted source are byte-for-byte the ones that run measured, '
-                f'so nothing was submitted to the judge.[/status]\n'
-                f'[status]Delete [item]{_testrun_cache_dir()}[/item] to measure it '
-                f'again.[/status]'
-            )
+        # A cache hit is deliberately *not* announced here. It used to print a
+        # two-line explanation per solution, which drowned the report it was
+        # attached to; the solution's own board slot already says `cached`, which
+        # is enough to tell an instant answer from a judged one.
 
         # Once per testrun, not once per testcase, and only when the report has
         # actually got here. `warned` is set before anything awaits, so two

--- a/tests/rbx/box/runners/moj/test_cache.py
+++ b/tests/rbx/box/runners/moj/test_cache.py
@@ -18,7 +18,6 @@ same fake the rest of the runner's tests drive.
 import asyncio
 import json
 import pathlib
-import re
 from typing import Dict, List, Optional, Tuple
 
 import pytest
@@ -36,8 +35,6 @@ from tests.rbx.box.runners.moj.test_run_solution import (
 from tests.rbx.box.runners.moj.test_runner import _context
 
 pytestmark = pytest.mark.shared_cache
-
-_ANSI = re.compile(r'\x1b\[[0-9;]*m')
 
 
 # What every solution in this file is measured as, unless a test says otherwise.
@@ -139,47 +136,6 @@ async def test_a_hit_produces_exactly_the_evaluations_a_miss_did(
     hit = await _time(fake, ctx)
 
     assert _dump(hit) == _dump(missed)
-
-
-async def test_a_hit_is_reported_once_and_says_how_to_measure_again(
-    testing_pkg, tmp_path, monkeypatch, capsys
-):
-    """A setter who expected a judge round-trip and got an instant answer has to
-    be told why -- and told the one way to force a real measurement.
-
-    There is no `--no-cache` flag: the key already covers everything rbx can
-    observe, and what it cannot observe (somebody else's upload, a park that
-    changed) is fixed by throwing the observations away. So the line names the
-    directory to delete. Said once per testrun, not once per testcase, and from
-    the consumer's own thread of control -- the polling tasks say nothing.
-    """
-    fake = _session(testing_pkg, tmp_path, monkeypatch)
-    ctx = _context(tmp_path, entries=build_entries(tmp_path, ['samples']))
-
-    await _time(fake, ctx)
-    capsys.readouterr()
-    await _time(fake, ctx)
-
-    out = _ANSI.sub('', capsys.readouterr().out)
-    assert out.count('Reused MOJ timings') == 1
-    assert 'sol.cpp' in out
-    # The real testrun id, so the run that was actually measured can be looked up.
-    assert fake.submissions[0][0] in out
-    # And where the observations live, which is the escape hatch.
-    assert runner_module.TESTRUN_CACHE_DIR_NAME in out
-
-
-async def test_nothing_is_said_when_the_judge_really_ran_it(
-    testing_pkg, tmp_path, monkeypatch, capsys
-):
-    """The counter-test: a message printed unconditionally would satisfy the one
-    above while telling the setter a submission never happened."""
-    fake = _session(testing_pkg, tmp_path, monkeypatch)
-    ctx = _context(tmp_path, entries=build_entries(tmp_path, ['samples']))
-
-    await _time(fake, ctx)
-
-    assert 'Reused MOJ timings' not in _ANSI.sub('', capsys.readouterr().out)
 
 
 async def test_the_cache_lives_in_the_disposable_problem_cache(


### PR DESCRIPTION
The two-line explanation printed for every reused MOJ testrun drowned the run report it was attached to:

> Reused MOJ timings for solutions/good/moro_py.py from testrun 0c3541047d2ee6873a8d0b53a7ee53b4: the probe package and the submitted source are byte-for-byte the ones that run measured, so nothing was submitted to the judge.
> Delete .../.rbx/moj-testruns to measure it again.

The solution's own board slot already reads `cached`, which is what distinguishes an instant answer from a judged one, so the paragraph is gone.

- `rbx/box/runners/moj/runner.py` — drop the print in `_evaluation_from_job` and the now-unused `announced` field.
- `tests/rbx/box/runners/moj/test_cache.py` — drop the two tests asserting the message (and the `_ANSI` helper they needed).
- `rbx/box/CLAUDE.md` — the cache section still documents deleting the cache directory as the way to force a fresh measurement.

Verified: `uv run pytest tests/rbx/box/runners/moj -q` → 148 passed; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MZtvfoFw8QkJsC9QqwPWJ