### PR TITLE
feat(checkers): add --keep-checker-stderr to persist full checker output

### DIFF
--- a/docs/setters/running/index.md
+++ b/docs/setters/running/index.md
@@ -68,6 +68,32 @@ problem: the testcases that never ran are reported as **failed**, not as unmeasu
 timing summary is omitted entirely, since a solution that stopped early was only timed on the
 testcases that ran.
 
+## Reading what the checker said
+
+A checker's verdict line is only its **last** line. Everything it printed before that —
+differing tokens, a dump of the offending context, whatever debugging it does — is
+discarded, and even the line that survives is clipped when it is shown.
+
+`--keep-checker-stderr` keeps the whole thing. Every testcase then gets a `.checker.err`
+file next to its output, holding exactly what the checker wrote:
+
+```bash
+rbx run --keep-checker-stderr
+rbx irun sol.cpp -t samples/0 --keep-checker-stderr
+```
+
+The report prints the path of the file for the testcase whose message it shows, and the
+run explorer (`rbx ui`) opens it with `4`. Nothing else changes: the verdict, the
+message and every other artifact are exactly what they would have been without the flag.
+
+It is a debugging flag, not an everyday one — a `.checker.err` per testcase per solution
+adds up, and almost nobody reads them. Reach for it when a verdict surprises you.
+
+!!! tip
+    You do not have to decide up front. Checker runs are cached, so re-running the same
+    command *with* the flag after an unexpected verdict still writes the file — the
+    checker's output is already in the cache, and the re-run is a cache hit.
+
 ## Running on the judge itself
 
 `--runner` runs the solutions **on the judge park** rather than in the sandbox on your machine,

--- a/rbx/box/checkers.py
+++ b/rbx/box/checkers.py
@@ -268,6 +268,7 @@ async def _check(
     testcase: Testcase,
     program_output: pathlib.Path,
     skip_run_log: bool = False,
+    checker_stderr_path: Optional[pathlib.Path] = None,
 ) -> CheckerResult:
     if not skip_run_log:
         result = _check_pre_output(run_log)
@@ -314,6 +315,16 @@ async def _check(
     )
     message = await package.get_digest_as_string(error.value) or ''
 
