### PR TITLE
docs: tighten prose on agent-written pages

### DIFF
--- a/docs/generators-and-rbx-h.md
+++ b/docs/generators-and-rbx-h.md
@@ -1,20 +1,19 @@
 # Generators and `rbx.h`
 
 `rbx` refuses to build a problem when a **generator** depends on `rbx.h`. This
-page explains why and how to proceed if you really need to.
+page explains why, and how to opt out.
 
 ## Why this is an error
 
 `rbx.h` exposes `getVar<T>("NAME")`, which reads the problem's
-[variables](setters/variables.md) — your constraints — at compile time. That is
-exactly what a **validator** wants. A **generator** is different: its job is to
-produce a fixed, reproducible testset.
+[variables](setters/variables.md), your constraints, at compile time. That is what a
+**validator** wants. A **generator** is different: its job is to produce a fixed,
+reproducible testset.
 
-If a generator reads a constraint through `getVar`, then changing that constraint
-silently changes every test the generator produces — with no edit to the
-generator and no warning. A test that used to stress `N = 10^5` quietly becomes
-`N = 10^6` (or shrinks), solutions that were once correctly judged may flip, and
-nothing in your diff hints at why.
+If a generator reads a constraint through `getVar`, changing that constraint
+silently changes every test the generator produces. A test that used to stress
+`N = 10^5` quietly becomes `N = 10^6`, solutions that were once correctly judged
+may flip, and nothing in your diff hints at why.
 
 ### Example
 

--- a/docs/migrating-to-v1.md
+++ b/docs/migrating-to-v1.md
@@ -4,7 +4,7 @@ rbx v1 removes a few {{boca}} configuration knobs in `env.rbx.yml` that were kep
 only for backward compatibility. They are marked **deprecated** in the current
 schema and will stop working in v1.
 
-If you rely on the bundled `default` preset, there's nothing to do — it has already
+If you rely on the bundled `default` preset, there's nothing to do: it has already
 been migrated. You only need to act if you maintain a **custom `env.rbx.yml`** (run
 `rbx config edit` to open it). Each section below shows the old form and its
 replacement.
@@ -84,8 +84,8 @@ extensions:
     template: "cc"             # required, names the template dir to source scripts from
 ```
 
-After v1, loading an `env.rbx.yml` that uses any removed field (or omits a now-required
-`template`) fails with a clear validation error.
+After v1, loading an `env.rbx.yml` that uses any removed field, or omits a now-required
+`template`, fails with a validation error.
 
 ## Also removed: `maximumTimeError`
 

--- a/docs/setters/custom-checker-walkthrough.md
+++ b/docs/setters/custom-checker-walkthrough.md
@@ -5,8 +5,8 @@
     through it yet, start there — we pick up right where it left off.
 
 In [First steps](first-steps.md) we built a problem that asks for the **sum of `N` integers**.
-That problem has a single correct answer, so {{rbx}}'s default checker — `wcmp`, which simply
-compares the participant's output token-by-token against the model answer — works perfectly.
+That problem has a single correct answer, so {{rbx}}'s default checker does the job: `wcmp`
+compares the participant's output token-by-token against the model answer.
 
 But not every problem has a unique answer. Let's mutate our problem into one that doesn't, and
 see why we need a **checker**.
@@ -20,7 +20,7 @@ Let's change the problem to:
 
 Now there are many correct answers. For `N = 10`, both `1 9` and `5 5` are valid. This breaks
 token comparison: if your solution prints `1 9` but the model solution printed `5 5`, `wcmp`
-would wrongly flag a {{tags.wrong_answer}} even though `1 9` is perfectly correct.
+would wrongly flag a {{tags.wrong_answer}} even though `1 9` is correct.
 
 We need a checker that *verifies the property* (`a + b = N`) instead of comparing strings.
 
@@ -55,9 +55,9 @@ filename prefix (`wa-`) tells {{rbx}} the expected outcome.
 
 !!! note "What about the validator, generator and statement?"
     Switching problems also means updating the input validator, the generator and the
-    statement. The mechanics are exactly what you learned in
-    [First steps](first-steps.md) — the input is now a single integer `N` — so we won't
-    re-walk them here and will keep the spotlight on the checker.
+    statement. The input is now a single integer `N`, and the mechanics are the ones from
+    [First steps](first-steps.md), so we keep the spotlight on the checker instead of
+    re-walking them.
 
 ## Writing the checker
 
@@ -102,19 +102,19 @@ the model answer.
         line arguments. Every checker starts with this call.
 
     2.  Reading with bounds is your first line of defense. `ouf.readInt(1, n - 1, "a")` reads an
-        integer named `a` and **automatically** fails with a {{tags.wrong_answer}} if it is
-        missing or outside `[1, n - 1]` — no extra code needed.
+        integer named `a` and fails with a {{tags.wrong_answer}} if it is missing or outside
+        `[1, n - 1]`, with no extra code.
 
     3.  `quitf(_wa, ...)` ends the checker with a {{tags.wrong_answer}} and a **custom message**.
-        Notice you can use `printf`-style format specifiers, so the report tells the setter
-        exactly what went wrong.
+        Notice you can use `printf`-style format specifiers, so the report says what went
+        wrong.
 
     4.  `quitf(_ok, ...)` ends the checker with an {{tags.accepted}} verdict.
 
 !!! tip "When you *do* need the model answer"
     Some problems (e.g. "find the **shortest** path") can only be checked by comparing against
-    the jury's solution via the `ans` stream. That's a more advanced pattern — see the
-    [Checkers](grading/checkers.md) feature guide for the full *output + answer* example.
+    the jury's solution via the `ans` stream. For that pattern, see the
+    [Checkers](grading/checkers.md) feature guide and its *output + answer* example.
 
 ### Wiring it into `problem.rbx.yml`
 
@@ -133,7 +133,7 @@ new file instead:
 Now run `rbx run` again. Two things change compared to step 1:
 
 - Your `main.cpp` passes on every test, even when it prints a different pair than the model
-  solution — the checker verifies the *property*, not the exact tokens.
+  solution, because the checker verifies the *property* rather than the tokens.
 - `wa-offbyone.cpp` fails, and instead of an opaque token diff you get the checker's custom
   message, e.g. `a + b = 11, expected 10`.
 
@@ -141,8 +141,8 @@ Now run `rbx run` again. Two things change compared to step 1:
 
 ## Testing the checker with `rbx unit`
 
-A buggy checker can silently let wrong solutions through (or reject correct ones). {{rbx}} lets
-you **unit test** your checker so you can trust it.
+A buggy checker can silently let wrong solutions through, or reject correct ones. {{rbx}} lets
+you **unit test** your checker before you rely on it.
 
 Declare the expected outcomes in `problem.rbx.yml`:
 
@@ -189,7 +189,7 @@ rbx unit
 
 {{ asciinema("unit-checker") }}
 
-For many small cases you can avoid one-file-per-test with **test plans** — see the
+For many small cases, **test plans** avoid one file per test. See the
 [Unit tests](verification/unit-tests.md) feature guide.
 
 ## Next steps

--- a/docs/setters/presets/index.md
+++ b/docs/setters/presets/index.md
@@ -4,17 +4,15 @@
     This documentation is mainly targeted at head setters trying to create a contest
     from scratch.
 
-    If you're just a setter that wants to contribute to an already existing contest,
-    you can probably just clone the repository the head setters shared with you and skip
-    this documentation altogether.
+    If you're a setter contributing to an existing contest, clone the repository the head
+    setters shared with you and skip this page.
 
-Presets is a feature that allows head setters to create a contest template that can be reused
-across multiple contests.
+A preset is a contest template that head setters reuse across contests.
 
-A preset consists of four different pieces:
+It consists of four pieces:
 
-- A **contest template**: simply, a contest folder with some sensible defaults set that will
-  be used to bootstrap a contest based on this preset
+- A **contest template**: a contest folder with defaults set, used to bootstrap a contest
+  based on this preset
 - A **problem template**: a problem folder with some sensible defaults set that will
   be used to bootstrap each problem based on this preset
 - An **environment**: a configuration file that will be inherited by contests and problems
@@ -24,15 +22,12 @@ A preset consists of four different pieces:
 
 ## Why a preset?
 
-Presets strongly encourage code reuse across different contests. Besides that, it provides
-a way to standardize the contest environment across different contests, making it easier
-for setters to focus on creating the contest instead of configuring the environment.
+A preset standardizes the environment across contests, so setters spend their time writing
+problems instead of configuring one. It also gives every new problem in a contest a starting
+point the head setter defined.
 
-Also, it makes it easier for setters to create new problems in a contest, offering a way for
-the head setter to define a starting point for the problem.
-
-Also, if the head setter wants to change the preset at some point, presets offer a way
-to synchronize the changes across all the problems and contests that use the preset.
+And when the head setter changes the preset later, `rbx presets sync` carries the change into
+every problem and contest built from it.
 
 ## Creating a preset
 
@@ -67,11 +62,8 @@ The GitHub URI will be an unique identifier of your preset, and
 can be used by other {{rbx}} users to fetch your preset from there if you decide to share
 it publicly.
 
-You can start from a preset of your own by specifying the `-p` flag.
-
 !!! tip
-    If you want to start from a preset of your own, you can do so by specifying the `-p`
-    flag.
+    To start from a preset of your own, pass the `-p` flag.
 
     ```bash
     rbx presets create -p your-base-preset
