### PR TITLE
fix(ui): keep copied pane output byte-for-byte (UTF-8 clipboard + cell-correct cursor)

### DIFF
--- a/rbx/box/ui/_vendor/toad/README.md
+++ b/rbx/box/ui/_vendor/toad/README.md
@@ -29,6 +29,16 @@ Only the files required for the `CommandPane` terminal widget are included:
   `virtual_size` on a write, so a resize that reflows the buffer with nothing written
   afterwards -- a command that already finished -- leaves the extents describing the old
   fold count and an anchored terminal scrolls past the end of its own output.
+- `ansi/_ansi.py`, `widgets/terminal.py`: the cursor is positioned in **cells**, while lines
+  are stored as **characters** -- and a CJK ideograph or an emoji is one character and two
+  cells wide. Upstream uses `cursor_offset` directly as an index, so any program that
+  positions the cursor by column on a line holding wide characters (a `\r` redraw, a
+  progress bar, `ESC[nG`) lands at the wrong place: the gap gets padded with spaces that
+  were never printed, or a character that was printed gets eaten. `cell_to_index`,
+  `cell_span` and `index_to_cell` convert between the two spaces, and `Buffer.cursor`,
+  `Buffer.update_cursor`, `TerminalState.get_cursor_position` (replacing
+  `get_cursor_line_offset`), content writes, `ECH`/`DCH`, `_reflow` and the cursor
+  rendering all go through them. `cursor_offset` is now documented as a cell column.
 - `command_pane.py`: `CommandPane` takes an optional `get_fallback_dimensions` callable,
   used when its own region is zero-sized (a hidden pane), and exposes
   `refresh_terminal_size()` so an owner can re-apply the size to a pane that gets no

--- a/rbx/box/ui/_vendor/toad/ansi/__init__.py
+++ b/rbx/box/ui/_vendor/toad/ansi/__init__.py
@@ -1,1 +1,4 @@
 from rbx.box.ui._vendor.toad.ansi._ansi import TerminalState as TerminalState
+from rbx.box.ui._vendor.toad.ansi._ansi import cell_span as cell_span
+from rbx.box.ui._vendor.toad.ansi._ansi import cell_to_index as cell_to_index
+from rbx.box.ui._vendor.toad.ansi._ansi import index_to_cell as index_to_cell

--- a/rbx/box/ui/_vendor/toad/ansi/_ansi.py
+++ b/rbx/box/ui/_vendor/toad/ansi/_ansi.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from typing import Awaitable, Callable, Iterable, Literal, Mapping, NamedTuple
 
 import rich.repr
+from rich.cells import cell_len, get_character_cell_size
 
 from textual import events
 from textual.color import Color
@@ -31,6 +32,71 @@ from rbx.box.ui._vendor.toad.ansi._stream_parser import (
 )
 
 from rbx.box.ui._vendor.toad.dec import CHARSET_MAP
+
+
+def cell_to_index(text: str, cell: int) -> tuple[int, int]:
+    """Convert a cell column into an index into `text`.
+
+    Lines are stored as *characters*, but the terminal positions its cursor in
+    *cells* -- and a CJK ideograph or an emoji is one character wide and two
+    cells wide. Taking a cell column for an index writes at the wrong place, and
+    pads the difference with spaces that were never in the output.
+
+    A column landing on the right half of a wide character resolves to that
+    character: it is the cell the terminal would clobber.
+
+    Args:
+        text: Text to index into.
+        cell: Cell column.
+
+    Returns:
+        A pair of the index and the cells left over past the end of `text`
+        (non-zero only when the column sits beyond the last character).
+    """
+    width = 0
+    for index, character in enumerate(text):
+        size = get_character_cell_size(character)
+        if width + size > cell:
+            return index, 0
+        width += size
+    return len(text), max(0, cell - width)
+
+
+def cell_span(text: str, cells: int) -> int:
+    """How many characters of `text` cover `cells` columns.
+
+    Rounds up: a column falling inside a wide character covers the whole of it,
+    the way a terminal blanks a wide character it half-overwrites. Used to size
+    what an overwrite or an erase consumes.
+
+    Args:
+        text: Text to measure.
+        cells: Number of cells to cover.
+
+    Returns:
+        A number of characters, at most `len(text)`.
+    """
+    if cells <= 0:
+        return 0
+    width = 0
+    for index, character in enumerate(text):
+        width += get_character_cell_size(character)
+        if width >= cells:
+            return index + 1
+    return len(text)
+
+
+def index_to_cell(text: str, index: int) -> int:
+    """Convert an index into `text` into the cell column it renders at.
+
+    Args:
+        text: Text the index refers to.
+        index: Index within the text.
+
+    Returns:
+        Cell column.
+    """
+    return cell_len(text[:index])
 
 
 def character_range(start: int, end: int) -> frozenset:
@@ -794,7 +860,11 @@ class Buffer:
     cursor_line: int = 0
     """Folded line index."""
     cursor_offset: int = 0
-    """Folded line offset."""
+    """Cell column within the folded line.
+
+    Cells, not characters -- that is the space the terminal moves its cursor in.
+    Use `cell_to_index` before indexing a line with it.
+    """
     max_line_width: int = 0
     """The longest line in the buffer."""
     updates: int = 0
@@ -836,7 +906,9 @@ class Buffer:
         position = 0
         for folded_line_offset, folded_line in enumerate(line.folds):
             if folded_line_offset == cursor_line_offset:
-                position += self.cursor_offset
+                position += cell_to_index(
+                    folded_line.content.plain, self.cursor_offset
+                )[0]
                 break
             position += len(folded_line.content)
 
