### PR TITLE
feat(vscode): run the extension under development from any terminal

### DIFF
--- a/activate-venv.sh
+++ b/activate-venv.sh
@@ -29,6 +29,9 @@
 # — paste a PR URL to jump into the worktree you're reviewing. Requires gh, and
 # the PR's branch must be checked out in a local worktree.
 #
+# ./run-extension.sh takes the same <name> in the same way — both scripts share
+# scripts/worktree-lib.sh.
+#
 # For the activation to persist in your current shell you must SOURCE this
 # script:  `source ./activate-venv.sh my-feature`. When run directly it
 # instead drops you into a new sub-shell with the venv activated.
@@ -39,29 +42,32 @@ if [ -n "${ZSH_VERSION:-}" ]; then
   case "${ZSH_EVAL_CONTEXT:-}" in
     *:file*) _av_sourced=1 ;;
   esac
+elif [ -n "${BASH_VERSION:-}" ]; then
+  [ "${BASH_SOURCE[0]}" != "$0" ] && _av_sourced=1
+fi
+
+# --- locate the repository root (this script lives there) -------------------
+if [ -n "${ZSH_VERSION:-}" ]; then
   # zsh-specific way to read this file's own path, hidden from bash's parser.
   _av_self="$(eval 'printf "%s" "${(%):-%x}"')"
 elif [ -n "${BASH_VERSION:-}" ]; then
-  [ "${BASH_SOURCE[0]}" != "$0" ] && _av_sourced=1
   _av_self="${BASH_SOURCE[0]}"
 else
   _av_self="$0"
 fi
+_av_root="$(cd "$(dirname "$_av_self")" >/dev/null 2>&1 && pwd)"
+
+# shellcheck source=scripts/worktree-lib.sh
+. "$_av_root/scripts/worktree-lib.sh" || return 1 2>/dev/null || exit 1
+WT_PROG="activate-venv"
 
 # --- argument parsing -------------------------------------------------------
 _av_usage() {
-  cat >&2 <<'EOF'
+  cat >&2 <<EOF
 Usage: source ./activate-venv.sh [-b] [<name>]
        ./activate-venv.sh [-b] [<name>]
 
-  (no name)   use the root repository's venv
-  <name>      worktree directory name (under .worktrees or .claude/worktrees),
-              or a path to a worktree relative to the root repo (e.g.
-              .claude/worktrees/foo) or absolute; a "worktree-" prefixed name
-              that matches no directory is resolved as a branch (see -b)
-  <pr-url>    a GitHub pull request URL (…/pull/N); uses the worktree that has
-              the PR's head branch checked out (needs gh)
-  -b <name>   treat <name> as a git branch and use its checked-out worktree
+$(wt_name_help '  ')
 EOF
 }
 
@@ -85,80 +91,10 @@ if [ -z "$_av_name" ] && [ "$_av_by_branch" -eq 1 ]; then
   return 1 2>/dev/null || exit 1
 fi
 
-# --- locate the repository root (this script lives there) -------------------
-_av_root="$(cd "$(dirname "$_av_self")" >/dev/null 2>&1 && pwd)"
-
 # --- resolve the target worktree directory ----------------------------------
