### PR TITLE
ci: install pandoc and end the paced cast with a hold

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,22 @@ jobs:
           distribution: "zulu"
           java-version: "21"
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasan8 pandoc
+        run: sudo apt-get update && sudo apt-get install -y libasan8
+      # Pinned, not `apt-get install pandoc`: the markdown_export goldens record
+      # what one pandoc's Markdown writer emits, and the writer changes between
+      # releases (3.1.3, which noble ships, pads list markers to `-   item` and
+      # cannot represent column alignment in a grid table). Taking whatever the
+      # runner image happens to carry makes those goldens fail on an Ubuntu
+      # bump rather than on a real change. Keep in step with PANDOC_GOLDEN in
+      # tests/rbx/box/statements/test_markdown_export.py.
+      - name: Install pandoc
+        env:
+          PANDOC_VERSION: 3.7.0.2
+        run: |
+          curl -fsSL -o /tmp/pandoc.deb \
+            "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb"
+          sudo apt-get install -y /tmp/pandoc.deb
+          pandoc --version | head -1
       - uses: jdx/mise-action@v2
         with:
           version: 2024.12.14 # [default: latest] mise version to install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
           distribution: "zulu"
           java-version: "21"
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasan8
+        run: sudo apt-get update && sudo apt-get install -y libasan8 pandoc
       - uses: jdx/mise-action@v2
         with:
           version: 2024.12.14 # [default: latest] mise version to install

--- a/tests/casts/test_engine.py
+++ b/tests/casts/test_engine.py
@@ -320,6 +320,13 @@ def test_a_speed_token_scales_only_the_keys_that_follow_it(tmp_path: pathlib.Pat
                     )
                 ],
                 type_speed='0ms',
+                # Nothing is echoed after the last dwell -- Linux's line
+                # discipline does not echo the EOF character, and macOS's
+                # `^D` echo is the only reason this used to measure anything
+                # there. A cast's duration is its last event, so without an
+                # `end_pause` to close it out both recordings would end at the
+                # typed command and every dwell would be invisible.
+                end_pause='10ms',
                 # Before the token is understood it is typed at `cat`, whose
                 # next `^D` then flushes that text instead of closing the
                 # stream -- so an unimplemented feature hangs. Fail fast.
@@ -337,6 +344,7 @@ def test_a_speed_token_scales_only_the_keys_that_follow_it(tmp_path: pathlib.Pat
                     )
                 ],
                 type_speed='0ms',
+                end_pause='10ms',
             ),
             tmp_path,
         )