@@ -869,12 +941,14 @@ class Buffer:
                 and cursor_line_offset < position + line_length
             ):
                 self.cursor_line = fold_line_start + fold_offset
-                self.cursor_offset = cursor_line_offset - position
+                self.cursor_offset = index_to_cell(
+                    fold.content.plain, cursor_line_offset - position
+                )
                 break
             position += line_length
         else:
             self.cursor_line = fold_line_start + len(line.folds) - 1
-            self.cursor_offset = len(line.folds[-1].content)
+            self.cursor_offset = line.folds[-1].content.cell_length
 
     def update_line(self, line_no: int) -> None:
         """Record an updated line.
@@ -1165,7 +1239,9 @@ class TerminalState:
             for fold in reversed(line.folds):
                 if cursor_offset >= fold.offset:
                     fold_cursor_line += fold.line_offset
-                    fold_cursor_offset = cursor_offset - fold.offset
+                    fold_cursor_offset = index_to_cell(
+                        fold.content.plain, cursor_offset - fold.offset
+                    )
                     break
 
             buffer.cursor_line = fold_cursor_line
@@ -1215,8 +1291,17 @@ class TerminalState:
         # Return deltas accumulated during write
         return (scrollback_updates, alternate_updates)
 
-    def get_cursor_line_offset(self, buffer: Buffer) -> int:
-        """The cursor offset within the un-folded lines."""
+    def get_cursor_position(self, buffer: Buffer) -> tuple[int, int]:
+        """Where the cursor sits within the un-folded line.
+
+        Args:
+            buffer: Buffer to read the cursor from.
+
+        Returns:
+            A pair of the character index within the unfolded line, and the
+            number of cells the cursor sits *past* the end of the line -- what a
+            caller has to pad before it can write there.
+        """
         cursor_folded_line = buffer.folded_lines[buffer.cursor_line]
         cursor_line_offset = cursor_folded_line.line_offset
         line_no = cursor_folded_line.line_no
@@ -1224,10 +1309,12 @@ class TerminalState:
         position = 0
         for folded_line_offset, folded_line in enumerate(line.folds):
             if folded_line_offset == cursor_line_offset:
-                position += buffer.cursor_offset
-                break
+                index, pad = cell_to_index(
+                    folded_line.content.plain, buffer.cursor_offset
+                )
+                return position + index, pad
             position += len(folded_line.content)
-        return position
+        return position, 0
 
     def clear_buffer(self, clear: ClearType) -> None:
         buffer = self.buffer
@@ -1299,19 +1386,19 @@ class TerminalState:
                 )
 
     @classmethod
-    def _expand_content(cls, content: Content, offset: int, style: Style) -> Content:
-        """Expand content to be at least as long as a given offset.
+    def _expand_content(cls, content: Content, pad_cells: int, style: Style) -> Content:
+        """Pad content so the cursor's cell column falls within it.
 
         Args:
             content: Content to expand.
-            offset: Offset within the content.
+            pad_cells: Cells to pad with, as reported by `get_cursor_position`.
             style: Style of padding.
 
         Returns:
             New Content.
         """
-        if offset > len(content):
-            content += Content.blank(offset - len(content), style)
+        if pad_cells > 0:
+            content += Content.blank(pad_cells, style)
         return content
 
     async def _handle_ansi_command(self, ansi_command: ANSICommand) -> None:
@@ -1336,22 +1423,29 @@ class TerminalState:
                 line_no = folded_line.line_no
                 line = buffer.lines[line_no]
 
-                cursor_line_offset = self.get_cursor_line_offset(buffer)
+                cursor_line_offset, pad_cells = self.get_cursor_position(buffer)
                 line_content = line.content
-                if cursor_line_offset > len(line_content):
+                if pad_cells:
                     line_content = self._expand_content(
-                        line_content, cursor_line_offset, line.style
+                        line_content, pad_cells, line.style
                     )
+                    cursor_line_offset += pad_cells
                 content = Content.styled(
                     self.dec_state.translate(text),
                     self.style,
                     strip_control_codes=False,
                 )
                 if self.replace_mode:
+                    # Overwriting covers as many *cells* as the new content
+                    # occupies, so a two-cell character replaces two columns
+                    # rather than two characters.
+                    overwritten = cell_span(
+                        line_content.plain[cursor_line_offset:], content.cell_length
+                    )
                     updated_line = Content.assemble(
                         line_content[:cursor_line_offset],
                         content,
-                        line_content[cursor_line_offset + len(content) :],
+                        line_content[cursor_line_offset + overwritten :],
                         strip_control_codes=False,
                     )
                 else:
@@ -1408,18 +1502,33 @@ class TerminalState:
                     line.style = self.style
 
                 if clear_range is not None:
-                    cursor_line_offset = self.get_cursor_line_offset(buffer)
+                    cursor_line_offset, pad_cells = self.get_cursor_position(buffer)
 
                     line_content = line.content
-                    if cursor_line_offset > len(line.content):
+                    if pad_cells:
                         line_content = self._expand_content(
-                            line.content, cursor_line_offset, line.style
+                            line.content, pad_cells, line.style
                         )
+                        cursor_line_offset += pad_cells
 
                     # Start and end replace are *inclusive*
-                    clear_start, clear_end = ansi_command.get_clear_offsets(
-                        cursor_line_offset, len(line_content)
-                    )
+                    if ansi_command.relative:
+                        # DCH and ECH count cells from the cursor, so the span
+                        # has to be measured in cells before it can index a line.
+                        tail = line_content.plain[cursor_line_offset:]
+                        start_cells, end_cells = clear_range
+                        clear_start = cursor_line_offset + cell_to_index(
+                            tail, start_cells or 0
+                        )[0]
+                        clear_end = (
+                            cursor_line_offset
+                            + cell_span(tail, (end_cells or 0) + 1)
+                            - 1
+                        )
+                    else:
+                        clear_start, clear_end = ansi_command.get_clear_offsets(
+                            cursor_line_offset, len(line_content)
+                        )
 
                     before_clear = line_content[:clear_start]
                     after_clear = line_content[clear_end + 1 :]