+    # Everything the checker printed, before `process_checker_run_log` narrows
+    # it to the last line. Only persisted when a caller asked for it, since most
+    # runs never read it. An empty message writes nothing: an empty file would
+    # say exactly what its absence already says. A message that was captured but
+    # whose blob has since been evicted from the store arrives here as `''` too,
+    # and is skipped for the same reason rather than raising.
+    if checker_stderr_path is not None and message:
+        checker_stderr_path.parent.mkdir(parents=True, exist_ok=True)
+        checker_stderr_path.write_text(message)
+
     processed_checker_result = process_checker_run_log(checker_run_log, message)
     if processed_checker_result.outcome == Outcome.INTERNAL_ERROR:
         console.console.print(
@@ -358,9 +369,21 @@ async def check(
     testcase: Testcase,
     program_output: pathlib.Path,
     skip_run_log: bool = False,
+    checker_stderr_path: Optional[pathlib.Path] = None,
 ) -> CheckerResult:
+    """Judge `program_output` with the compiled checker.
+
+    ``checker_stderr_path``, when given, is where the checker's *full* stderr is
+    persisted. ``CheckerResult.message`` keeps its last-line semantics either
+    way, so nothing downstream changes shape when the sink is on.
+    """
     result = await _check(
-        checker_digest, run_log, testcase, program_output, skip_run_log
+        checker_digest,
+        run_log,
+        testcase,
+        program_output,
+        skip_run_log,
+        checker_stderr_path=checker_stderr_path,
     )
     result.sanitizer_warnings = _check_sanitizer_warnings(run_log)
     return result
@@ -374,6 +397,7 @@ async def check_communication(
     testcase: Testcase,
     program_output: pathlib.Path,
     skip_run_log: bool = False,
+    checker_stderr_path: Optional[pathlib.Path] = None,
 ) -> CheckerResult:
     def _extra_check_and_sanitize(result: CheckerResult) -> CheckerResult:
         result.sanitizer_warnings = _check_sanitizer_warnings(run_log)
@@ -459,7 +483,12 @@ async def check_communication(
     # 6. Now actually check the output with a checker.
     if checker_digest is not None:
         result = await check(
-            checker_digest, run_log, testcase, program_output, skip_run_log
+            checker_digest,
+            run_log,
+            testcase,
+            program_output,
+            skip_run_log,
+            checker_stderr_path=checker_stderr_path,
         )
 
     return _extra_check_and_sanitize(result)

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -516,6 +516,13 @@ async def run(
         help='Capture the run report and copy it to the clipboard. '
         'Pass a format: --share png or --share text.',
     ),
+    keep_checker_stderr: bool = typer.Option(
+        False,
+        '--keep-checker-stderr',
+        help="Also keep each testcase's full checker stderr, as a `.checker.err` file "
+        "next to its output. Only the checker's last line reaches the verdict, so "
+        'this is how to read whatever it printed before that.',
+    ),
     fail_fast: bool = typer.Option(
         False,
         '--fail-fast',
@@ -632,6 +639,7 @@ async def run(
             sanitized=sanitized,
             abort_on=fail_fast_abort_predicate if fail_fast else None,
             runner=solution_runner,
+            keep_checker_stderr=keep_checker_stderr,
             # Said explicitly even though it is the default: this is the purpose
             # a backend stages for, and a remote one uploads to a different
             # problem for each. Leaving it implicit here would make the two
@@ -1002,6 +1010,13 @@ async def irun(
         '(colored distinctly). Requires -p. Default: stderr is shown in a '
         'separate section.',
     ),
+    keep_checker_stderr: bool = typer.Option(
+        False,
+        '--keep-checker-stderr',
+        help="Also keep each testcase's full checker stderr, as a `.checker.err` file "
+        "next to its output. Only the checker's last line reaches the verdict, so "
+        'this is how to read whatever it printed before that.',
+    ),
     sanitized: bool = typer.Option(
         False,
         '--sanitized',
@@ -1085,6 +1100,7 @@ async def irun(
             custom_output=output,
             print=print,
             merge_stderr=merge_stderr,
+            keep_checker_stderr=keep_checker_stderr,
             sanitized=sanitized,
             validate=validate,
             visualize=visualize,

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -229,6 +229,17 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': "Also keep each testcase's full checker stderr, as a "
+                    "`.checker.err` file next to its output. Only the checker's "
+                    'last line reaches the verdict, so this is how to read whatever '
+                    'it printed before that.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--keep-checker-stderr'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'Whether to stop running a solution as soon as it gets a '
                     'non-accepted verdict. Only meant for quick experimentation, as '
                     'the remaining tests are reported as failed.',
@@ -507,6 +518,17 @@ SPEC = {
                     'kind': 'option',
                     'multiple': False,
                     'names': ['--merge-stderr', '-e'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': "Also keep each testcase's full checker stderr, as a "
+                    "`.checker.err` file next to its output. Only the checker's "
+                    'last line reaches the verdict, so this is how to read whatever '
+                    'it printed before that.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--keep-checker-stderr'],
                     'takes_value': False,
                     'value': {'kind': 'none'},
                 },

--- a/rbx/box/runners/local.py
+++ b/rbx/box/runners/local.py
@@ -72,6 +72,7 @@ class LocalRunner:
                     timelimit_override=solution_timelimit,
                     nruns=ctx.nruns,
                     capture_pipes=ctx.skeleton.capture_pipes,
+                    keep_checker_stderr=ctx.skeleton.keep_checker_stderr,
                 )
 
             res.append(Deferred(run_fn))

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -303,6 +303,12 @@ class SolutionReportSkeleton(BaseModel):
     # serving a stale merged capture (irun only caches with an explicit
     # --testcase).
     merge_stderr: bool = False
+    # When set (`--keep-checker-stderr`), each testcase also keeps the checker's
+    # full stderr as a `.checker.err` artifact. Rides on the skeleton for the
+    # same reason `merge_stderr` does: it decides what a run writes to disk, so a
+    # cached skeleton must never serve a run that was asked for the artifact as
+    # though it had one.
+    keep_checker_stderr: bool = False
 
     def get_solution_limits(self, solution: Solution) -> Limits:
         return _resolve_solution_limits(solution, self.limits, self.verification)
@@ -714,6 +720,7 @@ async def _get_report_skeleton(
     timelimit_override: Optional[TimelimitOverride] = None,
     progress: Optional[StatusProgress] = None,
     sanitized: bool = False,
+    keep_checker_stderr: bool = False,
 ) -> SolutionReportSkeleton:
     pkg = package.find_problem_package_or_die()
 
@@ -788,6 +795,7 @@ async def _get_report_skeleton(
         compilation=compilation,
         verification=verification,
         capture_pipes=should_capture_pipes(package.get_interactor_or_nil()),
+        keep_checker_stderr=keep_checker_stderr,
     )
 
     skeleton_file = runs_dir / 'skeleton.yml'
@@ -1042,6 +1050,7 @@ async def run_solutions(
     abort_on: Optional[AbortPredicate] = None,
     runner: Optional['SolutionRunner'] = None,
     purpose: Optional['RunPurpose'] = None,
+    keep_checker_stderr: bool = False,
 ) -> RunSolutionResult:
     # Imported here, not at module scope: `runners.local` imports this module
     # back -- for `run_solution_on_testcase` and for `SolutionSkeleton` -- so an
@@ -1062,12 +1071,24 @@ async def run_solutions(
     # says should cost nothing and fail by name.
     _check_capabilities(runner, nruns=nruns, sanitized=sanitized, check=check)
 
+    # A warning rather than a refusal: unlike a dropped sanitizer or a dropped
+    # repeat, a missing `.checker.err` does not change what the report says --
+    # it only leaves a debugging aid unwritten. Said out loud all the same, so
+    # the setter goes looking for the file knowing it will not be there.
+    if keep_checker_stderr and not runner.caps.captures_artifacts:
+        console.console.print(
+            f'[warning]Runner [item]{runner.name}[/item] writes no per-testcase '
+            f'artifacts, so [item]--keep-checker-stderr[/item] has no effect on '
+            f'this run.[/warning]'
+        )
+
     skeleton = await _get_report_skeleton(
         progress=progress,
         tracked_solutions=tracked_solutions,
         verification=verification,
         timelimit_override=timelimit_override,
         sanitized=sanitized,
+        keep_checker_stderr=keep_checker_stderr,
     )
 
     checker_digest, interactor_digest = await _compile_checking_digests(check)
@@ -1279,6 +1300,7 @@ async def _run_interactive_solutions(
                 verification=verification,
                 capture_pipes=skeleton.capture_pipes,
                 merge_stderr=skeleton.merge_stderr,
+                keep_checker_stderr=skeleton.keep_checker_stderr,
             )
 
         yield EvaluationItem(
@@ -1307,6 +1329,7 @@ async def _get_interactive_skeleton(
     verification: VerificationLevel = VerificationLevel.NONE,
     check: bool = True,
     merge_stderr: bool = False,
+    keep_checker_stderr: bool = False,
 ) -> SolutionReportSkeleton:
     solutions, compiled_solutions, _, _ = await _get_compiled_solutions_for_skeleton(
         tracked_solutions,
@@ -1341,6 +1364,7 @@ async def _get_interactive_skeleton(
         compiled_solutions=compiled_solutions,
         capture_pipes=should_capture_pipes(package.get_interactor_or_nil()),
         merge_stderr=merge_stderr,
+        keep_checker_stderr=keep_checker_stderr,
     )
 
     skeleton_file = irun_dir / 'skeleton.yml'
@@ -1359,6 +1383,7 @@ async def run_and_print_interactive_solutions(
     custom_output: bool = False,
     print: bool = False,
     merge_stderr: bool = False,
+    keep_checker_stderr: bool = False,
     sanitized: bool = False,
     validate: bool = True,
     visualize: bool = False,
@@ -1402,6 +1427,7 @@ async def run_and_print_interactive_solutions(
             progress=progress,
             check=check,
             merge_stderr=merge_stderr,
+            keep_checker_stderr=keep_checker_stderr,
         )
         items = _run_interactive_solutions(
             entry,
@@ -1467,6 +1493,7 @@ async def run_and_print_interactive_solutions(
 
             if eval.log.stderr_absolute_path is not None:
                 print_stderr_section(eval.log.stderr_absolute_path)
+            _print_checker_stderr_hint(eval)
         elif stdout_path is not None:
             if stdout_path.with_suffix('.pout').is_file():
                 stdout_path = stdout_path.with_suffix('.pout')
@@ -1484,7 +1511,23 @@ async def run_and_print_interactive_solutions(
                 console.console.print(
                     f'[status]Stderr:[/status] {href(package.relpath(eval.log.stderr_absolute_path))}'
                 )
+            _print_checker_stderr_hint(eval)
             console.console.print()
+
+
+def _print_checker_stderr_hint(eval: Evaluation) -> None:
+    """Point at the `.checker.err` artifact, when the run kept one.
+
+    Only the checker's *last* line reaches the verdict, so a chatty checker's
+    diagnostics are only reachable through this file -- and a file nobody is
+    told about is not much better than no file at all.
+    """
+    checker_stderr_path = eval.log.checker_stderr_absolute_path
+    if checker_stderr_path is None:
+        return
+    console.console.print(
+        f'[status]Checker stderr:[/status] {href(package.relpath(checker_stderr_path))}'
+    )
 
 
 def _get_solution_repr(sol: Solution) -> List[Tuple[str, str]]:
@@ -1864,6 +1907,8 @@ class SolutionOutcomeReport(BaseModel):
     evals: List[Evaluation]
     status: SolutionOutcomeStatus
     message: Optional[Tuple[GenerationTestcaseEntry, str]]
+    # `.checker.err` for the testcase `message` came from, when the run kept one.
+    messageCheckerStderr: Optional[pathlib.Path] = None
     expectedOutcome: ExpectedOutcome
     gotVerdicts: Set[Outcome]
     # Status of the pooled ``outcome`` layer on its own.
@@ -2020,6 +2065,14 @@ class SolutionOutcomeReport(BaseModel):
             if msg:
                 msg = get_truncated_message(msg)
                 res += f'\nMessage for {utils.escape_markup(str(entry))}: {utils.escape_markup(msg)}'
+            # Only the last line of the checker's stderr survives into `msg`, and
+            # it is truncated on top of that. When the run kept the whole thing,
+            # say where it is -- this is the only pointer to it.
+            if self.messageCheckerStderr is not None:
+                res += (
+                    f'\nChecker stderr: '
+                    f'{href(package.relpath(self.messageCheckerStderr))}'
+                )
         return res
 
 
@@ -2230,12 +2283,16 @@ def get_solution_outcome_report(
         else SolutionOutcomeStatus.UNEXPECTED_VERDICTS
     )
     message: Optional[Tuple[GenerationTestcaseEntry, str]] = None
+    # The `.checker.err` of the very testcase `message` was taken from, so the
+    # two always describe the same run of the same checker.
+    message_checker_stderr: Optional[pathlib.Path] = None
     for eval, entry in zip(evals, skeleton.entries):
         if eval.result.outcome in [
             Outcome.WRONG_ANSWER,
             Outcome.JUDGE_FAILED,
         ]:
             message = (entry, eval.result.message)
+            message_checker_stderr = eval.log.checker_stderr_absolute_path
             break
 
     evals_per_group = _get_evals_per_group(evals, skeleton)
@@ -2364,6 +2421,7 @@ def get_solution_outcome_report(
         status=status,
         pooledStatus=pooled_status,
         message=message,
+        messageCheckerStderr=message_checker_stderr,
         expectedOutcome=verdict_report.expected_outcome,
         gotVerdicts=verdict_report.got_verdicts,
         perGroup=per_group,

--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -81,6 +81,36 @@ def write_evaluation(eval: Evaluation, output_path: pathlib.Path) -> str:
     return rendered
 
 
+def _prepare_checker_stderr_path(
+    output_path: pathlib.Path, keep_checker_stderr: bool
+) -> Optional[pathlib.Path]:
+    """Where this run should persist the checker's full stderr, if anywhere.
+
+    The file is dropped up front rather than overwritten, so a `.checker.err`
+    that survives the run is always this run's -- never a leftover from a
+    previous one whose checker happened to be chattier, and never one left
+    behind by a run that never reached the checker at all.
+    """
+    if not keep_checker_stderr:
+        return None
+    checker_error_path = output_path.with_suffix('.checker.err')
+    checker_error_path.unlink(missing_ok=True)
+    return checker_error_path
+
+
+def _resolve_checker_stderr_path(
+    checker_error_path: Optional[pathlib.Path],
+) -> Optional[pathlib.Path]:
+    """The path to record on the log, or `None` if nothing was written there.
+
+    A checker that printed nothing leaves no file, and pointing the log at a
+    path that does not exist would only send readers chasing it.
+    """
+    if checker_error_path is None or not checker_error_path.is_file():
+        return None
+    return checker_error_path.absolute()
+
+
 def _check_stderr(solution: CodeItem, stderr_path: pathlib.Path):
     # The stderr file is absent when the program failed to even start (e.g. a
     # missing interpreter/runtime), in which case there is no stderr to inspect.
@@ -134,6 +164,7 @@ async def run_solution_on_testcase(
     capture_pipes: Optional[bool] = None,
     line_capture: bool = False,
     merge_stderr: bool = False,
+    keep_checker_stderr: bool = False,
     nruns: int = 0,
     filestem: Optional[str] = None,
     is_stress: bool = False,
@@ -158,6 +189,7 @@ async def run_solution_on_testcase(
             is_stress=is_stress,
             line_capture=line_capture,
             merge_stderr=merge_stderr,
+            keep_checker_stderr=keep_checker_stderr,
         )
 
     async def run_fn(retry_index: int) -> Evaluation:
@@ -176,6 +208,10 @@ async def run_solution_on_testcase(
         error_path = output_path.with_suffix('.err')
         log_path = output_path.with_suffix('.log')
         output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        checker_error_path = _prepare_checker_stderr_path(
+            output_path, keep_checker_stderr
+        )
 
         # When interleaving is requested, tee stdout/stderr into a merged '.pio'
         # file in true write order; the clean stdout/stderr files are unaffected.
@@ -203,6 +239,7 @@ async def run_solution_on_testcase(
                     run_log,
                     testcase,
                     program_output=output_path,
+                    checker_stderr_path=checker_error_path,
                 )
         else:
             checker_result = checkers.check_with_no_output(run_log)
@@ -221,6 +258,9 @@ async def run_solution_on_testcase(
                 stdout_absolute_path=output_path.absolute(),
                 stderr_absolute_path=error_path.absolute(),
                 log_absolute_path=log_path.absolute(),
+                checker_stderr_absolute_path=_resolve_checker_stderr_path(
+                    checker_error_path
+                ),
             ),
         )
 
@@ -282,6 +322,7 @@ async def _run_communication_solution_on_testcase(
     capture_pipes: Optional[bool] = None,
     line_capture: bool = False,
     merge_stderr: bool = False,
+    keep_checker_stderr: bool = False,
     nruns: int = 0,
     filestem: Optional[str] = None,
     is_stress: bool = False,
@@ -323,6 +364,11 @@ async def _run_communication_solution_on_testcase(
         interactor_error_path = output_path.with_suffix('.int.err')
         log_path = output_path.with_suffix('.log')
         output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Sits next to the interactor's own `.int.err`, which is always kept.
+        checker_error_path = _prepare_checker_stderr_path(
+            output_path, keep_checker_stderr
+        )
 
         interactor_capture_path = (
             output_path.with_suffix('.pin') if capture_pipes else None
@@ -390,6 +436,7 @@ async def _run_communication_solution_on_testcase(
             interactor_error_path,
             testcase,
             output_path,
+            checker_stderr_path=checker_error_path,
         )
 
         _check_stderr(solution, solution_error_path)
@@ -406,6 +453,9 @@ async def _run_communication_solution_on_testcase(
                 stdout_absolute_path=output_path.absolute(),
                 stderr_absolute_path=solution_error_path.absolute(),
                 log_absolute_path=log_path.absolute(),
+                checker_stderr_absolute_path=_resolve_checker_stderr_path(
+                    checker_error_path
+                ),
             ),
         )
 

--- a/rbx/box/ui/screens/run_test_explorer.py
+++ b/rbx/box/ui/screens/run_test_explorer.py
@@ -38,6 +38,7 @@ class RunTestExplorerScreen(TestListSearchMixin, Screen):
         Binding('1', 'show_output', 'Show output', show=False),
         Binding('2', 'show_stderr', 'Show stderr', show=False),
         Binding('3', 'show_log', 'Show log', show=False),
+        Binding('4', 'show_checker_stderr', 'Show checker stderr', show=False),
         Binding('m', 'toggle_test_metadata', 'Toggle metadata', show=False),
         Binding('r', 'toggle_metadata', 'Toggle run metadata', show=False),
         Binding('s', 'toggle_side_by_side', 'Toggle sxs', show=False),
@@ -237,6 +238,11 @@ class RunTestExplorerScreen(TestListSearchMixin, Screen):
 
     def action_show_log(self):
         self.query_one('#test-output', TwoSidedTestBoxWidget).show_log()
+
+    def action_show_checker_stderr(self):
+        # Empty unless the run was made with `--keep-checker-stderr`; the
+        # metadata panel is what says whether there is anything to look at.
+        self.query_one('#test-output', TwoSidedTestBoxWidget).show_checker_stderr()
 
     def action_toggle_metadata(self):
         self.query_one('#test-output', TwoSidedTestBoxWidget).toggle_metadata()

--- a/rbx/box/ui/utils/run_ui.py
+++ b/rbx/box/ui/utils/run_ui.py
@@ -243,4 +243,9 @@ def get_run_testcase_metadata_markup(
     lines.append(f'[b]Time:[/b] {time_str} / [b]Memory:[/b] {memory_str}')
     if checker_msg is not None:
         lines.append(f'[b]Checker:[/b] {utils.escape_markup(checker_msg)}')
+    # Only `--keep-checker-stderr` runs have one, and only its presence is worth
+    # saying: the file itself is one keystroke away (`4`), and dumping it here
+    # would push the verdict off the panel.
+    if eval.log.checker_stderr_absolute_path is not None:
+        lines.append('[b]Checker stderr:[/b] press [b]4[/b] to view')
     return '\n'.join(lines)

--- a/rbx/box/ui/widgets/test_output_box.py
+++ b/rbx/box/ui/widgets/test_output_box.py
@@ -21,6 +21,7 @@ class TestcaseRenderingData:
     stderr_path: Optional[pathlib.Path] = None
     interaction_path: Optional[pathlib.Path] = None
     log_path: Optional[pathlib.Path] = None
+    checker_stderr_path: Optional[pathlib.Path] = None
     rich_content: Optional[str] = None
 
     @classmethod
@@ -31,6 +32,10 @@ class TestcaseRenderingData:
             stderr_path=path.with_suffix('.err'),
             log_path=path.with_suffix('.log'),
             interaction_path=path.with_suffix('.pio'),
+            # Only present when the run was asked to keep it
+            # (`--keep-checker-stderr`); `FileLog` renders a missing path as an
+            # empty box, which is what an unasked-for artifact should look like.
+            checker_stderr_path=path.with_suffix('.checker.err'),
         )
 
 
@@ -46,6 +51,7 @@ class TestBoxWidget(Widget, can_focus=False):
         stderr: FileLog
         log: FileLog
         interaction: InteractionBox
+        checker_stderr: FileLog
 
     def logs(self) -> Logs:
         return self.Logs(
@@ -53,6 +59,7 @@ class TestBoxWidget(Widget, can_focus=False):
             stderr=self.query_one('#test-box-stderr', FileLog),
             log=self.query_one('#test-box-log', FileLog),
             interaction=self.query_one('#test-box-interaction', InteractionBox),
+            checker_stderr=self.query_one('#test-box-checker-stderr', FileLog),
         )
 
     def compose(self) -> ComposeResult:
@@ -62,6 +69,7 @@ class TestBoxWidget(Widget, can_focus=False):
                 yield FileLog(id='test-box-stderr')
                 yield FileLog(id='test-box-log')
                 yield InteractionBox(id='test-box-interaction')
+                yield FileLog(id='test-box-checker-stderr')
             yield RichLogBox(id='test-box-metadata')
 
     def on_mount(self):
@@ -70,6 +78,7 @@ class TestBoxWidget(Widget, can_focus=False):
         logs.stderr.border_title = 'Stderr'
         logs.log.border_title = 'Log'
         logs.interaction.border_title = 'Interaction'
+        logs.checker_stderr.border_title = 'Checker stderr'
         metadata = self.query_one('#test-box-metadata', RichLogBox)
         metadata.display = False
         metadata.border_title = 'Metadata'
@@ -86,6 +95,7 @@ class TestBoxWidget(Widget, can_focus=False):
         logs.stderr.path = data.stderr_path
         logs.log.path = data.log_path
         logs.interaction.path = data.interaction_path
+        logs.checker_stderr.path = data.checker_stderr_path
         metadata = self.query_one('#test-box-metadata', RichLogBox)
         metadata.clear()
         if data.rich_content is not None:
@@ -107,6 +117,9 @@ class TestBoxWidget(Widget, can_focus=False):
 
     def show_interaction(self):
         self.query_one(ContentSwitcher).current = 'test-box-interaction'
+
+    def show_checker_stderr(self):
+        self.query_one(ContentSwitcher).current = 'test-box-checker-stderr'
 
     def toggle_metadata(self):
         metadata = self.query_one('#test-box-metadata', RichLogBox)

--- a/rbx/box/ui/widgets/two_sided_test_output_box.py
+++ b/rbx/box/ui/widgets/two_sided_test_output_box.py
@@ -55,6 +55,10 @@ class TwoSidedTestBoxWidget(Widget, can_focus=False):
         self.query_one('#test-box-1', TestBoxWidget).show_interaction()
         self.query_one('#test-box-2', TestBoxWidget).show_interaction()
 
+    def show_checker_stderr(self):
+        self.query_one('#test-box-1', TestBoxWidget).show_checker_stderr()
+        self.query_one('#test-box-2', TestBoxWidget).show_checker_stderr()
+
     def toggle_metadata(self):
         self.query_one('#test-box-1', TestBoxWidget).toggle_metadata()
         self.query_one('#test-box-2', TestBoxWidget).toggle_metadata()

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -313,6 +313,11 @@ class TestcaseLog(RunLog):
     stderr_absolute_path: Optional[pathlib.Path] = None
     log_absolute_path: Optional[pathlib.Path] = None
     eval_absolute_path: Optional[pathlib.Path] = None
+    # The checker's *full* stderr, kept only when the run asked for it
+    # (`--keep-checker-stderr`). `None` -- the overwhelmingly common case -- is
+    # dropped from the serialized `.eval`/`.log`, so a run without the flag
+    # writes exactly the bytes it always did.
+    checker_stderr_absolute_path: Optional[pathlib.Path] = None
 
 
 class CheckerResult(BaseModel):

--- a/rbx/testdata/checkers/checker-silent.cpp
+++ b/rbx/testdata/checkers/checker-silent.cpp
@@ -1,0 +1,5 @@
+#include <cstdlib>
+
+// Accepts everything without writing a single byte to stderr, so tests can
+// cover the "checker said nothing" case.
+int main(int argc, char *argv[]) { return 0; }

--- a/rbx/testdata/checkers/checker-verbose.cpp
+++ b/rbx/testdata/checkers/checker-verbose.cpp
@@ -1,0 +1,15 @@
+#include "testlib.h"
+
+using namespace std;
+
+// A checker that dumps diagnostics to stderr before its verdict line, so tests
+// can tell the full stderr apart from the last line rbx keeps in
+// `CheckerResult.message`.
+int main(int argc, char *argv[]) {
+  registerTestlibCmd(argc, argv);
+
+  fprintf(stderr, "diagnostic line 1\n");
+  fprintf(stderr, "diagnostic line 2\n");
+
+  quitf(_wa, "verdict line");
+}

--- a/tests/e2e/testdata/keep-checker-stderr/checker/checker.cpp
+++ b/tests/e2e/testdata/keep-checker-stderr/checker/checker.cpp
@@ -1,0 +1,21 @@
+#include "testlib.h"
+
+using namespace std;
+
+// A deliberately chatty checker: it dumps context to stderr before its verdict
+// line, so the scenario can tell the full stderr apart from the single line
+// that reaches the verdict.
+int main(int argc, char* argv[]) {
+    registerTestlibCmd(argc, argv);
+
+    int expected = ans.readInt();
+    int got = ouf.readInt();
+
+    fprintf(stderr, "CHK_CONTEXT_MARKER expected=%d\n", expected);
+    fprintf(stderr, "CHK_CONTEXT_MARKER got=%d\n", got);
+
+    if (expected != got) {
+        quitf(_wa, "CHK_VERDICT_MARKER differ");
+    }
+    quitf(_ok, "CHK_VERDICT_MARKER equal");
+}

--- a/tests/e2e/testdata/keep-checker-stderr/e2e.rbx.yml
+++ b/tests/e2e/testdata/keep-checker-stderr/e2e.rbx.yml
@@ -1,0 +1,27 @@
+scenarios:
+  # Without the flag, nothing changes: the checker's diagnostics are dropped and
+  # no `.checker.err` is written anywhere.
+  - name: absent-by-default
+    steps:
+      - cmd: build
+      - cmd: run -v4
+        expect:
+          files_absent:
+            - "**/*.checker.err"
+          solutions:
+            sols/main.cpp: ac
+            sols/wrong.cpp: wa
+
+  # With it, every testcase keeps the whole stderr -- including the lines the
+  # checker printed *before* its verdict line, which is the only place they
+  # survive.
+  - name: keeps-full-stderr
+    steps:
+      - cmd: build
+      - cmd: run --keep-checker-stderr -v4
+        expect:
+          files_exist:
+            - "**/*.checker.err"
+          solutions:
+            sols/main.cpp: ac
+            sols/wrong.cpp: wa

--- a/tests/e2e/testdata/keep-checker-stderr/gens/gen.cpp
+++ b/tests/e2e/testdata/keep-checker-stderr/gens/gen.cpp
@@ -1,0 +1,14 @@
+#include <cstdio>
+#include <cstdlib>
+
+// Minimal generator: takes two integers as args and prints them as the input.
+// Usage: gen <a> <b>
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        return 1;
+    }
+    int a = atoi(argv[1]);
+    int b = atoi(argv[2]);
+    printf("%d %d\n", a, b);
+    return 0;
+}

--- a/tests/e2e/testdata/keep-checker-stderr/problem.rbx.yml
+++ b/tests/e2e/testdata/keep-checker-stderr/problem.rbx.yml
@@ -1,0 +1,26 @@
+name: keep-checker-stderr
+timeLimit: 1000
+memoryLimit: 256
+
+checker:
+  path: checker/checker.cpp
+
+generators:
+  - name: gen
+    path: gens/gen.cpp
+
+solutions:
+  - path: sols/main.cpp
+    outcome: ac
+  - path: sols/wrong.cpp
+    outcome: wa
+
+testcases:
+  - name: main
+    subgroups:
+      - name: gen
+        generators:
+          - name: gen
+            args: 1 2
+          - name: gen
+            args: 3 4

--- a/tests/e2e/testdata/keep-checker-stderr/sols/main.cpp
+++ b/tests/e2e/testdata/keep-checker-stderr/sols/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+using namespace std;
+
+int main() {
+    int a, b;
+    cin >> a >> b;
+    cout << a + b << endl;
+    return 0;
+}

--- a/tests/e2e/testdata/keep-checker-stderr/sols/wrong.cpp
+++ b/tests/e2e/testdata/keep-checker-stderr/sols/wrong.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+using namespace std;
+
+// Off by one, so the chatty checker always reaches its WA branch.
+int main() {
+    int a, b;
+    cin >> a >> b;
+    cout << a + b + 1 << endl;
+    return 0;
+}

--- a/tests/rbx/box/checkers_test.py
+++ b/tests/rbx/box/checkers_test.py
@@ -25,6 +25,8 @@ INTERESTING_CHECKERS = [
     'checkers/checker.cpp',
     'checkers/checker-fl.cpp',
     'checkers/checker-crash.cpp',
+    'checkers/checker-verbose.cpp',
+    'checkers/checker-silent.cpp',
 ]
 
 
@@ -905,3 +907,81 @@ def test_process_checker_run_log_falls_back_when_no_sandbox_message() -> None:
     result = checkers.process_checker_run_log(run_log, message='')
     assert result.outcome == Outcome.INTERNAL_ERROR
     assert result.message == 'sandbox failed to run checker'
+
+
+# Persisting the checker's full stderr (`--keep-checker-stderr`).
+async def test_check_writes_full_checker_stderr_to_sink(
+    checker_digest_dict: Dict[str, str],
+    testcase: Testcase,
+    program_output: pathlib.Path,
+    run_log: RunLog,
+    tmp_path: pathlib.Path,
+) -> None:
+    assert testcase.outputPath
+    testcase.outputPath.write_text('123\n')
+    program_output.write_text('456\n')
+    sink = tmp_path / 'checker.err'
+
+    result = await checkers.check(
+        checker_digest_dict['checkers/checker-verbose.cpp'],
+        run_log,
+        testcase,
+        program_output,
+        checker_stderr_path=sink,
+    )
+
+    assert result.outcome == Outcome.WRONG_ANSWER
+    # The result keeps its last-line semantics...
+    assert result.message == 'wrong answer verdict line'
+    # ...while the sink holds everything the checker printed.
+    contents = sink.read_text()
+    assert 'diagnostic line 1' in contents
+    assert 'diagnostic line 2' in contents
+    assert 'verdict line' in contents
+
+
+async def test_check_does_not_write_checker_stderr_without_sink(
+    checker_digest_dict: Dict[str, str],
+    testcase: Testcase,
+    program_output: pathlib.Path,
+    run_log: RunLog,
+    tmp_path: pathlib.Path,
+) -> None:
+    assert testcase.outputPath
+    testcase.outputPath.write_text('123\n')
+    program_output.write_text('456\n')
+
+    await checkers.check(
+        checker_digest_dict['checkers/checker-verbose.cpp'],
+        run_log,
+        testcase,
+        program_output,
+    )
+
+    assert not list(tmp_path.iterdir())
+
+
+async def test_check_skips_checker_stderr_file_when_checker_said_nothing(
+    checker_digest_dict: Dict[str, str],
+    testcase: Testcase,
+    program_output: pathlib.Path,
+    run_log: RunLog,
+    tmp_path: pathlib.Path,
+) -> None:
+    assert testcase.outputPath
+    testcase.outputPath.write_text('123\n')
+    program_output.write_text('123\n')
+    sink = tmp_path / 'checker.err'
+
+    result = await checkers.check(
+        checker_digest_dict['checkers/checker-silent.cpp'],
+        run_log,
+        testcase,
+        program_output,
+        checker_stderr_path=sink,
+    )
+
+    assert result.outcome == Outcome.ACCEPTED
+    # An empty file would read as "the checker was run and said nothing", which
+    # is exactly what its absence already says -- without the clutter.
+    assert not sink.exists()

--- a/tests/rbx/box/runners/test_local_runner.py
+++ b/tests/rbx/box/runners/test_local_runner.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 
 import pytest
 
+from rbx.box import solutions
 from rbx.box.deferred import Deferred
 from rbx.box.environment import VerificationLevel
 from rbx.box.generation_schema import GenerationTestcaseEntry
@@ -227,3 +228,30 @@ async def test_local_runner_yields_one_lazy_deferred_per_testcase(
     assert first.eval.peek() is evaluation
     assert await first.eval() is evaluation
     assert evaluation.result.outcome == Outcome.ACCEPTED
+
+
+@pytest.mark.test_pkg('problems/box1')
+async def test_local_runner_forwards_keep_checker_stderr(
+    pkg_from_testdata: pathlib.Path,
+):
+    """`--keep-checker-stderr` has to reach the one call that can honour it."""
+    await _build_testset()
+
+    seen: List[bool] = []
+    real_run = solutions.run_solution_on_testcase
+
+    async def spy(*args, **kwargs):
+        seen.append(kwargs.get('keep_checker_stderr', False))
+        return await real_run(*args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(solutions, 'run_solution_on_testcase', spy)
+        result = await run_solutions(
+            verification=VerificationLevel.FULL,
+            tracked_solutions=['sol.cpp'],
+            runner=LocalRunner(),
+            keep_checker_stderr=True,
+        )
+        await result.items[0].eval()
+
+    assert seen == [True]

--- a/tests/rbx/box/tasks_test.py
+++ b/tests/rbx/box/tasks_test.py
@@ -1,7 +1,7 @@
 import textwrap
 
 from rbx import testing_utils
-from rbx.box import code, tasks
+from rbx.box import checkers, code, tasks
 from rbx.box.environment import VerificationLevel
 from rbx.box.schema import CodeItem, Testcase
 from rbx.box.testing import testing_package
@@ -378,3 +378,62 @@ class TestGetLimitsForLanguage:
         assert limits.time is None
         assert limits.configuredTime == 1000
         assert limits.display_time() == 1000
+
+
+class TestKeepCheckerStderr:
+    """`run_solution_on_testcase(keep_checker_stderr=...)` and its artifact."""
+
+    async def _run(
+        self,
+        testing_pkg: testing_package.TestingPackage,
+        keep_checker_stderr: bool,
+    ):
+        testing_pkg.set_checker('checker.cpp', src='checkers/checker-verbose.cpp')
+        checker_digest = await checkers.compile_checker()
+
+        py_file = testing_pkg.add_file(
+            'solution.py', src='program_test/simple_hello.py'
+        )
+        solution = CodeItem(path=py_file)
+        compiled_digest = await code.compile_item(solution)
+
+        input_file = testing_pkg.add_file('test.in')
+        input_file.write_text('')
+        output_file = testing_pkg.path('test.ans')
+        output_file.write_text('Hello, World!\n')
+
+        output_dir = testing_pkg.path('outputs')
+        output_dir.mkdir(exist_ok=True)
+
+        return await tasks.run_solution_on_testcase(
+            solution=solution,
+            compiled_digest=compiled_digest,
+            checker_digest=checker_digest,
+            testcase=Testcase(inputPath=input_file, outputPath=output_file),
+            output_dir=output_dir,
+            verification=VerificationLevel.NONE,
+            use_retries=False,
+            keep_checker_stderr=keep_checker_stderr,
+        )
+
+    async def test_writes_checker_err_artifact_when_asked(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        evaluation = await self._run(testing_pkg, keep_checker_stderr=True)
+
+        checker_stderr_path = evaluation.log.checker_stderr_absolute_path
+        assert checker_stderr_path is not None
+        assert checker_stderr_path.name == 'test.checker.err'
+        contents = checker_stderr_path.read_text()
+        assert 'diagnostic line 1' in contents
+        assert 'diagnostic line 2' in contents
+        # The verdict message is unchanged -- still the last line only.
+        assert evaluation.result.message == 'wrong answer verdict line'
+
+    async def test_writes_nothing_by_default(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        evaluation = await self._run(testing_pkg, keep_checker_stderr=False)
+
+        assert evaluation.log.checker_stderr_absolute_path is None
+        assert not list(testing_pkg.path('outputs').glob('*.checker.err'))


### PR DESCRIPTION
Closes #375.

A checker's verdict line is only its **last** line. Everything it printed before that — differing tokens, context dumps, debug output — was captured intact and then discarded in `process_checker_run_log` before anything was stored or displayed. Nothing recovered it: there was no `.checker.err` on disk, `--detailed` carries no checker message at all, `irun -p` prints the *solution's* stderr, and the TUI re-split an already-single-line string. The text survived only as an unaddressable blob in `.box/.storage`.

This adds `--keep-checker-stderr`, which persists the whole thing as a `.checker.err` artifact next to each testcase's output.

## Why opt-in, and why it's nearly free

Writing the file for every testcase of every solution on every run would bloat `.box/runs/` for output almost nobody reads — so it follows the `--merge-stderr/-e` precedent of a flag that conditionally writes one extra file through an existing path.

The full text is **already in memory** at the point where the sink writes it (`message = await package.get_digest_as_string(error.value)`), so persisting it is a plain `write_text` of a value we already hold: no extra sandbox execution, no extra checker run, no change to what gets captured.

It's also cache-friendly in a useful way. The checker run is cached at the `code.run_item` level, and a hit repopulates the stderr `DigestHolder` (`caching.py:469` — I verified this rather than taking it on faith). So a setter who runs *without* the flag, sees an unexpected verdict, and re-runs *with* it still gets the file. No `rbx clear`, no forced re-execution.

## Changes

| | |
|---|---|
| `checkers.py` | `check()` / `_check()` / `check_communication()` take an optional `checker_stderr_path`; the full stderr is written there *before* `_get_last_line` narrows it. |
| `tasks.py` | Derives `<stem>.checker.err` on both the batch and communication paths (where it sits beside the existing `.int.err`). Unlinked up front, so a surviving file is always the current run's. |
| `grading/steps.py` | `TestcaseLog.checker_stderr_absolute_path`. |
| `cli.py`, `solutions.py`, `runners/local.py` | `--keep-checker-stderr` on `rbx run` and `rbx irun`, riding the skeleton the way `merge_stderr` does. Completion spec regenerated. |
| `solutions.py`, `ui/` | Surfacing: the report prints the path under the message it shows, `irun` prints it next to Stderr, and the run explorer gets a "Checker stderr" pane. |

## Compatibility

`CheckerResult.message` keeps its last-line semantics, so no existing consumer changes shape. The new `TestcaseLog` field is `Optional` and `model_to_yaml` uses `exclude_none`, so **a run without the flag writes byte-identical `.eval`/`.log` artifacts**.

Edge cases from the issue are handled: an evicted blob and an empty stderr both skip the write (an empty file would say exactly what its absence already says), and retries reuse the path so the file reflects the last attempt, consistent with `.err`/`.out`.

## Two judgement calls that differ from the issue

- **The TUI binding is `4`, not `3`** — `3` is already "Show log" in `run_test_explorer`.
- **A backend with `captures_artifacts=False` (i.e. `--runner moj`) now warns** that the flag has no effect, rather than silently producing nothing. A warning rather than a refusal: unlike a dropped sanitizer or a dropped repeat, a missing debug artifact doesn't change what the report *means*.

## Testing

Built test-first — each layer's test was watched failing before the implementation landed. Targeted runs, all green: checkers 46, solutions 92, run_report + checkers_communication 51, tasks 11, local runner 6, completion 936 (no spec drift), plus two new e2e scenarios (`absent-by-default`, `keeps-full-stderr`).

Also adds `rbx/testdata/checkers/checker-verbose.cpp` and `checker-silent.cpp` — a chatty checker and a silent one, for the "keeps everything" and "writes nothing" cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiKmyi3aVUcWyGNz4SHvuN
