### PR TITLE
feat(ui): copy all output and select it with the keyboard in the command pane

### DIFF
--- a/docs/plans/2026-08-24-command-pane-visual-select-design.md
+++ b/docs/plans/2026-08-24-command-pane-visual-select-design.md
@@ -1,0 +1,189 @@
+# Command pane: copy-all and keyboard visual selection (#717)
+
+Status: design, approved 2026-08-24.
+
+## Problem
+
+The command pane in `rbx contest on` / `rbx contest each` (`rbxCommandApp`,
+`rbx/box/ui/command_app.py`) can only copy what the mouse has selected. Two things
+are missing:
+
+1. There is no way to copy the whole output of a command in one keystroke.
+2. Mouse selection breaks down exactly where it is most needed. Output that overflows
+   the pane cannot be dragged past the edge of the scroll region, and a logical line
+   folded across several rows comes back with the fold breaks baked in.
+
+## What the current code gives us
+
+Grounding, because it decides most of the design:
+
+- `_AppCommandPane.on_key` (`command_app.py:60`) already intercepts `ctrl+y` **ahead of**
+  `Terminal.on_key`. That matters: while a command is running, `Terminal.on_key` forwards
+  every key to the pty, so any new binding has to be stolen the same way.
+- `Terminal.get_selection` extracts from `state.buffer.lines` — the *unfolded logical*
+  lines. So a selection covering a wrapped line yields the line as the program wrote it,
+  with no fold breaks. Copy-all gets that property for free.
+- Textual's `Screen.selections` is a plain writable `dict[Widget, Selection]`, and
+  `Terminal._render_line` already highlights from `self.text_selection`. A keyboard mode
+  can therefore drive the **existing** rendering and `Screen.get_selected_text()` without
+  touching the vendored renderer.
+- `Selection` offsets are logical `(line_no, column-in-unfolded-content)`, while the
+  viewport scrolls in *folded* rows. `buffer.folded_lines[y] -> (line_no, line_offset,
+  offset, line, updates)` is the bridge, and `_render_line` shows how the alternate
+  screen is offset by `scrollback_buffer.height`.
+- `Terminal.allow_select` is already `False` while a non-finalized alternate screen is
+  active (a full-screen child TUI owns the display).
+
+The vendored `toad` tree stays untouched, per `_vendor/toad/CLAUDE.md`.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Selection UX | Vim-style visual mode, in place in the pane |
+| Enter visual mode | `ctrl+v` |
+| Copy the whole content | `ctrl+y` with no active selection |
+| Vendored changes | None |
+
+`ctrl+y` becomes contextual: with a selection it copies the selection (today's
+behaviour, unchanged); with none it copies the entire buffer. That steals no additional
+key from the running child process, and the border subtitle always says which of the two
+the next `ctrl+y` will do.
+
+## Design
+
+### Where the code lives
+
+A new `rbx/box/ui/terminal_select.py` holds `TerminalSelectMixin`, mixed in *ahead of*
+`CommandPane` in the MRO so its `on_key` runs first:
+
+```python
+class SelectableCommandPane(TerminalSelectMixin, CommandPane): ...
+```
+
+`_AppCommandPane` subclasses `SelectableCommandPane` and drops its bespoke `ctrl+y`
+branch (the mixin owns it). `screens/command.py` yields `SelectableCommandPane()` instead
+of `CommandPane()`, so `rbx ui`'s build/run screens get the same behaviour from a
+one-line change.
+
+### Copy-all
+
+On `ctrl+y` with `screen.selections.get(self)` empty:
+
+```python
+text, _ = self.get_selection(Selection(None, None))
+```
+
+`Selection(None, None)` means "from the start of the first line to the end of the last",
+so this is the whole active buffer as logical lines. Two clean-ups before copying, since
+terminal buffers pad to the terminal width: `rstrip()` each line, then drop trailing
+empty lines. Copy-all has no on-screen effect, so it confirms with a toast
+(`Copied N lines`) rather than only a subtitle change.
+
+### Visual mode
+
+State on the mixin, all in **logical** coordinates:
+
+- `_cursor: Offset | None` — `(x=column, y=logical line)`; `None` means mode is off
+- `_anchor: Offset | None` — set by `v` / `V`, `None` while only moving
+- `_linewise: bool`
+- `_desired_x: int` — vim's sticky column across short lines
+
+`ctrl+v` enters, but only when `self.allow_select`; otherwise it is forwarded to the
+process, so a full-screen child TUI keeps the key. Entry puts the cursor at the logical
+position of the top-left visible cell — you scrolled there to look at something. The pane
+gains a `-selecting` CSS class (accent border) so the mode is unmistakable, and the
+border subtitle switches to `v select · y copy · esc exit`.
+
+Bindings inside the mode, none of which reach the process:
+
+| Keys | Action |
+|---|---|
+| `h j k l`, arrows | move the cursor (no line wrap; `j`/`k` keep `_desired_x`) |
+| `0 ^ $` | line start / first non-blank / line end |
+| `w b` | word motions (`\w+|\S`) |
+| `gg G` | first / last logical line |
+| `ctrl+d ctrl+u`, page keys | half / full viewport, measured in folded rows |
+| `v` | start or drop a charwise selection at the cursor |
+| `V` | linewise selection |
+| `y`, `ctrl+y`, `enter` | copy and leave the mode |
+| `esc`, `ctrl+v` | leave without copying |
+| anything else | ignored |
+
+Selection is published by assigning `screen.selections = {self: selection}`:
+
+- **No anchor yet** — a one-cell `Selection(cursor, cursor + (1, 0))`. The existing
+  highlight then *is* the cursor, which the pane otherwise has no way to draw once the
+  command is finalized and the pty cursor is hidden.
+- **Charwise** — the ordered pair of anchor and cursor, with the end column `+1`, because
+  `Selection.extract` slices with an exclusive end and the cell under the cursor is part
+  of the selection in vim.
+- **Linewise** — `Selection(Offset(0, top), Offset(len(lines[bottom]), bottom))`.
+
+### Coordinate mapping and why it is logical-first
+
+Folded row → logical is a direct index into `buffer.folded_lines`, plus the
+alternate-screen offset. Logical → folded row is a `bisect` over the same list, which is
+ordered by `line_no`.
+
+Anchoring the mode's state in logical coordinates is the load-bearing choice. Scrollback
+only ever appends, so a command that keeps printing while you are selecting cannot shift
+the indices under you, and a **resize reflows every folded row while leaving logical
+coordinates intact**. The alternative — tracking viewport rows — breaks under both.
+
+Two consequences to implement deliberately:
+
+- After each motion, map the cursor to its folded row and `scroll_to(..., animate=False)`
+  if it left the viewport. This is the whole point of the feature: reaching content the
+  mouse cannot drag to.
+- While the mode is on, suppress the pane's follow-the-output scrolling, or a chatty
+  command yanks the view away from the cursor.
+
+### Discoverability
+
+`HelpModal` in `command_app.py` grows its Terminal section:
+
+```
+ctrl+v      Enter select mode (hjkl move, v/V select, y copy)
+ctrl+y      Copy selection, or all output when nothing is selected
+```
+
+The unification with `RbxHelpPanel` tracked in #483 is left alone.
+
+### Known edges
+
+- **Tabs.** `_render_line` applies `content.expand_tabs(8)` before mapping a selection
+  span, while `get_selection` does not. On a line containing tabs the highlight and the
+  copied text can disagree by the tab expansion. rbx command output effectively never
+  contains tabs; expanding tabs in the column arithmetic is the fix if it ever bites.
+- **Alternate screen.** `get_selection` reads `state.buffer` (the active one) whereas
+  `_render_line` composes scrollback + alternate. They agree in the normal case, and the
+  mode refuses to start in the alternate case, so the divergence is unreachable — but it
+  is why `ctrl+v` gates on `allow_select` rather than on `is_finalized`.
+- **Render cache.** A one-cell cursor selection sets `cache_key = None` for that line
+  only, so the cost of drawing the cursor is one uncached line per frame.
+
+## Testing
+
+New `tests/rbx/box/ui/test_command_pane_select.py`, driven by `app.run_test()` + pilot in
+the style of `test_command_pane.py`, asserting on `app._clipboard` and
+`screen.selections`:
+
+1. `ctrl+y` with nothing selected copies the whole buffer, rstripped and without trailing
+   blank lines.
+2. `ctrl+y` with a selection still copies only the selection.
+3. `ctrl+v` enters the mode and keys stop reaching the process (run `cat`, press `j`,
+   assert nothing is echoed).
+4. Motions move the one-cell cursor selection.
+5. `v` then `G` then `y` copies from the cursor to the end of the output.
+6. `V` over a line longer than the pane width copies the **unwrapped** logical line — the
+   regression this feature exists for.
+7. A motion past the viewport changes `scroll_offset`.
+8. `esc` leaves the mode without copying and restores key forwarding.
+9. `ctrl+v` is forwarded to the process while the alternate screen is active.
+
+## Out of scope
+
+Search in output, extending a mouse selection with the keyboard, block/rectangular
+selection, copying with ANSI styling preserved, "copy the last command's output block",
+and persisting a selection across pane switches.

