### PR TITLE
fix: clear six root causes behind the CI test failures

### DIFF
--- a/rbx/grading/judge/cacher.py
+++ b/rbx/grading/judge/cacher.py
@@ -158,9 +158,21 @@ class FileCacher:
             logger.debug('File %s not in cache, downloading from database.', digest)
 
             if (symlink := await self.backend.path_for_symlink(digest)) is not None:
-                cache_file_path.unlink(missing_ok=True)
-                cache_file_path.symlink_to(symlink)
-                return cache_file_path.open('rb') if not cache_only else None
+                # Same hazard the download path below guards against, plus one
+                # more: `self.lock` is an asyncio lock, so it only serializes
+                # callers on a single event loop. Two loops can be inside this
+                # branch for the same digest at once. Unlinking and re-linking
+                # in place leaves a window in which cache_file_path does not
+                # exist, and the racing loop's open() raises FileNotFoundError.
+                # Stage the link under a private name and move it in atomically
+                # so the entry is never observably missing.
+                temp_link_path = self.temp_dir / f'_link{os.urandom(8).hex()}'
+                temp_link_path.symlink_to(symlink)
+                fd = temp_link_path.open('rb') if not cache_only else None
+                # temp_dir lives inside file_dir, so this rename stays on one
+                # filesystem and is atomic by POSIX requirement.
+                temp_link_path.replace(cache_file_path)
+                return fd
 
             ftmp_handle, temp_file_path = tempfile.mkstemp(
                 dir=self.temp_dir, text=False

--- a/tests/rbx/box/contest/test_contest_state.py
+++ b/tests/rbx/box/contest/test_contest_state.py
@@ -3,6 +3,32 @@ import pytest
 from rbx.box.contest import contest_state
 
 
+@pytest.fixture
+def unregister_probe_commands():
+    """Take probe commands back off the real Typer apps after the test.
+
+    These tests exercise the root callbacks, so they have to hang a throwaway
+    command off the genuine `cli.app` / contest `app` rather than a copy. Typer
+    exposes no removal API, but `registered_commands` is a plain list, so
+    restoring the snapshot un-registers whatever the decorator appended.
+
+    Leaving them registered leaks the probes into every later consumer of the
+    app in the same process. The completion drift test is the one that notices:
+    it serializes the live CLI and compares it against the committed spec, so a
+    leaked `probe-contest-*` shows up as spurious drift whenever these tests
+    happen to run first.
+    """
+    from rbx.box import cli
+    from rbx.box.contest import main as contest_main
+
+    snapshots = [
+        (app, list(app.registered_commands)) for app in (cli.app, contest_main.app)
+    ]
+    yield
+    for app, commands in snapshots:
+        app.registered_commands[:] = commands
+
+
 def test_variant_id_pattern_accepts_typical_ids():
     assert contest_state.is_valid_variant_id('div1')
     assert contest_state.is_valid_variant_id('warmup')
@@ -63,7 +89,7 @@ def test_apply_cli_selection_noop_on_none():
     assert contest_state.get_selected_variant_id() is None
 
 
-def test_root_callback_sets_contextvar_from_flag():
+def test_root_callback_sets_contextvar_from_flag(unregister_probe_commands):
     """Smoke: invoking the root callback with -C sets the contextvar."""
     from typer.testing import CliRunner
 
@@ -76,18 +102,13 @@ def test_root_callback_sets_contextvar_from_flag():
     def probe():
         captured['value'] = selected_variant_id_var.get()
 
-    try:
-        runner = CliRunner()
-        result = runner.invoke(cli.app, ['-C', 'div1', 'probe-contest-rcv'])
-        assert result.exit_code == 0, result.output
-        assert captured['value'] == 'div1'
-    finally:
-        # Best-effort cleanup of the registered command. Typer doesn't expose a
-        # public removal API, so leak is fine for a unit test.
-        pass
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ['-C', 'div1', 'probe-contest-rcv'])
+    assert result.exit_code == 0, result.output
+    assert captured['value'] == 'div1'
 
 
-def test_root_callback_rejects_invalid_id():
+def test_root_callback_rejects_invalid_id(unregister_probe_commands):
     from typer.testing import CliRunner
 
     from rbx.box import cli
@@ -102,7 +123,7 @@ def test_root_callback_rejects_invalid_id():
     assert 'Invalid contest id' in result.output
 
 
-def test_contest_subapp_callback_sets_contextvar_from_flag():
+def test_contest_subapp_callback_sets_contextvar_from_flag(unregister_probe_commands):
     from typer.testing import CliRunner
 
     from rbx.box.contest import main as contest_main