@@ -79,9 +71,8 @@ You can start from a preset of your own by specifying the `-p` flag.
 
 ### Setting up the problem template
 
-You can go to the problem template and modify it to your liking: package structure,
-the `problem.rbx.yml` file, default testlib components, statement templates, etc. Everything
-can be customized to fulfill your requirements.
+Modify the problem template to your liking: package structure, the `problem.rbx.yml` file,
+default testlib components, statement templates, and anything else the template carries.
 
 Every problem created from this preset will be a clone of this folder, except for the folder name
 and the `name` field of the `problem.rbx.yml` file, which will be changed to match your problem name.
@@ -126,8 +117,7 @@ see when picking a variant, so make it say what the template is *for*.
 
 #### Adding a variant
 
-There is nothing magic about a variant directory -- it is just another problem template, so
-you build it the same way you built the canonical one:
+A variant directory is another problem template, built the same way as the canonical one:
 
 ```bash
 # Start from the canonical template, so you keep your own conventions.
@@ -217,8 +207,8 @@ one library for this variant only, and every other declared library still applie
 Variants are usually near-duplicates of each other, and you don't want to maintain the same
 `.gitignore` or `validator.cpp` twice. Two options, both supported:
 
-- **Plain copies**: just keep a copy of the file in each template directory. Simple, and
-  what the bundled `default` preset does.
+- **Plain copies**: keep a copy of the file in each template directory. This is what the
+  bundled `default` preset does.
 - **Symlinks inside the preset**: point a file in one template at a file elsewhere in the
   preset. When the package is created, {{rbx}} rewrites such a symlink into a relative link
   into the installed package's `.local.rbx/`, so the created package stays self-contained
@@ -249,8 +239,8 @@ above — the reserved `default` id, the picker, the merge rule — applies unch
 
 ### Setting up the contest template
 
-You can go to the contest template and modify it to your liking: statement templates, `contest.rbx.yml` file,
-etc. Everything can be customized to fulfill your requirements.
+Modify the contest template to your liking: statement templates, the `contest.rbx.yml` file,
+and anything else it carries.
 
 Usually, the contest template should have no problems initially. One should add problems with
 `rbx contest add` after the contest has been created.
@@ -267,10 +257,10 @@ and the `name` field of the `contest.rbx.yml` file, which will be changed to mat
 The environment file will be used to configure the execution environment of {{rbx}} to be used
 in the contest.
 
-This file is rather complex, and its full reference documentation can be found [here](../reference/environment).
+This file is complex, and its full reference documentation lives [here](../reference/environment).
 
-You can usually get away with the environment used by the `default` preset, which is
-a good starting point for most contests. You can check its code [here](https://github.com/rsalesc/rbx/blob/main/rbx/resources/presets/default/env.rbx.yml).
+The environment of the `default` preset is a good starting point for most contests. You can read
+it [here](https://github.com/rsalesc/rbx/blob/main/rbx/resources/presets/default/env.rbx.yml).
 
 ### Setting up the preset definition
 
@@ -317,18 +307,18 @@ tracking:
 
 ```
 