@@ -1433,8 +1542,12 @@ class TerminalState:
                         )
                         self.update_line(buffer, folded_line.line_no, updated_line)
                     else:
-                        # Range is replaced with spaces
-                        blank_width = clear_end - clear_start + 1
+                        # Range is replaced with spaces -- as many as the cleared
+                        # text occupied on screen, so the columns after it stay
+                        # where they were.
+                        blank_width = cell_len(
+                            line_content.plain[clear_start : clear_end + 1]
+                        )
 
                         updated_line = Content.assemble(
                             before_clear,

--- a/rbx/box/ui/_vendor/toad/widgets/terminal.py
+++ b/rbx/box/ui/_vendor/toad/widgets/terminal.py
@@ -384,9 +384,13 @@ Tap escape *twice* to exit.
             and state.show_cursor
             and buffer.cursor_line == y - buffer_offset
         ):
-            if buffer.cursor_offset >= len(line):
-                line = line.pad_right(buffer.cursor_offset - len(line) + 1)
-            line_cursor_offset = buffer.cursor_offset
+            # The cursor is a cell column; the line is indexed by character.
+            line_cursor_offset, pad_cells = ansi.cell_to_index(
+                line.plain, buffer.cursor_offset
+            )
+            if pad_cells or line_cursor_offset >= len(line):
+                line = line.pad_right(pad_cells + 1)
+                line_cursor_offset += pad_cells
             line = line.stylize(
                 self.CURSOR_STYLE, line_cursor_offset, line_cursor_offset + 1
             )

--- a/rbx/box/ui/clipboard.py
+++ b/rbx/box/ui/clipboard.py
@@ -1,0 +1,113 @@
+"""Getting copied text onto the clipboard intact.
+
+Textual copies by writing an OSC 52 escape sequence: the text, encoded as UTF-8
+and then base64, handed to whatever terminal the app is running in. The terminal
+decodes it and puts the result on the clipboard -- and that last step is where
+the bytes stop being ours. A terminal that decodes them as latin-1 (xterm.js,
+which VS Code's integrated terminal is built on, historically did exactly this
+via `atob`) turns every character rbx prints outside ASCII into mojibake:
+
+    ✓ (E2 9C 93) -> â  ⧖ (E2 A7 96) -> â§  · (C2 B7) -> Â·
+
+which is what the copied output looks like when it is pasted anywhere else.
+
+So when the clipboard is reachable without going through the terminal, write to
+it directly -- `pbcopy` and friends take bytes, and we hand them UTF-8. OSC 52
+stays the fallback, because over SSH it is the only channel that reaches the
+machine the user is actually sitting at.
+"""
+
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+from typing import List, Optional, Sequence
+
+_MACOS_COMMAND = ['pbcopy']
+_WINDOWS_COMMAND = ['clip']
+_WAYLAND_COMMAND = ['wl-copy']
+_X11_COMMANDS = [
+    ['xclip', '-selection', 'clipboard'],
+    ['xsel', '--clipboard', '--input'],
+]
+
+
+def is_remote_session() -> bool:
+    """Is the app running over SSH?
+
+    The local clipboard tools would then be the *server's*, which no one can
+    paste from. OSC 52 travels back down the connection, so it is the only thing
+    that reaches the user.
+    """
+    return bool(os.environ.get('SSH_CONNECTION') or os.environ.get('SSH_TTY'))
+
+
+def native_clipboard_command() -> Optional[List[str]]:
+    """The command that writes this machine's clipboard, if there is one.
+
+    Returns:
+        A command to pipe UTF-8 bytes into, or `None` when the clipboard is only
+        reachable through the terminal.
+    """
+    if is_remote_session():
+        return None
+
+    candidates: List[List[str]] = []
+    if sys.platform == 'darwin':
+        candidates.append(_MACOS_COMMAND)
+    elif sys.platform == 'win32':
+        candidates.append(_WINDOWS_COMMAND)
+    else:
+        # Asking a display-less session for its clipboard hangs or fails; both
+        # tools want the display they were built for.
+        if os.environ.get('WAYLAND_DISPLAY'):
+            candidates.append(_WAYLAND_COMMAND)
+        if os.environ.get('DISPLAY'):
+            candidates.extend(_X11_COMMANDS)
+
+    for candidate in candidates:
+        if shutil.which(candidate[0]) is not None:
+            return candidate
+    return None
+
+
+async def write_native(command: Sequence[str], text: str) -> bool:
+    """Pipe `text` into a clipboard command as UTF-8.
+
+    Args:
+        command: Command to run.
+        text: Text to copy.
+
+    Returns:
+        `True` if the command took it.
+    """
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        await process.communicate(text.encode('utf-8'))
+    except (OSError, ValueError):
+        return False
+    return process.returncode == 0
+
+
+async def _copy(app, text: str) -> None:
+    command = native_clipboard_command()
+    if command is not None and await write_native(command, text):
+        return
+    # No local clipboard, or the tool for it failed: let the terminal try.
+    app.copy_to_clipboard(text)
+
+
+def copy(app, text: str) -> None:
+    """Copy text to the clipboard.
+
+    Args:
+        app: The running app.
+        text: Text to copy.
+    """
+    app.run_worker(_copy(app, text), group='clipboard', exit_on_error=False)

