### PR TITLE
fix(grading): stop charging sandboxed programs the parent's memory

### DIFF
--- a/rbx/grading/judge/program.py
+++ b/rbx/grading/judge/program.py
@@ -16,6 +16,16 @@ from rbx.utils import PathOrStr
 
 FileLike = Union[PathOrStr, IO[bytes], int]
 
+# How often the alarm thread samples the child's RSS. Where ru_maxrss cannot be
+# trusted (see `maxrss_inherits_parent`) this sampling is the only measurement
+# of a program that stays under the parent's footprint, so it has to be fine
+# enough to catch a program that allocates and exits in a few hundred
+# milliseconds. A sample costs a few microseconds.
+RSS_SAMPLE_INTERVAL = 0.02
+# CPU time is read on its own, coarser cadence -- it is compared against a limit
+# in seconds and needs no such resolution.
+CPU_CHECK_INTERVAL = 0.3
+
 
 def _maybe_close_files(files):
     for fobj in files:
@@ -316,16 +326,20 @@ class Program:
             self._sample_rss(process)
         except psutil.Error:
             return
-        while not self._stop_alarm_handler.wait(0.3):
+        elapsed_since_cpu_check = 0.0
+        while not self._stop_alarm_handler.wait(RSS_SAMPLE_INTERVAL):
             try:
                 if process.create_time() != create_time:
                     return