-The first few sections are pretty self-explanatory. Let's focus on the `tracking` section.
+The first few sections are self-explanatory. The `tracking` section deserves a closer look.
 
 The `tracking` section describes a set of files that should be tracked by {{rbx}} when a problem
 or contest is created from this preset.
 
 If a file is tracked, it means that -- in theory -- it should be automatically synced with the preset.
 Let's say you have a `.tex` file that is imported by all the problems in your contest. Let's say your
-contest has 10 problems, but just now you realized you have to modify this `.tex` file to fix a typo.
+contest has 10 problems, and you have to modify this `.tex` file to fix a typo.
 
-Usually, this would mean you have to repeat the same change in all 10 problems. With presets, you
-can just modify the `.tex` file in the preset definition, and run `rbx presets sync` inside your
-contest folder, as long as the file is tracked.
+Without presets, that means repeating the same change in all 10 problems. With them, you modify
+the `.tex` file in the preset definition and run `rbx presets sync` inside your contest folder,
+as long as the file is tracked.
 
 This will sync all packages that use this preset with its newest changes, based on the set of tracked files.
 Files that are not tracked **will not** be synced.
@@ -340,7 +330,7 @@ Tracked files can be specified both explicitly, or through Python-compliant glob
 ##### Flag-based symlink tracking
 
 When you know for sure that a file should always be kept in sync (without manual intervention), you can
-also create them as symlinks. Just mark the tracked file with the `symlink: true` flag, and {{rbx}} will
+also create them as symlinks. Mark the tracked file with the `symlink: true` flag, and {{rbx}} will
 create a symlink to the file in the package instead of copying it. Then, every modification you do to it
 will be instantly reflected in all other packages that use the preset.
 
@@ -359,9 +349,9 @@ problem/
 └── common_icpc.sty
 ```
 
-In this case, you can track both `contest/documents/icpc.sty` and `problem/documents/icpc.sty` (no need for the `symlink: true` flag), and {{rbx}} will make sure to create a symlink to `common_icpc.sty` automagically for you.
+In this case, you can track both `contest/documents/icpc.sty` and `problem/documents/icpc.sty` (no need for the `symlink: true` flag), and {{rbx}} creates the symlink to `common_icpc.sty` for you.
 
-This approach is particularly useful when you want to share a common file between the contest and the problem packages.
+Use this to share a common file between the contest and the problem packages.
 
 ## Libraries
 
@@ -432,9 +422,8 @@ libraries:
 
 ### Fetching libraries manually
 
-You usually don't need to fetch libraries by hand -- they are materialized automatically when packages
-are created and refreshed on `rbx presets sync`. When you do want to fetch them explicitly, use
-`rbx download`:
+You rarely need to fetch libraries by hand: they are materialized when packages are created and
+refreshed on `rbx presets sync`. To fetch one explicitly, use `rbx download`:
 
 ```bash
 # Fetch and materialize a single declared library, by name.
@@ -453,8 +442,8 @@ resolve the declared library of the same name.
 
 !!! note
     The `default` preset declares `testlib`, `jngen`, and `tgen`, all with `always_include: true`.
-    Packages created from it therefore behave just like before -- those headers are available to every
-    source -- but now they are versioned, fetched, and cached instead of being hardcoded into {{rbx}}.
+    Those headers stay available to every source in packages created from it, but they are now
+    versioned, fetched, and cached instead of hardcoded into {{rbx}}.
 
 ## Using a preset
 
@@ -468,7 +457,7 @@ rbx contest create -p your-preset
 # Initialize a contest (in the current directory) from a preset.
 rbx contest init -p your-preset
 
-# Add a problem to a contest (that already has its own preset), using the very same preset.
+# Add a problem to a contest (that already has its own preset), using that same preset.
 rbx contest add
 
 # Create a standalone problem from a preset.
@@ -508,8 +497,8 @@ rbx create my-problem --preset default
 
 The registry is the merge of two files:
 
-- a **built-in** registry shipped with {{rbx}} (currently just the `default`
-  preset);
+- a **built-in** registry shipped with {{rbx}} (currently the `default`
+  preset alone);
 - a **user** registry stored in your {{rbx}} app directory
   (`presets/registry.yml`), initially empty.
 
@@ -539,7 +528,7 @@ registry for you.
 ## Sharing a preset publicly
 
 You can share your preset publicly by uploading it to a GitHub repository. If your repository is