--- a/rbx/box/ui/terminal_select.py
+++ b/rbx/box/ui/terminal_select.py
@@ -36,6 +36,7 @@ from textual import events
 from textual.geometry import Offset
 from textual.selection import Selection
 
+from rbx.box.ui import clipboard
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
 
 _WORD_RE = re.compile(r'\w+|[^\w\s]')
@@ -176,7 +177,7 @@ class TerminalSelectMixin:
         if self._select_was_anchored:
             self._anchor_released = False
         if text:
-            self.app.copy_to_clipboard(text)
+            clipboard.copy(self.app, text)
 
     def _publish_selection(self) -> None:
         cursor = self._select_cursor
@@ -338,7 +339,7 @@ class TerminalSelectMixin:
         if not text:
             self.app.notify('Nothing to copy.', severity='warning')
             return
-        self.app.copy_to_clipboard(text)
+        clipboard.copy(self.app, text)
         count = len(text.split('\n'))
         self.app.notify(f'Copied {count} line{"" if count == 1 else "s"}.')
 
@@ -353,7 +354,7 @@ class TerminalSelectMixin:
             event.prevent_default()
             selected = self.screen.get_selected_text()
             if selected:
-                self.app.copy_to_clipboard(selected)
+                clipboard.copy(self.app, selected)
                 self.screen.clear_selection()
             else:
                 self.copy_all()

--- a/tests/rbx/box/ui/test_clipboard.py
+++ b/tests/rbx/box/ui/test_clipboard.py
@@ -1,0 +1,175 @@
+"""Copied text has to reach the clipboard as UTF-8.
+
+Textual copies over OSC 52: the terminal is handed base64 and decides for itself
+what encoding the bytes were. A terminal that guesses latin-1 -- xterm.js, which
+VS Code's integrated terminal is built on, decoded the payload with `atob` --
+turns rbx's verdict markers into mojibake the moment they are pasted anywhere:
+`✓` comes out as `â`, `⧖` as `â§`, `·` as `Â·`.
+
+Writing the clipboard ourselves takes that guess out of the loop.
+"""
+
+import asyncio
+import shutil
+import sys
+
+import pytest
+
+from rbx.box.ui import clipboard
+from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
+from rbx.box.ui.command_app import CommandEntry, rbxCommandApp
+
+# The characters rbx prints for verdicts, and the mojibake each turns into when
+# its UTF-8 bytes are read back as latin-1.
+_VERDICTS = '✓✗⧖⊘·'
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for name in (
+        'SSH_CONNECTION',
+        'SSH_TTY',
+        'WAYLAND_DISPLAY',
+        'DISPLAY',
+    ):
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def test_a_remote_session_has_no_local_clipboard(clean_env):
+    # Over SSH the local tools would write the *server's* clipboard, which the
+    # user cannot paste from. OSC 52 is the only channel that reaches them.
+    clean_env.setenv('SSH_CONNECTION', '10.0.0.1 22 10.0.0.2 22')
+    assert clipboard.is_remote_session()
+    assert clipboard.native_clipboard_command() is None
+
+
+def test_a_local_session_is_not_remote(clean_env):
+    assert not clipboard.is_remote_session()
+
+
+@pytest.mark.skipif(sys.platform != 'darwin', reason='macOS clipboard')
+def test_macos_uses_pbcopy(clean_env):
+    assert clipboard.native_clipboard_command() == ['pbcopy']
+
+
+def test_a_display_less_linux_session_has_no_clipboard(clean_env, monkeypatch):
+    monkeypatch.setattr(sys, 'platform', 'linux')
+    assert clipboard.native_clipboard_command() is None
+
+
+def test_linux_picks_the_tool_for_the_display(clean_env, monkeypatch):
+    monkeypatch.setattr(sys, 'platform', 'linux')
+    monkeypatch.setenv('DISPLAY', ':0')
+    monkeypatch.setattr(
+        shutil, 'which', lambda name: '/usr/bin/xclip' if name == 'xclip' else None
+    )
+    assert clipboard.native_clipboard_command() == ['xclip', '-selection', 'clipboard']
+
+
+def test_wayland_is_preferred_when_it_is_the_session(clean_env, monkeypatch):
+    monkeypatch.setattr(sys, 'platform', 'linux')
+    monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-0')
+    monkeypatch.setenv('DISPLAY', ':0')
+    monkeypatch.setattr(shutil, 'which', lambda name: f'/usr/bin/{name}')
+    assert clipboard.native_clipboard_command() == ['wl-copy']
+
+
+async def test_the_bytes_handed_over_are_utf_8(tmp_path):
+    # The whole point: what the clipboard command receives on stdin is UTF-8,
+    # not whatever a terminal would have guessed.
+    written = tmp_path / 'clipboard'
+    command = [
+        sys.executable,
+        '-c',
+        f'import sys; open({str(written)!r}, "wb").write(sys.stdin.buffer.read())',
+    ]
+
+    assert await clipboard.write_native(command, f'manual (20) 1/{_VERDICTS}')
+
+    assert written.read_bytes() == f'manual (20) 1/{_VERDICTS}'.encode('utf-8')
+    assert written.read_bytes().decode('utf-8') == f'manual (20) 1/{_VERDICTS}'
+
+
+async def test_a_failing_clipboard_command_is_reported():
+    assert not await clipboard.write_native(
+        [sys.executable, '-c', 'raise SystemExit(1)'], 'text'
+    )
+
+
+async def test_a_missing_clipboard_command_is_reported():
+    assert not await clipboard.write_native(['rbx-no-such-clipboard-tool'], 'text')
+
+
+async def test_osc_52_carries_the_copy_when_there_is_no_local_clipboard(monkeypatch):
+    monkeypatch.setattr(clipboard, 'native_clipboard_command', lambda: None)
+    fallback: list[str] = []
+
+    class _App:
+        def copy_to_clipboard(self, text: str) -> None:
+            fallback.append(text)
+
+    await clipboard._copy(_App(), _VERDICTS)  # noqa: SLF001
+
+    assert fallback == [_VERDICTS]
+
+
+async def test_the_terminal_is_not_asked_when_the_clipboard_took_it(monkeypatch):
+    # Both would race for the clipboard, and the terminal is the one that gets
+    # the encoding wrong -- so it is only used when nothing else worked.
+    monkeypatch.setattr(clipboard, 'native_clipboard_command', lambda: ['true'])
+
+    async def _accept(command, text):
+        return True
+
+    monkeypatch.setattr(clipboard, 'write_native', _accept)
+    fallback: list[str] = []
+
+    class _App:
+        def copy_to_clipboard(self, text: str) -> None:
+            fallback.append(text)
+
+    await clipboard._copy(_App(), _VERDICTS)  # noqa: SLF001
+
+    assert fallback == []
+
+
+async def test_pressing_ctrl_y_writes_utf_8_to_the_clipboard(tmp_path, monkeypatch):
+    # The whole path, unpatched: pane -> clipboard.copy -> worker -> command.
+    written = tmp_path / 'clipboard'
+    monkeypatch.setattr(
+        clipboard,
+        'native_clipboard_command',
+        lambda: [
+            sys.executable,
+            '-c',
+            f'import sys; open({str(written)!r}, "wb").write(sys.stdin.buffer.read())',
+        ],
+    )
+
+    body = f'print({_VERDICTS!r})'
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[[sys.executable, '-c', body]], name='a')], parallel=True
+    )
+    async with app.run_test(size=(80, 20)) as pilot:
+        pane = None
+        for _ in range(100):
+            await pilot.pause()
+            await asyncio.sleep(0.05)
+            panes = list(app.query(CommandPane))
+            if panes and all(p.return_code is not None for p in panes):
+                (pane,) = panes
+                break
+        assert pane is not None, 'command did not finish in time'
+
+        app.set_focus(pane)
+        await pilot.pause()
+        await pilot.press('ctrl+y')
+        for _ in range(100):
+            await pilot.pause()
+            await asyncio.sleep(0.05)
+            if written.exists():
+                break
+
+    assert written.read_bytes() == _VERDICTS.encode('utf-8')
+    assert written.read_bytes().decode('utf-8') == _VERDICTS

