### PR TITLE
feat(cli): let `rbx run`/`irun` pick a limits profile too

### DIFF
--- a/docs/setters/packaging-walkthrough.md
+++ b/docs/setters/packaging-walkthrough.md
@@ -115,11 +115,12 @@ Once your profile is ready, you can run your solutions under the BOCA limits to 
 sure everything still passes:
 
 ```bash
-rbx -p boca run
+rbx run -p boca
 ```
 
-The `-p` (or `--profile`) flag is a **global** flag that tells {{rbx}} to use the
-specified limits profile for the run.
+The `-p` (or `--profile`) flag tells {{rbx}} to use the specified limits profile
+for the run. It also works as a global flag, before the command
+(`rbx -p boca run`).
 
 ### Working with multiple profiles
 

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -531,14 +531,25 @@ solutions with `rbx run` without specifying a profile.
 
 ### Using profiles when running solutions
 
-You can tell {{rbx}} to use a specific limits profile when running solutions with the global `--profile` flag:
+You can tell {{rbx}} to use a specific limits profile when running solutions with the `--profile` flag:
 
 ```bash
-rbx --profile=boca run
+rbx run -p boca
+rbx irun --profile=polygon
 rbx -p polygon run
 ```
 
 This applies the limits from the specified profile instead of the package defaults.
+
+The flag exists both on `rbx` itself (global, before the command) and on `rbx run`
+/ `rbx irun` (after the command); the two spellings mean the same thing, and the
+subcommand-level flag wins when both are passed. `rbx run` fails loudly if the
+named profile doesn't exist for the current problem, so you never run against
+limits you didn't ask for.
+
+!!! note
+    `rbx irun` only takes the long `--profile` spelling: `-p` is already
+    `--print` there.
 
 ### Using profiles when building statements
 

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -348,6 +348,24 @@ async def build(
         raise typer.Exit(1)
 
 
+def _set_timing_profile(profile: Optional[str]) -> None:
+    """Apply a command-level `--profile`, if one was given.
+
+    Mirrors the root callback's `-p`, so `rbx run -p boca` and `rbx -p boca run`
+    mean the same thing. Unlike the root flag, a missing profile is an error
+    here: naming one is a deliberate act, and falling back to the package limits
+    would silently run the solutions against limits the setter did not ask for.
+    """
+    if profile is None:
+        # Leaves whatever the root callback set (or nothing) in place.
+        return
+
+    from rbx.box import limits_info
+
+    limits_info.get_limits_profile(profile, fallback_to_package_profile=False)
+    limits_info.profile_var.set(profile)
+
+
 @app.command(
     'run, r',
     rich_help_panel='Testing',
@@ -432,7 +450,18 @@ async def run(
         ),
         autocompletion=annotations._adapt('runner'),  # noqa: SLF001
     ),
+    profile: Annotated[
+        Optional[str],
+        typer.Option(
+            '-p',
+            '--profile',
+            help='Timing profile to run the solutions against. Must exist in this problem.',
+            autocompletion=annotations._adapt('profile'),  # noqa: SLF001
+        ),
+    ] = None,
 ):
+    _set_timing_profile(profile)
+
     if share is not None and share not in ('png', 'text'):
         console.console.print(
             f'[error]Invalid --share format: {share!r} (use png or text).[/error]'
@@ -898,7 +927,19 @@ async def irun(
         '-c',
         help='Whether to pick solutions interactively.',
     ),
+    profile: Annotated[
+        Optional[str],
+        typer.Option(
+            # No short flag: `-p` is already `--print` here, and stealing it
+            # would silently change what an existing `rbx irun -p` does.
+            '--profile',
+            help='Timing profile to run the solutions against. Must exist in this problem.',
+            autocompletion=annotations._adapt('profile'),  # noqa: SLF001
+        ),
+    ] = None,
 ):