-_av_wt=""          # resolved worktree path, once known
-_av_branch=""      # set when <name> should be resolved via git branch lookup
-_av_branch_from="" # human description of where the branch came from, if indirect
-if [ "$_av_by_branch" -eq 1 ]; then
-  _av_branch="$_av_name"
-elif [ -z "$_av_name" ]; then
-  # No name: use the root repository this script lives in.
-  _av_wt="$_av_root"
-else
-  case "$_av_name" in
-    *://*/pull/*)
-      # A GitHub pull request URL: resolve its head branch via gh, then treat it
-      # like a branch (it must be checked out in a local worktree). The branch is
-      # only looked up, never checked out.
-      if ! command -v gh >/dev/null 2>&1; then
-        echo "activate-venv: gh (GitHub CLI) is required to resolve a pull request URL" >&2
-        return 1 2>/dev/null || exit 1
-      fi
-      _av_branch="$(gh pr view "$_av_name" --json headRefName -q .headRefName)"
-      if [ -z "$_av_branch" ]; then
-        echo "activate-venv: could not resolve a head branch for pull request '$_av_name' (check the URL and 'gh auth status')" >&2
-        return 1 2>/dev/null || exit 1
-      fi
-      _av_branch_from="pull request $_av_name"
-      ;;
-    */*)
-      # A path to a worktree: relative to the root repo, or absolute.
-      case "$_av_name" in
-        /*) _av_wt="$_av_name" ;;
-        *)  _av_wt="$_av_root/$_av_name" ;;
-      esac
-      if [ ! -d "$_av_wt" ]; then
-        echo "activate-venv: no such directory: $_av_wt" >&2
-        return 1 2>/dev/null || exit 1
-      fi
-      ;;
-    *)
-      # A bare worktree directory name.
-      for _av_base in "$_av_root/.worktrees" "$_av_root/.claude/worktrees"; do
-        if [ -d "$_av_base/$_av_name" ]; then
-          _av_wt="$_av_base/$_av_name"
-          break
-        fi
-      done
-      # No directory matched. A "worktree-<name>" branch (what the harness names
-      # its worktree branches) maps to the worktree dir <name>, so resolve it as
-      # a branch and activate that existing worktree directly.
-      if [ -z "$_av_wt" ]; then
-        case "$_av_name" in
-          worktree-*) _av_branch="$_av_name" ;;
-          *) echo "activate-venv: no worktree named '$_av_name' under .worktrees or .claude/worktrees" >&2
-             return 1 2>/dev/null || exit 1 ;;
-        esac
-      fi
-      ;;
-  esac
-fi
-
-# Resolve a branch name to the worktree that currently has it checked out. This
-# only reads the worktree list; it never checks the branch out anywhere.
-if [ -n "$_av_branch" ]; then
-  _av_wt="$(git -C "$_av_root" worktree list --porcelain 2>/dev/null | awk -v b="$_av_branch" '
-    /^worktree / { path = substr($0, 10); next }
-    /^branch /   { ref = substr($0, 8)
-                   if (ref == "refs/heads/" b) { print path; exit } }')"
-  if [ -z "$_av_wt" ]; then
-    echo "activate-venv: no worktree found with branch '$_av_branch'${_av_branch_from:+ (from $_av_branch_from)}" >&2
-    return 1 2>/dev/null || exit 1
-  fi
-fi
+_av_wt="$(wt_resolve "$_av_root" "$_av_name" "$_av_by_branch")" || {
+  return 1 2>/dev/null || exit 1
+}
 
 # --- locate and run the activation script -----------------------------------
 _av_activate="$_av_wt/.venv/bin/activate"

--- a/run-extension.sh
+++ b/run-extension.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+#
+# run-extension.sh — run the VS Code extension under development.
+#
+# Usage:
+#   ./run-extension.sh [-b] [<name>] [-e <editor>]... [-f <folder>] [options]
+#
+# Builds vscode/ in the worktree <name> names and launches an Extension
+# Development Host loading it, so the editor runs the extension *from that
+# checkout* — no .vsix, no install, no `rbx vscode install`. This is what
+# pressing F5 in vscode/ does, from any terminal and for any worktree.
+#
+# <name> is resolved exactly as ./activate-venv.sh resolves it (both scripts
+# share scripts/worktree-lib.sh): with no name the root repository this script
+# lives in, otherwise a worktree directory name, a path, a "worktree-" branch,
+# a branch with -b, or a GitHub pull request URL. So the review you already
+# have checked out is one command away from running in your editor:
+#
+#   ./run-extension.sh https://github.com/rsalesc/rbx/pull/723 -e cursor
+#
+# The extension is always bundled before the editor starts (npm install first
+# if node_modules is missing), because a development host pointed at a checkout
+# that was never built fails on activation with a missing dist/extension.js.
+# Pass --no-build to skip that when you already have `npm run watch` going.
+
+set -euo pipefail
+
+WT_PROG="run-extension"
+
+_re_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=scripts/worktree-lib.sh
+. "$_re_root/scripts/worktree-lib.sh"
+
+# --- editors ----------------------------------------------------------------
+# Keyed the same way as rbx/box/vscode/extension.py, so --editor takes the same
+# names as `rbx vscode install --editor`.
+_re_editor_binary() {
+  case "$1" in
+    code) echo "code" ;;
+    cursor) echo "cursor" ;;
+    windsurf) echo "windsurf" ;;
+    codium) echo "codium" ;;
+    code-insiders) echo "code-insiders" ;;
+    *) return 1 ;;
+  esac
+}
+
+_re_editor_label() {
+  case "$1" in
+    code) echo "VS Code" ;;
+    cursor) echo "Cursor" ;;
+    windsurf) echo "Windsurf" ;;
+    codium) echo "VSCodium" ;;
+    code-insiders) echo "VS Code Insiders" ;;
+  esac
+}
+
+# The app bundle each editor installs its CLI inside, so a Mac that never ran
+# "Shell Command: Install 'code' command in PATH" still works.
+_re_editor_app() {
+  case "$1" in
+    code) echo "/Applications/Visual Studio Code.app" ;;
+    cursor) echo "/Applications/Cursor.app" ;;
+    windsurf) echo "/Applications/Windsurf.app" ;;
+    codium) echo "/Applications/VSCodium.app" ;;
+    code-insiders) echo "/Applications/Visual Studio Code - Insiders.app" ;;
+  esac
+}
+
+_re_editors="code cursor windsurf codium code-insiders"
+
+# Which editor's integrated terminal we are in, if any. TERM_PROGRAM=vscode is
+# set by VS Code *and every fork*, so the app path is what tells them apart —
+# the same reasoning as detect_editor() in rbx/box/vscode/extension.py.
+_re_detect_editor() {
+  [ "${TERM_PROGRAM:-}" = "vscode" ] || return 1
+  _re_app="$(printf '%s' "${VSCODE_GIT_ASKPASS_NODE:-${VSCODE_GIT_ASKPASS_MAIN:-}}" | tr '[:upper:]' '[:lower:]')"
+  case "$_re_app" in
+    *cursor*) echo cursor; return 0 ;;
+    *windsurf*) echo windsurf; return 0 ;;
+    *codium*) echo codium; return 0 ;;
+    *"code - insiders"*) echo code-insiders; return 0 ;;
+  esac
+  # An integrated terminal that told us nothing else is VS Code.
+  echo code
+}
+
+# The command that starts <editor>: its CLI on PATH, else the one in its app
+# bundle. Fails, with what to do about it, when neither exists.
+_re_editor_command() {
+  _re_key="$1"
+  _re_bin="$(_re_editor_binary "$_re_key")"
+  if command -v "$_re_bin" >/dev/null 2>&1; then
+    command -v "$_re_bin"
+    return 0
+  fi
+  _re_inapp="$(_re_editor_app "$_re_key")/Contents/Resources/app/bin/$_re_bin"
+  if [ -x "$_re_inapp" ]; then
+    echo "$_re_inapp"
+    return 0
+  fi
+  echo "$WT_PROG: could not find the '$_re_bin' command for $(_re_editor_label "$_re_key")" >&2
+  echo "$WT_PROG: add it from the editor with \"Shell Command: Install '$_re_bin' command in PATH\", or install $(_re_editor_label "$_re_key")" >&2
+  return 1
+}
+
+# --- argument parsing -------------------------------------------------------
+_re_usage() {
+  cat >&2 <<EOF
+Usage: ./run-extension.sh [-b] [<name>] [-e <editor>]... [-f <folder>] [options]
+
+$(wt_name_help '  ')
+
+  -e, --editor <key>    editor to launch: $(echo "$_re_editors" | tr ' ' ',')
+                        (repeatable; defaults to the editor whose terminal this
+                        is, else code)
+  -f, --folder <path>   folder the development host opens; defaults to the
+                        current directory when it holds a problem.rbx.yml or a
+                        contest.rbx.yml, else nothing
+  -n, --no-build        do not build first (use with 'npm run watch')
+  -c, --clean           disable your other extensions in the development host
+  -p, --print           print the command instead of running it
+  -h, --help            this message
+EOF
+}
+
+_re_by_branch=0
+_re_name=""
+_re_editor_keys=""
+_re_folder=""
+_re_build=1
+_re_clean=0
+_re_print=0
+
+_re_need_value() {
+  if [ "$2" -lt 2 ]; then
+    echo "$WT_PROG: $1 requires a value" >&2
+    _re_usage
+    exit 1
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -b|--branch) _re_by_branch=1 ;;
+    -e|--editor)
+      _re_need_value "$1" "$#"
+      _re_editor_keys="$_re_editor_keys $2"
+      shift
+      ;;
+    -f|--folder)
+      _re_need_value "$1" "$#"
+      _re_folder="$2"
+      shift
+      ;;
+    -n|--no-build) _re_build=0 ;;
+    -c|--clean) _re_clean=1 ;;
+    -p|--print) _re_print=1 ;;
+    -h|--help) _re_usage; exit 0 ;;
+    --) shift; _re_name="${1:-}"; break ;;
+    -*) echo "$WT_PROG: unknown option: $1" >&2; _re_usage; exit 1 ;;
+    *) _re_name="$1" ;;
+  esac
+  shift
+done
+
+if [ -z "$_re_name" ] && [ "$_re_by_branch" -eq 1 ]; then
+  echo "$WT_PROG: -b requires a branch name" >&2
+  _re_usage
+  exit 1
+fi
+
+# No editor named: the one whose terminal we are in, else VS Code.
+if [ -z "${_re_editor_keys// /}" ]; then
+  _re_editor_keys="$(_re_detect_editor || echo code)"
+fi
+
+for _re_key in $_re_editor_keys; do
+  if ! _re_editor_binary "$_re_key" >/dev/null; then
+    echo "$WT_PROG: unknown editor: $_re_key" >&2
+    echo "$WT_PROG: known editors: $(echo "$_re_editors" | tr ' ' ',')" >&2
+    exit 1
+  fi
+done
+
+# --- resolve the worktree and its extension ---------------------------------
+_re_wt="$(wt_resolve "$_re_root" "$_re_name" "$_re_by_branch")"
+_re_ext="$_re_wt/vscode"
+if [ ! -f "$_re_ext/package.json" ]; then
+  echo "$WT_PROG: no extension at $_re_ext (is $_re_wt an rbx worktree?)" >&2
+  exit 1
+fi
+
+# --- resolve the folder the host opens --------------------------------------
+# A development host with no folder open activates nothing: the extension is
+# only awake once it sees a package. Defaulting to the current directory means
+# running this from a problem is enough.
+if [ -z "$_re_folder" ]; then
+  if [ -f "$PWD/problem.rbx.yml" ] || [ -f "$PWD/contest.rbx.yml" ]; then
+    _re_folder="$PWD"
+  fi
+elif [ ! -d "$_re_folder" ]; then
+  echo "$WT_PROG: no such folder: $_re_folder" >&2
+  exit 1
+fi
+if [ -n "$_re_folder" ]; then
+  _re_folder="$(cd "$_re_folder" >/dev/null 2>&1 && pwd)"
+fi
+
+# --- build ------------------------------------------------------------------
+# A development host loads dist/extension.js directly from the checkout, so an
+# unbuilt (or stale) checkout only fails later, inside the editor, as a failed
+# activation. Build before launching rather than after the report.
+if [ "$_re_build" -eq 1 ]; then
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "$WT_PROG: npm is required to build the extension (or pass --no-build)" >&2
+    exit 1
+  fi
+  if [ ! -d "$_re_ext/node_modules" ]; then
+    echo "$WT_PROG: installing npm dependencies in $_re_ext"
+    (cd "$_re_ext" && npm install)
+  fi
+  echo "$WT_PROG: building $_re_ext"
+  (cd "$_re_ext" && npm run compile)
+fi
+
+if [ ! -f "$_re_ext/dist/extension.js" ]; then
+  echo "$WT_PROG: $_re_ext/dist/extension.js is missing — the development host would fail to activate" >&2
+  if [ "$_re_build" -eq 0 ]; then
+    echo "$WT_PROG: run without --no-build, or 'npm run compile' in $_re_ext" >&2
+  fi
+  exit 1
+fi
+
+# --- launch -----------------------------------------------------------------
+for _re_key in $_re_editor_keys; do
+  _re_cmd="$(_re_editor_command "$_re_key")"
+
+  set -- --new-window --extensionDevelopmentPath="$_re_ext"
+  if [ "$_re_clean" -eq 1 ]; then
+    set -- "$@" --disable-extensions
+  fi
+  if [ -n "$_re_folder" ]; then
+    set -- "$@" "$_re_folder"
+  fi
+
+  if [ "$_re_print" -eq 1 ]; then
+    printf '%q ' "$_re_cmd" "$@"
+    printf '\n'
+    continue
+  fi
+
+  echo "$WT_PROG: launching $(_re_editor_label "$_re_key") with $_re_ext${_re_folder:+ on $_re_folder}"
+  "$_re_cmd" "$@"
+done

--- a/scripts/worktree-lib.sh
+++ b/scripts/worktree-lib.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# worktree-lib.sh — resolve a worktree from a name, a path, a branch or a PR.
+#
+# Sourced by the repository's developer scripts (activate-venv.sh,
+# run-extension.sh) so they all accept the same <name> in the same way. It is
+# written in POSIX shell so it works when sourced from bash and from zsh.
+#
+# Functions:
+#   wt_name_help <indent>   the shared <name> lines of a script's usage text
+#   wt_resolve <root> <name> <by-branch>
+#                           echo the worktree directory <name> refers to, with
+#                           <root> the repository the calling script lives in
+#                           and <by-branch> 1 to read <name> as a git branch
+#
+# Messages are prefixed with $WT_PROG, which the calling script sets to its own
+# name so its errors all look like they came from one script.
+
+# The <name> paragraph of a usage message, indented by $1, so both scripts
+# describe the argument they share in the same words.
+wt_name_help() {
+  _wt_i="${1:-}"
+  cat <<EOF
+${_wt_i}(no name)   use the root repository this script lives in
+${_wt_i}<name>      worktree directory name (under .worktrees or .claude/worktrees),
+${_wt_i}            or a path to a worktree relative to the root repo (e.g.
+${_wt_i}            .claude/worktrees/foo) or absolute; a "worktree-" prefixed name
+${_wt_i}            that matches no directory is resolved as a branch (see -b)
+${_wt_i}<pr-url>    a GitHub pull request URL (…/pull/N); uses the worktree that has
+${_wt_i}            the PR's head branch checked out (needs gh)
+${_wt_i}-b <name>   treat <name> as a git branch and use its checked-out worktree
+EOF
+  unset _wt_i
+}
+
+# Resolve a branch name to the worktree that currently has it checked out. This
+# only reads the worktree list; it never checks the branch out anywhere.
+_wt_by_branch() {
+  _wt_root="$1"
+  _wt_branch="$2"
+  _wt_from="$3"
+  _wt_path="$(git -C "$_wt_root" worktree list --porcelain 2>/dev/null | awk -v b="$_wt_branch" '
+    /^worktree / { path = substr($0, 10); next }
+    /^branch /   { ref = substr($0, 8)
+                   if (ref == "refs/heads/" b) { print path; exit } }')"
+  if [ -z "$_wt_path" ]; then
+    echo "${WT_PROG:-worktree}: no worktree found with branch '$_wt_branch'${_wt_from:+ (from $_wt_from)}" >&2
+    return 1
+  fi
+  printf '%s' "$_wt_path"
+}
+
+# Echo the worktree directory <name> refers to, or fail with a message on
+# stderr. Callers report the failure their own way, so this only returns 1.
+wt_resolve() {
+  _wt_root="$1"
+  _wt_name="$2"
+  _wt_bybranch="${3:-0}"
+
+  if [ "$_wt_bybranch" -eq 1 ]; then
+    _wt_by_branch "$_wt_root" "$_wt_name" ""
+    return $?
+  fi
+
+  if [ -z "$_wt_name" ]; then
+    # No name: use the root repository the calling script lives in.
+    printf '%s' "$_wt_root"
+    return 0
+  fi
+
+  case "$_wt_name" in
+    *://*/pull/*)
+      # A GitHub pull request URL: resolve its head branch via gh, then treat it
+      # like a branch (it must be checked out in a local worktree). The branch is
+      # only looked up, never checked out.
+      if ! command -v gh >/dev/null 2>&1; then
+        echo "${WT_PROG:-worktree}: gh (GitHub CLI) is required to resolve a pull request URL" >&2
+        return 1
+      fi
+      _wt_branch="$(gh pr view "$_wt_name" --json headRefName -q .headRefName)"
+      if [ -z "$_wt_branch" ]; then
+        echo "${WT_PROG:-worktree}: could not resolve a head branch for pull request '$_wt_name' (check the URL and 'gh auth status')" >&2
+        return 1
+      fi
+      _wt_by_branch "$_wt_root" "$_wt_branch" "pull request $_wt_name"
+      return $?
+      ;;
+    */*)
+      # A path to a worktree: relative to the root repo, or absolute.
+      case "$_wt_name" in
+        /*) _wt_path="$_wt_name" ;;
+        *)  _wt_path="$_wt_root/$_wt_name" ;;
+      esac
+      if [ ! -d "$_wt_path" ]; then
+        echo "${WT_PROG:-worktree}: no such directory: $_wt_path" >&2
+        return 1
+      fi
+      printf '%s' "$_wt_path"
+      return 0
+      ;;
+    *)
+      # A bare worktree directory name.
+      for _wt_base in "$_wt_root/.worktrees" "$_wt_root/.claude/worktrees"; do
+        if [ -d "$_wt_base/$_wt_name" ]; then
+          printf '%s' "$_wt_base/$_wt_name"
+          return 0
+        fi
+      done
+      # No directory matched. A "worktree-<name>" branch (what the harness names
+      # its worktree branches) maps to the worktree dir <name>, so resolve it as
+      # a branch and use that existing worktree directly.
+      case "$_wt_name" in
+        worktree-*)
+          _wt_by_branch "$_wt_root" "$_wt_name" ""
+          return $?
+          ;;
+        *)
+          echo "${WT_PROG:-worktree}: no worktree named '$_wt_name' under .worktrees or .claude/worktrees" >&2
+          return 1
+          ;;
+      esac
+      ;;
+  esac
+}

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -559,6 +559,30 @@ npm run watch      # esbuild, incremental
 Then press <kbd>F5</kbd> to launch an Extension Development Host, and open a
 folder containing a `problem.rbx.yml`.
 
+From any terminal, `./run-extension.sh` in the repository root does the same
+without the editor being the one you launch from -- it bundles the extension
+and starts a development host on it:
+
+```bash
+./run-extension.sh                     # this checkout, in VS Code
+./run-extension.sh -e cursor           # ... in Cursor
+./run-extension.sh -e code -e cursor   # ... in both at once
+```
+
+Run it from a problem directory and the host opens that problem. It takes the
+worktree, branch or pull request URL `./activate-venv.sh` takes, in the same
+way, so the branch you are reviewing runs in one command:
+
+```bash
+./run-extension.sh https://github.com/rsalesc/rbx/pull/723 -e cursor
+```
+
+It always builds first, since a development host pointed at a checkout that was
+never bundled only fails later, inside the editor, as a failed activation. Pass
+`--no-build` when `npm run watch` is already doing that for you, `--clean` to
+disable your other extensions in the host, and `--print` to see the command
+instead of running it.
+
 ```bash
 npm run typecheck  # tsc --noEmit
 npm test           # node --test, over esbuild-compiled sources


### PR DESCRIPTION
Pressing <kbd>F5</kbd> in `vscode/` is the only way to run the extension from a
checkout, and it only works from the window that has `vscode/` open. This adds
`./run-extension.sh`, which does the same from any terminal, for any worktree,
and into either editor.

```bash
./run-extension.sh                     # this checkout, in VS Code
./run-extension.sh -e cursor           # ... in Cursor
./run-extension.sh -e code -e cursor   # ... in both at once
```

### Same `<name>` as `activate-venv.sh`

The two scripts now share `scripts/worktree-lib.sh`, which holds the resolution
lifted out of `activate-venv.sh` unchanged: a worktree directory name, a
relative or absolute path, a `worktree-`-prefixed branch, a branch with `-b`, or
a GitHub pull request URL. So the branch you are reviewing is one command away
from running in your editor:

```bash
./run-extension.sh https://github.com/rsalesc/rbx/pull/723 -e cursor
```

`activate-venv.sh` keeps its interface and its messages; it just sources the lib
now, so the two cannot drift apart.

### It always builds first

A development host loads `dist/extension.js` straight from the checkout, so an
unbuilt one does not fail in the terminal that launched it -- it fails minutes
later, inside the editor, as a failed activation. The script runs `npm install`
(when `node_modules` is missing) and `npm run compile` before launching, and
refuses to launch at all if the bundle still is not there. `--no-build` opts out
for when `npm run watch` is already doing it.

### Other conveniences

- `--editor` takes the same keys as `rbx vscode install --editor`, and defaults
  to the editor whose integrated terminal you are in via the same detection as
  `rbx/box/vscode/extension.py`, falling back to `code`.
- The editor CLI is found on `PATH` or inside its app bundle, so a Mac that
  never ran "Shell Command: Install 'code' command in PATH" still works.
- The host opens the current directory when it holds a `problem.rbx.yml` or a
  `contest.rbx.yml` -- a host with no folder open activates nothing.
- `--clean` disables your other extensions in the host; `--print` shows the
  command instead of running it.

### Verification

`bash -n`/`zsh -n` over all three shell files; every error path exercised
(unknown worktree, unknown editor, missing option value, unbuilt checkout); the
resolver checked against all five name forms and a missing branch;
`activate-venv.sh` re-checked sourced from both zsh and bash; and one full run
that installed, bundled and launched a real Extension Development Host --
confirmed live with `pgrep -f extensionDevelopmentPath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MAMn2LnHNrHzAgmrkGmXd