--- a/tests/rbx/box/ui/test_command_pane_select.py
+++ b/tests/rbx/box/ui/test_command_pane_select.py
@@ -11,9 +11,11 @@ import asyncio
 import sys
 from typing import List
 
+import pytest
 from textual.geometry import Offset
 from textual.selection import Selection
 
+from rbx.box.ui import clipboard
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
 from rbx.box.ui.command_app import CommandEntry, rbxCommandApp
 
@@ -48,19 +50,19 @@ async def _focus_pane(app, pilot, pane) -> None:
     await pilot.pause()
 
 
-def _capture_clipboard(app) -> List[str]:
-    """Record what the app copies, instead of poking at its private state."""
-    copied: List[str] = []
-    app.copy_to_clipboard = copied.append  # type: ignore[method-assign]
-    return copied
+@pytest.fixture
+def copied(monkeypatch) -> List[str]:
+    """Record what the pane copies, at the seam the clipboard is written from."""
+    writes: List[str] = []
+    monkeypatch.setattr(clipboard, 'copy', lambda app, text: writes.append(text))
+    return writes
 
 
-async def test_ctrl_y_copies_the_whole_output_when_nothing_is_selected():
+async def test_ctrl_y_copies_the_whole_output_when_nothing_is_selected(copied):
     app = _make_app('alpha', 'beta', 'gamma')
     async with app.run_test(size=(150, 40)) as pilot:
         (pane,) = await _running_app(pilot, app)
         await _focus_pane(app, pilot, pane)
-        copied = _capture_clipboard(app)
 
         await pilot.press('ctrl+y')
         await pilot.pause()
@@ -68,12 +70,11 @@ async def test_ctrl_y_copies_the_whole_output_when_nothing_is_selected():
         assert copied == ['alpha\nbeta\ngamma']
 
 
-async def test_ctrl_y_still_copies_only_the_selection():
+async def test_ctrl_y_still_copies_only_the_selection(copied):
     app = _make_app('alpha', 'beta', 'gamma')
     async with app.run_test(size=(150, 40)) as pilot:
         (pane,) = await _running_app(pilot, app)
         await _focus_pane(app, pilot, pane)
-        copied = _capture_clipboard(app)
 
         pane.screen.selections = {pane: Selection(Offset(0, 1), Offset(4, 1))}
         await pilot.pause()
@@ -83,12 +84,11 @@ async def test_ctrl_y_still_copies_only_the_selection():
         assert copied == ['beta']
 
 
-async def test_ctrl_y_copies_a_wrapped_line_unwrapped():
+async def test_ctrl_y_copies_a_wrapped_line_unwrapped(copied):
     app = _make_app(_LONG_LINE)
     async with app.run_test(size=(150, 40)) as pilot:
         (pane,) = await _running_app(pilot, app)
         await _focus_pane(app, pilot, pane)
-        copied = _capture_clipboard(app)
         # The line really is folded across several rows.
         assert len(pane.state.scrollback_buffer.folded_lines) > 1
 
@@ -98,7 +98,7 @@ async def test_ctrl_y_copies_a_wrapped_line_unwrapped():
         assert copied == [_LONG_LINE]
 
 