--- a/docs/plans/2026-08-24-command-pane-visual-select-design.md
+++ b/docs/plans/2026-08-24-command-pane-visual-select-design.md
@@ -1,6 +1,6 @@
 # Command pane: copy-all and keyboard visual selection (#717)
 
-Status: design, approved 2026-08-24.
+Status: implemented 2026-08-24 (`rbx/box/ui/terminal_select.py`).
 
 ## Problem
 
@@ -187,3 +187,21 @@ the style of `test_command_pane.py`, asserting on `app._clipboard` and
 Search in output, extending a mouse selection with the keyboard, block/rectangular
 selection, copying with ANSI styling preserved, "copy the last command's output block",
 and persisting a selection across pane switches.
+
+## As built
+
+Four deltas from the design above, all found while implementing:
+
+- **`y` with no anchor yanks the cursor line**, `yy`-style, instead of copying nothing.
+  Pressing `ctrl+v` then `y` doing nothing at all read as a broken key.
+- **Auto-scroll passes `immediate=True`.** Textual's `scroll_to` otherwise defers the
+  scroll until after the next refresh, which leaves the cursor drawn off-screen for a
+  frame -- and never scrolls at all under `run_test`.
+- **`ctrl+c` also exits the mode**, alongside `esc` and `ctrl+v`. It cannot reach the
+  child process from inside the mode anyway, so swallowing it silently would be worse
+  than treating it as "get me out".
+- **`can_select()` gates on the alternate screen, not on `is_finalized`.**
+  `Terminal.finalize()` turns out never to be called anywhere in rbx, so `allow_select`
+  reduces to that one condition.
+
+The tab-expansion edge under "Known edges" is unchanged and still unaddressed.