-                if self.params.time_limit is not None:
-                    times = process.cpu_times()
-                    cpu_time = times.user + times.system
-                    if cpu_time > self.params.time_limit:
-                        self._alarm_msg = 'timelimit'
-                        self._kill_process()
+                elapsed_since_cpu_check += RSS_SAMPLE_INTERVAL
+                if elapsed_since_cpu_check >= CPU_CHECK_INTERVAL:
+                    elapsed_since_cpu_check = 0.0
+                    if self.params.time_limit is not None:
+                        times = process.cpu_times()
+                        cpu_time = times.user + times.system
+                        if cpu_time > self.params.time_limit:
+                            self._alarm_msg = 'timelimit'
+                            self._kill_process()
                 memory_used = self._sample_rss(process)
                 if (
                     self.params.memory_limit is not None

--- a/rbx/grading/judge/program.py
+++ b/rbx/grading/judge/program.py
@@ -131,6 +131,65 @@ def get_memory_usage(ru: resource.struct_rusage) -> int:
     return (ru.ru_maxrss + ru.ru_ixrss + ru.ru_idrss + ru.ru_isrss) * 1024
 
 
+def maxrss_inherits_parent() -> bool:
+    """Whether a child's ru_maxrss is contaminated by the parent's memory.
+
+    On Linux, a forked child starts out with its `mm->hiwater_rss` seeded from
+    the parent's current RSS, and `execve` folds that high-water mark into the
+    new process' accounting -- so the `ru_maxrss` reported by `os.wait4()` is
+    really `max(parent_rss_at_fork, child_peak)`. A trivial program forked from
+    a fat parent is charged the parent's whole footprint.
+
+    Darwin resets the high-water mark at exec, so the value is the child's alone.
+    """
+    return sys.platform != 'darwin'
+
+
+def is_own_rss(rss: int, rss_baseline: int) -> bool:
+    """Whether an RSS sample reflects the child rather than the inherited parent.
+
+    A sample taken before the child has exec'd still shows the parent's
+    copy-on-write footprint, so anything at or above the baseline is not
+    trustworthy as the child's own -- those are the cases `ru_maxrss` measures
+    exactly anyway.
+    """
+    return not maxrss_inherits_parent() or rss < rss_baseline
+
+
+def get_child_memory_usage(
+    ru: resource.struct_rusage, rss_baseline: int, sampled_peak: int
+) -> int:
+    """Peak memory of a child, in bytes, with the parent's share removed.
+
+    Where `ru_maxrss` is `max(parent_rss_at_fork, child_peak)` (see
+    `maxrss_inherits_parent`), a value above the baseline can only have come
+    from the child, so it is the peak, exactly. A value at or below the baseline
+    tells us nothing beyond that bound, and the peak sampled from the child
+    itself is used instead -- a lower bound, but one that is never inflated by
+    whatever the parent happened to be holding.
+
+    Args:
+        ru: Resource usage statistics from os.wait4() or similar
+        rss_baseline: RSS of the parent right before forking, in bytes
+        sampled_peak: Peak RSS observed on the child itself, in bytes
+
+    Returns:
+        int: Peak memory usage of the child, in bytes
+    """
+    memory_used = get_memory_usage(ru)
+    if maxrss_inherits_parent() and memory_used <= rss_baseline:
+        return sampled_peak
+    return memory_used
+
+
+def get_self_rss() -> int:
+    """Current RSS of this process, in bytes, or 0 if it cannot be read."""
+    try:
+        return psutil.Process().memory_info().rss
+    except psutil.Error:
+        return 0
+
+
 def get_cpu_time(ru: resource.struct_rusage) -> float:
     """Get CPU time in seconds from resource usage statistics.
 
@@ -208,6 +267,11 @@ class Program:
         self._stop_wall_handler = threading.Event()
         self._stop_alarm_handler = threading.Event()
         self._alarm_msg = ''
+        # RSS of this process right before forking, and the peak RSS sampled
+        # from the child itself. Both are needed to undo the ru_maxrss
+        # contamination described in `maxrss_inherits_parent`.
+        self._rss_baseline = 0
+        self._peak_rss = 0
 
         self._run()
 
@@ -236,13 +300,21 @@ class Program:
         self._alarm_msg = 'wall timelimit'
         self._kill_process()
 
+    def _sample_rss(self, process: psutil.Process) -> int:
+        """Sample the child's own RSS, keeping track of its peak."""
+        rss = process.memory_info().rss
+        if is_own_rss(rss, self._rss_baseline):
+            self._peak_rss = max(self._peak_rss, rss)
+        return rss
+
     def _handle_alarm(self):
         # Pin the child by (pid, create_time) so a poll after PID reuse
         # cannot read another process's stats and trigger a false MLE/TLE.
         try:
             process = psutil.Process(self.pid)
             create_time = process.create_time()
-        except psutil.NoSuchProcess:
+            self._sample_rss(process)
+        except psutil.Error:
             return
         while not self._stop_alarm_handler.wait(0.3):
             try:
@@ -254,17 +326,20 @@ class Program:
                     if cpu_time > self.params.time_limit:
                         self._alarm_msg = 'timelimit'
                         self._kill_process()
-                if self.params.memory_limit is not None:
-                    memory_info = process.memory_info()
-                    memory_used = memory_info.rss
-                    if memory_used > self.params.memory_limit * 1024 * 1024:
-                        self._alarm_msg = 'memorylimit'
-                        self._kill_process()
+                memory_used = self._sample_rss(process)
+                if (
+                    self.params.memory_limit is not None
+                    and memory_used > self.params.memory_limit * 1024 * 1024
+                ):
+                    self._alarm_msg = 'memorylimit'
+                    self._kill_process()
             except psutil.NoSuchProcess:
                 return
 
     def _run(self):
         self._files = self.params.io.get_file_objects()
+        if maxrss_inherits_parent():
+            self._rss_baseline = get_self_rss()
         try:
             self.popen = subprocess.Popen(
                 self.command,
@@ -303,7 +378,7 @@ class Program:
         wall_time = monotonic() - self.start_time
         _maybe_close_files(self._files)
         cpu_time = get_cpu_time(ru)
-        memory_used = get_memory_usage(ru)
+        memory_used = get_child_memory_usage(ru, self._rss_baseline, self._peak_rss)
         file_sizes = get_file_sizes(self.params.io)
         exitcode = os.waitstatus_to_exitcode(exitstatus)
         killing_signal = None

--- a/rbx/grading/judge/program.py
+++ b/rbx/grading/judge/program.py
@@ -18,10 +18,11 @@ FileLike = Union[PathOrStr, IO[bytes], int]
 
 # How often the alarm thread samples the child's RSS. Where ru_maxrss cannot be
 # trusted (see `maxrss_inherits_parent`) this sampling is the only measurement
-# of a program that stays under the parent's footprint, so it has to be fine
-# enough to catch a program that allocates and exits in a few hundred
-# milliseconds. A sample costs a few microseconds.
-RSS_SAMPLE_INTERVAL = 0.02
+# of a program that stays under the parent's footprint, and sampling cannot be
+# made precise -- a program that allocates and frees between two ticks is
+# invisible at any interval. This is a compromise, not a guarantee; #725 tracks
+# measuring the peak properly instead.
+RSS_SAMPLE_INTERVAL = 0.1
 # CPU time is read on its own, coarser cadence -- it is compared against a limit
 # in seconds and needs no such resolution.
 CPU_CHECK_INTERVAL = 0.3

--- a/tests/rbx/grading/judge/test_program.py
+++ b/tests/rbx/grading/judge/test_program.py
@@ -818,3 +818,23 @@ class TestMaxrssCorrection:
         assert result.exitcode == 0
         assert ProgramCode.ML not in result.program_codes
         assert result.memory_used < 64 * 1024 * 1024
+
+    def test_a_real_offender_is_still_caught_under_a_fat_parent(self, testdata_path):
+        """The other side of it: no false negatives in the band we cannot measure.
+
+        A program peaking at 96 MB is over its 32 MB limit and under the parent's
+        150 MB, which is exactly where ru_maxrss carries no information about the
+        child. The RSS sampler has to catch it before it exits.
+        """
+        script = testdata_path / 'steps_run_test' / 'memory_heavy.py'
+        ballast = bytearray(150 * 1024 * 1024)
+        try:
+            for i in range(0, len(ballast), 4096):
+                ballast[i] = 1
+
+            params = ProgramParams(memory_limit=32)
+            result = Program([sys.executable, str(script), '96'], params).wait()
+        finally:
+            del ballast
+
+        assert ProgramCode.ML in result.program_codes

--- a/tests/rbx/grading/judge/test_program.py
+++ b/tests/rbx/grading/judge/test_program.py
@@ -14,9 +14,13 @@ from rbx.grading.judge.program import (
     ProgramNotFoundError,
     ProgramParams,
     ProgramResult,
+    get_child_memory_usage,
     get_cpu_time,
     get_memory_usage,
     get_preexec_fn,
+    get_self_rss,
+    is_own_rss,
+    maxrss_inherits_parent,
 )
 
 
@@ -515,6 +519,9 @@ class TestProgramCode:
 class TestProgramMocks:
     """Test Program functionality using mocks to verify intended behavior."""
 
+    # The ru_maxrss correction is covered by TestMaxrssCorrection; disable it
+    # here so the mocked rusage reaches the result untouched on every platform.
+    @mock.patch('rbx.grading.judge.program.maxrss_inherits_parent', return_value=False)
     @mock.patch('rbx.grading.judge.program.get_file_sizes')
     @mock.patch('rbx.grading.judge.program.get_memory_usage')
     @mock.patch('rbx.grading.judge.program.get_cpu_time')
@@ -525,6 +532,7 @@ class TestProgramMocks:
         mock_get_cpu_time,
         mock_get_memory_usage,
         mock_get_file_sizes,
+        mock_maxrss_inherits_parent,
         simple_hello_program,
     ):
         """Test that process_exit correctly processes resource usage data."""
@@ -625,6 +633,8 @@ class TestProgramMocks:
         # Mock CPU times exceeding limit
         mock_process.cpu_times.return_value.user = 3.0
         mock_process.cpu_times.return_value.system = 2.5
+        # The alarm handler samples RSS on every tick, limit or no limit.
+        mock_process.memory_info.return_value.rss = 1024 * 1024
 
         command = [sys.executable, '-c', 'import time; time.sleep(1)']
         params = ProgramParams(time_limit=5.0)  # CPU total will be 5.5 > 5.0
@@ -706,3 +716,105 @@ class TestEdgeCases:
         # All should succeed
         for result in results:
             assert result.exitcode == 0
+
+
+class TestMaxrssCorrection:
+    """Test that a child is not charged the parent's memory (issue #720)."""
+
+    def test_get_self_rss_is_positive(self):
+        assert get_self_rss() > 0
+
+    def test_maxrss_inherits_parent_matches_the_platform(self):
+        with mock.patch('sys.platform', 'darwin'):
+            assert not maxrss_inherits_parent()
+        with mock.patch('sys.platform', 'linux'):
+            assert maxrss_inherits_parent()
+
+    @mock.patch('rbx.grading.judge.program.get_memory_usage')
+    @mock.patch('rbx.grading.judge.program.maxrss_inherits_parent', return_value=True)
+    def test_usage_above_baseline_comes_from_the_child(
+        self, mock_inherits, mock_get_memory_usage
+    ):
+        """Above the baseline, ru_maxrss can only be the child's own peak."""
+        mock_get_memory_usage.return_value = 300 * 1024 * 1024
+
+        assert (
+            get_child_memory_usage(
+                mock.MagicMock(),
+                rss_baseline=200 * 1024 * 1024,
+                sampled_peak=1024,
+            )
+            == 300 * 1024 * 1024
+        )
+
+    @mock.patch('rbx.grading.judge.program.get_memory_usage')
+    @mock.patch('rbx.grading.judge.program.maxrss_inherits_parent', return_value=True)
+    def test_usage_under_baseline_falls_back_to_the_sampled_peak(
+        self, mock_inherits, mock_get_memory_usage
+    ):
+        """Under the baseline, ru_maxrss is the parent's footprint, not the child's."""
+        mock_get_memory_usage.return_value = 200 * 1024 * 1024
+
+        assert (
+            get_child_memory_usage(
+                mock.MagicMock(),
+                rss_baseline=200 * 1024 * 1024,
+                sampled_peak=5 * 1024 * 1024,
+            )
+            == 5 * 1024 * 1024
+        )
+
+    @mock.patch('rbx.grading.judge.program.get_memory_usage')
+    @mock.patch('rbx.grading.judge.program.maxrss_inherits_parent', return_value=False)
+    def test_usage_is_untouched_where_maxrss_is_reset_at_exec(
+        self, mock_inherits, mock_get_memory_usage
+    ):
+        mock_get_memory_usage.return_value = 1024
+
+        assert (
+            get_child_memory_usage(
+                mock.MagicMock(),
+                rss_baseline=200 * 1024 * 1024,
+                sampled_peak=5 * 1024 * 1024,
+            )
+            == 1024
+        )
+
+    @mock.patch('rbx.grading.judge.program.maxrss_inherits_parent', return_value=True)
+    def test_samples_taken_before_exec_are_discarded(self, mock_inherits):
+        """A pre-exec sample still shows the parent's copy-on-write footprint."""
+        baseline = 100 * 1024 * 1024
+
+        assert not is_own_rss(baseline, baseline)
+        assert not is_own_rss(baseline + 1, baseline)
+        assert is_own_rss(7 * 1024 * 1024, baseline)
+
+    @mock.patch('rbx.grading.judge.program.maxrss_inherits_parent', return_value=False)
+    def test_every_sample_is_the_child_where_maxrss_is_reset_at_exec(
+        self, mock_inherits
+    ):
+        assert is_own_rss(300 * 1024 * 1024, 100 * 1024 * 1024)
+
+    def test_fat_parent_does_not_push_a_trivial_program_over_its_limit(
+        self, simple_hello_program
+    ):
+        """The regression itself: a bloated parent used to make everything MLE.
+
+        On Linux the child inherits the parent's RSS at fork, so before the fix a
+        hello world forked from a process holding 150 MB was charged all of it and
+        blew a 64 MB limit while exiting cleanly.
+        """
+        ballast = bytearray(150 * 1024 * 1024)
+        try:
+            for i in range(0, len(ballast), 4096):
+                ballast[i] = 1
+            assert get_self_rss() > 64 * 1024 * 1024
+
+            params = ProgramParams(memory_limit=64)
+            result = Program([sys.executable, str(simple_hello_program)], params).wait()
+        finally:
+            del ballast
+
+        assert result.exitcode == 0
+        assert ProgramCode.ML not in result.program_codes
+        assert result.memory_used < 64 * 1024 * 1024


### PR DESCRIPTION
Fixes #720.

## What was happening

On Linux, a forked child's `mm->hiwater_rss` is seeded from the parent's current RSS, and `execve` folds that high-water mark into the new process' accounting. So the `ru_maxrss` that `os.wait4()` reports for a sandboxed program is really `max(parent_rss_at_fork, child_peak)` — it is not the child's memory.

A pytest worker holding ~300 MB therefore charged **every** program it ran ~300 MB, and everything running under a 256 MB problem limit came back `memory limit exceeded` while exiting cleanly with `exitcode == 0`. That is 68 of the 79 failures on `main`, most of them surfacing as a bare `click.exceptions.Exit: 1` from `generate_output_for_testcase`.

Darwin resets the high-water mark at exec, which is why this never reproduced locally.

Measured with the same script on both platforms, running `true`:

| | parent maxrss | child maxrss |
|---|---|---|
| Linux (`python:3.13-slim`) | 13 MB | 12 MB |
| Linux, after the parent touches 400 MB | 423 MB | **412 MB** |
| macOS | 13 MB | 0.92 MB |
| macOS, after the parent touches 400 MB | 413 MB | 0.92 MB |

This also explains the loose end in the issue: a `g++` that dies instantly on a missing source reporting 309 MB is not a bug in the compiler path — 309 MB *was* the worker's RSS. And the issue's own container check came back clean at 12.7 MiB only because it ran from a bare interpreter; the contamination is invisible unless the parent is fat. Importing `pytest` plus a handful of `rbx.box` modules already high-waters at ~123 MiB before any test does work.

## The fix

Take the parent's RSS immediately before forking as a baseline:

- **Above the baseline**, `ru_maxrss` can only have come from the child, so it is the peak, exactly — unchanged behaviour.
- **At or below it**, the value carries no information about the child, so fall back to the peak RSS sampled from the child itself by the existing alarm thread (which now samples on every tick, and once up front, rather than only when a memory limit is set).

The fallback is a lower bound rather than an exact peak, but it is never inflated by whatever the parent happened to be holding, and any program that actually approaches its limit lands on the exact path. Samples at or above the baseline are discarded, since a sample racing a not-yet-exec'd child would still show the parent's copy-on-write footprint.

Because that sampling is now load-bearing — it is the only measurement of a program whose peak stays under the parent's footprint — it also had to get finer. The first CI run on this branch caught the consequence: at one sample every 0.3 s, `test_run_with_memory_limit_regression_test` (100 MB allocated under a 50 MB limit, held for 0.1 s) slipped through as `ok`. RSS is now sampled every 0.1 s, and CPU time keeps its own 0.3 s cadence, where a limit measured in seconds needs no such resolution.

Sampling cannot be made precise at any interval — a program that allocates and frees between two ticks is invisible either way — so 0.1 s is a compromise rather than a guarantee, and the comment says so instead of implying a bound it cannot honour.

On Darwin nothing changes: `maxrss_inherits_parent()` is false and `ru_maxrss` is used as before.

This also fixes reported memory across the board on Linux, which until now read as roughly the parent's RSS for every solution.

## Tests

`TestMaxrssCorrection` in `tests/rbx/grading/judge/test_program.py` covers both branches of the correction, the pre-exec sample guard, the platform predicate, and the two sides of the behaviour, both run from a parent deliberately holding 150 MB:

- a hello world under a 64 MB limit must **not** come back MLE (the bug);
- a program peaking at 96 MB under a 32 MB limit must **still** be caught (the false negative the first CI run exposed) — that one sits in exactly the band where `ru_maxrss` carries no information about the child, so only the sampler can see it.

`tests/rbx/grading` is 404 passed / 1 skipped on macOS.

On Linux, where the bug actually lives, this branch's CI run takes the suite from **79 failures to 35**, and no test reports `memory limit exceeded` any more. Everything the issue attributed to this root cause is gone: `solutions_test`, `runners/`, `validators_test`, `tasks_test`, `generator_outputs_test`, and `steps_run_test`. The 35 that remain are a different root cause — 34 are `pandoc not found` (`rbx/tooling.py` exits 1; the runner has no pandoc installed, which the MLE cascade was masking) and 1 is a timing assertion in `tests/casts/test_engine.py`. Neither is touched by this PR; they are tracked in #730.

## Follow-up

The fallback is the best estimate available without changing how programs are spawned. #725 tracks researching a sturdier measurement (a small spawner process so the fork is cheap, or cgroup v2 `memory.peak`).