-async def test_ctrl_v_enters_visual_mode_and_shows_a_cursor():
+async def test_ctrl_v_enters_visual_mode_and_shows_a_cursor(copied):
     app = _make_app('alpha', 'beta', 'gamma')
     async with app.run_test(size=(150, 40)) as pilot:
         (pane,) = await _running_app(pilot, app)
@@ -113,7 +113,7 @@ async def test_ctrl_v_enters_visual_mode_and_shows_a_cursor():
         assert pane.screen.selections[pane] == Selection(Offset(0, 0), Offset(1, 0))
 
 
-async def test_visual_mode_keys_do_not_reach_the_process():
+async def test_visual_mode_keys_do_not_reach_the_process(copied):
     app = rbxCommandApp(
         [
             CommandEntry(
@@ -147,7 +147,7 @@ async def test_visual_mode_keys_do_not_reach_the_process():
         assert 'j' not in text
 
 
-async def test_hjkl_and_arrows_both_move_the_cursor():
+async def test_hjkl_and_arrows_both_move_the_cursor(copied):
     app = _make_app('alpha', 'beta', 'gamma')
     async with app.run_test(size=(150, 40)) as pilot:
         (pane,) = await _running_app(pilot, app)
@@ -171,12 +171,11 @@ async def test_hjkl_and_arrows_both_move_the_cursor():
         assert pane.select_cursor == Offset(0, 0)
 
 
-async def test_charwise_selection_to_the_end_copies_the_tail():
+async def test_charwise_selection_to_the_end_copies_the_tail(copied):
     app = _make_app('alpha', 'beta', 'gamma')
     async with app.run_test(size=(150, 40)) as pilot:
         (pane,) = await _running_app(pilot, app)
         await _focus_pane(app, pilot, pane)
-        copied = _capture_clipboard(app)
 
         await pilot.press('ctrl+v', 'j', 'v', 'G', '$', 'y')
         await pilot.pause()
@@ -186,12 +185,11 @@ async def test_charwise_selection_to_the_end_copies_the_tail():
         assert not pane.screen.selections
 
 
-async def test_linewise_selection_copies_the_unwrapped_logical_line():
+async def test_linewise_selection_copies_the_unwrapped_logical_line(copied):
     app = _make_app('alpha', _LONG_LINE, 'gamma')
     async with app.run_test(size=(150, 40)) as pilot:
         (pane,) = await _running_app(pilot, app)
         await _focus_pane(app, pilot, pane)
-        copied = _capture_clipboard(app)
 
         await pilot.press('ctrl+v', 'j', 'V', 'y')
         await pilot.pause()
@@ -199,7 +197,7 @@ async def test_linewise_selection_copies_the_unwrapped_logical_line():
         assert copied == [_LONG_LINE]
 
 
-async def test_moving_past_the_viewport_scrolls_the_pane():
+async def test_moving_past_the_viewport_scrolls_the_pane(copied):
     # One-liner on purpose: the sub-command Select renders the command string as
     # its label, so a multi-line `python -c` would grow it until the pane collapses.
     app = rbxCommandApp(
@@ -238,12 +236,11 @@ async def test_moving_past_the_viewport_scrolls_the_pane():
         assert pane.select_cursor.y == len(pane.state.scrollback_buffer.lines) - 1
 
 
-async def test_escape_leaves_visual_mode_without_copying():
+async def test_escape_leaves_visual_mode_without_copying(copied):
     app = _make_app('alpha', 'beta', 'gamma')
     async with app.run_test(size=(150, 40)) as pilot:
         (pane,) = await _running_app(pilot, app)
         await _focus_pane(app, pilot, pane)
-        copied = _capture_clipboard(app)
 
         await pilot.press('ctrl+v', 'v', 'j', 'escape')
         await pilot.pause()
@@ -253,12 +250,11 @@ async def test_escape_leaves_visual_mode_without_copying():
         assert copied == []
 
 
-async def test_y_without_an_anchor_copies_the_cursor_line():
+async def test_y_without_an_anchor_copies_the_cursor_line(copied):
     app = _make_app('alpha', 'beta', 'gamma')
     async with app.run_test(size=(150, 40)) as pilot:
         (pane,) = await _running_app(pilot, app)
         await _focus_pane(app, pilot, pane)
-        copied = _capture_clipboard(app)
 
         await pilot.press('ctrl+v', 'j', 'y')
         await pilot.pause()

--- a/tests/rbx/box/ui/test_terminal_wide_characters.py
+++ b/tests/rbx/box/ui/test_terminal_wide_characters.py
@@ -13,6 +13,7 @@ import sys
 
 import pytest
 
+from rbx.box.ui import clipboard
 from rbx.box.ui._vendor.toad.ansi import cell_span, cell_to_index, index_to_cell
 from rbx.box.ui._vendor.toad.ansi._ansi import TerminalState
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
@@ -136,7 +137,7 @@ async def test_a_line_of_wide_characters_survives_a_redraw():
 # --- what actually reaches the clipboard ------------------------------------
 
 
-async def test_ctrl_y_copies_redrawn_unicode_output_verbatim():
+async def test_ctrl_y_copies_redrawn_unicode_output_verbatim(monkeypatch):
     body = (
         'import sys\n'
         f'for frame in ["\\u280b {_WIDE} lendo", "\\u2714 {_WIDE} pronto"]:\n'
@@ -160,7 +161,7 @@ async def test_ctrl_y_copies_redrawn_unicode_output_verbatim():
         app.set_focus(pane)
         await pilot.pause()
         copied: list[str] = []
-        app.copy_to_clipboard = copied.append  # type: ignore[method-assign]
+        monkeypatch.setattr(clipboard, 'copy', lambda app, text: copied.append(text))
 
         await pilot.press('ctrl+y')
         await pilot.pause()

--- a/tests/rbx/box/ui/test_terminal_wide_characters.py
+++ b/tests/rbx/box/ui/test_terminal_wide_characters.py
@@ -1,0 +1,168 @@
+"""Wide characters in the terminal emulator, and what `ctrl+y` copies back.
+
+Lines are stored as characters; the terminal moves its cursor in *cells*. A CJK
+ideograph or an emoji is one character and two cells wide, so any program that
+positions the cursor by column on such a line -- a `\\r` redraw, a progress bar,
+`ESC[nG` -- used to land at the wrong index: the emulator padded the difference
+with spaces that were never printed, or ate a character that was.
+
+The output looked close enough on screen to miss; pasting it did not.
+"""
+
+import sys
+
+import pytest
+
+from rbx.box.ui._vendor.toad.ansi import cell_span, cell_to_index, index_to_cell
+from rbx.box.ui._vendor.toad.ansi._ansi import TerminalState
+from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
+from rbx.box.ui.command_app import CommandEntry, rbxCommandApp
+
+_WIDE = '日本語'
+_EMOJI = '🎉'
+
+
+async def _noop(text: str) -> None:
+    pass
+
+
+async def _write(text: str, width: int = 40) -> list[str]:
+    """Feed `text` to a bare emulator and return its unfolded lines."""
+    state = TerminalState(_noop, width=width, height=24)
+    await state.write(text)
+    return [line.content.plain for line in state.scrollback_buffer.lines]
+
+
+# --- the conversions --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('text', 'cell', 'expected'),
+    [
+        ('abc', 0, (0, 0)),
+        ('abc', 2, (2, 0)),
+        # Past the end: the caller has to pad the difference.
+        ('abc', 5, (3, 2)),
+        # Each ideograph is two cells, so cell 6 is the end of the line.
+        (_WIDE, 6, (3, 0)),
+        (_WIDE, 4, (2, 0)),
+        (_WIDE, 7, (3, 1)),
+        # A column inside a wide character resolves to that character.
+        (_WIDE, 1, (0, 0)),
+        (_EMOJI + 'ab', 2, (1, 0)),
+        ('', 3, (0, 3)),
+    ],
+)
+def test_cell_to_index(text, cell, expected):
+    assert cell_to_index(text, cell) == expected
+
+
+@pytest.mark.parametrize(
+    ('text', 'cells', 'expected'),
+    [
+        ('abc', 2, 2),
+        ('abc', 9, 3),
+        (_WIDE, 2, 1),
+        (_WIDE, 4, 2),
+        # Rounds up: one column of a two-cell character covers all of it.
+        (_WIDE, 1, 1),
+        (_WIDE, 3, 2),
+        ('abc', 0, 0),
+    ],
+)
+def test_cell_span(text, cells, expected):
+    assert cell_span(text, cells) == expected
+
+
+def test_index_to_cell():
+    assert index_to_cell(_WIDE, 0) == 0
+    assert index_to_cell(_WIDE, 2) == 4
+    assert index_to_cell('ab' + _EMOJI, 3) == 4
+
+
+# --- the emulator -----------------------------------------------------------
+
+
+async def test_absolute_column_after_wide_characters_is_not_padded():
+    # ESC[7G is the column just past 日本語 (six cells). Indexing by character
+    # put it three columns further out, and the gap came back as spaces.
+    assert await _write(f'{_WIDE}\x1b[7GEND') == [f'{_WIDE}END']
+
+
+async def test_carriage_return_overwrite_consumes_cells():
+    # Two columns of 日 are overwritten, not two characters.
+    assert await _write(f'{_WIDE}abc\rXY') == ['XY本語abc']
+
+
+async def test_cursor_forward_counts_cells():
+    assert await _write(f'{_WIDE}abc\r\x1b[4CZZ') == ['日本ZZabc']
+
+
+async def test_erase_characters_blanks_the_cells_it_covered():
+    # ECH of two cells clears 日 and leaves two spaces, so 本語 stays put.
+    assert await _write(f'{_WIDE}abc\r\x1b[2X') == ['  本語abc']
+
+
+async def test_writing_past_the_end_pads_to_the_right_column():
+    # The emoji covers cells 0 and 1; ESC[6G asks for cell 5, so three columns
+    # of padding stand between them -- counted in cells, not characters.
+    assert await _write(f'{_EMOJI}\x1b[6Gx') == [f'{_EMOJI}   x']
+
+
+async def test_a_redraw_of_a_wrapped_wide_line_hits_the_current_row():
+    # The line folds every ten cells, so `\r` returns to the start of the last
+    # row -- which is a fold-local cell offset, not a character one.
+    wrapped = f'{_WIDE * 3}abc'
+    assert await _write(f'{wrapped}\rXY', width=10) == [f'{_WIDE * 3}abXY']
+
+
+async def test_reflow_keeps_wide_lines_intact():
+    state = TerminalState(_noop, width=10, height=24)
+    await state.write(f'{_WIDE * 3}abc')
+    state.update_size(30, 24)
+    state.update_size(8, 24)
+    await state.write('!')
+
+    lines = [line.content.plain for line in state.scrollback_buffer.lines]
+    assert lines == [f'{_WIDE * 3}abc!']
+
+
+async def test_a_line_of_wide_characters_survives_a_redraw():
+    # What a spinner does: rewrite the same line, each frame a little different.
+    frames = ''.join(f'\r⠋ {_WIDE} passo {index}' for index in range(3))
+    assert await _write(frames) == [f'⠋ {_WIDE} passo 2']
+
+
+# --- what actually reaches the clipboard ------------------------------------
+
+
+async def test_ctrl_y_copies_redrawn_unicode_output_verbatim():
+    body = (
+        'import sys\n'
+        f'for frame in ["\\u280b {_WIDE} lendo", "\\u2714 {_WIDE} pronto"]:\n'
+        '    sys.stdout.write("\\r" + frame)\n'
+        'sys.stdout.write("\\n")\n'
+    )
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[[sys.executable, '-c', body]], name='a')],
+        parallel=True,
+    )
+    async with app.run_test(size=(80, 30)) as pilot:
+        pane = None
+        for _ in range(100):
+            await pilot.pause()
+            panes = list(app.query(CommandPane))
+            if panes and all(p.return_code is not None for p in panes):
+                (pane,) = panes
+                break
+        assert pane is not None, 'command did not finish in time'
+
+        app.set_focus(pane)
+        await pilot.pause()
+        copied: list[str] = []
+        app.copy_to_clipboard = copied.append  # type: ignore[method-assign]
+
+        await pilot.press('ctrl+y')
+        await pilot.pause()
+
+        assert copied == [f'✔ {_WIDE} pronto']


### PR DESCRIPTION
Follow-up to #723. Two independent defects; the second is the one that produced the garbled paste.

## 1. The mojibake: the terminal was guessing the encoding

`ctrl+y` copies via Textual's `App.copy_to_clipboard`, which writes an **OSC 52** escape sequence — the text as UTF-8, then base64, handed to whatever terminal rbx is running in. The terminal decodes it and puts the result on the clipboard, and *that* step is where the bytes stop being ours. A terminal that reads them back as latin-1 — xterm.js, which VS Code's integrated terminal is built on, decoded the payload with `atob` — mangles every marker rbx prints outside ASCII:

| rbx prints | UTF-8 | pasted as |
|---|---|---|
| `✓` | `E2 9C 93` | `â` |
| `⧖` | `E2 A7 96` | `â§` |
| `·` | `C2 B7` | `Â·` |

Which is exactly the reported paste: `manual (20) 1/â 5/â … Â· cached`. Verified against the real clipboard on macOS — the bytes `pbcopy` returns are correct UTF-8, and reading those same bytes as latin-1 reproduces the report character for character.

**Fix:** when the clipboard is reachable without going through the terminal, write it ourselves — `pbcopy`, `wl-copy`, `xclip`, `xsel`, `clip` all take bytes, and they get UTF-8. OSC 52 remains the fallback, and stays the *only* path under SSH, where it is the one channel that reaches the machine the user is sitting at. The two are never used together: they would race for the clipboard, and the terminal is the one that gets the encoding wrong.

New `rbx/box/ui/clipboard.py`; the pane's three copy sites route through it.

## 2. The cursor was positioned in characters, not cells

Separate bug, found while chasing the first. Lines are stored as **characters**; the terminal moves its cursor in **cells** — and a CJK ideograph or an emoji is one character and two cells wide. `Buffer.cursor_offset` holds the column an ANSI sequence asked for, and upstream used it directly as a string index, so on a line holding wide characters every column move landed in the wrong place:

| input | before | a terminal shows |
|---|---|---|
| `日本語` + `ESC[7G` + `END` | `日本語   END` | `日本語END` |
| `日本語abc` + `\r` + `XY` | `XY語abc` | `XY本語abc` |
| `日本語abc` + `\r` + `ESC[4C` + `ZZ` | `日本語ZZ` | `日本ZZabc` |
| `日本語abc` + `\r` + `ESC[2X` | `語abc` | `  本語abc` |

Either a gap gets padded with spaces that were never printed, or a printed character gets eaten. Anything that redraws a line it already wrote hits it: `\r` progress output, spinners, `ESC[nG`.

Three conversions in `ansi/_ansi.py` (`cell_to_index`, `cell_span`, `index_to_cell`) and every crossing point now goes through them: the cursor round-trip, writing past end-of-line, overwrite width, `ECH`/`DCH`, `_reflow`, and cursor rendering. `cursor_offset` is documented as a cell column, which also makes the `ESC[6n` report correct.

**Note:** every marker rbx itself prints (`✓ ✗ ⧖ ⊘ ·`) is one cell wide, so this bug did **not** contribute to the reported paste. It bites CJK, emoji, and any output from a subprocess that prints them.

The vendored tree is modified here; recorded in `_vendor/toad/README.md` per its editing guidelines.

## Testing

- `tests/rbx/box/ui/test_clipboard.py` — 12 tests: tool selection per platform and display, SSH forcing OSC 52, the fallback and no-race rules, the bytes on stdin being UTF-8, and a full unpatched `ctrl+y` → worker → clipboard-command round trip asserting the exact UTF-8 bytes.
- `tests/rbx/box/ui/test_terminal_wide_characters.py` — 26 tests: the conversions (including columns landing inside a wide character), each emulator case above, a redraw of a *wrapped* wide line, reflow across two resizes, and an end-to-end copy of redrawn unicode output.
- Existing copy tests now assert at the clipboard seam rather than on `App.copy_to_clipboard`.
- Full UI suite: 160 passed. `ruff check .` clean.

## Not reproduced

The truncated `  samp` line in the report (`  samples (2) (0 ms, -)` cut to six characters) is **not** explained by either fix, and I could not reproduce it: Rich tables, panels, spinners, shrinking live blocks, and live blocks redrawn while the buffer scrolls all copy back verbatim. Ruled out: the emulator does not lose content on any redraw shape tested, and the mojibake path is a pure re-encoding, so it cannot truncate. Left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BypH4YiindSFeNdTtVRn6S