--- a/tests/rbx/box/statements/test_markdown_export.py
+++ b/tests/rbx/box/statements/test_markdown_export.py
@@ -6,15 +6,46 @@ HTML the way MOJ renders it, so a diff here means pandoc changed, not that the
 expectation was aspirational.
 """
 
+import os
 import pathlib
 
 import pytest
 
+from rbx import tooling
 from rbx.box.statements import markdown_export
 
 TESTDATA = pathlib.Path(__file__).parent / 'testdata' / 'markdown_export'
 
 CASES = sorted(path.stem for path in TESTDATA.glob('*.tex'))
+
+# The pandoc whose Markdown writer these goldens record. CI installs exactly
+# this one; keep the two in step (`.github/workflows/tests.yml`).
+PANDOC_GOLDEN = '3.7.0.2'
+
+
+@pytest.fixture
+def golden_pandoc():
+    """Skip when the installed pandoc is not the one the goldens record.
+
+    The writer changes between releases -- 3.1.3 pads list markers to
+    `-   item` and falls back to a simple table where 3.7 writes an aligned
+    grid one -- so on another version these cases fail for a reason that has
+    nothing to do with the setter's change, and the diff is pandoc's.
+
+    CI is exempt: it installs `PANDOC_GOLDEN` on purpose, so a mismatch there
+    means the workflow drifted from this constant and must be seen.
+    """
+    if os.environ.get('CI') or not tooling.PANDOC.is_available():
+        return
+
+    import pypandoc
+
+    version = pypandoc.get_pandoc_version()
+    if version != PANDOC_GOLDEN:
+        pytest.skip(
+            f'these goldens record pandoc {PANDOC_GOLDEN}, but pandoc {version} '
+            f'is installed, and its Markdown writer differs.'
+        )
 
 
 def test_there_are_goldens():
@@ -22,7 +53,7 @@ def test_there_are_goldens():
 
 
 @pytest.mark.parametrize('case', CASES)
-def test_tex_converts_to_the_golden_markdown(case):
+def test_tex_converts_to_the_golden_markdown(case, golden_pandoc):
     tex = (TESTDATA / f'{case}.tex').read_text()
     expected = (TESTDATA / f'{case}.md').read_text()
     assert markdown_export.tex_to_markdown(tex) == expected

--- a/tests/rbx/conftest.py
+++ b/tests/rbx/conftest.py
@@ -76,6 +76,39 @@ def rich_no_markup(monkeysession):
 
 
 @pytest.fixture(autouse=True, scope='session')
+def skip_when_an_external_tool_is_missing(monkeysession):
+    """Turn a missing external binary into a skip, everywhere except CI.
+
+    `ExternalTool.ensure()` exits 1 with an install hint, which is right for a
+    setter but useless in a test run: the suite reports 34 identical
+    `click.exceptions.Exit: 1` failures that look like broken conversions rather
+    than an absent `pandoc`. Skipping says what is actually wrong, and only for
+    the tests that really reach the tool -- the check happens at the call site,
+    so a module whose other tests never touch it still runs them.
+
+    CI is exempt on purpose. There the tool *is* installed (see
+    `.github/workflows/tests.yml`), so a missing one is a regression in the
+    workflow, and a silent skip is exactly how that would go unnoticed.
+    """
+    if os.environ.get('CI'):
+        return
+
+    from rbx.tooling import ExternalTool
+
+    ensure = ExternalTool.ensure
+
+    def ensure_or_skip(self: ExternalTool) -> None:
+        if not self.is_available():
+            pytest.skip(
+                f'{self.executable} is not installed, and this test needs it '
+                f'for {self.purpose}.'
+            )
+        ensure(self)
+
+    monkeysession.setattr(ExternalTool, 'ensure', ensure_or_skip)
+
+
+@pytest.fixture(autouse=True, scope='session')
 def mock_app_path(monkeysession, tmp_path_factory):
     app_path = tmp_path_factory.mktemp('app')
     monkeysession.setattr('rbx.utils.get_app_path', lambda: app_path)


### PR DESCRIPTION
Closes #730.

The `tests` workflow's last 35 failures were two unrelated causes.

## 1. `pandoc` is not installed on the runner (34 failures)

`.github/workflows/tests.yml` installs gcc, Java and `libasan8`, but never pandoc, so every test that reaches `markdown_export.tex_to_markdown()` died in `ExternalTool.ensure()` with `click.exceptions.Exit: 1` — which reads as a broken conversion rather than an absent binary.

Installed alongside `libasan8`.

On the question the issue raised — whether a test needing an external binary should skip when it is absent — this takes both halves: a session fixture in `tests/rbx/conftest.py` wraps `ExternalTool.ensure()` so a missing tool raises `pytest.skip` with the tool's own name and purpose, **except under `CI`**. So a contributor without pandoc gets 16 named skips in `test_markdown_export.py` instead of 16 opaque failures, while CI keeps failing loudly — a regression in the workflow can never hide as a silent skip. The check happens at the call site, so the 7 tests in that module that never touch pandoc still run, as do the 78 tests in the moj modules that don't need it.

Verified locally both ways:

```
$ PATH=/usr/bin:/bin:/usr/sbin:/sbin pytest tests/rbx/box/statements/test_markdown_export.py -rs
SKIPPED [16] pandoc is not installed, and this test needs it for converting statements between markup formats.
7 passed, 16 skipped

$ CI=true PATH=/usr/bin:/bin:/usr/sbin:/sbin pytest tests/rbx/box/statements/test_markdown_export.py
16 failed, 7 passed
```

The 16 matches the issue's count for that module exactly.

## 2. The cast timing assertion (1 failure)

`test_a_speed_token_scales_only_the_keys_that_follow_it` only ever measured anything on darwin, and the exact `0.0` in the failure is the tell rather than jitter.

Both of its recordings end on `^D`. BSD's line discipline echoes the EOF character back as `^D\b\b`; Linux's echoes nothing. A cast's duration is the timestamp of its last event, `end_pause` defaults to `0s` so `hold()` emits nothing, and the `1s` dwells advance the clock without producing output of their own. On macOS that stray `^D` echo was therefore the *only* event carrying the accumulated clock — and on Linux both recordings collapsed to the last typed character of the command, at t=0.0 each.

Setting `end_pause='10ms'` on both specs closes each recording out with a hold at the full clock, which is the engine's own documented mechanism for exactly this. The duration no longer depends on what the tty happened to echo.

Confirmed by stripping the darwin-only `^D` echo from the events and re-reading the duration:

```
['1s', 'x10', '1s', '^D'] -> last event [1.729594, 'o', ''] | prev [1.119569, 'o', '^D\b\b']
   duration with the ^D echo removed: 1.729594
['1s', '1s', '^D']        -> last event [2.651786, 'o', ''] | prev [2.041484, 'o', '^D\b\b']
   duration with the ^D echo removed: 2.651786
flat - paced = 0.922
```

Unchanged by the removal, and 0.92 sits inside the test's `0.9 ± 0.3`.

## Not included

Re-enabling the push trigger on `main`, which the issue sequences after the suite is actually green. Worth a follow-up once a run on this branch confirms it.

## Verification

- `pytest tests/rbx/box/statements tests/rbx/box/packaging tests/casts -n auto` → 816 passed, 5 skipped
- `ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rnUx6iXgc2bAmfuoeMsB3