+    _set_timing_profile(profile)
+
     if not print:
         console.console.print(
             '[warning]Outputs will be written to files. If you wish to print them to the terminal, use the "-p" parameter.'

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -227,6 +227,15 @@ SPEC = {
                     'value': {'completer': 'runner', 'kind': 'completer'},
                 },
                 {
+                    'help': 'Timing profile to run the solutions against. Must exist in '
+                    'this problem.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['-p', '--profile'],
+                    'takes_value': True,
+                    'value': {'completer': 'profile', 'kind': 'completer'},
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,
@@ -496,6 +505,15 @@ SPEC = {
                     'names': ['--choice', '--choose', '-c'],
                     'takes_value': False,
                     'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Timing profile to run the solutions against. Must exist in '
+                    'this problem.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--profile'],
+                    'takes_value': True,
+                    'value': {'completer': 'profile', 'kind': 'completer'},
                 },
                 {
                     'help': 'Show this message and exit.',

--- a/tests/rbx/box/test_run_profile_cli.py
+++ b/tests/rbx/box/test_run_profile_cli.py
@@ -1,0 +1,231 @@
+"""What `rbx run -p` / `rbx irun --profile` select, and what an unknown one costs.
+
+The flag is a per-command spelling of the root callback's `-p`: it picks which
+`.limits/<name>.yml` the solutions are run against. What is pinned here is that
+the profile is active by the time solutions run, that its absence changes
+nothing, and that a name the package does not define stops the command before
+anything is built.
+"""
+
+import asyncio
+from typing import Any, Dict, Tuple
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box import cli, limits_info, package, schema
+from rbx.box.testing import testing_package
+from rbx.utils import model_to_yaml
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _skip_preset_check():
+    # The root Typer callback checks the active preset's compatibility, which is
+    # unrelated to the wiring under test and fails for the bare testing package.
+    with mock.patch('rbx.box.presets.check_active_preset_compatibility'):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_profile():
+    # The profile lives in a context var that the CLI sets; a test that sets it
+    # must not decide what the next one sees.
+    token = limits_info.profile_var.set(None)
+    yield
+    limits_info.profile_var.reset(token)
+
+
+def _write_profile(name: str) -> None:
+    path = package.get_limits_file(name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(model_to_yaml(schema.LimitsProfile(timeLimit=2500)))
+
+
+async def _build_ok(*args, **kwargs):
+    return True
+
+
+def _invoke_run(runner: CliRunner, *args: str) -> Tuple[Any, Dict[str, Any]]:
+    """`rbx run`, with the build and the run itself stubbed out."""
+    calls: Dict[str, Any] = {}
+
+    async def run_solutions(*positional, **kwargs):
+        calls['profile'] = limits_info.get_active_profile()
+        calls['kwargs'] = kwargs
+        result = mock.MagicMock()
+        result.close = mock.AsyncMock()
+        return result
+
+    async def print_run_report(*positional, **kwargs):
+        return True
+
+    with (
+        mock.patch('rbx.box.builder.build', _build_ok),
+        mock.patch('rbx.box.cli.run_solutions', run_solutions),
+        mock.patch('rbx.box.cli.print_run_report', print_run_report),
+    ):
+        result = runner.invoke(cli.app, ['run', *args])
+    return result, calls
+
+
+def _invoke_irun(runner: CliRunner, *args: str) -> Tuple[Any, Dict[str, Any]]:
+    """`rbx irun -t 0/0`, with the run itself stubbed out.
+
+    A testcase is named because a bare `rbx irun` reads testcases from the
+    terminal, which has nothing to do with which profile is active.
+    """
+    calls: Dict[str, Any] = {}
+
+    async def run_and_print_interactive_solutions(*positional, **kwargs):
+        calls['profile'] = limits_info.get_active_profile()
+
+    with mock.patch(
+        'rbx.box.cli.run_and_print_interactive_solutions',
+        run_and_print_interactive_solutions,
+    ):
+        result = runner.invoke(cli.app, ['irun', '-t', '0/0', *args])
+    return result, calls
+
+
+def test_no_flag_runs_against_the_package_limits(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    """The behaviour every existing `rbx run` has: the flag's absence must not
+    change which limits the solutions are run against."""
+    result, calls = _invoke_run(runner)
+
+    assert result.exit_code == 0, result.output
+    assert calls['profile'] is None
+
+
+def test_a_profile_is_active_while_the_solutions_run(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    _write_profile('boca')
+
+    result, calls = _invoke_run(runner, '-p', 'boca')
+
+    assert result.exit_code == 0, result.output
+    assert calls['profile'] == 'boca'
+
+
+def test_the_short_and_long_spellings_agree(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    _write_profile('boca')
+
+    short_result, short_calls = _invoke_run(runner, '-p', 'boca')
+    long_result, long_calls = _invoke_run(runner, '--profile', 'boca')
+
+    assert short_result.exit_code == long_result.exit_code == 0
+    assert short_calls['profile'] == long_calls['profile'] == 'boca'
+
+    # Nothing else the command decides is decided differently. Compared by
+    # identity where the value is one (the progress bar, the runner object).
+    def comparable(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            k: type(v) if k in ('progress', 'runner') else v for k, v in kwargs.items()
+        }
+
+    assert comparable(short_calls['kwargs']) == comparable(long_calls['kwargs'])
+
+
+def test_the_command_flag_means_the_same_as_the_root_flag(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    """`rbx run -p boca` and `rbx -p boca run` are two spellings of one thing."""
+    _write_profile('boca')
+
+    root_result, root_calls = _invoke_run_with_root_flag(runner, 'boca')
+    command_result, command_calls = _invoke_run(runner, '-p', 'boca')
+
+    assert root_result.exit_code == command_result.exit_code == 0
+    assert root_calls['profile'] == command_calls['profile'] == 'boca'
+
+
+def _invoke_run_with_root_flag(
+    runner: CliRunner, profile: str
+) -> Tuple[Any, Dict[str, Any]]:
+    calls: Dict[str, Any] = {}
+
+    async def run_solutions(*positional, **kwargs):
+        calls['profile'] = limits_info.get_active_profile()
+        result = mock.MagicMock()
+        result.close = mock.AsyncMock()
+        return result
+
+    async def print_run_report(*positional, **kwargs):
+        return True
+
+    with (
+        mock.patch('rbx.box.builder.build', _build_ok),
+        mock.patch('rbx.box.cli.run_solutions', run_solutions),
+        mock.patch('rbx.box.cli.print_run_report', print_run_report),
+    ):
+        result = runner.invoke(cli.app, ['-p', profile, 'run'])
+    return result, calls
+
+
+def test_an_unknown_profile_is_refused_before_anything_is_built(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    """Falling back to the package limits would run the solutions against limits
+    the setter did not ask for, and the run would look like it worked."""
+    result, calls = _invoke_run(runner, '-p', 'bcoa')
+
+    assert result.exit_code != 0
+    assert 'bcoa' in result.output
+    # Nothing ran.
+    assert calls == {}
+
+
+def test_irun_takes_the_long_spelling_only(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    """`-p` is `--print` in `irun`, and stealing it would silently change what an
+    existing `rbx irun -p` does."""
+    _write_profile('boca')
+
+    result, calls = _invoke_irun(runner, '-v4', '--profile', 'boca')
+
+    assert result.exit_code == 0, result.output
+    assert calls['profile'] == 'boca'
+
+
+def test_irun_p_still_prints(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    result, calls = _invoke_irun(runner, '-v4', '-p')
+
+    assert result.exit_code == 0, result.output
+    assert calls['profile'] is None
+    # The warning shown only when outputs are *not* printed to the terminal.
+    assert 'Outputs will be written to files' not in result.output
+
+
+def test_irun_refuses_an_unknown_profile(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    result, calls = _invoke_irun(runner, '-v4', '--profile', 'bcoa')
+
+    assert result.exit_code != 0
+    assert 'bcoa' in result.output
+    assert calls == {}


### PR DESCRIPTION
## What

Adds `--profile` to `rbx run` and `rbx irun`, so a limits profile can be picked as part of the command it configures:

```bash
rbx run -p boca
rbx irun --profile boca
```

Previously the only spelling was the root flag (`rbx -p boca run`), which reads as a global setting rather than as part of the run.

## Details

- `run` gets `-p/--profile`; `irun` gets `--profile` **only** — `-p` is already `--print` there, and stealing it would silently change what an existing `rbx irun -p` does.
- The subcommand flag wins over the root one, matching `rbx statements build -p`.
- Unlike the root flag, an unknown profile is an error before anything is built, rather than a silent fallback to the package limits — running against limits the setter didn't ask for looks like it worked.

## Tests

- New `tests/rbx/box/test_run_profile_cli.py` (8 tests): default unchanged, profile active while solutions run, short/long spellings agree, command flag == root flag, unknown profile refused before the build, `irun -p` still prints.
- Regenerated the committed completion spec.
- Docs updated in `docs/setters/profiling/index.md` and `docs/setters/packaging-walkthrough.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173gD9yrEicASyCuwThtX5b