-`<your-organization>/<your-preset-name>`, other uses can create a package from it by using
+`<your-organization>/<your-preset-name>`, other users can create a package from it with
 
 ```bash
 rbx contest create -p <your-organization>/<your-preset-name>

--- a/docs/setters/profiling/index.md
+++ b/docs/setters/profiling/index.md
@@ -6,13 +6,12 @@ created and managed through the CLI or the TUI.
 
 ## Why profile?
 
-Different judge systems (BOCA, Polygon, etc.) may run on different hardware with different performance
-characteristics. A time limit that works well on your local machine may be too tight or too generous
-on the actual judge. By creating separate profiles for each target system, you can fine-tune
-limits independently.
+Judge systems run on different hardware, so a time limit that fits your local machine may be
+too tight or too generous on BOCA or Polygon. One profile per target system lets you tune each
+independently.
 
-Even if you only target a single judge, profiling automates the tedious process of choosing a time limit
-that is generous enough for intended solutions but tight enough to reject slow ones.
+Even against a single judge, profiling picks a limit generous enough for the intended solutions
+and tight enough to reject the slow ones, instead of leaving you to guess.
 
 ## Quick start
 
@@ -40,16 +39,16 @@ solutions and applying the estimation strategy configured in the environment: ei
 
 1. **Displays current profile** -- If a profile already exists for the given name, its current limits are shown.
 2. **Strategy selection** -- You are prompted to choose how to define the time limit (unless `--auto` or `--strategy` is used).
-3. **Solution execution** -- For estimating strategies, the accepted solutions are run against all testcases, so that their true execution times can be measured. Every one of them is capped at [`inferenceTimeout`](#the-estimation-cap). The solutions expected to be too slow are *not* run here; see [Checking the upper bound](#checking-the-upper-bound).
+3. **Solution execution** -- The accepted solutions run against all testcases so their times can be measured, each capped at [`inferenceTimeout`](#the-estimation-cap). The solutions expected to be too slow are *not* run here. See [Checking the upper bound](#checking-the-upper-bound).
 4. **Time report** -- The fastest and slowest solution times are shown, along with per-language breakdowns if solutions in multiple languages exist.
 5. **Estimation** -- The ratios (or the formula) are applied to compute the estimated time limit.
-6. **Language groups** -- You are shown every environment language and can place each one into a group, so related languages (e.g. `c`/`cpp`, or `java`/`kotlin`) share a single estimated limit and unrepresented languages inherit a sensible limit instead of falling back to the base. See [Language groups](#language-groups).
-7. **Upper-bound check** -- Each solution expected to be too slow is run at the limit the estimate demands of it, to confirm it really is too slow. See [Checking the upper bound](#checking-the-upper-bound).
+6. **Language groups** -- You are shown every environment language and can place each one into a group, so related languages (e.g. `c`/`cpp`, or `java`/`kotlin`) share a single estimated limit and unrepresented languages inherit a represented sibling's limit instead of falling back to the base. See [Language groups](#language-groups).
+7. **Upper-bound check** -- Each solution expected to be too slow is run at the limit the estimate demands of it, to confirm it is too slow. See [Checking the upper bound](#checking-the-upper-bound).
 8. **Profile persistence** -- The result is written to `.limits/<profile>.yml`, together with the chosen grouping and what the check found.
 
-All the steps in one run, taking the recommended **Estimate** strategy and the default
-grouping — note the preview table updating as the languages are bucketed, and the strategy
-printed just above the limits that get written:
+All the steps in one run, with the recommended **Estimate** strategy and the default grouping.
+Note the preview table updating as the languages are bucketed, and the strategy printed above
+the limits that get written:
 
 {{ asciinema("time-estimate", speed=2) }}
 
@@ -94,8 +93,8 @@ rbx time --strategy=estimate_custom
 
 ### Multiple runs
 
-By default, each solution is run once per testcase. If you want more stable timing measurements (e.g., to
-reduce variance from system load), use `--runs` to run each solution multiple times:
+By default, each solution runs once per testcase. To reduce variance from system load, run each
+one several times with `--runs`:
 
 ```bash
 rbx time --runs=3
@@ -115,11 +114,10 @@ to be too slow are allowed:
 | `timeLimitToTle` | The time limit times this must still fit within the fastest solution expected to be too slow. Omit it to leave the limit unbounded from above. |
 | `timeResolution` | The time limit is rounded up to a multiple of this, in milliseconds. |
 
-Unlike a formula, the ratios bound the time limit from **both** sides, so a limit that would
-let a solution meant to time out pass is caught while estimating: when no limit satisfies the
-ratios, `rbx time` says which solution binds each side, writes nothing to the profile, and
-exits with a non-zero status — as it does for any estimation that produces no limit, so a
-pipeline running it notices.
+Unlike a formula, the ratios bound the time limit from **both** sides, so a limit that would let
+a solution meant to time out pass is caught while estimating. When no limit satisfies the ratios,
+`rbx time` names the solution binding each side, writes nothing to the profile, and exits
+non-zero. Any estimation that produces no limit exits the same way, so a pipeline notices.
 
 Configure them environment-wide in `env.rbx.yml`:
 
@@ -153,8 +151,8 @@ timing:
 
 An accepted solution that hits the cap is an error: its measured time is truncated, so it
 cannot bound the limit from below. Raise the cap, or speed the solution up. Either way the
-solution stops there -- its remaining testcases are skipped, since they would measure nothing
-usable.
+solution stops there, and its remaining testcases are skipped, since they would measure
+nothing usable.
 
 The cap does not apply to the solutions expected to be too slow. They are not measured at all;
 they are checked against the estimated limit instead, at a limit derived from it. Raising
@@ -203,11 +201,11 @@ exactly that bound answers it, without waiting to find out how slow it really is
 So once the limit is decided, `rbx time` runs each of those solutions at
 `timeLimitToTle × <the limit for its language>`, and reads the verdict:
 
-- It **runs out of time** -- confirmed. It respects the upper bound, and its remaining
-  testcases are skipped: one timeout settles the question.
-- It **finishes** -- the upper bound is violated, and now there is a real time to report it
+- It **runs out of time**: confirmed. It respects the upper bound, and its remaining
+  testcases are skipped, since one timeout settles the question.
+- It **finishes**: the upper bound is violated, and now there is a real time to report it
   with. `rbx` names the solution, what it took, and what the limit demands of it.
-- It **fails some other way** (a crash, a wrong answer) -- evidence of nothing either way, and
+- It **fails some other way** (a crash, a wrong answer): evidence of nothing either way, and
   an error. Fix it, or set `inference: false` to leave it out.
 
 A violation is not the end of the run. The language-group picker re-opens, this time knowing
@@ -215,7 +213,7 @@ what the check found, so its preview shows which groupings cannot work. From the
 regroup to satisfy the bound, press ++f++ to keep the limits anyway, or cancel. Nothing is
 written until you settle on one of the three.
 
-Where there is no picker to re-open -- `--auto`, or a problem with a single language -- the
+Where there is no picker to re-open (`--auto`, or a problem with a single language) the
 violation is reported, recorded in the profile under `upperValidation`, and the limit is
 written anyway.
 