--- a/rbx/box/ui/CLAUDE.md
+++ b/rbx/box/ui/CLAUDE.md
@@ -122,6 +122,48 @@ finished left the scroll extents stale and the anchored view scrolled past the r
 the output -- the tail (e.g. a time-limits table) looked eaten. `update_size()` now calls
 `_update_virtual_size()`. Both are covered by `tests/rbx/box/ui/test_command_pane.py`.
 
+## Pane copying & keyboard selection (`terminal_select.py`)
+
+`TerminalSelectMixin` gives a `CommandPane` two things the mouse could not (#717):
+`ctrl+y` copies the selection **or**, when there is none, the whole buffer; `ctrl+v`
+opens a vim-style visual mode (`hjkl`/arrows, `0 ^ $ w b`, `gg G`, `ctrl+d/u`, `v`/`V`,
+`y` copy, `esc` cancel). `SelectableCommandPane` is the mixin over `CommandPane`;
+`_AppCommandPane` (`command_app.py`) and `CommandScreen` (`screens/command.py`) both use
+it. The vendored `toad` tree is untouched.
+
+Three facts hold it up:
+
+- **Keys are intercepted ahead of `Terminal.on_key`**, which forwards *everything* to the
+  pty. That interception is the only reason the mode can work while a command runs; the
+  same trick is what the old `ctrl+y` branch used. Nothing in select mode reaches the
+  child.
+- **State is logical, never viewport.** The cursor and anchor are `Offset(column,
+  line_no)` into `Buffer.lines` (the *unfolded* lines), so a wrapped line copies back as
+  the program wrote it, appended output cannot shift a live selection, and a resize
+  reflows every folded row without disturbing it. `Buffer.line_to_fold` /
+  `Buffer.folded_lines` convert to rows when the view has to scroll. `Selection(None,
+  None)` over the same space is the whole of copy-all.
+- **Rendering is Textual's.** The mode assigns `screen.selections = {pane: selection}` and
+  `Terminal._render_line` highlights from it, so `get_selected_text()` works unchanged.
+  With no anchor yet the mode publishes a *one-cell* selection -- that highlight **is** the
+  cursor, since the pty cursor sits wherever the command left it.
+
+Two traps worth keeping:
+
+- `scroll_to` defaults to `immediate=False`, which defers the scroll until after the next
+  refresh; the cursor is then drawn off-screen for a frame and headless tests never scroll
+  at all. Auto-scroll passes `immediate=True`.
+- The mode releases the pane's scroll anchor on entry (and restores it on exit), or a
+  still-printing command drags the view off the cursor.
+
+`Terminal.finalize()` is never called anywhere in rbx, so panes stay focusable and
+`allow_select` reduces to "not on the alternate screen" -- which is what `can_select()`
+gates on. A full-screen child TUI therefore keeps `ctrl+v` for itself.
+
+Tests: `tests/rbx/box/ui/test_command_pane_select.py`. Note the fixtures use **one-line**
+commands: the sub-command `Select` renders the command string as its label, so a
+multi-line `python -c` grows the label until the pane is squeezed to zero height.
+
 ## Keybindings
 
 Vim navigation lives in `vim_nav.py` (`VimNavMixin`, mixed into `rbxBaseApp` in `main.py`, ahead of `App` in the MRO). It registers app-level `h/j/k/l` bindings that dispatch to the focused widget's existing `cursor_*` action, falling back to `scroll_*`: `j`/`k` move down/up everywhere; `h`/`l` move left/right only where horizontal movement exists (e.g. `DataTable` cells, scroll viewers). `check_action` disables the keys while an `Input`/`TextArea` is focused, so typing is never hijacked. The mixin subclasses `DOMNode` so Textual merges its `BINDINGS`.

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -24,12 +24,14 @@ from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
 from rbx.box.ui.main import rbxBaseApp
 from rbx.box.ui.screens.tab_selector import TabSelectorModal
 from rbx.box.ui.task_queue import Task, TaskQueue
+from rbx.box.ui.terminal_select import SelectableCommandPane
 from rbx.box.ui.widgets.menu import Menu, MenuItem
 
 _ESCAPE_TAP_DURATION = 0.4
+_FOCUSED_SUBTITLE = '[b]esc×2[/b] exit  [b]ctrl+v[/b] select  [b]ctrl+y[/b] copy all'
 
 
-class _AppCommandPane(CommandPane):
+class _AppCommandPane(SelectableCommandPane):
     """CommandPane that redirects focus to sidebar on blur (double-escape)."""
 
     def on_resize(self, event: events.Resize) -> None:
@@ -50,24 +52,18 @@ class _AppCommandPane(CommandPane):
     def on_blur(self) -> None:
         self.border_subtitle = '[b]tab[/b] to focus'
 
+    def on_focus(self) -> None:
+        self.border_subtitle = _FOCUSED_SUBTITLE
+
     def selection_updated(self, selection: Selection | None) -> None:
         super().selection_updated(selection)
+        if self.in_select_mode:
+            # The select mode owns the subtitle while it is on.
+            return
         if self.has_focus and selection is not None:
             self.border_subtitle = '[b]ctrl+y[/b] copy selection'
         elif self.has_focus:
-            self.border_subtitle = 'Tap [b]esc[/b] [i]twice[/i] to exit'
-
-    async def on_key(self, event: events.Key) -> None:
-        if event.key == 'ctrl+y':
-            selected = self.screen.get_selected_text()
-            if selected:
-                self.app.copy_to_clipboard(selected)
-                self.screen.clear_selection()
-                self.border_subtitle = 'Tap [b]esc[/b] [i]twice[/i] to exit'
-                event.stop()
-                event.prevent_default()
-                return
-        await super().on_key(event)
+            self.border_subtitle = _FOCUSED_SUBTITLE
 
 
 class ShellInput(Input):
@@ -172,8 +168,19 @@ class HelpModal(ModalScreen[None]):
             yield Label(
                 '[b]Terminal[/b]\n'
                 '  [b]esc\u00d72[/b]        Return to sidebar\n'
-                '  [b]ctrl+y[/b]      Copy selected text\n'
+                '  [b]ctrl+y[/b]      Copy the selection, or all output\n'
+                '  [b]ctrl+v[/b]      Enter select mode\n'
                 '  (all other keys go to the running process)',
+                markup=True,
+            )
+            yield Label(
+                '[b]Select mode[/b] ([b]ctrl+v[/b])\n'
+                '  [b]hjkl[/b] / arrows  Move the cursor\n'
+                '  [b]0 ^ $ w b[/b]     Line start / first word / end / word\n'
+                '  [b]gg G[/b]          Top / bottom  ([b]ctrl+d ctrl+u[/b] half page)\n'
+                '  [b]v[/b] / [b]V[/b]           Select by character / by line\n'
+                '  [b]y[/b]             Copy and exit ([b]y[/b] alone yanks the line)\n'
+                '  [b]esc[/b]           Exit without copying',
                 markup=True,
             )
             yield Label(

--- a/rbx/box/ui/screens/command.py
+++ b/rbx/box/ui/screens/command.py
@@ -6,6 +6,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Header
 
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
+from rbx.box.ui.terminal_select import SelectableCommandPane
 
 
 class CommandScreen(Screen):
@@ -19,7 +20,7 @@ class CommandScreen(Screen):
     def compose(self) -> ComposeResult:
         yield Header()
         yield Footer()
-        yield CommandPane()
+        yield SelectableCommandPane()
 
     def on_mount(self):
         pane = self.query_one(CommandPane)

--- a/rbx/box/ui/terminal_select.py
+++ b/rbx/box/ui/terminal_select.py
@@ -1,0 +1,381 @@
+"""Keyboard selection and copying for terminal panes (#717).
+
+The pane could only copy what the mouse had selected, which breaks down exactly
+where it matters: a drag cannot reach output that overflows the scroll region,
+and a logical line folded across rows came back with the fold breaks baked in.
+
+`TerminalSelectMixin` adds two things on top of a `CommandPane`:
+
+* `ctrl+y` copies the selection when there is one, and the **whole buffer** when
+  there is not.
+* `ctrl+v` opens a vim-style visual mode: motions move a cursor (with
+  auto-scroll), `v`/`V` start a char- or line-wise selection, `y` copies.
+
+Two properties carry the design.
+
+First, all state is kept in *logical* coordinates -- `Offset(column, line_no)`
+into `Buffer.lines`, the unfolded lines -- and never in viewport rows. Scrollback
+only ever appends, so a command still printing cannot shift the indices under a
+selection, and a resize reflows every folded row while leaving logical positions
+untouched. `Buffer.line_to_fold` and `Buffer.folded_lines` map between the two
+spaces when the view has to scroll.
+
+Second, the mode publishes into Textual's `Screen.selections`, which the vendored
+`Terminal._render_line` already reads. Highlighting and `get_selected_text()`
+therefore come for free, and the vendored tree needs no changes.
+
+Keys are intercepted ahead of `Terminal.on_key`, which otherwise forwards
+everything to the pty -- that interception is what lets the mode work while a
+command is still running.
+"""
+
+import re
+from typing import List, Optional
+
+from textual import events
+from textual.geometry import Offset
+from textual.selection import Selection
+
+from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
+
+_WORD_RE = re.compile(r'\w+|[^\w\s]')
+
+SELECT_SUBTITLE = '[b]v[/b] select  [b]y[/b] copy  [b]esc[/b] exit'
+
+_EXIT_KEYS = frozenset({'escape', 'ctrl+v', 'ctrl+c'})
+_COPY_KEYS = frozenset({'y', 'ctrl+y', 'enter'})
+
+
+def _tidy(text: str) -> str:
+    """Drop the padding a terminal buffer leaves on its lines."""
+    lines = [line.rstrip() for line in text.split('\n')]
+    while lines and not lines[-1]:
+        lines.pop()
+    return '\n'.join(lines)
+
+
+class TerminalSelectMixin:
+    """Vim-style visual selection over a terminal pane's logical buffer.
+
+    Mix in *ahead of* `CommandPane` so `on_key` runs before the key-forwarding
+    path in `Terminal`.
+    """
+
+    _select_cursor: Optional[Offset] = None
+    _select_anchor: Optional[Offset] = None
+    _select_linewise: bool = False
+    _select_desired_x: int = 0
+    _select_pending_g: bool = False
+    _select_was_anchored: bool = False
+
+    # --- state -----------------------------------------------------------
+
+    @property
+    def in_select_mode(self) -> bool:
+        """Is the visual selection mode active?"""
+        return self._select_cursor is not None
+
+    @property
+    def select_cursor(self) -> Optional[Offset]:
+        """Cursor position in logical `(column, line_no)` coordinates."""
+        return self._select_cursor
+
+    @property
+    def _buffer(self):
+        return self.state.scrollback_buffer
+
+    def _lines(self) -> List[str]:
+        return [line.content.plain for line in self._buffer.lines]
+
+    def _line_text(self, line_no: int) -> str:
+        lines = self._buffer.lines
+        if 0 <= line_no < len(lines):
+            return lines[line_no].content.plain
+        return ''
+
+    def can_select(self) -> bool:
+        """Can a keyboard selection be started right now?
+
+        Not while a full-screen child owns the display: the alternate buffer and
+        the scrollback share the `line_no` space that selections are expressed
+        in, so a selection there would be ambiguous, and the child should keep
+        the key anyway.
+        """
+        return (
+            self.allow_select
+            and not self.state.alternate_screen
+            and bool(self._buffer.lines)
+        )
+
+    # --- coordinate mapping ----------------------------------------------
+
+    def _clamp(self, position: Offset) -> Offset:
+        lines = self._buffer.lines
+        if not lines:
+            return Offset(0, 0)
+        y = max(0, min(position.y, len(lines) - 1))
+        x = max(0, min(position.x, max(0, len(self._line_text(y)) - 1)))
+        return Offset(x, y)
+
+    def _folded_row_of(self, position: Offset) -> int:
+        """Map a logical position to the folded row that renders it."""
+        buffer = self._buffer
+        line_no = position.y
+        if line_no >= len(buffer.line_to_fold):
+            return max(0, buffer.height - 1)
+        row = buffer.line_to_fold[line_no]
+        consumed = 0
+        folds = buffer.lines[line_no].folds
+        for index, fold in enumerate(folds):
+            length = len(fold.content)
+            if position.x < consumed + length:
+                return row + index
+            consumed += length
+        return row + max(0, len(folds) - 1)
+
+    def _logical_of_row(self, row: int) -> Offset:
+        """Map a folded row to the logical position of its first cell."""
+        folded_lines = self._buffer.folded_lines
+        if not folded_lines:
+            return Offset(0, 0)
+        row = max(0, min(row, len(folded_lines) - 1))
+        fold = folded_lines[row]
+        return Offset(fold.offset, fold.line_no)
+
+    # --- mode -------------------------------------------------------------
+
+    def enter_select_mode(self) -> None:
+        # Start where you are looking: the top-left cell of the viewport.
+        self._select_cursor = self._clamp(self._logical_of_row(self.scroll_offset.y))
+        self._select_anchor = None
+        self._select_linewise = False
+        self._select_desired_x = self._select_cursor.x
+        self._select_pending_g = False
+        # Stop following the output, or a chatty command drags the view away
+        # from the cursor mid-selection.
+        self._select_was_anchored = not self._anchor_released
+        self.release_anchor()
+        self.add_class('-selecting')
+        self._publish_selection()
+        self.border_subtitle = SELECT_SUBTITLE
+
+    def exit_select_mode(self, copy: bool = False) -> None:
+        text = None
+        if copy and self._select_cursor is not None:
+            if self._select_anchor is None:
+                # No anchor yet: `y` yanks the cursor line, as `yy` would.
+                text = self._line_text(self._select_cursor.y).rstrip()
+            else:
+                text = self.screen.get_selected_text()
+        self._select_cursor = None
+        self._select_anchor = None
+        self._select_linewise = False
+        self._select_pending_g = False
+        self.remove_class('-selecting')
+        self.screen.clear_selection()
+        if self._select_was_anchored:
+            self._anchor_released = False
+        if text:
+            self.app.copy_to_clipboard(text)
+
+    def _publish_selection(self) -> None:
+        cursor = self._select_cursor
+        if cursor is None:
+            return
+        anchor = self._select_anchor
+        if anchor is None:
+            # The one-cell highlight *is* the cursor: the pane has no other way
+            # to draw one, since the pty cursor sits wherever the command left it.
+            selection = Selection(cursor, cursor + Offset(1, 0))
+        elif self._select_linewise:
+            top, bottom = sorted((anchor.y, cursor.y))
+            selection = Selection(
+                Offset(0, top), Offset(len(self._line_text(bottom)), bottom)
+            )
+        else:
+            start, end = sorted([anchor, cursor], key=lambda offset: offset.transpose)
+            # `Selection.extract` slices with an exclusive end, and the cell
+            # under the cursor is part of the selection.
+            selection = Selection(start, end + Offset(1, 0))
+        self.screen.selections = {self: selection}
+
+    def _toggle_anchor(self, linewise: bool) -> None:
+        if self._select_anchor is not None and self._select_linewise == linewise:
+            self._select_anchor = None
+        else:
+            if self._select_anchor is None:
+                self._select_anchor = self._select_cursor
+            self._select_linewise = linewise
+        self._publish_selection()
+
+    # --- motions ----------------------------------------------------------
+
+    def _move_to(self, position: Offset, sticky: bool = True) -> None:
+        self._select_cursor = self._clamp(position)
+        if sticky:
+            self._select_desired_x = self._select_cursor.x
+        self._publish_selection()
+        self._scroll_to_cursor()
+
+    def _move_rows(self, delta: int) -> None:
+        assert self._select_cursor is not None
+        row = self._folded_row_of(self._select_cursor) + delta
+        target = self._logical_of_row(row)
+        self._move_to(Offset(max(target.x, self._select_desired_x), target.y), False)
+
+    def _scroll_to_cursor(self) -> None:
+        assert self._select_cursor is not None
+        row = self._folded_row_of(self._select_cursor)
+        top = self.scroll_offset.y
+        height = max(1, self.scrollable_content_region.height)
+        # `immediate`, because the default defers the scroll until after the next
+        # refresh -- the cursor would then be drawn off-screen for a frame, and a
+        # burst of motions would each be waiting on a repaint they caused.
+        if row < top:
+            self.scroll_to(y=row, animate=False, immediate=True)
+        elif row >= top + height:
+            self.scroll_to(y=row - height + 1, animate=False, immediate=True)
+
+    def _word_move(self, forward: bool) -> None:
+        cursor = self._select_cursor
+        assert cursor is not None
+        starts = [
+            match.start() for match in _WORD_RE.finditer(self._line_text(cursor.y))
+        ]
+        if forward:
+            following = [start for start in starts if start > cursor.x]
+            if following:
+                self._move_to(Offset(following[0], cursor.y))
+            elif cursor.y + 1 < len(self._buffer.lines):
+                self._move_to(Offset(0, cursor.y + 1))
+        else:
+            preceding = [start for start in starts if start < cursor.x]
+            if preceding:
+                self._move_to(Offset(preceding[-1], cursor.y))
+            elif cursor.y > 0:
+                previous = [
+                    match.start()
+                    for match in _WORD_RE.finditer(self._line_text(cursor.y - 1))
+                ]
+                self._move_to(Offset(previous[-1] if previous else 0, cursor.y - 1))
+
+    # --- keys -------------------------------------------------------------
+
+    def _handle_select_key(self, key: str, character: Optional[str]) -> None:
+        cursor = self._select_cursor
+        assert cursor is not None
+        pending_g = self._select_pending_g
+        self._select_pending_g = False
+        last_line = max(0, len(self._buffer.lines) - 1)
+        height = max(1, self.scrollable_content_region.height)
+        token = character if character and character.isprintable() else key
+
+        if pending_g and token == 'g':
+            self._move_to(Offset(0, 0))
+            return
+        if key in _EXIT_KEYS:
+            self.exit_select_mode()
+            return
+        if token in _COPY_KEYS or key in _COPY_KEYS:
+            self.exit_select_mode(copy=True)
+            return
+        if token == 'v':
+            self._toggle_anchor(linewise=False)
+            return
+        if token == 'V':
+            self._toggle_anchor(linewise=True)
+            return
+        if token == 'g':
+            self._select_pending_g = True
+            return
+        if token == 'G':
+            self._move_to(Offset(self._select_desired_x, last_line), False)
+            return
+        if token == 'h' or key == 'left':
+            self._move_to(cursor - Offset(1, 0))
+            return
+        if token == 'l' or key == 'right':
+            self._move_to(cursor + Offset(1, 0))
+            return
+        if token == 'j' or key == 'down':
+            self._move_to(Offset(self._select_desired_x, cursor.y + 1), False)
+            return
+        if token == 'k' or key == 'up':
+            self._move_to(Offset(self._select_desired_x, cursor.y - 1), False)
+            return
+        if token == '0' or key == 'home':
+            self._move_to(Offset(0, cursor.y))
+            return
+        if token == '$' or key == 'end':
+            self._move_to(Offset(len(self._line_text(cursor.y)), cursor.y))
+            return
+        if token == '^':
+            text = self._line_text(cursor.y)
+            self._move_to(Offset(len(text) - len(text.lstrip()), cursor.y))
+            return
+        if token == 'w':
+            self._word_move(forward=True)
+            return
+        if token == 'b':
+            self._word_move(forward=False)
+            return
+        if key == 'ctrl+d':
+            self._move_rows(height // 2)
+            return
+        if key == 'ctrl+u':
+            self._move_rows(-(height // 2))
+            return
+        if key == 'pagedown':
+            self._move_rows(height)
+            return
+        if key == 'pageup':
+            self._move_rows(-height)
+
+    def copy_all(self) -> None:
+        """Copy the whole buffer, as logical (unwrapped) lines."""
+        extracted = self.get_selection(Selection(None, None))
+        text = _tidy(extracted[0]) if extracted else ''
+        if not text:
+            self.app.notify('Nothing to copy.', severity='warning')
+            return
+        self.app.copy_to_clipboard(text)
+        count = len(text.split('\n'))
+        self.app.notify(f'Copied {count} line{"" if count == 1 else "s"}.')
+
+    async def on_key(self, event: events.Key) -> None:
+        if self.in_select_mode:
+            event.stop()
+            event.prevent_default()
+            self._handle_select_key(event.key, event.character)
+            return
+        if event.key == 'ctrl+y':
+            event.stop()
+            event.prevent_default()
+            selected = self.screen.get_selected_text()
+            if selected:
+                self.app.copy_to_clipboard(selected)
+                self.screen.clear_selection()
+            else:
+                self.copy_all()
+            return
+        if event.key == 'ctrl+v' and self.can_select():
+            event.stop()
+            event.prevent_default()
+            self.enter_select_mode()
+            return
+        await super().on_key(event)
+
+    def selection_updated(self, selection: Optional[Selection]) -> None:
+        super().selection_updated(selection)
+        if self.in_select_mode:
+            self.border_subtitle = SELECT_SUBTITLE
+
+
+class SelectableCommandPane(TerminalSelectMixin, CommandPane):
+    """A `CommandPane` with keyboard selection and copy-all."""
+
+    DEFAULT_CSS = """
+    SelectableCommandPane.-selecting {
+        border: solid $success;
+    }
+    """

--- a/tests/rbx/box/ui/test_command_pane_select.py
+++ b/tests/rbx/box/ui/test_command_pane_select.py
@@ -1,0 +1,266 @@
+"""Tests for copying and keyboard selection in the command pane (#717).
+
+Two features share one mixin: `ctrl+y` copies the whole buffer when nothing is
+selected, and `ctrl+v` opens a vim-style visual mode whose state lives in
+*logical* (unfolded) coordinates -- which is what makes a wrapped line copy back
+as the program wrote it, and what lets the selection reach content the mouse
+cannot drag to.
+"""
+
+import asyncio
+import sys
+from typing import List
+
+from textual.geometry import Offset
+from textual.selection import Selection
+
+from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
+from rbx.box.ui.command_app import CommandEntry, rbxCommandApp
+
+_LONG_LINE = 'X' * 300
+
+
+def _print(*lines: str):
+    body = '\n'.join(f'print({line!r})' for line in lines)
+    return [sys.executable, '-c', body]
+
+
+async def _running_app(pilot, app, panes_expected: int = 1):
+    for _ in range(100):
+        await pilot.pause()
+        await asyncio.sleep(0.05)
+        panes = list(app.query(CommandPane))
+        if len(panes) == panes_expected and all(
+            p.return_code is not None for p in panes
+        ):
+            return panes
+    raise AssertionError('commands did not finish in time')
+
+
+def _make_app(*lines: str) -> rbxCommandApp:
+    return rbxCommandApp(
+        [CommandEntry(argvs=[_print(*lines)], name='a')], parallel=True
+    )
+
+
+async def _focus_pane(app, pilot, pane) -> None:
+    app.set_focus(pane)
+    await pilot.pause()
+
+
+def _capture_clipboard(app) -> List[str]:
+    """Record what the app copies, instead of poking at its private state."""
+    copied: List[str] = []
+    app.copy_to_clipboard = copied.append  # type: ignore[method-assign]
+    return copied
+
+
+async def test_ctrl_y_copies_the_whole_output_when_nothing_is_selected():
+    app = _make_app('alpha', 'beta', 'gamma')
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+        copied = _capture_clipboard(app)
+
+        await pilot.press('ctrl+y')
+        await pilot.pause()
+
+        assert copied == ['alpha\nbeta\ngamma']
+
+
+async def test_ctrl_y_still_copies_only_the_selection():
+    app = _make_app('alpha', 'beta', 'gamma')
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+        copied = _capture_clipboard(app)
+
+        pane.screen.selections = {pane: Selection(Offset(0, 1), Offset(4, 1))}
+        await pilot.pause()
+        await pilot.press('ctrl+y')
+        await pilot.pause()
+
+        assert copied == ['beta']
+
+
+async def test_ctrl_y_copies_a_wrapped_line_unwrapped():
+    app = _make_app(_LONG_LINE)
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+        copied = _capture_clipboard(app)
+        # The line really is folded across several rows.
+        assert len(pane.state.scrollback_buffer.folded_lines) > 1
+
+        await pilot.press('ctrl+y')
+        await pilot.pause()
+
+        assert copied == [_LONG_LINE]
+
+
+async def test_ctrl_v_enters_visual_mode_and_shows_a_cursor():
+    app = _make_app('alpha', 'beta', 'gamma')
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+
+        await pilot.press('ctrl+v')
+        await pilot.pause()
+
+        assert pane.in_select_mode
+        assert pane.has_class('-selecting')
+        # With no anchor yet the selection is a single cell -- that *is* the cursor.
+        assert pane.screen.selections[pane] == Selection(Offset(0, 0), Offset(1, 0))
+
+
+async def test_visual_mode_keys_do_not_reach_the_process():
+    app = rbxCommandApp(
+        [
+            CommandEntry(
+                argvs=[[sys.executable, '-u', '-c', "print('ready'); input()"]],
+                name='a',
+            )
+        ],
+        parallel=True,
+    )
+    async with app.run_test(size=(150, 40)) as pilot:
+        # Wait until the command has printed, so there is a buffer to select in.
+        for _ in range(100):
+            await pilot.pause()
+            await asyncio.sleep(0.05)
+            panes = list(app.query(CommandPane))
+            if panes and panes[0].state.scrollback_buffer.lines:
+                break
+        (pane,) = panes
+        await _focus_pane(app, pilot, pane)
+
+        await pilot.press('ctrl+v')
+        for _ in range(5):
+            await pilot.press('j')
+        await pilot.pause()
+        await asyncio.sleep(0.2)
+        await pilot.pause()
+
+        text = '\n'.join(
+            line.content.plain for line in pane.state.scrollback_buffer.lines
+        )
+        assert 'j' not in text
+
+
+async def test_hjkl_and_arrows_both_move_the_cursor():
+    app = _make_app('alpha', 'beta', 'gamma')
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+        await pilot.press('ctrl+v')
+
+        await pilot.press('j', 'l')
+        await pilot.pause()
+        assert pane.select_cursor == Offset(1, 1)
+
+        await pilot.press('down', 'right')
+        await pilot.pause()
+        assert pane.select_cursor == Offset(2, 2)
+
+        await pilot.press('up', 'left')
+        await pilot.pause()
+        assert pane.select_cursor == Offset(1, 1)
+
+        await pilot.press('k', 'h')
+        await pilot.pause()
+        assert pane.select_cursor == Offset(0, 0)
+
+
+async def test_charwise_selection_to_the_end_copies_the_tail():
+    app = _make_app('alpha', 'beta', 'gamma')
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+        copied = _capture_clipboard(app)
+
+        await pilot.press('ctrl+v', 'j', 'v', 'G', '$', 'y')
+        await pilot.pause()
+
+        assert copied == ['beta\ngamma']
+        assert not pane.in_select_mode
+        assert not pane.screen.selections
+
+
+async def test_linewise_selection_copies_the_unwrapped_logical_line():
+    app = _make_app('alpha', _LONG_LINE, 'gamma')
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+        copied = _capture_clipboard(app)
+
+        await pilot.press('ctrl+v', 'j', 'V', 'y')
+        await pilot.pause()
+
+        assert copied == [_LONG_LINE]
+
+
+async def test_moving_past_the_viewport_scrolls_the_pane():
+    # One-liner on purpose: the sub-command Select renders the command string as
+    # its label, so a multi-line `python -c` would grow it until the pane collapses.
+    app = rbxCommandApp(
+        [
+            CommandEntry(
+                argvs=[
+                    [
+                        sys.executable,
+                        '-c',
+                        "[print(f'line-{index}') for index in range(200)]",
+                    ]
+                ],
+                name='a',
+            )
+        ],
+        parallel=True,
+    )
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+
+        await pilot.press('ctrl+v')
+        await pilot.pause()
+        # The pane follows its output, so it starts parked at the bottom.
+        bottom = pane.scroll_offset.y
+        assert bottom > 0
+
+        await pilot.press('g', 'g')
+        await pilot.pause()
+        assert pane.scroll_offset.y == 0
+        assert pane.select_cursor == Offset(0, 0)
+
+        await pilot.press('G')
+        await pilot.pause()
+        assert pane.scroll_offset.y == bottom
+        assert pane.select_cursor.y == len(pane.state.scrollback_buffer.lines) - 1
+
+
+async def test_escape_leaves_visual_mode_without_copying():
+    app = _make_app('alpha', 'beta', 'gamma')
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+        copied = _capture_clipboard(app)
+
+        await pilot.press('ctrl+v', 'v', 'j', 'escape')
+        await pilot.pause()
+
+        assert not pane.in_select_mode
+        assert not pane.screen.selections
+        assert copied == []
+
+
+async def test_y_without_an_anchor_copies_the_cursor_line():
+    app = _make_app('alpha', 'beta', 'gamma')
+    async with app.run_test(size=(150, 40)) as pilot:
+        (pane,) = await _running_app(pilot, app)
+        await _focus_pane(app, pilot, pane)
+        copied = _capture_clipboard(app)
+
+        await pilot.press('ctrl+v', 'j', 'y')
+        await pilot.pause()
+
+        assert copied == ['beta']


### PR DESCRIPTION
Closes #717.

The command pane (`rbx contest on` / `each`) could only copy what the mouse had selected. That breaks down exactly where it matters: a drag cannot reach output that overflows the scroll region, and a logical line folded across rows came back with the fold breaks baked in.

## What changed

- **`ctrl+y` is contextual** — copies the selection when there is one, the **whole buffer** when there is not. No extra key is stolen from the running child process.
- **`ctrl+v` opens a vim-style visual mode**: `hjkl` and arrows move a cursor with auto-scroll, `0 ^ $ w b` / `gg G` / `ctrl+d ctrl+u` for larger jumps, `v` / `V` select char- or line-wise, `y` copies and exits (`y` with no selection yanks the cursor line), `esc` cancels. Keys are intercepted ahead of the pty forwarding, so the mode works **while a command is still running**.
- The help modal and the pane's border subtitle document both.
- `rbx ui`'s build/run panes get the same behaviour from a one-line change.

## How it works

Three things carry it, all in the new `rbx/box/ui/terminal_select.py`:

1. **Keys are intercepted ahead of `Terminal.on_key`**, which otherwise forwards everything to the pty — the same trick the old `ctrl+y` branch used.
2. **State is logical, never viewport-based.** Cursor and anchor are `Offset(column, line_no)` into the *unfolded* `Buffer.lines`. So a wrapped line copies back as the program wrote it, appended output cannot shift a live selection, and a resize reflows every folded row without disturbing it. `Buffer.line_to_fold` / `folded_lines` convert to rows only when the view has to scroll.
3. **Rendering is Textual's own.** The mode assigns `screen.selections`, which `Terminal._render_line` already reads. **The vendored `toad` tree is untouched.**

## Testing

`tests/rbx/box/ui/test_command_pane_select.py` — 11 tests covering copy-all, copy-selection, the unwrapped-wrapped-line case, mode entry, key swallowing (verified against a live `input()` child), `hjkl` *and* arrows, charwise and linewise copy, auto-scroll in both directions, and cancel. Full UI suite: 122 passed. `ruff check .` clean.

Design doc: `docs/plans/2026-08-24-command-pane-visual-select-design.md`, with an "As built" section recording the deltas found while implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQz1kEATbaGNc9vGgxo1XD