@@ -120,7 +141,9 @@ def test_contest_subapp_callback_sets_contextvar_from_flag():
     assert captured['value'] == 'div2'
 
 
-def test_root_callback_resolves_from_env(monkeypatch: pytest.MonkeyPatch):
+def test_root_callback_resolves_from_env(
+    monkeypatch: pytest.MonkeyPatch, unregister_probe_commands
+):
     """RBX_CONTEST env var alone (no -C flag) populates the contextvar."""
     from typer.testing import CliRunner
 

--- a/tests/rbx/box/test_header.py
+++ b/tests/rbx/box/test_header.py
@@ -984,7 +984,7 @@ _GROUP_VARS_MAIN = """
 int main() {
   std::printf("AB.min=%lld\\n", (long long)getVar<int64_t>("AB.min"));
   std::printf("AB.max=%lld\\n", (long long)getVar<int64_t>("AB.max"));
-  std::printf("name=%s\\n", getVar<std::string>("name").c_str());
+  std::printf("label=%s\\n", getVar<std::string>("label").c_str());
   std::printf("ratio=%.2f\\n", getVar<double>("ratio"));
   std::printf("flag=%d\\n", (int)getVar<bool>("flag"));
   return 0;
@@ -1044,7 +1044,7 @@ _UNSUPPORTED_PLATFORM_GUARD = (
 
 _PACKAGE_VARS: RecVars = {
     'AB': {'min': -200, 'max': 200},
-    'name': 'pkg',
+    'label': 'pkg',
     'ratio': 1.5,
     'flag': True,
 }
@@ -1074,7 +1074,7 @@ class TestGroupVars:
             {
                 'sub2': {
                     'AB': {'min': 0},
-                    'name': 'sub2name',
+                    'label': 'sub2label',
                     'ratio': 2.5,
                     'flag': False,
                 },
@@ -1086,15 +1086,15 @@ class TestGroupVars:
         header.generate_header()
         _compile(gpp, _GROUP_VARS_MAIN, 'groupvars', ['-Wextra'])
 
-        package_expected = 'AB.min=-200\nAB.max=200\nname=pkg\nratio=1.50\nflag=1\n'
+        package_expected = 'AB.min=-200\nAB.max=200\nlabel=pkg\nratio=1.50\nflag=1\n'
         cases = [
             (
                 ['--group', 'sub2'],
-                'AB.min=0\nAB.max=200\nname=sub2name\nratio=2.50\nflag=0\n',
+                'AB.min=0\nAB.max=200\nlabel=sub2label\nratio=2.50\nflag=0\n',
             ),
             (
                 ['--group', 'sub3'],
-                'AB.min=-200\nAB.max=0\nname=pkg\nratio=1.50\nflag=1\n',
+                'AB.min=-200\nAB.max=0\nlabel=pkg\nratio=1.50\nflag=1\n',
             ),
             (['--group', 'sub4'], package_expected),
             (['--group', 'unknown'], package_expected),

--- a/tests/rbx/box/ui/test_command_pane.py
+++ b/tests/rbx/box/ui/test_command_pane.py
@@ -116,7 +116,7 @@ async def test_scrollbar_does_not_narrow_the_terminal_mid_command():
     # printed until the next genuine resize is then one column too wide, and
     # that resize re-folds it one short -- spilling a trailing character onto a
     # line of its own. Reserving the gutter keeps the width constant instead.
-    app = rbxCommandApp([CommandEntry(argv=_OVERFLOW, name='a')])
+    app = rbxCommandApp([CommandEntry(argvs=[_OVERFLOW], name='a')])
     async with app.run_test(size=(150, 40)) as pilot:
         await _wait_for_commands(app, pilot, panes_expected=1)
         pane = app.query_one(CommandPane)

--- a/tests/rbx/box/walltime_test.py
+++ b/tests/rbx/box/walltime_test.py
@@ -121,10 +121,10 @@ def test_compute_walltime_uses_active_environment(
     testing_pkg: testing_package.TestingPackage,
 ):
     # The default preset environment has wallTimeMultiplier=2.0 and
-    # wallTimeIncrement=1000ms, so wall = 2 * cpu_tl + 1000 for languages
+    # wallTimeIncrement=500ms, so wall = 2 * cpu_tl + 500 for languages
     # without a per-language override (cpp, and the env default).
-    assert compute_walltime(1000, 'cpp') == 3000
-    assert compute_walltime(1000, None) == 3000
+    assert compute_walltime(1000, 'cpp') == 2500
+    assert compute_walltime(1000, None) == 2500
     # Slow languages add a larger per-language increment in the preset:
     # py +2000ms, java/kt +3000ms.
     assert compute_walltime(1000, 'py') == 4000

--- a/tests/rbx/grading/steps_compile_test.py
+++ b/tests/rbx/grading/steps_compile_test.py
@@ -890,12 +890,17 @@ InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault
         self, sandbox: SandboxBase, cleandir: pathlib.Path
     ):
         """On macOS, a missing C/C++ compiler points the user at the macOS guide."""
+        # The name has to be unresolvable everywhere yet still read as C/C++:
+        # detection is substring-based on the executable, so the `g++` prefix
+        # picks the CXX branch. A real version like `g++-14` resolves on any
+        # machine that has GCC installed -- CI does -- and the compiler then
+        # fails on the missing source instead of never being found.
         artifacts = GradingArtifacts(root=cleandir)
         params = SandboxParams()
         with patch('rbx.grading.steps.sys.platform', 'darwin'):
             with pytest.raises(steps.CompilationError) as exc_info:
                 await steps.compile(
-                    ['g++-14 src.cpp -o exe'],
+                    ['g++-not-a-real-compiler-xyz src.cpp -o exe'],
                     params,
                     sandbox,
                     artifacts,
@@ -914,7 +919,7 @@ InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault
         with patch('rbx.grading.steps.sys.platform', 'linux'):
             with pytest.raises(steps.CompilationError) as exc_info:
                 await steps.compile(
-                    ['g++-14 src.cpp -o exe'],
+                    ['g++-not-a-real-compiler-xyz src.cpp -o exe'],
                     params,
                     sandbox,
                     artifacts,


### PR DESCRIPTION
Clears six of the seven root causes behind the CI test failures. The seventh — every sandboxed run reporting `memory-limit-exceeded`, which accounts for 68 of the 79 failures on `main` — is filed separately as #720, since it needs a diagnosis on a Linux runner rather than a test fix.

## What was failing

A dispatched `tests.yml` run on `main` (run `32678437778`, commit `f1ee9d52`) reported **79 failures**. Grouped by cause, this PR covers everything except the sandbox regression:

| Cause | Failures | Fix |
|---|---|---|
| `TestGroupVars` declares a var named `name`, now reserved | 5 | rename to `label` |
| Missing-compiler tests assume `g++-14` is absent; CI installs GCC | 2 | use a name that cannot resolve |
| `CommandEntry(argv=…)` missed the `argv` → `argvs` rename | 1 | pass `argvs=[…]` |
| Walltime expectation predates `wallTimeIncrement: 500` | 1 | correct the expectation |
| Completion spec reads as drifted | 1 | stop probe commands leaking into the CLI |
| Digest cache dies under concurrent event loops | 1 | make the symlink swap atomic |

## Two of these were not what they looked like

**The completion spec was not stale.** `drift_test` says "run `mise run gen-completion-spec` and commit", but regenerating produces no diff. `test_contest_state.py` registers throwaway `probe-contest-*` commands on the real `cli.app` and never removes them — a leak the code explicitly waved through as "fine for a unit test". The drift test serializes the live CLI, so it sees the probes as drift whenever it runs after those tests in the same worker. Fixed by restoring the `registered_commands` snapshot.

**The digest cache failure is a real race, not flake.** `FileCacher._load`'s symlink branch unlinks the entry and re-creates it in place, so the path is briefly absent. `self.lock` is an asyncio lock and only serializes one event loop, so a second loop can read mid-window and get `FileNotFoundError`. The download path immediately below already stages into a temp file and renames atomically, for exactly this reason; the symlink branch now matches it.

## Verification

Full suite (`pytest --ignore=tests/rbx/box/cli -n auto`), before and after, on the same machine:

- baseline: **46 failed**, 5262 passed
- after: **38 failed**, 5270 passed
- **8 fixed, 0 newly broken**

The 38 remaining are the pre-existing local macOS sandbox/e2e failures, identical in both runs.

The completion-drift fix has a direct before/after: running `test_contest_state.py` and `drift_test.py` in one process fails without it and passes with it.

**Caveat:** the cacher race does not reproduce on macOS, so that one fix is reasoned from the CI traceback rather than verified against the flake. It is strictly safer than the code it replaces — it removes a window where the path is missing — but it should be watched on CI rather than assumed closed.

Note that the sandbox regression (#720) masks many of these files, so a green CI run needs that fixed too.
