### PR TITLE
fix(statements): isolate statement build failures (#705)

### DIFF
--- a/docs/plans/2026-08-23-statement-partial-failure-design.md
+++ b/docs/plans/2026-08-23-statement-partial-failure-design.md
@@ -1,0 +1,233 @@
+# Statement builds should fail in isolation
+
+Design for [#705](https://github.com/rsalesc/rbx/issues/705).
+Date: 2026-08-23.
+
+## Problem
+
+`rbx contest st b` aborts the whole command the moment any one statement fails.
+If a contest builds `en` and `pt` and one problem has no `en` statement, `pt`
+never builds — even though nothing about `pt` is broken.
+
+Two distinct defects hide behind that symptom, and they pull in opposite
+directions.
+
+### Defect 1 — statements are not isolated from each other
+
+The command has two nested loops and only the inner one is protected:
+
+- **outer loop**, `rbx/box/contest/statements.py:130`, over `valid_statements`
+  (one per contest statement, i.e. per language/name) — bare, no `try`. The
+  first statement that raises kills every later one.
+- **inner loop**, `rbx/box/contest/build_contest_statements.py:209`, over the
+  contest's problems — has a `try`, and deliberately re-raises a subset of
+  errors.
+
+A problem with no matching `en` statement raises `StatementResolverError`
+(`rbx/box/statements/resolver.py:211-216`), an `RbxException`. That hits the
+inner loop's deliberate re-raise at `build_contest_statements.py:228-232`,
+escapes `build_statement`, and lands in the unprotected outer loop. `pt` dies
+with it.
+
+The missing-language case in the issue is not the only vector. A pdflatex
+failure exits through `_finish` → `render.compile_pdf`
+(`rbx/box/statements/render.py:247-250`) with `typer.Exit(1)`, which kills the
+remaining languages just as effectively and is more common in practice.
+
+The problem-level command has the same unprotected shape at
+`rbx/box/statements/build_statements.py:403`, so a broken `en` also stops `pt`
+under plain `rbx st b`.
+
+A further consequence of the escape: the built/failed report at
+`contest/statements.py:165-173` never prints, because the exception leaves the
+function before it. The user gets a traceback-or-error and no account of what
+did build.
+
+### Defect 2 — criticality is decided by accident, not by design
+
+The inner loop classifies failures by exception *type*:
+
+```python
+except (typer.Exit, RbxException):
+    raise            # "hard config/abort errors must surface"
+except Exception as exc:
+    ...              # warn, add issue, drop this problem, continue
+```
+
+That tuple is not a policy, it is a guess about which types authors reach for.
+Two common failures fall on the wrong side of it:
+
+- A **Jinja undefined-variable** error in a problem fragment raises
+  `typer.Abort` (`rbx/box/statements/latex_jinja.py:305-318`), which is not in
+  the tuple. It is silently demoted to a per-problem skip — exactly the
+  "statement silently goes partial" outcome the tiering was meant to prevent.
+- A missing `contestProblemTemplate` is a bare `assert`
+  (`build_contest_statements.py:314`) → `AssertionError`, also outside the
+  tuple. Every problem is skipped, each with a confusing per-problem message,
+  and a near-empty PDF is produced.
+
+And the soft branch does not affect the exit code. `build_statement` returns
+normally after skipping a problem, and only the samples-phase `failed_problems`
+list drives `typer.Exit(1)` (`contest/statements.py:175-182`). So **a problem
+can vanish from the problemset PDF and the command reports success.**
+
+### The pre-existing silent-partial paths
+
+Partial problemset PDFs are already emitted today, in two places, neither
+flagged:
+
+1. **Samples phase** — a problem whose samples fail to build is dropped from
+   `problems_of_interest` (`contest/statements.py:111-118`). The joined PDF is
+   then built without it, written to `build/`, and the command exits 1
+   afterwards.
+2. **Inner render skip** — as above, exit 0.
+
+Structurally nothing notices: `problem_ctxs` is just a list
+(`build_contest_statements.py:240-241`), the contest template emits one fewer
+`\subimport`, the problem lettering shifts, and the PDF compiles fine. There is
+no cross-check between `contest.problems` and `problem_ctxs`.
+
+This matters for the design: shipping a `--partial` flag while these paths stay
+unflagged would make the flag describe something the tool already does without
+it.
+
+## Requirements
+
+1. A failure building one statement must never prevent another statement from
+   building. This is unconditional, not opt-in.
+2. Within one statement, anything that would make that statement *partial* is
+   fatal **to that statement** — by default.
+3. `--partial` opts into best-effort: a problem that fails is dropped and the
+   statement is still produced.
+4. No partial artifact is ever written without `--partial`.
+5. The packagers must keep fail-fast. A silently incomplete Polygon/MOJ/BOCA
+   upload is worse than an aborted one.
+6. The command ends with an account of what built and what did not, and exits
+   nonzero if anything failed.
+
+## Design
+
+### 1. Explicit criticality, replacing type-based tiering
+
+Delete the `(typer.Exit, RbxException)` tuple from
+`build_contest_statements.py`. The inner problem loop becomes:
+
+```python
+except Exception as exc:
+    if partial:
+        console.console.print(...)          # warn
+        issue_stack.add_issue(StatementBuildIssue(problem))
+        continue                            # drop the problem, keep the statement
+    raise StatementBuildError(statement, problem, exc) from exc
+```
+
+Default: any problem-level failure fails **this statement**. `--partial`: drop
+the problem and carry on.
+
+This satisfies requirement 2 directly and fixes the `typer.Abort` /
+`AssertionError` misclassification for free — the classification no longer
+exists, so nothing can fall on the wrong side of it.
+
+`StatementBuildError` is a new `RbxException` subclass carrying the statement,
+the offending problem and the underlying error, so the summary can render a
+one-line reason.
+
+The bare `assert`s at `build_contest_statements.py:196`, `:306` and `:314`
+should become real errors with messages; under the new rule they are fatal to
+the statement either way, but an `AssertionError` in the summary tells the user
+nothing.
+
+### 2. Outer-loop isolation
+
+`contest/statements.py:_execute_build` and
+`build_statements.py:execute_build_on_statements` wrap each `build_statement`
+call:
+
+```python
+for statement in valid_statements:
+    try:
+        built.append(await build_statement(...))
+    except Exception as exc:
+        issue_stack.add_issue(StatementFailedIssue(statement, exc))
+        failed_statements.append((statement, exc))
+```
+
+Unconditional — no flag gates it. Requirement 1.
+
+`execute_build_on_statements` is shared with the packagers, so it takes
+`keep_going: bool = False`. The CLI passes `True`; every packager caller keeps
+the current fail-fast behaviour by default. Requirement 5.
+
+### 3. Closing the silent-partial holes
+
+The samples-phase drop (`contest/statements.py:111-118`) currently removes a
+problem from `problems_of_interest` and lets the join proceed. Under the new
+rule a problem that failed its samples makes every joining statement partial,
+so without `--partial` those statements fail; with `--partial` the problem is
+dropped as today. Requirement 4.
+
+### 4. Reporting
+
+The summary goes through the existing issue stack rather than a second channel:
+
+- `StatementBuildIssue(problem)` — already exists
+  (`build_contest_statements.py:50-61`, overview section `('statement',)`).
+  Retained for the `--partial` per-problem drop.
+- `StatementFailedIssue(statement, reason)` — new, same section, for a whole
+  statement failing.
+
+`within_contest` already calls `issue_stack.print_current_report()` in a
+`finally` (`rbx/box/contest/contest_package.py:230-238`), so the report survives
+a nonzero exit.
+
+The issue tree dedups by message, so it can under-report when several
+statements fail the same way. The explicit built/failed rule at
+`contest/statements.py:165-173` therefore stays and is extended with a failed
+section listing each statement and its one-line reason. Outer-loop isolation is
+what makes that rule reachable at all.
+
+### 5. The flag
+
+`--partial`, off by default, on `rbx contest st b`, `rbx contest tut b`,
+`rbx st b`, `rbx tut b`. Not exposed to packagers.
+
+Named for what it permits (an incomplete statement) rather than `--keep-going`,
+which would describe the outer-loop behaviour — and that is unconditional, so it
+needs no flag.
+
+### Exit codes
+
+- Any statement failed → **1**.
+- `--partial` given and problems were dropped, but every statement was produced
+  → **0**. The flag is an explicit statement of intent; forcing nonzero would
+  make it unusable in scripts. The dropped problems are still listed in the
+  issue report.
+
+## Consequences accepted
+
+- **Without `--partial`, one problem's sample failure now fails every
+  statement**, where today it produced short PDFs and exit 1. This is
+  requirement 4 working as intended, but it makes `--partial` load-bearing for a
+  workflow that currently needs no flag. Accepted: the current behaviour writes
+  a wrong PDF, and a wrong artifact is worse than a missing one.
+- Keep-going makes failing runs slower — each language re-renders every problem
+  fragment from scratch (`_fresh_dir`, `build_contest_statements.py:197`), so a
+  contest that used to abort on language 2 now does the full N×M work. No
+  correctness impact.
+
+## Testing
+
+- Contest, two languages, problem B has no `en` statement: `pt` PDF exists, no
+  `en` PDF, exit 1, summary names `en` and problem B.
+- Same, with `--partial`: both PDFs exist, `en` omits problem B, issue report
+  lists the drop, exit 0.
+- pdflatex failure in `en`: `pt` still builds, exit 1.
+- Jinja undefined variable in a problem fragment: fatal to that statement (no
+  partial PDF), not a silent skip — the current-behaviour regression test.
+- Missing `contestProblemTemplate`: one clear error, not one confusing message
+  per problem.
+- Sample-build failure in one problem: all joining statements fail without
+  `--partial`; dropped with it.
+- Packager path (`execute_build_on_statements` default `keep_going=False`) still
+  aborts on the first statement failure.
+- Problem-level `rbx st b` with a broken `en`: `pt` still builds.

--- a/docs/plans/2026-08-23-statement-partial-failure.md
+++ b/docs/plans/2026-08-23-statement-partial-failure.md
@@ -1,0 +1,1039 @@
+# Isolated Statement Build Failures Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** A failure building one statement must never stop another statement from building, and a statement must never be silently produced with a problem missing.
+
+**Architecture:** Two changes to the statement build loops. (1) The *outer* loops — over contest statements in `rbx/box/contest/statements.py` and over problem statements in `rbx/box/statements/build_statements.py` — become fault-isolating: each statement builds in its own `try`, failures are collected, and the loop always runs to completion. (2) The *inner* loop over problems in `rbx/box/contest/build_contest_statements.py` drops its exception-type-based tiering (`except (typer.Exit, RbxException): raise`) in favour of an explicit `partial` policy: by default any problem-level failure fails that whole statement; under `--partial` the problem is dropped and the statement is still produced. Failures are reported through the existing `issue_stack` overview plus an explicit end-of-run summary.
+
+**Tech Stack:** Python 3, Typer (CLI), pytest + pytest-asyncio, `rbx.box.sanitizers.issue_stack` (existing failure-reporting mechanism), `rbx.box.exception.RbxException`.
+
+**Design doc:** `docs/plans/2026-08-23-statement-partial-failure-design.md` — read it first. It explains *why* the current tiering is wrong, which this plan assumes.
+
+---
+
+## Background you need before starting
+
+Read these, in this order. You will not be able to write correct code without them.
+
+1. `docs/plans/2026-08-23-statement-partial-failure-design.md` — the design.
+2. `rbx/box/statements/CLAUDE.md` — how statements v2 builds. In particular the
+   "Build entry points" section.
+3. `rbx/box/contest/statements.py` — the contest CLI driver. `_execute_build` at
+   `:29` is the outer loop.
+4. `rbx/box/contest/build_contest_statements.py` — `build_statement` at `:155`
+   holds the inner loop at `:209`.
+5. `rbx/box/sanitizers/issue_stack.py` — the `Issue` base class (`:19`) and
+   `add_issue` (`:140`). Issues are accumulated and rendered as a tree,
+   **deduplicated by message**. That dedup is why we also keep an explicit
+   summary; do not rely on the issue tree alone to enumerate failures.
+
+### Vocabulary
+
+- A **contest statement** is one entry under `statements:` in `contest.rbx.yml`.
+  There is one per language (per `(language, variant)`), and each produces one
+  joined PDF containing every problem. `main-en` and `main-pt` are two contest
+  statements.
+- A **problem statement** is one entry under `statements:` in a
+  `problem.rbx.yml`.
+- A contest statement **joins** the problem statements whose
+  `(language, variant)` matches its own. A problem that has no matching entry
+  cannot be joined.
+- **Partial** means: a contest statement was produced without one or more of the
+  contest's problems in it.
+
+### Test conventions in this repo
+
+- Tests are `async def` and run under pytest-asyncio; no `@pytest.mark.asyncio`
+  decorator is needed (see `tests/rbx/box/contest/test_contest_build_v2.py`).
+- `@pytest.mark.test_pkg('contests/<name>')` + the `cleandir_with_testdata`
+  fixture copies `rbx/testdata/contests/<name>/` into a temp cwd and yields the
+  path. **The fixture directory lives under `rbx/testdata/`, not under
+  `tests/`.**
+- Contest CLI commands are Typer + `@syncer.sync`; tests call the unwrapped
+  coroutine via `inspect.unwrap(...)`. See the `_run` helper at
+  `tests/rbx/box/contest/test_contest_build_v2.py:12`.
+- Build with `output=StatementType.TeX` to avoid needing pdflatex.
+- Single quotes for strings, absolute imports only (ruff `TID`).
+
+### Running tests
+
+```bash
+uv run pytest tests/rbx/box/contest/test_contest_partial_build.py -v
+```
+
+Never run the full suite to check your work — it has known unrelated local
+failures. Run the specific test file.
+
+---
+
+## Task 1: Test fixture with a problem missing a language
+
+A fixture where one contest statement can build and another cannot, so every
+later task has something to assert against.
+
+**Files:**
+- Create: `rbx/testdata/contests/statements_v2_partial/contest.rbx.yml`
+- Create: `rbx/testdata/contests/statements_v2_partial/A/problem.rbx.yml`
+- Create: `rbx/testdata/contests/statements_v2_partial/A/statement/statement.rbx.tex`
+- Create: `rbx/testdata/contests/statements_v2_partial/A/statement/statement-pt.rbx.tex`
+- Create: `rbx/testdata/contests/statements_v2_partial/B/problem.rbx.yml`
+- Create: `rbx/testdata/contests/statements_v2_partial/B/statement/statement.rbx.tex`
+- Create: `rbx/testdata/contests/statements_v2_partial/statements/contest.rbx.tex`
+- Create: `rbx/testdata/contests/statements_v2_partial/statements/problem-standalone.rbx.tex`
+- Create: `rbx/testdata/contests/statements_v2_partial/statements/problem-in-contest.rbx.tex`
+
+**Step 1: Copy the existing fixture as a base**
+
+```bash
+cp -r rbx/testdata/contests/statements_v2 rbx/testdata/contests/statements_v2_partial
+rm -rf rbx/testdata/contests/statements_v2_partial/A/statement/editorial.rbx.tex \
+       rbx/testdata/contests/statements_v2_partial/B/statement/editorial.rbx.tex \
+       rbx/testdata/contests/statements_v2_partial/statements/editorial-in-contest.rbx.tex \
+       rbx/testdata/contests/statements_v2_partial/statements/editorial-sheet.rbx.tex \
+       rbx/testdata/contests/statements_v2_partial/statements/editorial-standalone.rbx.tex \
+       rbx/testdata/contests/statements_v2_partial/statements/info.jinja.tex
+```
+
+We drop tutorials and documents: this fixture exists to exercise statement
+isolation only, and fewer moving parts means clearer failures.
+
+**Step 2: Write the contest config**
+
+`rbx/testdata/contests/statements_v2_partial/contest.rbx.yml`:
+
+```yaml
+---
+name: 'sv2-partial'
+titles:
+  en: 'Partial Contest'
+  pt: 'Contest Parcial'
+vars:
+  year: 2026
+problems:
+  - short_name: 'A'
+  - short_name: 'B'
+statements:
+  - name: 'main-pt'
+    language: 'pt'
+    file: 'statements/contest.rbx.tex'
+    type: 'rbxTeX'
+    standaloneProblemTemplate: 'statements/problem-standalone.rbx.tex'
+    contestProblemTemplate: 'statements/problem-in-contest.rbx.tex'
+  - name: 'main-en'
+    language: 'en'
+    file: 'statements/contest.rbx.tex'
+    type: 'rbxTeX'
+    standaloneProblemTemplate: 'statements/problem-standalone.rbx.tex'
+    contestProblemTemplate: 'statements/problem-in-contest.rbx.tex'
+```
+
+**`main-pt` is listed first, deliberately.** It is the one that will fail (B has
+no `pt` statement). Ordering it first is what makes the tests prove that a
+*later* statement still builds after an earlier one blew up — which is the whole
+bug. Do not reorder these.
+
+**Step 3: Give A both languages, B only English**
+
+`A/problem.rbx.yml`:
+
+```yaml
+name: 'problem-a'
+timeLimit: 1000
+memoryLimit: 256
+vars:
+  author: 'Alice'
+statements:
+  - language: 'en'
+    title: 'Problem A'
+    file: 'statement/statement.rbx.tex'
+    type: 'rbxTeX'
+  - language: 'pt'
+    title: 'Problema A'
+    file: 'statement/statement-pt.rbx.tex'
+    type: 'rbxTeX'
+```
+
+`B/problem.rbx.yml` — note there is **no `pt` entry**; this is the fixture's
+whole point:
+
+```yaml
+name: 'problem-b'
+timeLimit: 1000
+memoryLimit: 256
+vars:
+  author: 'Bob'
+statements:
+  - language: 'en'
+    title: 'Problem B'
+    file: 'statement/statement.rbx.tex'
+    type: 'rbxTeX'
+```
+
+**Step 4: Write the statement bodies**
+
+`A/statement/statement.rbx.tex`:
+
+```tex
+%- block legend
+Problem A in English, authored by \VAR{vars.author}.
+%- endblock
+```
+
+`A/statement/statement-pt.rbx.tex`:
+
+```tex
+%- block legend
+Problema A em portugues, escrito por \VAR{vars.author}.
+%- endblock
+```
+
+`B/statement/statement.rbx.tex`:
+
+```tex
+%- block legend
+Problem B in English, authored by \VAR{vars.author}.
+%- endblock
+```
+
+**Step 5: Keep the templates from the copy**
+
+`statements/contest.rbx.tex`, `statements/problem-standalone.rbx.tex` and
+`statements/problem-in-contest.rbx.tex` come from the `statements_v2` copy
+unchanged. Verify `statements/contest.rbx.tex` still contains the join loop:
+
+```bash
+grep -n 'subimport' rbx/testdata/contests/statements_v2_partial/statements/contest.rbx.tex
+```
+
+Expected: a line with `\subimport{\VAR{problem.import_dir}}{\VAR{problem.import_file}}`.
+
+**Step 6: Confirm the fixture reproduces the bug**
+
+Create `tests/rbx/box/contest/test_contest_partial_build.py`:
+
+```python
+import inspect
+
+import pytest
+import typer
+
+from rbx.box.contest import statements as contest_statements_cli
+from rbx.box.statements.schema import StatementType
+
+_build_async = inspect.unwrap(contest_statements_cli.build)
+
+
+async def _run(**kwargs):
+    defaults = dict(
+        verification=0,
+        names=None,
+        languages=None,
+        validate=False,
+        output=StatementType.TeX,
+        samples=False,
+        vars=None,
+        install_tex=False,
+        profile=None,
+    )
+    defaults.update(kwargs)
+    await _build_async(**defaults)
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_fixture_currently_aborts_every_statement(cleandir_with_testdata):
+    # Characterization of the bug: main-pt fails (B has no pt statement) and
+    # takes main-en down with it. Deleted in Task 3.
+    with pytest.raises(Exception):
+        await _run()
+    assert not (cleandir_with_testdata / 'build' / 'main-en.tex').exists()
+```
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_partial_build.py -v`
+Expected: PASS. This is a characterization test proving the bug exists. If it
+fails, the fixture is wrong — fix the fixture before continuing.
+
+**Step 7: Commit**
+
+```bash
+git add rbx/testdata/contests/statements_v2_partial tests/rbx/box/contest/test_contest_partial_build.py
+git commit -m "$(cat <<'EOF'
+test(statements): add fixture reproducing cross-language build abort (#705)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Failure types
+
+Two small types the later tasks need. No test of their own — Task 3 exercises
+them.
+
+**Files:**
+- Modify: `rbx/box/contest/build_contest_statements.py` (after
+  `StatementBuildIssue`, around `:61`)
+
+**Step 1: Add `StatementFailedIssue` next to the existing `StatementBuildIssue`**
+
+`StatementBuildIssue` already exists at `:50-61` and reports *a problem* that
+failed. This new one reports *a whole statement* that failed.
+
+```python
+class StatementFailedIssue(Issue):
+    """An issue-stack entry flagging that an entire statement failed to build,
+    surfaced in the contest build overview.
+
+    Distinct from :class:`StatementBuildIssue`, which flags a single problem
+    that was dropped from an otherwise-successful statement (only possible
+    under ``--partial``).
+    """
+
+    def __init__(self, statement_name: str, reason: str):
+        self.statement_name = statement_name
+        self.reason = reason
+
+    def get_overview_section(self) -> Optional[Tuple[str, ...]]:
+        return ('statement',)
+
+    def get_overview_message(self) -> str:
+        return (
+            f'Failed to build statement [item]{self.statement_name}[/item]: '
+            f'{self.reason}'
+        )
+```
+
+**Step 2: Add `StatementBuildError`**
+
+This is what the inner loop raises when a problem fails and `--partial` was not
+given. It carries enough to render a one-line reason in the summary.
+
+`RbxException.__init__` takes no arguments and builds its message through a
+captured console (see `rbx/box/exception.py:32-40`), so follow that shape rather
+than passing a string to `super().__init__`:
+
+```python
+class StatementBuildError(RbxException):
+    """A problem failed to render into a statement, so that statement cannot be
+    produced.
+
+    Raised instead of silently dropping the problem. Under ``--partial`` the
+    caller drops the problem and keeps building instead of raising this.
+    """
+
+    def __init__(self, statement_name: str, problem_short_name: str, cause: str):
+        super().__init__()
+        self.statement_name = statement_name
+        self.problem_short_name = problem_short_name
+        self.cause = cause
+        with self.possibly_capture() as err:
+            err.print(
+                f'[error]Cannot build statement [item]{statement_name}[/item]: '
+                f'problem [item]{problem_short_name}[/item] failed to render '
+                f'({cause}). Pass [item]--partial[/item] to build it without '
+                f'this problem.[/error]'
+            )
+```
+
+Read `rbx/box/exception.py` and confirm the `possibly_capture` usage matches how
+other `RbxException` subclasses build their message (e.g.
+`rbx/box/statements/resolver.py:211-216` uses `with StatementResolverError() as
+err: err.print(...)`). **Match the established idiom** — if the codebase's
+pattern is `with SomeError() as err`, adapt this constructor accordingly rather
+than inventing a new one.
+
+**Step 3: Verify it imports**
+
+Run: `uv run python -c "from rbx.box.contest.build_contest_statements import StatementFailedIssue, StatementBuildError; print('ok')"`
+Expected: `ok`
+
+**Step 4: Commit**
+
+```bash
+git add rbx/box/contest/build_contest_statements.py
+git commit -m "$(cat <<'EOF'
+feat(statements): add statement-level failure types (#705)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Isolate the contest outer loop
+
+**This is the bug fix.** Everything else is consequence management.
+
+**Files:**
+- Modify: `rbx/box/contest/statements.py:130-148` (the statement loop) and
+  `:165-182` (the report)
+- Test: `tests/rbx/box/contest/test_contest_partial_build.py`
+
+**Step 1: Delete the characterization test and write the real one**
+
+Remove `test_fixture_currently_aborts_every_statement` from Task 1 and add:
+
+```python
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_failing_statement_does_not_stop_later_ones(cleandir_with_testdata):
+    # main-pt is listed first and fails (problem B has no pt statement).
+    # main-en must still build.
+    with pytest.raises(typer.Exit) as exc_info:
+        await _run()
+
+    assert exc_info.value.exit_code == 1
+    assert (cleandir_with_testdata / 'build' / 'main-en.tex').exists()
+    assert not (cleandir_with_testdata / 'build' / 'main-pt.tex').exists()
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_successful_statement_joins_all_problems(cleandir_with_testdata):
+    with pytest.raises(typer.Exit):
+        await _run()
+
+    contest_tex = (cleandir_with_testdata / 'build' / 'main-en.tex').read_text()
+    assert '\\subimport{.problems/A/}{statement}' in contest_tex
+    assert '\\subimport{.problems/B/}{statement}' in contest_tex
+```
+
+**Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_partial_build.py -v`
+Expected: FAIL. `main-en.tex` does not exist, because the `main-pt` failure
+aborted the loop before `main-en` was reached.
+
+**Step 3: Wrap the statement loop**
+
+In `rbx/box/contest/statements.py`, replace the loop at `:132-148`. Note it is
+inside the `with limits_info.use_profile(...)` block — keep it there.
+
+```python
+    failed_statements: List[Tuple[str, str]] = []
+
+    with limits_info.use_profile(profile, when=lambda: profile is not None):
+        for statement in valid_statements:
+            try:
+                built_statements.append(
+                    await build_statement(
+                        statement,
+                        contest,
+                        problems_of_interest=problems_of_interest,
+                        output_type=output,
+                        use_samples=samples,
+                        install_tex=install_tex,
+                        custom_vars=expand_any_vars(
+                            annotations.parse_dictionary_items(vars)
+                        ),
+                        kind=kind,
+                    )
+                )
+            except Exception as exc:
+                reason = _describe_failure(exc)
+                console.console.print(
+                    f'[error]Failed to build {kind.singular} '
+                    f'[item]{statement.name}[/item]: {reason}[/error]'
+                )
+                issue_stack.add_issue(StatementFailedIssue(statement.name, reason))
+                failed_statements.append((statement.name, reason))
+```
+
+Two things to be careful about:
+
+- `built_statements` is later `zip`ped against `valid_statements` at `:166` to
+  print the report. That zip is now **wrong**, because a failed statement
+  appends nothing and the lists fall out of alignment. Change
+  `built_statements` to collect `(statement, path)` pairs and iterate those
+  directly instead of zipping.
+- Do the same for the `valid_documents` / `built_documents` loop at `:152-161`.
+  Documents fail independently of statements for the same reason.
+
+**Step 4: Add the failure-description helper**
+
+Near the top of `rbx/box/contest/statements.py`:
+
+```python
+def _describe_failure(exc: BaseException) -> str:
+    """A one-line reason for the build summary.
+
+    ``typer.Exit`` carries no message (the code that raised it already printed
+    one), and ``RbxException`` accumulates its message into ``msg`` rather than
+    ``str(exc)``, so neither renders usefully via ``str``.
+    """
+    if isinstance(exc, typer.Exit):
+        return 'see the error above'
+    if isinstance(exc, RbxException):
+        return ' '.join(part.strip() for part in exc.msg).strip() or 'see the error above'
+    return str(exc) or type(exc).__name__
+```
+
+Check `rbx/box/exception.py` for how `RbxException.msg` is populated and whether
+a helper for flattening it already exists. **Reuse it if so** — do not duplicate.
+
+**Step 5: Extend the report and the exit**
+
+Replace `:165-182`:
+
+```python
+    console.console.rule(title=f'Built {kind.value}')
+    for statement, built_path in built_statements:
+        console.console.print(
+            f'[item]{statement.name} {statement.language}[/item] -> {href(built_path)}'
+        )
+    for document, built_path in built_documents:
+        console.console.print(
+            f'[item]{document.name} {document.language}[/item] (document) -> {href(built_path)}'
+        )
+
+    if failed_statements:
+        console.console.rule(title=f'Failed {kind.value}')
+        for name, reason in failed_statements:
+            console.console.print(f'[error]{name}[/error]: {reason}')
+
+    if failed_statements or failed_problems:
+        raise typer.Exit(1)
+```
+
+Note `failed_problems` (the samples-phase list) still contributes to the exit;
+Task 6 changes what it *does*, not whether it fails the command.
+
+**Step 6: Add the imports**
+
+`StatementFailedIssue` from `rbx.box.contest.build_contest_statements`,
+`RbxException` from `rbx.box.exception`, and `Tuple` from `typing`.
+
+**Step 7: Run tests**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_partial_build.py -v`
+Expected: PASS.
+
+Then the existing contest suite, to catch the zip change:
+
+Run: `uv run pytest tests/rbx/box/contest/ -v`
+Expected: PASS. If `test_statements_profile.py` or `test_contest_build_v2.py`
+break, it is almost certainly the `built_statements` shape change — fix the
+call sites, do not weaken the tests.
+
+**Step 8: Commit**
+
+```bash
+git add rbx/box/contest/statements.py tests/rbx/box/contest/test_contest_partial_build.py
+git commit -m "$(cat <<'EOF'
+fix(statements): build every contest statement even when one fails (#705)
+
+A statement that failed aborted the whole command, so a broken en statement
+prevented pt from building. Each statement now builds in isolation and the
+failures are collected into an end-of-run summary.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Replace the type-based tiering with an explicit `--partial` policy
+
+**Files:**
+- Modify: `rbx/box/contest/build_contest_statements.py:155` (`build_statement`
+  signature) and `:214-241` (the inner loop)
+- Test: `tests/rbx/box/contest/test_contest_partial_build.py`
+
+**Step 1: Write the failing tests**
+
+```python
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_partial_builds_the_statement_without_the_problem(
+    cleandir_with_testdata,
+):
+    await _run(partial=True)
+
+    pt_tex = (cleandir_with_testdata / 'build' / 'main-pt.tex').read_text()
+    assert '\\subimport{.problems/A/}{statement}' in pt_tex
+    assert '\\subimport{.problems/B/}{statement}' not in pt_tex
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_partial_exits_zero(cleandir_with_testdata):
+    # --partial is an explicit request for best-effort output, so a dropped
+    # problem is not a command failure. The issue report still lists it.
+    await _run(partial=True)
+    assert (cleandir_with_testdata / 'build' / 'main-en.tex').exists()
+    assert (cleandir_with_testdata / 'build' / 'main-pt.tex').exists()
+```
+
+**Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_partial_build.py -v`
+Expected: FAIL with `TypeError: ... unexpected keyword argument 'partial'`.
+
+**Step 3: Thread `partial` through**
+
+Add `partial: bool = False` to `build_statement` (`:155`) and to
+`_execute_build` in `rbx/box/contest/statements.py`, and pass it at the call
+site added in Task 3. Document it in the `build_statement` docstring's `Args:`
+block alongside the existing entries.
+
+**Step 4: Replace the tiering**
+
+At `build_contest_statements.py:214-241`, the current code is:
+
+```python
+        try:
+            problem_ctx = await _render_problem_fragment_async(...)
+        except (typer.Exit, RbxException):
+            # Hard config/abort errors ... must surface, not be downgraded ...
+            raise
+        except Exception as exc:
+            console.console.print(...)
+            issue_stack.add_issue(StatementBuildIssue(problem))
+            continue
+```
+
+Replace with:
+
+```python
+        try:
+            problem_ctx = await _render_problem_fragment_async(...)
+        except Exception as exc:
+            if not partial:
+                # Dropping the problem would silently produce a statement that
+                # is missing it. Fail this statement instead; the caller keeps
+                # building the other statements.
+                raise StatementBuildError(
+                    statement.name, problem.short_name, _describe_cause(exc)
+                ) from exc
+            console.console.print(
+                f'[warning]Dropping problem [item]{problem.short_name}[/item] '
+                f'from {kind.singular} [item]{statement.name}[/item]: '
+                f'{exc}[/warning]'
+            )
+            issue_stack.add_issue(StatementBuildIssue(problem))
+            continue
+```
+
+**Delete the `(typer.Exit, RbxException)` clause entirely**, along with its
+comment. That comment describes the old policy and is now false. This is the
+change that fixes the `typer.Abort` and `AssertionError` misclassification
+described in the design — those types no longer take a different path because
+there is no longer a different path.
+
+`_describe_cause` is the same flattening logic as `_describe_failure` from Task
+3. **Do not write it twice** — put one helper somewhere both modules can import
+(a small function in `rbx/box/exception.py` is the natural home, since it is
+about rendering an `RbxException`) and import it from both.
+
+**Step 5: Run tests**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_partial_build.py -v`
+Expected: PASS, including the Task 3 tests (default is still fail-that-statement).
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/contest/build_contest_statements.py rbx/box/contest/statements.py rbx/box/exception.py tests/rbx/box/contest/test_contest_partial_build.py
+git commit -m "$(cat <<'EOF'
+feat(statements): fail a statement whose problem cannot render (#705)
+
+Failures were tiered by exception type, which routed Jinja abort and
+assertion errors into a silent per-problem skip at exit 0. Any problem-level
+failure now fails that statement unless --partial is given.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Turn the bare asserts into real errors
+
+Under the new rule these are fatal either way, but an `AssertionError` in the
+summary tells the user nothing.
+
+**Files:**
+- Modify: `rbx/box/contest/build_contest_statements.py:196`, `:306`, `:314`
+
+**Step 1: Write the failing test**
+
+Add a second fixture variant, or reuse the existing one with a monkeypatched
+config. The simplest honest test: a fixture whose contest statement omits
+`contestProblemTemplate`.
+
+```python
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_missing_contest_problem_template_reports_clearly(
+    cleandir_with_testdata, capsys
+):
+    config = cleandir_with_testdata / 'contest.rbx.yml'
+    config.write_text(
+        config.read_text().replace(
+            "    contestProblemTemplate: 'statements/problem-in-contest.rbx.tex'\n",
+            '',
+        )
+    )
+
+    with pytest.raises(typer.Exit):
+        await _run()
+
+    out = capsys.readouterr().out
+    assert 'contestProblemTemplate' in out
+    assert 'AssertionError' not in out
+```
+
+Verify by hand first that removing that key is actually accepted by the schema
+(`ContestStatement` in `rbx/box/contest/schema.py` — check whether
+`contestProblemTemplate` is `Optional`). If the schema rejects it outright, the
+assert is unreachable and this test should instead assert the *schema* error is
+clear; adjust the test to match reality rather than forcing the fixture.
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_partial_build.py::test_missing_contest_problem_template_reports_clearly -v`
+
+**Step 3: Replace the asserts**
+
+Each becomes a `StatementResolverError`-style raise naming the missing field and
+the statement it belongs to. Follow the idiom in
+`rbx/box/statements/resolver.py:211-216`.
+
+- `:196` `assert statement.file is not None` → contest statement has no `file`.
+- `:306` `assert problem_statement.file is not None` → problem statement has no
+  `file`.
+- `:314` `assert contest_statement.contestProblemTemplate is not None` → contest
+  statement defines no `contestProblemTemplate`, which is required to join.
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/rbx/box/contest/test_contest_partial_build.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/build_contest_statements.py tests/rbx/box/contest/test_contest_partial_build.py
+git commit -m "$(cat <<'EOF'
+fix(statements): report missing join config instead of asserting (#705)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Close the samples-phase silent-partial hole
+
+Today a problem whose samples fail is dropped from `problems_of_interest` and
+the joined PDF is built without it. That is a partial statement produced without
+`--partial`.
+
+**Files:**
+- Modify: `rbx/box/contest/statements.py:97-127`
+- Test: `tests/rbx/box/contest/test_contest_partial_build.py`
+
+**Step 1: Write the failing test**
+
+You need a fixture whose samples fail. Look at how existing tests provoke a
+sample failure — search for `build_samples` in `tests/` and reuse that approach
+rather than inventing one:
+
+```bash
+grep -rn 'build_samples' tests/ | head
+```
+
+The test asserts: without `--partial`, a problem whose samples fail causes every
+joining statement to fail and **no `.tex` is written**; with `--partial`, the
+statements are written without that problem.
+
+If provoking a real sample failure is disproportionately awkward, patch
+`rbx.box.testcase_sample_utils.build_samples` to return `False` for problem `B`
+with `mock.patch` (stdlib `unittest.mock`, per the repo's testing conventions).
+Patching that public function is acceptable; do not patch private helpers.
+
+**Step 2: Run to verify it fails**
+
+**Step 3: Gate the drop on `partial`**
+
+At `:111-118`, when `build_samples` returns `False` or raises:
+
+- if `partial`: current behaviour — issue, add to `failed_problems`, exclude
+  from `problems_of_interest`.
+- if not `partial`: record the problem as failed and **do not** exclude it from
+  `problems_of_interest`. Leaving it in means the render loop will hit it, fail,
+  and raise `StatementBuildError` — which is exactly the desired outcome and
+  avoids a second, parallel failure path.
+
+Consider instead marking those problems in a set and raising
+`StatementBuildError` up-front for any statement that joins them, if that reads
+more clearly. Either is fine; pick one and say why in a comment.
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/rbx/box/contest/ -v`
+Expected: PASS. Existing tests that relied on short PDFs being produced on
+sample failure will now fail — those encode the old behaviour and should be
+updated to pass `partial=True`, with a comment saying so.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/statements.py tests/rbx/box/contest/
+git commit -m "$(cat <<'EOF'
+fix(statements): do not join a contest without a problem whose samples failed (#705)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Isolate the problem-level loop, keeping packagers fail-fast
+
+**Files:**
+- Modify: `rbx/box/statements/build_statements.py:371-415`
+  (`execute_build_on_statements`) and `:418` (`execute_build`)
+- Test: `tests/rbx/box/statements/test_build_statements.py`
+
+**Step 1: Write the failing test**
+
+A problem with two statements where the first fails (e.g. a Jinja undefined
+variable) and the second is fine. Assert the second still builds. Follow the
+existing conventions in `tests/rbx/box/statements/test_build_statements.py`.
+
+Also write the guard test:
+
+```python
+async def test_packager_callers_still_fail_fast():
+    # execute_build_on_statements defaults to keep_going=False so a packager
+    # never ships a silently incomplete set of statements.
+    import inspect
+
+    from rbx.box.statements import build_statements
+
+    sig = inspect.signature(build_statements.execute_build_on_statements)
+    assert sig.parameters['keep_going'].default is False
+```
+
+That signature assertion is a weak test on its own. Pair it with a real one that
+calls `execute_build_on_statements(..., keep_going=False)` over two statements
+where the first fails, and asserts it raises without building the second.
+
+**Step 2: Run to verify they fail**
+
+**Step 3: Add `keep_going` and wrap the loop**
+
+```python
+async def execute_build_on_statements(
+    statements: List[Statement],
+    ...,
+    keep_going: bool = False,
+) -> List[pathlib.Path]:
+```
+
+Document in the docstring: *"``keep_going`` isolates each statement so one
+failure does not stop the rest; it defaults to False so packagers, which cannot
+ship an incomplete set, keep aborting on the first failure. The CLI passes
+True."*
+
+Wrap the loop at `:403-414` the same way as Task 3. When `keep_going` and
+anything failed, print a summary and raise `typer.Exit(1)` at the end.
+
+**Step 4: Pass `keep_going=True` from the CLI only**
+
+`execute_build` (`:418`) is called by both the CLI and packagers. Check every
+caller:
+
+```bash
+grep -rn 'execute_build_on_statements\|execute_build(' rbx/ --include='*.py'
+```
+
+Only the CLI path (`build` at `:477` and the tutorials twin) sets it. Every
+packager caller keeps the default. **List the callers you found in the commit
+body** so the reviewer can check you did not miss one.
+
+**Step 5: Run tests**
+
+Run: `uv run pytest tests/rbx/box/statements/ -v`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add rbx/box/statements/build_statements.py tests/rbx/box/statements/test_build_statements.py
+git commit -m "$(cat <<'EOF'
+fix(statements): build every problem statement even when one fails (#705)
+
+Packagers keep the fail-fast default; only the CLI opts into keep_going.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Wire the `--partial` CLI flag
+
+**Files:**
+- Modify: `rbx/box/contest/statements.py:188` (`build`) and `:258`
+  (`build_tutorials`)
+- Modify: `rbx/box/statements/build_statements.py:477` (`build`) and its
+  tutorials twin
+- Test: `tests/rbx/box/completion/drift_test.py` (regenerated, not edited)
+
+**Step 1: Add the option to all four commands**
+
+```python
+    partial: Annotated[
+        bool,
+        typer.Option(
+            '--partial',
+            help='Build a statement even if some of its problems fail, '
+            'omitting them. Without this, a problem that fails makes its '
+            'statement fail.',
+        ),
+    ] = False,
+```
+
+Pass it down to `_execute_build` / `execute_build`.
+
+**Step 2: Verify the help renders**
+
+Run: `uv run rbx contest statements build --help`
+Expected: the `--partial` line appears.
+
+**Step 3: Regenerate the completion spec**
+
+This repo commits a serialized Typer spec, and a drift test compares it against
+the live app. A new CLI flag **will** trip it.
+
+Run: `uv run python -m rbx.box.completion.serialize && uv run ruff format rbx/box/completion/_spec.py`
+
+Do **not** use `mise run gen-completion-spec` — it is a no-op inside a worktree.
+Run the two commands directly, as above.
+
+**Step 4: Run the drift test**
+
+Run: `uv run pytest tests/rbx/box/completion/drift_test.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/contest/statements.py rbx/box/statements/build_statements.py rbx/box/completion/_spec.py
+git commit -m "$(cat <<'EOF'
+feat(statements): add --partial to the statement build commands (#705)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `rbx/box/statements/CLAUDE.md` ("Build entry points" section)
+- Modify: the user-facing statements docs under `docs/` — find them with
+  `grep -rln 'contest st b\|statements build' docs/`
+
+**Step 1: Update the module guide**
+
+Add to the "Build entry points" section: statement builds are fault-isolated
+(one failure never stops another), a problem that fails makes its statement fail
+by default, and `--partial` opts into dropping it. Note that
+`execute_build_on_statements` defaults to `keep_going=False` for packagers.
+
+Keep it to a few sentences — that file is a map, not a manual.
+
+**Step 2: Update the user docs**
+
+Document `--partial` and the exit-code contract (any statement failed → 1;
+`--partial` with dropped problems but every statement produced → 0).
+
+**Step 3: Verify the docs build**
+
+Run: `uv run mkdocs build 2>&1 | tail -20`
+
+Use the **non-strict** build. `--strict` fails on about nine pre-existing
+warnings unrelated to this change; do not try to fix those.
+
+**Step 4: Commit**
+
+```bash
+git add rbx/box/statements/CLAUDE.md docs/
+git commit -m "$(cat <<'EOF'
+docs(statements): document --partial and statement build isolation (#705)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Final verification
+
+**Step 1: Lint and format**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+```
+
+Expected: clean. Fix anything reported.
+
+**Step 2: Run the affected suites**
+
+```bash
+uv run pytest tests/rbx/box/contest/ tests/rbx/box/statements/ tests/rbx/box/completion/ -v
+```
+
+Expected: PASS.
+
+**Step 3: Run the broader suite, minus the slow CLI tests**
+
+```bash
+uv run pytest --ignore=tests/rbx/box/cli -n auto 2>&1 | tail -30
+```
+
+There are known pre-existing local failures in this repo unrelated to this work
+(C++/sandbox/docker-dependent tests, and a stale
+`test_compute_walltime_uses_active_environment`). **Compare against a baseline
+rather than assuming**: if anything fails, run the same command on `main`
+(`git stash` or a second worktree) and confirm it failed there too. Report any
+failure you cannot attribute to the baseline — do not wave it away.
+
+**Step 4: Manual smoke test**
+
+```bash
+cd $(mktemp -d)
+cp -r <repo>/rbx/testdata/contests/statements_v2_partial .
+cd statements_v2_partial
+uv run --project <repo> rbx contest statements build --output tex ; echo "exit=$?"
+uv run --project <repo> rbx contest statements build --output tex --partial ; echo "exit=$?"
+```
+
+Expected: first run builds `build/main-en.tex` only, prints a "Failed
+statements" section naming `main-pt` and problem `B`, exits 1. Second run builds
+both, exits 0.
+
+**Step 5: Push and open a draft PR**
+
+```bash
+git push -u origin worktree-statement-partial-failure
+gh pr create --draft --title 'fix(statements): isolate statement build failures (#705)' --body '...'
+```
+
+`gh pr edit` / `gh pr view` fail in this repo with a classic-Projects GraphQL
+error; if you need to edit the PR afterwards use
+`gh api -X PATCH repos/rsalesc/rbx/pulls/<N>` instead.
+
+The PR body should state: closes #705; the two defects fixed; the accepted
+behaviour change (a sample failure without `--partial` now fails the statements
+rather than emitting short PDFs); and that packagers are unaffected.

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -1131,6 +1131,7 @@ rbx contest statements build <NAMES> [OPTIONS]
 | `--vars` | TEXT | Variables to be used in the statements. | - |
 | `--install-tex` | BOOLEAN | Whether to install missing LaTeX packages. | `False` |
 | `-p`, `--profile` | TEXT | Timing profile to render statements against. Problems missing this profile are skipped with a warning. | - |
+| `--partial` | BOOLEAN | Build a statement even if some of its problems fail, omitting them. Without this, a problem that fails makes its statement fail. | `False` |
 
 
 ---
@@ -1172,6 +1173,7 @@ rbx contest tutorials build <NAMES> [OPTIONS]
 | `--vars` | TEXT | Variables to be used in the tutorials. | - |
 | `--install-tex` | BOOLEAN | Whether to install missing LaTeX packages. | `False` |
 | `-p`, `--profile` | TEXT | Timing profile to render tutorials against. Problems missing this profile are skipped with a warning. | - |
+| `--partial` | BOOLEAN | Build a statement even if some of its problems fail, omitting them. Without this, a problem that fails makes its statement fail. | `False` |
 
 
 ---

--- a/docs/setters/statements/index.md
+++ b/docs/setters/statements/index.md
@@ -88,6 +88,35 @@ rbx statements build -p icpc
 
 The built statements will be placed in the `build/` directory of your package.
 
+### When a statement fails to build
+
+Statements are built **independently of each other**. If your contest has an
+English and a Portuguese statement and the English one fails, the Portuguese
+one is still built; the command lists everything that failed at the end and
+exits non-zero. One broken language never blocks the others.
+
+Within a single statement the rule is the opposite, and deliberately strict: if
+any problem cannot be rendered into a contest statement — it has no statement
+in that language, its samples failed to build, its template is broken — then
+**that statement fails**. {{rbx}} will not quietly hand you a problemset PDF
+with a problem missing from it.
+
+When you *do* want the incomplete document — proofreading a book mid-edit, say,
+while one problem is still being written — pass `--partial`:
+
+```bash
+# Build the contest book without the problems that fail, instead of failing.
+rbx contest statements build --partial
+```
+
+`--partial` omits the failing problems and reports each one it dropped. Because
+you asked for best-effort output, the command exits `0` when every statement
+was produced this way.
+
+!!! warning
+    Problem lettering follows the problems that made it into the document, so a
+    partial book is not a preview of the final one. Don't ship it.
+
 ### Rendering against a timing profile
 
 The `-p` / `--profile` flag tells {{rbx}} to render the statement using the time

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -2333,6 +2333,17 @@ SPEC = {
                                     },
                                 },
                                 {
+                                    'help': 'Build a statement even if some of '
+                                    'its problems fail, omitting them. '
+                                    'Without this, a problem that fails '
+                                    'makes its statement fail.',
+                                    'kind': 'option',
+                                    'multiple': False,
+                                    'names': ['--partial'],
+                                    'takes_value': False,
+                                    'value': {'kind': 'none'},
+                                },
+                                {
                                     'help': 'Show this message and exit.',
                                     'kind': 'option',
                                     'multiple': False,
@@ -2464,6 +2475,17 @@ SPEC = {
                                     'multiple': False,
                                     'names': ['-p', '--profile'],
                                     'takes_value': True,
+                                    'value': {'kind': 'none'},
+                                },
+                                {
+                                    'help': 'Build a statement even if some of '
+                                    'its problems fail, omitting them. '
+                                    'Without this, a problem that fails '
+                                    'makes its statement fail.',
+                                    'kind': 'option',
+                                    'multiple': False,
+                                    'names': ['--partial'],
+                                    'takes_value': False,
                                     'value': {'kind': 'none'},
                                 },
                                 {

--- a/rbx/box/contest/build_contest_statements.py
+++ b/rbx/box/contest/build_contest_statements.py
@@ -28,7 +28,7 @@ from rbx.box.contest.contest_package import (
     get_contest_statements_build_path,
 )
 from rbx.box.contest.schema import Contest, ContestProblem, ContestStatement, Document
-from rbx.box.exception import RbxException
+from rbx.box.exception import RbxException, describe_exception
 from rbx.box.formatting import href
 from rbx.box.sanitizers import issue_stack
 from rbx.box.sanitizers.issue_stack import Issue
@@ -203,6 +203,7 @@ async def build_statement(
     custom_vars: Optional[Dict[str, Any]] = None,
     install_tex: bool = False,
     kind: StatementKind = StatementKind.STATEMENTS,
+    partial: bool = False,
 ) -> pathlib.Path:
     """Build one contest statement (or tutorial) and return its output path.
 
@@ -222,6 +223,10 @@ async def build_statement(
         use_samples: stage sample I/O (assumes samples were already built).
         custom_vars: ``--vars`` overrides merged on top of each problem's vars.
         install_tex: best-effort ``texliveonfly`` install before compiling.
+        partial: build the statement even if some of its problems fail to
+            render, omitting them. Off by default: a problem that fails
+            otherwise makes this whole statement fail, since producing it
+            without that problem would silently ship an incomplete document.
     """
     output_type = output_type or StatementType.PDF
     custom_vars = custom_vars or {}
@@ -267,15 +272,18 @@ async def build_statement(
                 custom_vars,
                 kind,
             )
-        except (typer.Exit, RbxException):
-            # Hard config/abort errors (e.g. a missing matching statement, or
-            # conflicting explanation files) must surface, not be downgraded to a
-            # per-problem skip.
-            raise
         except Exception as exc:
+            if not partial:
+                # Dropping the problem would silently produce a statement that
+                # is missing it. Fail this statement instead; the caller keeps
+                # building the other statements.
+                raise StatementBuildError(
+                    statement.name, problem.short_name, describe_exception(exc)
+                ) from exc
             console.console.print(
-                f'[error]Error building statement for problem '
-                f'[item]{problem.short_name}[/item]: {exc}[/error]'
+                f'[warning]Dropping problem [item]{problem.short_name}[/item] from '
+                f'{kind.singular} [item]{statement.name}[/item]: '
+                f'{describe_exception(exc)}[/warning]'
             )
             issue_stack.add_issue(StatementBuildIssue(problem))
             continue

--- a/rbx/box/contest/build_contest_statements.py
+++ b/rbx/box/contest/build_contest_statements.py
@@ -43,6 +43,7 @@ from rbx.box.statements.context import (
     contest_jinja_kwargs,
 )
 from rbx.box.statements.overlay import problem_overlay_dir
+from rbx.box.statements.resolver import StatementResolverError
 from rbx.box.statements.schema import BaseStatement, StatementKind, StatementType
 from rbx.box.testcase_sample_utils import get_statement_samples
 
@@ -240,7 +241,12 @@ async def build_statement(
             statement, contest, output_type, custom_vars, problems_of_interest
         )
 
-    assert statement.file is not None
+    if statement.file is None:
+        with StatementResolverError() as err:
+            err.print(
+                f'[error]Contest {kind.singular} [item]{statement.name}[/item] '
+                f'defines no [item]file[/item], which is required to build it.[/error]'
+            )
     overlay_root = _fresh_dir(get_statement_build_dir(statement))
     chrome_dir = (contest_root / statement.file).resolve().parent
     overlay.stage_chrome(overlay_root, chrome_dir)
@@ -353,7 +359,13 @@ async def _render_problem_fragment_async(
             contest_statement, problem_candidates, problem.short_name
         )
 
-        assert problem_statement.file is not None
+        if problem_statement.file is None:
+            with StatementResolverError() as err:
+                err.print(
+                    f'[error]Problem [item]{problem.short_name}[/item] statement '
+                    f'[item]{problem_statement.language}[/item] defines no '
+                    f'[item]file[/item], which is required to join it.[/error]'
+                )
         problem_dir = (problem_statement.file).resolve().parent
 
         short = problem.short_name
@@ -361,7 +373,14 @@ async def _render_problem_fragment_async(
         root_prefix = f'.problems/{short}/'
         overlay.stage_join_problem(overlay_root, problem_dir, short)
 
-        assert contest_statement.contestProblemTemplate is not None
+        if contest_statement.contestProblemTemplate is None:
+            with StatementResolverError() as err:
+                err.print(
+                    f'[error]Contest statement '
+                    f'[item]{contest_statement.name}[/item] defines no '
+                    f'[item]contestProblemTemplate[/item], which is required to '
+                    f'join problem statements into it.[/error]'
+                )
         template_rel = engine.relativize_template(
             contest_root,
             chrome_dir,
@@ -444,7 +463,12 @@ def _emit_simple(
     (e.g. a limits table); ``problems_of_interest`` bounds which problems that
     list covers (default: all contest problems)."""
     name: str = statement.name  # type: ignore[attr-defined]
-    assert statement.file is not None
+    if statement.file is None:
+        with StatementResolverError() as err:
+            err.print(
+                f'[error]Contest document [item]{name}[/item] defines no '
+                f'[item]file[/item], which is required to build it.[/error]'
+            )
     languages = get_environment_languages_for_statement()
     contest_root = find_contest()
     overlay_root = _fresh_dir(get_contest_statements_build_path() / name)

--- a/rbx/box/contest/build_contest_statements.py
+++ b/rbx/box/contest/build_contest_statements.py
@@ -61,6 +61,48 @@ class StatementBuildIssue(Issue):
         return f'Error building statement for problem [item]{self.problem.short_name}[/item].'
 
 
+class StatementFailedIssue(Issue):
+    """An issue-stack entry flagging that an entire statement failed to build.
+
+    Distinct from :class:`StatementBuildIssue`, which flags a single problem
+    dropped from an otherwise-successful statement -- only possible under
+    ``--partial``.
+    """
+
+    def __init__(self, statement_name: str, reason: str):
+        self.statement_name = statement_name
+        self.reason = reason
+
+    def get_overview_section(self) -> Optional[Tuple[str, ...]]:
+        return ('statement',)
+
+    def get_overview_message(self) -> str:
+        return (
+            f'Failed to build statement [item]{self.statement_name}[/item]: '
+            f'{self.reason}'
+        )
+
+
+class StatementBuildError(RbxException):
+    """A problem failed to render, so the statement joining it cannot be built.
+
+    Raised instead of silently dropping the problem, which would produce a
+    statement missing it. Under ``--partial`` the caller drops the problem and
+    keeps building rather than raising this.
+    """
+
+    def __init__(self, statement_name: str, problem_short_name: str, cause: str):
+        super().__init__()
+        self.statement_name = statement_name
+        self.problem_short_name = problem_short_name
+        self.cause = cause
+        self.print(
+            f'[error]Cannot build statement [item]{statement_name}[/item]: problem '
+            f'[item]{problem_short_name}[/item] failed to render ({cause}). Pass '
+            f'[item]--partial[/item] to build it without this problem.[/error]'
+        )
+
+
 def get_statement_build_dir(statement: BaseStatement) -> pathlib.Path:
     """The per-statement scratch overlay root under the contest's
     ``build/statements`` dir (keyed by the contest statement/document name)."""

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -136,6 +136,22 @@ async def _execute_build(
         for statement in valid_statements:
             # Each statement builds in isolation: one that fails must never stop
             # the others, so a broken `en` cannot keep `pt` from being built.
+            if failed_problems and not partial:
+                # Those problems were dropped from `problems_of_interest`, so
+                # building now would silently emit a document missing them.
+                # Refuse up-front rather than shipping a short statement.
+                dropped = ', '.join(p.short_name for p in failed_problems)
+                reason = (
+                    f'samples failed for problem(s) {dropped}; pass --partial to '
+                    f'build without them'
+                )
+                console.console.print(
+                    f'[error]Skipping {kind.singular} '
+                    f'[item]{statement.name}[/item]: {reason}[/error]'
+                )
+                issue_stack.add_issue(StatementFailedIssue(statement.name, reason))
+                failed_statements.append((statement.name, reason))
+                continue
             try:
                 built_statements.append(
                     (

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, Optional
+from typing import Annotated, List, Optional, Tuple
 
 import syncer
 import typer
@@ -7,6 +7,7 @@ from rbx import annotations, console
 from rbx.box import cd, environment, limits_info, package_utils
 from rbx.box.contest.build_contest_statements import (
     StatementBuildIssue,
+    StatementFailedIssue,
     build_document,
     build_statement,
 )
@@ -15,6 +16,7 @@ from rbx.box.contest.contest_package import (
     within_contest,
 )
 from rbx.box.contest.schema import ContestProblem
+from rbx.box.exception import describe_exception
 from rbx.box.formatting import href
 from rbx.box.sanitizers import issue_stack
 from rbx.box.schema import expand_any_vars
@@ -122,6 +124,7 @@ async def _execute_build(
 
     built_statements = []
     built_documents = []
+    failed_statements: List[Tuple[str, str]] = []
     valid_documents = (
         [doc for doc in contest.expanded_documents if should_process(doc)]
         if build_documents
@@ -130,47 +133,78 @@ async def _execute_build(
 
     with limits_info.use_profile(profile, when=lambda: profile is not None):
         for statement in valid_statements:
-            built_statements.append(
-                await build_statement(
-                    statement,
-                    contest,
-                    problems_of_interest=problems_of_interest,
-                    output_type=output,
-                    use_samples=samples,
-                    install_tex=install_tex,
-                    custom_vars=expand_any_vars(
-                        annotations.parse_dictionary_items(vars)
-                    ),
-                    kind=kind,
+            # Each statement builds in isolation: one that fails must never stop
+            # the others, so a broken `en` cannot keep `pt` from being built.
+            try:
+                built_statements.append(
+                    (
+                        statement,
+                        await build_statement(
+                            statement,
+                            contest,
+                            problems_of_interest=problems_of_interest,
+                            output_type=output,
+                            use_samples=samples,
+                            install_tex=install_tex,
+                            custom_vars=expand_any_vars(
+                                annotations.parse_dictionary_items(vars)
+                            ),
+                            kind=kind,
+                        ),
+                    )
                 )
-            )
+            except Exception as exc:
+                reason = describe_exception(exc)
+                console.console.print(
+                    f'[error]Failed to build {kind.singular} '
+                    f'[item]{statement.name}[/item]: {reason}[/error]'
+                )
+                issue_stack.add_issue(StatementFailedIssue(statement.name, reason))
+                failed_statements.append((statement.name, reason))
 
         # Documents (infosheets etc.) don't join problem statements or samples,
         # but may read problem metadata (e.g. an info sheet's limits table), so
         # pass the eligible problems and resolve their limits under the active
         # profile (hence inside the use_profile block).
         for document in valid_documents:
-            built_documents.append(
-                await build_document(
-                    document,
-                    contest,
-                    problems_of_interest=eligible_problems,
-                    output_type=output,
-                    custom_vars=expand_any_vars(
-                        annotations.parse_dictionary_items(vars)
-                    ),
+            try:
+                built_documents.append(
+                    (
+                        document,
+                        await build_document(
+                            document,
+                            contest,
+                            problems_of_interest=eligible_problems,
+                            output_type=output,
+                            custom_vars=expand_any_vars(
+                                annotations.parse_dictionary_items(vars)
+                            ),
+                        ),
+                    )
                 )
-            )
+            except Exception as exc:
+                reason = describe_exception(exc)
+                console.console.print(
+                    f'[error]Failed to build document '
+                    f'[item]{document.name}[/item]: {reason}[/error]'
+                )
+                issue_stack.add_issue(StatementFailedIssue(document.name, reason))
+                failed_statements.append((document.name, reason))
 
     console.console.rule(title=f'Built {kind.value}')
-    for statement, built_path in zip(valid_statements, built_statements):
+    for statement, built_path in built_statements:
         console.console.print(
             f'[item]{statement.name} {statement.language}[/item] -> {href(built_path)}'
         )
-    for document, built_path in zip(valid_documents, built_documents):
+    for document, built_path in built_documents:
         console.console.print(
             f'[item]{document.name} {document.language}[/item] (document) -> {href(built_path)}'
         )
+
+    if failed_statements:
+        console.console.rule(title=f'Failed {kind.value}')
+        for name, reason in failed_statements:
+            console.console.print(f'[error]{name}[/error]: {reason}')
 
     if failed_problems:
         # The statements that could be built were built, but samples are missing
@@ -179,6 +213,8 @@ async def _execute_build(
             f'[error]Failed to build samples for [item]{len(failed_problems)}[/item] '
             'problem(s), check the report above.[/error]'
         )
+
+    if failed_statements or failed_problems:
         raise typer.Exit(1)
 
 

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -41,6 +41,7 @@ async def _execute_build(
     profile: Optional[str],
     kind: StatementKind,
     build_documents: bool,
+    partial: bool = False,
 ) -> None:
     """Shared body of ``rbx contest st b`` / ``rbx contest tut b``.
 
@@ -150,6 +151,7 @@ async def _execute_build(
                                 annotations.parse_dictionary_items(vars)
                             ),
                             kind=kind,
+                            partial=partial,
                         ),
                     )
                 )
@@ -270,6 +272,13 @@ async def build(
             autocompletion=annotations._adapt('profile'),  # noqa: SLF001
         ),
     ] = None,
+    partial: Annotated[
+        bool,
+        typer.Option(
+            '--partial',
+            help='Build a statement even if some of its problems fail, omitting them. Without this, a problem that fails makes its statement fail.',
+        ),
+    ] = False,
 ):
     await _execute_build(
         verification=verification,
@@ -283,6 +292,7 @@ async def build(
         profile=profile,
         kind=StatementKind.STATEMENTS,
         build_documents=True,
+        partial=partial,
     )
 
 
@@ -342,6 +352,13 @@ async def build_tutorials(
             help='Timing profile to render tutorials against. Problems missing this profile are skipped with a warning.',
         ),
     ] = None,
+    partial: Annotated[
+        bool,
+        typer.Option(
+            '--partial',
+            help='Build a statement even if some of its problems fail, omitting them. Without this, a problem that fails makes its statement fail.',
+        ),
+    ] = False,
 ):
     await _execute_build(
         verification=verification,
@@ -355,6 +372,7 @@ async def build_tutorials(
         profile=profile,
         kind=StatementKind.TUTORIALS,
         build_documents=False,
+        partial=partial,
     )
 
 

--- a/rbx/box/exception.py
+++ b/rbx/box/exception.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 import rich.text
+import typer
 from rich.console import Capture, Console
 
 from rbx import console
@@ -87,3 +88,16 @@ class RbxException(RuntimeError):
 
     def plain(self) -> str:
         return self.from_ansi().plain
+
+
+def describe_exception(exc: BaseException) -> str:
+    """A short, single-line reason for a build summary.
+
+    ``typer.Exit`` carries no message at all -- whatever raised it already
+    printed one -- and ``RbxException`` accumulates rich-rendered output that
+    has to be stripped of ANSI before it can sit on a summary line.
+    """
+    if isinstance(exc, typer.Exit):
+        return 'see the error above'
+    text = exc.plain() if isinstance(exc, RbxException) else str(exc)
+    return ' '.join(text.split()) or type(exc).__name__

--- a/rbx/box/statements/CLAUDE.md
+++ b/rbx/box/statements/CLAUDE.md
@@ -97,6 +97,21 @@ The build is a pipeline of small, unit-tested pieces:
   passes a **metadata-only** `problems` list (via `_collect_problem_metadata`:
   title/short_name/limits/profiles/groups, no blocks/samples/import handles) so a
   Jinja document can render e.g. an info sheet's per-problem limits table.
+- **Failure isolation (#705).** Both outer loops — over contest statements in
+  `contest/statements.py` and over problem statements in
+  `execute_build_on_statements` — build each statement in its own `try`, so one
+  failure never stops the rest; failures are collected, reported through
+  `issue_stack` (`StatementFailedIssue`) plus an explicit end-of-run summary,
+  and the command exits 1. `execute_build_on_statements` gates this on
+  `keep_going`, **defaulting to False** so the packagers keep failing fast — a
+  silently incomplete Polygon/MOJ upload is worse than an aborted one; only the
+  CLI passes True. Inside one contest statement the inner problem loop has no
+  exception-type tiering (the old `except (typer.Exit, RbxException): raise`
+  misrouted `typer.Abort` and `AssertionError` into silent per-problem skips at
+  exit 0): any problem-level failure raises `StatementBuildError` and fails that
+  statement, unless `--partial` is passed, which drops the problem instead. The
+  samples-phase drop is gated on the same flag, so no short document is ever
+  written without it.
 - **Tutorials (editorials)** are the parallel `tutorials` section (design §3),
   built by the same code via a `StatementKind` arg threaded through
   `build_statement` / `execute_build` (problem) and `build_statement` (contest):

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -7,6 +7,7 @@ import typer
 
 from rbx import annotations, console, utils
 from rbx.box import environment, limits_info, naming, package
+from rbx.box.exception import describe_exception
 from rbx.box.formatting import href
 from rbx.box.schema import Package, expand_any_vars
 from rbx.box.statements import engine, overlay, render, resolver
@@ -378,6 +379,7 @@ async def execute_build_on_statements(
     extra_mergeable_params: Optional[List[ConversionStep]] = None,
     skip_building: bool = False,
     kind: StatementKind = StatementKind.STATEMENTS,
+    keep_going: bool = False,
 ) -> List[pathlib.Path]:
     """Build samples once (if any statement needs them) then build each statement.
 
@@ -386,6 +388,11 @@ async def execute_build_on_statements(
     pre-built samples instead of regenerating them (the packager builds them
     first). ``extra_mergeable_params`` carries packager export toggles. Returns
     the built output paths, one per statement.
+
+    ``keep_going`` isolates each statement so one failure does not stop the
+    rest, exiting non-zero at the end instead. It defaults to False because
+    packagers cannot ship an incomplete set of statements -- aborting on the
+    first failure is safer there than emitting the others. The CLI passes True.
     """
     pkg = package.find_problem_package_or_die()
     samples = samples and any(needs_samples(st) for st in statements)
@@ -400,18 +407,40 @@ async def execute_build_on_statements(
             raise typer.Exit(1)
 
     res = []
+    failed: List[Tuple[str, str]] = []
     for statement in statements:
-        res.append(
-            await build_statement(
-                statement,
-                pkg,
-                output_type=output,
-                use_samples=samples,
-                custom_vars=expand_any_vars(annotations.parse_dictionary_items(vars)),
-                extra_mergeable_params=extra_mergeable_params,
-                kind=kind,
+        try:
+            res.append(
+                await build_statement(
+                    statement,
+                    pkg,
+                    output_type=output,
+                    use_samples=samples,
+                    custom_vars=expand_any_vars(
+                        annotations.parse_dictionary_items(vars)
+                    ),
+                    extra_mergeable_params=extra_mergeable_params,
+                    kind=kind,
+                )
             )
-        )
+        except Exception as exc:
+            if not keep_going:
+                raise
+            # Isolated: a statement that fails must not stop the others, so a
+            # broken `en` cannot keep `pt` from being built.
+            reason = describe_exception(exc)
+            label = '/'.join(statement.key)
+            console.console.print(
+                f'[error]Failed to build {kind.singular} '
+                f'[item]{label}[/item]: {reason}[/error]'
+            )
+            failed.append((label, reason))
+
+    if failed:
+        console.console.rule(title=f'Failed {kind.value}')
+        for name, reason in failed:
+            console.console.print(f'[error]{name}[/error]: {reason}')
+        raise typer.Exit(1)
     return res
 
 
@@ -425,6 +454,7 @@ async def execute_build(
     validate: bool = True,
     profile: Optional[str] = None,
     kind: StatementKind = StatementKind.STATEMENTS,
+    keep_going: bool = False,
 ) -> None:
     """Select and build this problem's statements or tutorials (the ``rbx st b``
     / ``rbx tut b`` body).
@@ -471,6 +501,7 @@ async def execute_build(
             vars=vars,
             validate=validate,
             kind=kind,
+            keep_going=keep_going,
         )
 
 
@@ -537,6 +568,7 @@ async def build(
         vars,
         validate,
         profile=profile,
+        keep_going=True,
     )
 
 
@@ -610,6 +642,7 @@ async def build_tutorials(
         validate,
         profile=profile,
         kind=StatementKind.TUTORIALS,
+        keep_going=True,
     )
 
 

--- a/rbx/testdata/contests/statements_v2_partial/A/problem.rbx.yml
+++ b/rbx/testdata/contests/statements_v2_partial/A/problem.rbx.yml
@@ -1,0 +1,14 @@
+name: 'problem-a'
+timeLimit: 1000
+memoryLimit: 256
+vars:
+  author: 'Alice'
+statements:
+  - language: 'en'
+    title: 'Problem A'
+    file: 'statement/statement.rbx.tex'
+    type: 'rbxTeX'
+  - language: 'pt'
+    title: 'Problema A'
+    file: 'statement/statement-pt.rbx.tex'
+    type: 'rbxTeX'

--- a/rbx/testdata/contests/statements_v2_partial/A/statement/statement-pt.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_partial/A/statement/statement-pt.rbx.tex
@@ -1,0 +1,3 @@
+%- block legend
+Problema A em portugues, escrito por \VAR{vars.author}.
+%- endblock

--- a/rbx/testdata/contests/statements_v2_partial/A/statement/statement.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_partial/A/statement/statement.rbx.tex
@@ -1,0 +1,3 @@
+%- block legend
+Problem A in English, authored by \VAR{vars.author}.
+%- endblock

--- a/rbx/testdata/contests/statements_v2_partial/B/problem.rbx.yml
+++ b/rbx/testdata/contests/statements_v2_partial/B/problem.rbx.yml
@@ -1,0 +1,12 @@
+name: 'problem-b'
+timeLimit: 1000
+memoryLimit: 256
+vars:
+  author: 'Bob'
+statements:
+  # Deliberately no 'pt' statement: this is what makes the contest's main-pt
+  # statement unbuildable.
+  - language: 'en'
+    title: 'Problem B'
+    file: 'statement/statement.rbx.tex'
+    type: 'rbxTeX'

--- a/rbx/testdata/contests/statements_v2_partial/B/statement/statement.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_partial/B/statement/statement.rbx.tex
@@ -1,0 +1,3 @@
+%- block legend
+Problem B in English, authored by \VAR{vars.author}.
+%- endblock

--- a/rbx/testdata/contests/statements_v2_partial/contest.rbx.yml
+++ b/rbx/testdata/contests/statements_v2_partial/contest.rbx.yml
@@ -1,0 +1,26 @@
+---
+name: 'sv2-partial'
+titles:
+  en: 'Partial Contest'
+  pt: 'Contest Parcial'
+vars:
+  year: 2026
+problems:
+  - short_name: 'A'
+  - short_name: 'B'
+statements:
+  # main-pt is listed FIRST on purpose: it is the one that fails (problem B has
+  # no pt statement), so the tests can prove that a *later* statement still
+  # builds after an earlier one failed. Do not reorder.
+  - name: 'main-pt'
+    language: 'pt'
+    file: 'statements/contest.rbx.tex'
+    type: 'rbxTeX'
+    standaloneProblemTemplate: 'statements/problem-standalone.rbx.tex'
+    contestProblemTemplate: 'statements/problem-in-contest.rbx.tex'
+  - name: 'main-en'
+    language: 'en'
+    file: 'statements/contest.rbx.tex'
+    type: 'rbxTeX'
+    standaloneProblemTemplate: 'statements/problem-standalone.rbx.tex'
+    contestProblemTemplate: 'statements/problem-in-contest.rbx.tex'

--- a/rbx/testdata/contests/statements_v2_partial/statements/contest.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_partial/statements/contest.rbx.tex
@@ -1,0 +1,24 @@
+\documentclass[a4paper,11pt]{article}
+\usepackage{import}
+\usepackage{graphicx}
+\usepackage{fancyvrb}
+\newcommand{\example}[2]{%
+  \par\noindent\textbf{Input}\par
+  \VerbatimInput{#1}%
+  \par\noindent\textbf{Output}\par
+  \VerbatimInput{#2}%
+  \par
+}
+\begin{document}
+
+\begin{center}
+  {\Large \VAR{contest.title | escape}}\\[1ex]
+  Year \VAR{contest.vars.year}
+\end{center}
+
+%- for problem in problems
+  \subimport{\VAR{problem.import_dir}}{\VAR{problem.import_file}}
+  \clearpage
+%- endfor
+
+\end{document}

--- a/rbx/testdata/contests/statements_v2_partial/statements/problem-in-contest.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_partial/statements/problem-in-contest.rbx.tex
@@ -1,0 +1,13 @@
+\section*{Problem \VAR{problem.short_name}. \VAR{problem.title | escape}}
+
+\VAR{problem.blocks.legend}
+
+%- if problem.samples
+  \subsection*{Examples}
+  %- for sample in problem.samples
+    \example{\VAR{sample.input}}{\VAR{sample.output if sample.output is not none else ''}}
+    %- if sample.explanation_file is not none
+      \subimport{\VAR{sample.dir}}{\VAR{sample.explanation_file}}
+    %- endif
+  %- endfor
+%- endif

--- a/rbx/testdata/contests/statements_v2_partial/statements/problem-standalone.rbx.tex
+++ b/rbx/testdata/contests/statements_v2_partial/statements/problem-standalone.rbx.tex
@@ -1,0 +1,28 @@
+\documentclass[a4paper,11pt]{article}
+\usepackage{import}
+\usepackage{graphicx}
+\usepackage{fancyvrb}
+\newcommand{\example}[2]{%
+  \par\noindent\textbf{Input}\par
+  \VerbatimInput{#1}%
+  \par\noindent\textbf{Output}\par
+  \VerbatimInput{#2}%
+  \par
+}
+\begin{document}
+
+\section*{\VAR{problem.title | escape}}
+
+\VAR{problem.blocks.legend}
+
+%- if problem.samples
+  \subsection*{Examples}
+  %- for sample in problem.samples
+    \example{\VAR{sample.input}}{\VAR{sample.output if sample.output is not none else ''}}
+    %- if sample.explanation_file is not none
+      \subimport{\VAR{sample.dir}}{\VAR{sample.explanation_file}}
+    %- endif
+  %- endfor
+%- endif
+
+\end{document}

--- a/tests/e2e/testdata/standalone-collision/e2e.rbx.yml
+++ b/tests/e2e/testdata/standalone-collision/e2e.rbx.yml
@@ -11,4 +11,9 @@ scenarios:
       - cmd: st b --output tex --no-samples
         expect_exit: 1
         expect:
-          stderr_contains: "Asset name collision while merging"
+          # The build no longer lets this escape as an uncaught exception
+          # (#705): statements are built in isolation, so the collision is
+          # caught, reported and summarized by the command itself. The runner
+          # only synthesizes `stderr` from an *uncaught* exception, so the
+          # message is asserted where the command actually prints it.
+          stdout_contains: "Asset name collision while merging"

--- a/tests/rbx/box/contest/test_contest_partial_build.py
+++ b/tests/rbx/box/contest/test_contest_partial_build.py
@@ -1,9 +1,9 @@
 import inspect
 
 import pytest
+import typer
 
 from rbx.box.contest import statements as contest_statements_cli
-from rbx.box.statements.resolver import StatementResolverError
 from rbx.box.statements.schema import StatementType
 
 _build_async = inspect.unwrap(contest_statements_cli.build)
@@ -26,9 +26,22 @@ async def _run(**kwargs):
 
 
 @pytest.mark.test_pkg('contests/statements_v2_partial')
-async def test_fixture_currently_aborts_every_statement(cleandir_with_testdata):
-    # Characterization of the bug: main-pt fails (B has no pt statement) and
-    # takes main-en down with it. Deleted in Task 3.
-    with pytest.raises(StatementResolverError):
+async def test_failing_statement_does_not_stop_later_ones(cleandir_with_testdata):
+    # main-pt is listed first and fails (problem B has no pt statement).
+    # main-en must still build.
+    with pytest.raises(typer.Exit) as exc_info:
         await _run()
-    assert not (cleandir_with_testdata / 'build' / 'main-en.tex').exists()
+
+    assert exc_info.value.exit_code == 1
+    assert (cleandir_with_testdata / 'build' / 'main-en.tex').exists()
+    assert not (cleandir_with_testdata / 'build' / 'main-pt.tex').exists()
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_successful_statement_joins_all_problems(cleandir_with_testdata):
+    with pytest.raises(typer.Exit):
+        await _run()
+
+    contest_tex = (cleandir_with_testdata / 'build' / 'main-en.tex').read_text()
+    assert '\\subimport{.problems/A/}{statement}' in contest_tex
+    assert '\\subimport{.problems/B/}{statement}' in contest_tex

--- a/tests/rbx/box/contest/test_contest_partial_build.py
+++ b/tests/rbx/box/contest/test_contest_partial_build.py
@@ -66,3 +66,23 @@ async def test_partial_exits_zero(cleandir_with_testdata):
 
     assert (cleandir_with_testdata / 'build' / 'main-en.tex').exists()
     assert (cleandir_with_testdata / 'build' / 'main-pt.tex').exists()
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_missing_contest_problem_template_reports_clearly(
+    cleandir_with_testdata, capsys
+):
+    config = cleandir_with_testdata / 'contest.rbx.yml'
+    config.write_text(
+        config.read_text().replace(
+            "    contestProblemTemplate: 'statements/problem-in-contest.rbx.tex'\n",
+            '',
+        )
+    )
+
+    with pytest.raises(typer.Exit):
+        await _run()
+
+    out = capsys.readouterr().out
+    assert 'contestProblemTemplate' in out
+    assert 'AssertionError' not in out

--- a/tests/rbx/box/contest/test_contest_partial_build.py
+++ b/tests/rbx/box/contest/test_contest_partial_build.py
@@ -1,4 +1,6 @@
 import inspect
+import pathlib
+from unittest import mock
 
 import pytest
 import typer
@@ -86,3 +88,50 @@ async def test_missing_contest_problem_template_reports_clearly(
     out = capsys.readouterr().out
     assert 'contestProblemTemplate' in out
     assert 'AssertionError' not in out
+
+
+async def _build_samples_failing_for(short_name: str):
+    """A build_samples stand-in that fails only for one problem.
+
+    build_samples runs with the cwd already inside the problem's package, so
+    the problem is identified by that directory's name.
+    """
+
+    async def _fake(verification, validate, check_outputs_only=False):
+        return pathlib.Path.cwd().name != short_name
+
+    return _fake
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_sample_failure_does_not_silently_shorten_the_statement(
+    cleandir_with_testdata,
+):
+    # Without --partial a problem whose samples failed must not simply vanish
+    # from the joined document: every statement joining it fails instead.
+    with mock.patch(
+        'rbx.box.testcase_sample_utils.build_samples',
+        new=await _build_samples_failing_for('B'),
+    ):
+        with pytest.raises(typer.Exit):
+            await _run(samples=True, languages=['en'])
+
+    assert not (cleandir_with_testdata / 'build' / 'main-en.tex').exists()
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_sample_failure_drops_the_problem_under_partial(
+    cleandir_with_testdata,
+):
+    with mock.patch(
+        'rbx.box.testcase_sample_utils.build_samples',
+        new=await _build_samples_failing_for('B'),
+    ):
+        with pytest.raises(typer.Exit):
+            await _run(samples=True, languages=['en'], partial=True)
+
+    # The statement is produced, without B, and the command still exits 1
+    # because a problem's samples genuinely failed.
+    en_tex = (cleandir_with_testdata / 'build' / 'main-en.tex').read_text()
+    assert '\\subimport{.problems/A/}{statement}' in en_tex
+    assert '\\subimport{.problems/B/}{statement}' not in en_tex

--- a/tests/rbx/box/contest/test_contest_partial_build.py
+++ b/tests/rbx/box/contest/test_contest_partial_build.py
@@ -45,3 +45,24 @@ async def test_successful_statement_joins_all_problems(cleandir_with_testdata):
     contest_tex = (cleandir_with_testdata / 'build' / 'main-en.tex').read_text()
     assert '\\subimport{.problems/A/}{statement}' in contest_tex
     assert '\\subimport{.problems/B/}{statement}' in contest_tex
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_partial_builds_the_statement_without_the_problem(
+    cleandir_with_testdata,
+):
+    await _run(partial=True)
+
+    pt_tex = (cleandir_with_testdata / 'build' / 'main-pt.tex').read_text()
+    assert '\\subimport{.problems/A/}{statement}' in pt_tex
+    assert '\\subimport{.problems/B/}{statement}' not in pt_tex
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_partial_exits_zero(cleandir_with_testdata):
+    # --partial is an explicit request for best-effort output, so a dropped
+    # problem is not a command failure. The issue report still lists it.
+    await _run(partial=True)
+
+    assert (cleandir_with_testdata / 'build' / 'main-en.tex').exists()
+    assert (cleandir_with_testdata / 'build' / 'main-pt.tex').exists()

--- a/tests/rbx/box/contest/test_contest_partial_build.py
+++ b/tests/rbx/box/contest/test_contest_partial_build.py
@@ -1,0 +1,34 @@
+import inspect
+
+import pytest
+
+from rbx.box.contest import statements as contest_statements_cli
+from rbx.box.statements.resolver import StatementResolverError
+from rbx.box.statements.schema import StatementType
+
+_build_async = inspect.unwrap(contest_statements_cli.build)
+
+
+async def _run(**kwargs):
+    defaults = dict(
+        verification=0,
+        names=None,
+        languages=None,
+        validate=False,
+        output=StatementType.TeX,
+        samples=False,
+        vars=None,
+        install_tex=False,
+        profile=None,
+    )
+    defaults.update(kwargs)
+    await _build_async(**defaults)
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_fixture_currently_aborts_every_statement(cleandir_with_testdata):
+    # Characterization of the bug: main-pt fails (B has no pt statement) and
+    # takes main-en down with it. Deleted in Task 3.
+    with pytest.raises(StatementResolverError):
+        await _run()
+    assert not (cleandir_with_testdata / 'build' / 'main-en.tex').exists()

--- a/tests/rbx/box/statements/test_partial_build.py
+++ b/tests/rbx/box/statements/test_partial_build.py
@@ -1,0 +1,65 @@
+import inspect
+import pathlib
+
+import pytest
+import typer
+
+from rbx.box import cd, package_utils
+from rbx.box.statements import build_statements
+from rbx.box.statements.schema import StatementType
+
+
+def _break_statement(path: pathlib.Path) -> None:
+    """Make a statement fail to render, via a var no namespace defines."""
+    path.write_text(
+        '%- block legend\nBroken: \\VAR{vars.this_var_does_not_exist}.\n%- endblock\n'
+    )
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_failing_statement_does_not_stop_later_ones(cleandir_with_testdata):
+    # Problem A declares en first, then pt. Break en; pt must still build.
+    _break_statement(cleandir_with_testdata / 'A' / 'statement' / 'statement.rbx.tex')
+
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        with pytest.raises(typer.Exit) as exc_info:
+            await build_statements.execute_build(
+                verification=0,
+                samples=False,
+                validate=False,
+                output=StatementType.TeX,
+                keep_going=True,
+            )
+
+    assert exc_info.value.exit_code == 1
+    build_dir = cleandir_with_testdata / 'A' / 'build'
+    assert (build_dir / 'statement-pt.tex').exists()
+    assert not (build_dir / 'statement-en.tex').exists()
+
+
+@pytest.mark.test_pkg('contests/statements_v2_partial')
+async def test_packager_default_still_fails_fast(cleandir_with_testdata):
+    # execute_build_on_statements defaults to keep_going=False so a packager,
+    # which cannot ship an incomplete set of statements, keeps aborting on the
+    # first failure rather than silently emitting the rest.
+    _break_statement(cleandir_with_testdata / 'A' / 'statement' / 'statement.rbx.tex')
+
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        with pytest.raises(BaseException) as exc_info:
+            await build_statements.execute_build(
+                verification=0,
+                samples=False,
+                validate=False,
+                output=StatementType.TeX,
+            )
+
+    # It aborted on the first statement, so the later one was never attempted.
+    assert not isinstance(exc_info.value, typer.Exit) or exc_info.value.exit_code != 1
+    assert not (cleandir_with_testdata / 'A' / 'build' / 'statement-pt.tex').exists()
+
+
+def test_keep_going_defaults_to_false():
+    sig = inspect.signature(build_statements.execute_build_on_statements)
+    assert sig.parameters['keep_going'].default is False


### PR DESCRIPTION
Closes #705.

## Two defects, not one

**1. Statements were not isolated from each other.** The outer loop over contest statements (`contest/statements.py`) had no `try` at all, so the first statement to fail killed every later one — a problem missing an `en` statement stopped `pt` from building. A pdflatex error did the same thing, and is probably the more common trigger in practice. The problem-level `rbx st b` loop had the same shape.

**2. Criticality was decided by exception type, not by design.** The inner per-problem loop carved out `except (typer.Exit, RbxException): raise`, which is a guess about which types authors reach for rather than a policy. Two common failures fell on the wrong side of it:

- a Jinja **undefined variable** raises `typer.Abort`, outside the tuple → silently demoted to a per-problem skip;
- a missing `contestProblemTemplate` was a bare `assert` → `AssertionError`, also outside the tuple → every problem skipped with a confusing message.

And the soft branch didn't affect the exit code, so **a problem could vanish from the problemset PDF and the command reported success**. Partial PDFs were already being emitted, unflagged, from here and from the samples phase.

## What changed

- Both outer loops build each statement in isolation and collect failures into an end-of-run summary, reported through the existing `issue_stack` plus an explicit "Failed statements" section. Exits 1 if anything failed. This is unconditional — no flag.
- The exception-type tiering is gone. Any problem-level failure now raises `StatementBuildError` and fails **that statement**.
- `--partial` (contest statement/tutorial commands) opts into best-effort: failing problems are dropped, the statement is still produced, exit 0.
- The samples-phase drop is gated on the same flag, so no short document is written without it.
- The three bare `assert`s became real errors naming the missing field.

## Behaviour change to be aware of

Without `--partial`, one problem's sample failure now fails every statement joining it, where before you got short PDFs and exit 1. That is the point of the change — a wrong artifact is worse than a missing one — but it makes `--partial` load-bearing for a workflow that previously needed no flag.

`--partial` is deliberately **not** on `rbx st b` / `rbx tut b`: a single problem's statement has no sub-problems to omit, so the flag would be inert there.

## Packagers are unaffected

`execute_build_on_statements` gained `keep_going`, defaulting to `False`. Both non-CLI callers (`packaging/packager.py`, `wizard/app.py`) keep the fail-fast default; only the CLI passes `True`. A silently incomplete Polygon/MOJ upload is worse than an aborted one.

## Verification

- New tests: `tests/rbx/box/contest/test_contest_partial_build.py` (7), `tests/rbx/box/statements/test_partial_build.py` (3), on a new `statements_v2_partial` fixture whose failing statement is listed **first** so the tests prove a later one still builds.
- Full suite (`--ignore=tests/rbx/box/cli -n auto -p no:randomly`) run on this branch and on `main`: **failure sets are byte-identical**, 42 pre-existing failures on both, none introduced.
- Manual smoke test of the real CLI: default run builds `main-en.tex` only, prints the failed-statement summary, exits 1; `--partial` builds both, `main-pt` contains only problem A, exits 0.
- One e2e spec updated: `standalone-collision` asserted the collision message on `stderr`, but the runner only synthesizes `stderr` from an *uncaught* exception. The error is now caught and summarized; message and exit code are unchanged, so the assertion moved to `stdout`.

Design and plan: `docs/plans/2026-08-23-statement-partial-failure-design.md`, `docs/plans/2026-08-23-statement-partial-failure.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
