### PR TITLE
fix(libraries): keep testlib when a preset declares no libraries

### DIFF
--- a/rbx/box/libraries.py
+++ b/rbx/box/libraries.py
@@ -21,12 +21,33 @@ BUILTIN_TESTLIB = Library(
 )
 
 
+def _is_testlib(lib: Library) -> bool:
+    """Whether this library is the one `#include "testlib.h"` resolves to.
+
+    Compares the name the header is injected under, which is what decides the
+    include -- a preset is free to keep its testlib at any `path`/`dest`.
+    """
+    include_as = lib.include_as or pathlib.Path((lib.path or lib.dest).name)
+    return include_as.name == BUILTIN_TESTLIB.dest.name
+
+
 @functools.cache
 def get_declared_libraries() -> List[Library]:
     """Libraries declared by the active preset for the current package kind.
 
-    Falls back to just [[BUILTIN_TESTLIB]] when the package was not created from
-    a preset. Cwd-dependent and cached, so it is registered in
+    Falls back to [[BUILTIN_TESTLIB]] whenever nothing declared supplies
+    testlib -- for a package with no preset, and equally for one whose preset
+    simply never declared it. Only the bundled presets are known to declare it;
+    a hand-written one that does not would otherwise leave rbx's own builtin
+    checkers with an unresolvable `#include "testlib.h"`, since they live
+    outside the package root where the dependency scanner does not reach.
+
+    A preset that *does* declare testlib keeps it, unmaterialized included: it
+    is listed first, so `add_always_include_libraries` takes it and skips this
+    fallback, and a package out of sync with its preset still says so rather
+    than quietly compiling against rbx's copy.
+
+    Cwd-dependent and cached, so it is registered in
     `rbx.testing_utils.clear_all_functools_cache`.
     """
     from rbx.box import presets
@@ -34,10 +55,12 @@ def get_declared_libraries() -> List[Library]:
     preset = presets.get_active_preset_or_null()
     if preset is None:
         return [BUILTIN_TESTLIB]
-    libs = (
+    libs = list(
         preset.libraries.contest if presets.is_contest() else preset.libraries.problem
     )
-    return list(libs)
+    if not any(_is_testlib(lib) for lib in libs):
+        libs.append(BUILTIN_TESTLIB)
+    return libs
 
 
 def _builtin_fallback(lib: Library) -> Optional[pathlib.Path]:

--- a/tests/rbx/box/test_libraries.py
+++ b/tests/rbx/box/test_libraries.py
@@ -57,6 +57,14 @@ def test_add_always_include_dedups_existing(tmp_path, monkeypatch):
             src=tmp_path / 'mylib.h', dest=steps.INTERNAL_DIR / 'mylib.h'
         )
     )
+    # The preset declares no testlib, so the builtin is implied alongside
+    # `mylib`. Seed it too, or it is a genuinely new input and `added` says so
+    # -- which would be about the fallback rather than about deduping.
+    artifacts.inputs.append(
+        steps.GradingFileInput(
+            src=tmp_path / 'testlib.h', dest=steps.INTERNAL_DIR / 'testlib.h'
+        )
+    )
     added = libraries.add_always_include_libraries(artifacts)
 
     assert added is False  # already present => not added again
@@ -74,6 +82,53 @@ def test_no_preset_still_declares_testlib(tmp_path, monkeypatch):
     libraries.get_declared_libraries.cache_clear()
 
     assert [lib.name for lib in libraries.get_always_include_libraries()] == ['testlib']