@@ -234,8 +232,8 @@ Without `timeLimitToTle` there is no upper bound to check, so this phase does no
 ## Measuring on the judge itself
 
 `rbx time` measures where {{rbx}} runs, so the well-lit path is to run it *on* the judge
-machine. `--runner` is the other way: measure the solutions **on the judge park**, through
-the judge's own CLI, and feed the timings into the same estimation you would get locally.
+machine. `--runner` is the other way: it measures the solutions **on the judge park**, through
+the judge's own CLI, and feeds the timings into the same estimation you would get locally.
 
 MOJ is the first backend:
 
@@ -299,10 +297,9 @@ default formula, which is currently:
 ```
 
 That literal is read from `DEFAULT_TIMING_FORMULA` in `rbx/box/environment.py` when these docs
-are built, so it is always the formula {{rbx}} actually estimates with — the code is the
-authoritative source, not this page. Read it with the [variables](#variables) and
-[functions](#functions) below: the outer `step_up(..., 100)` rounds the estimate up to the
-nearest multiple of 100 ms.
+are built, so it is always the formula {{rbx}} estimates with. The code is the authoritative
+source, not this page. Read it with the [variables](#variables) and [functions](#functions)
+below: the outer `step_up(..., 100)` rounds the estimate up to the nearest multiple of 100 ms.
 
 ### Variables
 
@@ -373,7 +370,7 @@ step_up(fastest * 4, 100)
 By default, a single time limit is estimated from the pooled timings of all accepted solutions
 and applied to every language. This is a problem when your accepted solutions don't cover every
 language your contest accepts: a language with no solutions (say, Java in a problem solved only in
-C++ and Python) would simply inherit the base limit, which may be far too tight for it.
+C++ and Python) inherits the base limit, which may be far too tight for it.
 
 **Language groups** solve this. When you run `rbx time`, you are shown every environment language
 and can bucket related languages together. Each group gets its own estimated time limit from the
@@ -436,15 +433,14 @@ semantics.
 
 ## Wall time limits
 
-In addition to the CPU time limit estimated above, every solution is bounded by a **wall (real)
-time** limit. Slow languages (Java, Kotlin, Python) spend significant wall-clock time on JVM /
-interpreter startup before doing any real work, so a wall limit derived too tightly from the CPU
-limit produces spurious time-limit verdicts.
+Every solution is also bounded by a **wall (real) time** limit. Java, Kotlin and Python spend
+wall-clock time on JVM or interpreter startup before doing any work, so a wall limit derived too
+tightly from the CPU limit produces spurious time-limit verdicts.
 
-{{rbx}} computes the wall time limit from the CPU time limit with a configurable `a * x + b`
-formula (`wallTimeMultiplier` and `wallTimeIncrement`), configurable environment-wide and
-overridable per language. The same formula is used both when judging locally and when packaging
-for BOCA. See the [Environment reference](../reference/environment/#wall-time-limits) for details.
+{{rbx}} derives it from the CPU time limit with an `a * x + b` formula (`wallTimeMultiplier` and
+`wallTimeIncrement`), set environment-wide and overridable per language, both when judging
+locally and when packaging for BOCA. See the
+[Environment reference](../reference/environment/#wall-time-limits) for the details.
 
 ## Limits profiles
 
@@ -504,8 +500,8 @@ groups:
 
 ### Per-language modifiers
 
-The `modifiers` section allows you to override limits for specific languages. This is useful
-when your problem accepts solutions in multiple languages with very different performance characteristics.
+The `modifiers` section overrides limits for specific languages, which matters when your problem
+accepts solutions in languages with different performance characteristics.
 
 | Field | Description |
 | :--- | :--- |
@@ -585,8 +581,8 @@ rbx package boca
 
 ### Inheriting from the package
 
-If you want a profile to simply mirror the limits defined in `problem.rbx.yml`, you can create
-an inheriting profile:
+To make a profile mirror the limits defined in `problem.rbx.yml`, create an inheriting
+profile:
 
 ```bash
 rbx time --strategy=inherit -p polygon
@@ -605,8 +601,7 @@ rbx time --integrate -p local
 ```
 
 This copies `timeLimit`, `memoryLimit`, `outputLimit`, and any `modifiers` from the profile
-into your `problem.rbx.yml`. It is useful when you've fine-tuned limits in a profile and want
-to persist them as the package defaults.
+into your `problem.rbx.yml`.
 
 ## Editing profiles in the TUI
 
@@ -627,8 +622,8 @@ Select **"Edit limits profiles"** from the main menu to open the limits editor. 
 - **Delete** (<kbd>d</kbd> twice) -- Delete the selected profile.
 
 !!! tip
-    The TUI is especially handy for quickly tweaking per-language modifiers after an initial
-    `rbx time` estimation.
+    The TUI is the quickest way to tweak per-language modifiers after an initial `rbx time`
+    estimation.
 
 ## Manually editing profiles
 
@@ -650,5 +645,5 @@ You can globally scale all time limits by setting the `RBX_TIME_MULTIPLIER` envi
 RBX_TIME_MULTIPLIER=1.5 rbx run
 ```
 
-This multiplies all effective time limits by the given factor, which can be useful for running
-on slower hardware without changing any profile.
+This multiplies every effective time limit by the given factor, so you can run on slower
+hardware without touching a profile.

--- a/docs/setters/reference/environment/index.md
+++ b/docs/setters/reference/environment/index.md
@@ -1,10 +1,9 @@
 # Environment
 
-An environment file is a YAML configuration file that describes the environment in which {{rbx}} will execute
-your code.
+An environment file describes, in YAML, the environment {{rbx}} executes your code in.
 
-The [`Environment`][rbx.box.environment.Environment] class is used to describe the environment in which the code will be executed. You can follow the schema of this class to figure out everything you can
-configure in the environment file, but here we'll describe the most common fields.
+The [`Environment`][rbx.box.environment.Environment] schema lists everything an environment file
+can configure. This page covers the most common fields.
 
 ## Compilation configuration
 