+
+
+def test_preset_declaring_no_libraries_still_declares_testlib(tmp_path, monkeypatch):
+    """Having a preset at all must not cost the package testlib.
+
+    Only the bundled presets are known to declare it; a hand-written one that
+    lists no libraries used to return an empty set, which left the builtin
+    checkers compiling against an unresolvable `#include "testlib.h"`.
+    """
+    _write_preset(tmp_path, 'min_version: "1.0.0"\n')
+    monkeypatch.chdir(tmp_path)
+    libraries.get_declared_libraries.cache_clear()
+
+    assert [lib.name for lib in libraries.get_always_include_libraries()] == ['testlib']
+
+
+def test_preset_declaring_its_own_testlib_keeps_it(tmp_path, monkeypatch):
+    """A preset that pins its own testlib keeps it, and gets it only once.
+
+    The builtin is a fallback for a preset that never mentioned testlib, not an
+    extra copy competing with one that did -- so a setter's pinned version is
+    still what the checkers compile against.
+    """
+    _write_preset(
+        tmp_path,
+        'libraries:\n'
+        '  problem:\n'
+        '    - name: my-testlib\n'
+        '      source: x\n'
+        '      path: vendor/testlib.h\n'
+        '      dest: vendor/testlib.h\n'
+        '      always_include: true\n',
+    )
+    (tmp_path / 'vendor').mkdir()
+    (tmp_path / 'vendor' / 'testlib.h').write_text("// the preset's own testlib")
+    monkeypatch.chdir(tmp_path)
+    libraries.get_declared_libraries.cache_clear()
+
+    artifacts = steps.GradingArtifacts()
+    libraries.add_always_include_libraries(artifacts)
+
+    assert [lib.name for lib in libraries.get_always_include_libraries()] == [
+        'my-testlib'
+    ]
+    injected = [i for i in artifacts.inputs if str(i.dest) == '__internal__/testlib.h']
+    assert len(injected) == 1
+    assert injected[0].src == pathlib.Path('vendor/testlib.h')
 
 
 def test_no_preset_falls_back_to_the_bundled_testlib(tmp_path, monkeypatch):


### PR DESCRIPTION
Follow-up to #731. With the unit suite green, the `tests` workflow finally reached its **e2e step**, which had been gated behind the failing unit step and so had not run in CI for a long time. It fails 6 scenarios, all with:

```
wcmp.cpp:1:10: fatal error: testlib.h: No such file or directory
```

Pre-existing on `main` and unrelated to #731 — but it is now the only thing between the workflow and green.

## The bug

`get_declared_libraries()` fell back to `[BUILTIN_TESTLIB]` only when the package had **no preset at all**:

```python
preset = presets.get_active_preset_or_null()
if preset is None:
    return [BUILTIN_TESTLIB]
return list(preset.libraries.problem)   # empty => no testlib
```

A package *with* a preset that declares no libraries got an empty set, so nothing injected `testlib.h` into `__internal__/`, and rbx's own builtin checkers failed to compile. Those checkers `#include "testlib.h"` and live outside the package root, where the dependency scanner deliberately does not reach — the injection is the only thing that can resolve their include, as `BUILTIN_TESTLIB`'s own comment says.

The comment also states the assumption that broke: testlib is *"declared as an always_include library by every bundled preset"*. That holds for the bundled presets, and nothing enforces it for anyone else's — so **any hand-written preset that doesn't declare testlib hits this**, not just the test fixtures.

## Why exactly 6 e2e scenarios

Only two fixtures commit a `.local.rbx/preset.rbx.yml`:

```
tests/e2e/testdata/pkg-boca-min-running-time/.local.rbx/preset.rbx.yml
tests/e2e/testdata/multi-contest/.local.rbx/preset.rbx.yml
```

Neither declares `libraries`. They account for all 6 failures (1 + 5). Every other fixture has no preset and so took the old fallback and passed.

## The fix

Fall back whenever nothing declared supplies testlib, rather than only when there is no preset. A preset that *does* declare its own keeps it — it is listed first, so `add_always_include_libraries` takes it and skips the builtin.

That last part is deliberate: it preserves the existing behavior for a preset whose testlib is declared but **not materialized**, which still warns `run rbx presets sync` rather than quietly compiling against rbx's copy of a version the setter did not choose. Matching is on the name the header is injected under (`include_as`, else the basename of `path`/`dest`), since that is what decides the include.

## Verification

- `pytest -m 'e2e and not docker and not pdflatex'` → **44 passed** (was 6 failed, 38 passed)
- `tests/rbx/box/test_libraries.py` → 9 passed, including two new cases: a preset declaring no libraries still gets testlib, and a preset pinning its own keeps it exactly once
- Full unit suite diffed with and without the fix: the only change is the new regression test flipping from failing to passing. The handful of other differences between the two runs are load-dependent timing/TUI flakes (cast timing, command-pane width, `test_run_with_timeout`) that vary run to run on this machine and are unrelated to library resolution.
- `ruff check .` → clean

One existing test needed adjusting: `test_add_always_include_dedups_existing` asserted `added is False`, which now sees the implied testlib as a genuinely new input. Its subject is mylib dedup, so it seeds both headers to keep that assertion testing dedup rather than the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rnUx6iXgc2bAmfuoeMsB3