@@ -18,13 +17,12 @@ defaultCompilation:
   # Defines a few default limits when compiling in the sandbox.
   sandbox:
     timeLimit: 10000 # 10 seconds
-    wallTimeLimit: 10000 # 20 seconds
+    wallTimeLimit: 10000 # 10 seconds
     memoryLimit: 1024 # 1gb
 ```
 
-Usually, the default values here are enough, but you can customize this for your needs. For instance,
-if you have a very slow computer at hand, you might want to increase the limits to ensure the compilers
-have the time to do their job.
+The defaults are usually enough. On a slow machine, raise them so the compilers have time to
+finish.
 
 ## Default execution configuration
 
@@ -36,22 +34,18 @@ defaultExecution:
   # Defines a few default limits when running programs in the sandbox.
   sandbox:
     timeLimit: 10000 # 10 seconds
-    wallTimeLimit: 10000 # 20 seconds
+    wallTimeLimit: 10000 # 10 seconds
     memoryLimit: 1024 # 1gb
 ```
 
-Notice these limits are language agnostic, and problem agnostic. This means you should set this to a
-value larger than any limit you expect for any problem. This is mostly used to ensure programs that
-eat too much memory or take too long to finish, but don't have limits applied to them, don't hang forever
-or crash your system. Examples are checkers, validators, etc.
+These limits are language- and problem-agnostic, so set them above any limit you expect any
+problem to need. They are a backstop for programs that carry no limits of their own, such as
+checkers and validators, so a runaway one cannot hang forever or take your machine down.
 
 ## Languages
 
-The `languages` field is used to define the languages supported by the environment. This is
-a list of [`EnvironmentLanguage`][rbx.box.environment.EnvironmentLanguage] objects, which you can
-look at the schema for more details.
-
-Here's an example of a language definition:
+The `languages` field lists the languages the environment supports, as
+[`EnvironmentLanguage`][rbx.box.environment.EnvironmentLanguage] objects. Here's one:
 
 ```yaml
 languages:
@@ -101,7 +95,7 @@ languages:
         applies_to: [generators]                      # restrict to asset kinds
 ```
 
-- The **shorthand form** is just the linter name; it applies to every asset
+- The **shorthand form** is the linter name alone, and applies to every asset
   kind the linter supports.
 - The **full form** is an object with `name` and an optional `applies_to`
   list. `applies_to` restricts the linter to specific asset kinds. When it is
@@ -184,7 +178,7 @@ And you also have available to you a `@glob:...` command that is expanded into a
 
 ## Timing estimation
 
-Last but not least, you can configure how time limits are estimated when running `rbx time` or
+You can also configure how time limits are estimated when running `rbx time` or
 `rbx run -t`. There are two strategies, and they are **mutually exclusive**: declaring both
 `timing.multipliers` and `timing.formula` is an error. The published JSON schema does not
 express that exclusivity, so your editor will happily autocomplete both keys — {{rbx}} rejects
@@ -265,9 +259,8 @@ exactly as it did.
 Whichever strategy above is in use, the time limit is by default estimated once from the
 pooled timings of all accepted solutions and applied to every language. With `timing.groups`
 you can instead estimate a
-separate time limit per group of languages, which is useful when languages with very
-different performance characteristics (e.g. compiled vs. interpreted) should not share a
-single limit.
+separate time limit per group of languages, which matters when compiled and interpreted
+languages should not share a single limit.
 
 ```yaml
 timing:

--- a/docs/setters/running/index.md
+++ b/docs/setters/running/index.md
@@ -1,18 +1,16 @@
 # Running
 
-{{rbx}} provides a range of options to run your solutions. In the sections below,
-we'll go through each of them.
+{{rbx}} offers several ways to run your solutions. The sections below cover each one.
 
 ## Running solutions on the whole testset
 
-You can use the `rbx run` command to run your solutions on the whole testset.
-
-The command will run all selected solutions (or all declared solutions if none are selected) on all testcases,
-providing for each of them the solution outcome, and for the whole testset the timing and memory usage.
+`rbx run` runs the selected solutions on every testcase, or all declared solutions if you
+select none. It reports an outcome per solution, plus timing and memory usage for the whole
+testset.
 
 {{ asciinema("run-basic") }}
 
-Below are some examples of how to use the command.
+Some examples:
 
 ```bash
 # Run all solutions on all testcases
@@ -35,7 +33,7 @@ rbx run -d
 rbx run -c
 ```
 
-One can also set the verification level to be used when running the solutions.
+You can also set the verification level.
 
 ```bash
 rbx run -v{0,1,2,3,4}
@@ -43,13 +41,14 @@ rbx run -v{0,1,2,3,4}
 
 You can read more about each verification level [here](/setters/verification/#verification-level).
 
-By default, {{rbx}} will run solutions with the maximum verification level. This means tests will be built
-and verified, and that all solutions will be run with twice the time limit, and a warning will show up if a TLE solution passed in `2*TL`.
+By default, {{rbx}} runs solutions at the maximum verification level: tests are built and
+verified, every solution runs with twice the time limit, and a warning appears when a TLE
+solution passes within `2*TL`.
 
-Solutions are also bounded by a configurable **wall (real) time** limit, derived from the CPU time limit — see [Wall time limits](/setters/reference/environment/#wall-time-limits).
+Solutions are also bounded by a configurable **wall (real) time** limit, derived from the CPU
+time limit. See [Wall time limits](/setters/reference/environment/#wall-time-limits).
 
-The results of a `rbx run` command can be inspected through the `rbx ui` command, as shown in the
-animation below.
+Inspect the results of a run with `rbx ui`:
 
 {{ asciinema("ui-navigation") }}
 
@@ -72,11 +71,11 @@ what a judge cannot report back.
 
 Two things are specific to `rbx run`:
 
-- The judge enforces **the same time limits your local run would** — the ones from the
-  limits profile in effect, per language group.
+- The judge enforces **the same time limits your local run would**: the ones from the limits
+  profile in effect, per language group.
 - `--fail-fast` is honoured by the judge: it stops a solution at its first non-accepted
-  verdict, and the testcases it never reached are reported as skipped, exactly as they
-  are locally. Toggling the flag changes the uploaded package, so the first run after a
+  verdict, and the testcases it never reached are reported as skipped, as they are
+  locally. Toggling the flag changes the uploaded package, so the first run after a
   toggle pays for an upload and a calibration.
 
 `--no-check` is **refused** on a remote runner: the judge always judges with the packaged
@@ -84,9 +83,8 @@ checker, so there is no run it could do that means "do not check".
 
 ## Sharing a report
 
-Sometimes you want to send a run report (or a time-estimation report) to someone
-else. The `--share` flag captures the report exactly as it appears in your
-terminal and copies it to your **clipboard**, ready to paste into a chat, an
+`--share` captures a run report (or a time-estimation report) as it appears in
+your terminal and copies it to your **clipboard**, ready to paste into a chat, an
 issue, or an email.
 
 ```bash
@@ -108,9 +106,9 @@ A few things to keep in mind:
   `qlmanage`. If none is found, the report is saved as an SVG file instead and
   its path is printed.
 - Copying an **image** to the clipboard is supported on **macOS** and **Linux**
-  (the latter needs `xclip` or `wl-copy`). On other platforms — or when no
-  clipboard tool is available — the report is written to a file in your build
-  directory and its path is printed, so you never lose the artifact.
+  (the latter needs `xclip` or `wl-copy`). On other platforms, or when no
+  clipboard tool is available, the report is written to a file in your build
+  directory and its path is printed.
 - `--share text` works everywhere a clipboard tool is available, and falls back
   to a file otherwise.
 
@@ -119,8 +117,7 @@ A few things to keep in mind:
 You might want to run your solutions on a testcase that is not part of the testset, or even on a specific
 testcase of the testset.
 
-You can do this with the `rbx irun` command. The command will select which solutions to run similar to `rbx run`.
-This means you can specify with the following flags:
+`rbx irun` does that, and selects solutions the same way `rbx run` does:
 
 ```bash
 # Run a single solution (or a list of solutions) on a specific testcase
@@ -133,18 +130,17 @@ rbx irun --outcome AC
 rbx irun -c
 ```
 
-By default, `rbx irun` will prompt you to type a testcase input. After you've finished typing it, you can press
-`Ctrl+D` to tell {{rbx}} that you're done.
+By default, `rbx irun` prompts you to type a testcase input. Press `Ctrl+D` when you're done.
 
-{{rbx}} will then run the solutions on the testcase you've provided, and print the results into files. You can
-also use the `-p` flag to instruct it to print the results into the console instead.
+{{rbx}} then runs the solutions on that testcase and writes the results into files. Pass `-p`
+to print them to the console instead.
 
 {{ asciinema("irun-stdin") }}
 
 When printing with `-p`, the solution's `stderr` is shown in its own colored section right after the output.
-If you'd rather see it woven into the output in true line order — handy for debugging where each log line was
-emitted relative to the program's output — add the `--merge-stderr` / `-e` flag. The interleaved `stderr` lines
-are colored distinctly, and the clean output is left untouched so the checker still sees exactly what the
+To weave it into the output in true line order, add `--merge-stderr` / `-e`, which shows where
+each log line was emitted relative to the program's output. The interleaved `stderr` lines are
+colored distinctly, and the clean output is left untouched, so the checker still sees what the
 solution printed.
 
 ```bash
@@ -170,7 +166,7 @@ rbx irun -t sample/0
 
 {{ asciinema("irun-testcase") }}
 
-Last but not least, you can also specify a [generator call](/setters/testset/generators/#generator-call) to be used when generating the testcase.
+You can also name a [generator call](/setters/testset/generators/#generator-call) to produce the testcase.
 
 ```bash
 rbx irun -g "gen 100 123" -p

--- a/docs/setters/stress-testing-walkthrough.md
+++ b/docs/setters/stress-testing-walkthrough.md
@@ -5,7 +5,7 @@
     where `sols/main.cpp` is correct and `sols/wa-overflow.cpp` accumulates the sum into
     an `int32_t` that silently overflows.
 
-Our goal here is simple: ask {{rbx}} to find a **tiny** input that breaks `sols/wa-overflow.cpp`.
+Our goal: ask {{rbx}} to find a **tiny** input that breaks `sols/wa-overflow.cpp`.
 
 ## Describing the search
 
@@ -14,8 +14,8 @@ A stress test is described by two expressions:
 - a **generator expression**, which tells {{rbx}} how to keep producing random testcases, and
 - a **finder expression**, which describes the condition that makes a testcase a *match*.
 
-See [Stress testing](stress-testing.md) for the complete operator reference. Here we only
-need a couple of operators.
+See [Stress testing](stress-testing.md) for the complete operator reference. Here we
+need only a couple of operators.
 
 Our generator expression is:
 
@@ -30,8 +30,8 @@ tests/gen [1..5] <A.max> @
   different testcase.
 
 Why is such a small range enough? An `int32_t` overflows once the sum passes ~2.1×10⁹.
-With `A.max` up at ~10⁹, just a handful of large numbers already pushes the true sum past
-that line — which is exactly *why* the counterexample {{rbx}} finds comes out tiny.
+With `A.max` up at ~10⁹, a handful of large numbers already pushes the true sum past that
+line. That is why the counterexample comes out tiny.
 
 Our finder expression is:
 
@@ -60,9 +60,9 @@ match. You can tune both the number of findings and the timeout with `-n` and `-
 When a match is found, `rbx stress` prints a report and shows the exact generator call
 that produced the failing testcase, along with the input itself.
 
-It's a small input — just a few large numbers whose sum overflows `int32_t`, so
-`sols/wa-overflow.cpp` prints the wrong value while `sols/main.cpp` gets it right. That's
-the divergence {{rbx}} flagged as `INCORRECT`.
+It's a small input: a few large numbers whose sum overflows `int32_t`, so
+`sols/wa-overflow.cpp` prints the wrong value while `sols/main.cpp` gets it right. That
+divergence is what {{rbx}} flagged as `INCORRECT`.
 
 ## Making it stick
 
@@ -75,8 +75,8 @@ Answer **yes**. {{rbx}} then lists every test group backed by a `.txt` generator
 plus two extra options: `(create new script)` and `(skip)`. Choose `(create new script)`
 and name it `tests/corner.txt`.
 
-{{rbx}} appends the found generator call to that script — prefixed with a
-`# Obtained by running rbx stress ...` comment so you know where it came from — and adds a
+{{rbx}} appends the found generator call to that script, prefixed with a
+`# Obtained by running rbx stress ...` comment so you know where it came from, and adds a
 new `corner` test group to `problem.rbx.yml`:
 
 === "problem.rbx.yml"
@@ -113,8 +113,8 @@ Now run `rbx build`, and the counterexample is regenerated as a permanent test i
     here on.
 
 The same picker also lists your **manual** test groups, plus `(create new manual group)`.
-Choosing one saves each finding's actual failing input as a static `.in` file instead of a
-generator call — `rbx build` still fills in the `.out`.
+Choosing one saves each finding's failing input as a static `.in` file instead of a
+generator call, and `rbx build` still fills in the `.out`.
 
 !!! tip
     To freeze tests you *already* have, use [`rbx testcases promote`](/setters/reference/cli):

--- a/docs/setters/verification/index.md
+++ b/docs/setters/verification/index.md
@@ -1,8 +1,7 @@
 # Verification
 
-{{rbx}} provides a range of solutions to improve the quality and correctness of your testset and
-the {{testlib}} assets you use. You can see a quick summary of the features in the table below,
-and then read more about each one in the following sections.
+{{rbx}} offers several ways to check your testset and the {{testlib}} assets you use. The table
+below summarizes them, and the sections that follow cover each one.
 
 +-------------------------------------------+---------------------------------------------------------------+
 |                  Feature                  |                          Description                          |
@@ -19,10 +18,8 @@ and then read more about each one in the following sections.
 
 ## Verification Level
 
-{{rbx}} also has the concept of a verification level. This is a way to specify how strict the verification
-should be when building your testset and running solutions.
-
-The verification level will usually be specified along your {{rbx}} command.
+A verification level says how strict verification should be when building your testset and
+running solutions. You usually specify it on the command itself.
 
 ```bash
 rbx build -v{0,1}  # defaults to 1
@@ -44,14 +41,12 @@ the table below:
 | `3` / `ALL_SOLUTIONS`  | Run all solutions, including TLE.                                     |
 | `4` / `FULL`           | Run solutions with twice the TL to check if TLE solutions still pass. |
 
-Setting a larger value is usually the recommended approach to ensure all your expectations are being met.
-
-Setting a smaller value is usually useful when you want to run the commands faster, and you are sure that
-the checks you are running are not being violated.
+Prefer a larger value: it confirms more of your expectations. Drop to a smaller one to run
+faster, when you already know the skipped checks hold.
 
 ## Exit codes
 
-Verification is only useful in a pipeline if a failure actually fails the pipeline. The commands
+Verification is only useful in a pipeline if a failed check fails the pipeline. The commands
 below exit with status `1` when a check they ran did not pass, and `0` otherwise:
 
 | Command                      | Exits `1` when                                                           |
@@ -69,7 +64,7 @@ report tells you which problems are broken rather than stopping at the first one
 
     Up to and including `1.0.0`, `rbx build` and `rbx run` exited `0` even when they printed a
     failing report. A CI job that is silently green today on a broken package will start failing
-    once you upgrade — which is the point, but it may surprise you.
+    once you upgrade. That is the point, but it may surprise you.
 
     Use a lower [verification level](#verification-level) (or `--no-validate`) if you deliberately
     want a step that does not check the testset.


### PR DESCRIPTION
Applies the `scaffold-docs` prose rubric to the documentation pages that were written or largely grown by agents.

## How the target set was picked

Every nav page was attributed by line-level `git blame`, mapping each blame commit to whether it carries a `Co-Authored-By: Claude` trailer:

| Page | Agent-written lines |
| --- | --- |
| `setters/stress-testing-walkthrough.md` | 100% |
| `setters/custom-checker-walkthrough.md` | 100% |
| `migrating-to-v1.md` | 100% |
| `generators-and-rbx-h.md` | 100% |
| `setters/presets/index.md` | 54% |
| `setters/reference/environment/index.md` | 51% |
| `setters/running/index.md` | 45% |
| `setters/profiling/index.md` | 38% |
| `setters/verification/index.md` | 34% |

Human-written pages (`intro/*`, `packaging/polygon.md`, `grading/index.md`, `testset/visualizers.md`, `stack-limit.md`, `cpp-on-macos.md`) are untouched, and Statements is deliberately out of scope.

## What changed

47 targeted rewrites: overloaded em-dash sentences rewritten in a different shape rather than having the punctuation swapped, filler cut (`just`, `simply`, `exactly`, `really`, `very`), hype cut (`works perfectly`, `automagically`, `especially handy`), and restating tails removed. Presets also had a tip repeating the sentence directly above it verbatim.

Two content bugs fixed on the way:

- the environment reference annotated `wallTimeLimit: 10000` as `# 20 seconds`, twice;
- the preset-sharing section said "other uses" where it meant "other users".

## Verified

`mkdocs build` completes with 0 errors.

## Follow-ups, not in this PR

- Profiling duplicates the Environment reference wholesale (ratios, estimation cap, language groups, wall-time limits are each explained at length in both).
- Profiling mixes guide and reference: "Limits profiles" is reference material inside a Feature Guide page.
- Presets is one page doing five jobs; Variants alone is 1.1k words with six sub-headings.
- Section names are bare nouns where the headline rubric asks for the reader's action.
- Unrelated: the checked-in `setters/reference/cli.md` is stale against what `mkdocs build` regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMJqqdnCaBSjSHy3kAi5Wz