### PR TITLE
fix(visualizers): write visualizations as real files, not symlinks

### DIFF
--- a/docs/plans/2026-08-24-visualization-symlink-design.md
+++ b/docs/plans/2026-08-24-visualization-symlink-design.md
@@ -1,0 +1,123 @@
+# Visualizations must be real files, not symlinks
+
+## The problem
+
+A visualization that rbx writes under `build/tests/<group>/visualization/` is a
+symlink into the package's content-addressed storage:
+
+```
+build/tests/main/visualization/1-gen-000.html
+  -> .rbx/.storage/1be329cf1b722b5bff15ce7d43e520dd41d45b63
+```
+
+The link carries the extension the setter declared. The file it points at
+carries none, because a content-addressed blob is named by its digest.
+
+Every consumer that types a file by its extension resolves the link first and
+then finds nothing to go on. Measured on macOS:
+
+| `file://` target | Chrome renders |
+|---|---|
+| `link.html` → extension-less blob | plain text, wrapped in `<pre>` |
+| `link.html` → `blob.html` | parsed HTML |
+
+`mdls` agrees: LaunchServices types the *symlink* `link.html` as `public.data`,
+not `public.html`, so `open` does not route it to a browser as a page either.
+
+This is not a Chrome quirk and not a VS Code quirk -- both resolve the link and
+type the target. It bites anywhere a visualization is handed to something as a
+path:
+
+- the VS Code extension's testset panel, whose gallery draws an HTML
+  visualization in an `<iframe>`; the webview resource is served with the
+  resolved target's type, and an `<iframe>` honours a wrong `Content-Type`
+  where an `<img>` is rescued by content sniffing. That is why the same panel
+  renders SVG visualizations correctly and shows HTML ones as source.
+- opening the built file by hand, from Finder or an editor.
+
+`rbx ui` is already immune, and its workaround is the shape of the bug:
+`utils.start_symlinkable_file()` copies the bytes to a temp directory
+*preserving the file name* before calling `start_file()`. Every consumer paying
+that tax separately is the thing worth fixing.
+
+## Why not stop symlinking
+
+Symlinks are load-bearing. `FileCacher.digest_from_symlink()` lets the cache
+read an input's digest off the link instead of hashing the file
+(`caching.py:125` and `caching.py:238`), and testsets are large. Dropping them
+across the board trades a rendering bug for a rehash of every input on every
+run.
+
+The narrowing that makes this easy: `digest_from_symlink` is consulted for
+**inputs** only. A visualization is a terminal artifact -- nothing in rbx ever
+feeds one back in as an input. So visualizations can stop being symlinks at no
+cost to the cache machinery, while `*.in` and `*.out` keep theirs.
+
+## The change
+
+Three edits.
+
+1. `GradingFileOutput` gains a field:
+
+   ```python
+   # Whether the destination may be a symlink into the storage. Turn this off
+   # for an artifact that is opened by something outside rbx: a symlink is
+   # typed by its target, and a storage blob has no extension.
+   symlink: bool = True
+   ```
+
+2. `_copy_hashed_files` (`grading/caching.py`) takes the symlink branch only
+   when the output allows it, and otherwise falls through to the copy branch
+   already sitting there.
+
+3. `run_visualizer` (`box/visualizers.py`) declares its output with
+   `symlink=False`.
+
+### Why this is enough
+
+`_copy_hashed_files` is the single materialization site: a cache miss reaches
+it through `store_in_cache`, and a cache hit through `find_in_cache`. One flag
+covers both, so a visualization restored from cache is a copy too.
+
+The copy branch is not new code. It is what already runs on any storage backend
+that does not offer `path_for_symlink`, so it is exercised in production today.
+
+### What it costs
+
+The visualization bytes are duplicated: once in storage, once in the build
+tree. HTML and SVG visualizations are kilobytes. A large testset of PNG
+visualizations is the only case where this is measurable, and it is bounded by
+the size of the visualizations themselves.
+
+### One deliberate gap
+
+`_maybe_check_integrity` returns early unless the destination is a symlink
+pointing at an existing storage file, so a copied visualization is no longer
+tamper-checked. That check exists to notice a *storage* blob changing under a
+link; a terminal artifact that nothing reads back does not need it. Widening it
+to plain files is a separate decision, deliberately not taken here.
+
+## What it fixes
+
+`build/tests/**/visualization/*.html` becomes a real file with a real
+extension. The panel's `<iframe>` gets `text/html`, and Finder, `open`, and
+dragging the file into a browser all work. No change is needed on the extension
+side.
+
+## Alternatives considered
+
+**Hard-link the artifact to the storage blob.** Same inode, so no duplicated
+bytes, and the path a consumer sees is the file rather than a link to it. Also
+more robust than a symlink, which dangles if storage is cleaned. It needs the
+build tree and `.rbx/.storage` on one filesystem, and it needs the same
+explicit opt-in as the copy, so it can replace the copy behind this same field
+later without changing any call site.
+
+**Give the storage blob the extension** (`<sha>.html` beside `<sha>`). Fixes
+every artifact kind without touching call sites, but teaches a
+content-addressed store about extensions -- one digest can be materialized
+under several -- and costs an inode per (digest, extension) pair.
+
+**Fix it in the VS Code extension**, by resolving and copying, or by inlining
+the bytes. Leaves the build tree hostile to every other tool, and each new
+consumer pays the tax again.

--- a/docs/plans/2026-08-24-visualization-symlink.md
+++ b/docs/plans/2026-08-24-visualization-symlink.md
@@ -1,0 +1,356 @@
+# Visualizations as real files Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `build/tests/**/visualization/*` real files instead of symlinks into content-addressed storage, so anything that types a file by its extension (a browser, Finder, the VS Code panel's `<iframe>`) renders a visualization instead of showing its source.
+
+**Architecture:** A new `symlink: bool = True` field on `GradingFileOutput`, honoured at the single place that materializes a hashed output (`_copy_hashed_files` in `rbx/grading/caching.py`), and set to `False` by `run_visualizer`. The copy branch it falls through to already exists — it is what runs today on a storage backend without `path_for_symlink`. Cache keys, digest inference and the storage layout are untouched.
+
+**Tech Stack:** Python 3, pydantic v2 models, pytest (`pytest-asyncio`), `uv run` for everything.
+
+**Design:** [`2026-08-24-visualization-symlink-design.md`](2026-08-24-visualization-symlink-design.md)
+
+---
+
+### Task 1: `GradingFileOutput.symlink`, honoured by the cache
+
+**Files:**
+- Modify: `rbx/grading/steps.py:177-195` (the `GradingFileOutput` model)
+- Modify: `rbx/grading/caching.py:270-292` (`_copy_hashed_files`)
+- Modify: `rbx/grading/caching.py:132-149` (`_maybe_check_integrity`, comment only)
+- Test: `tests/rbx/grading/caching_test.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/rbx/grading/caching_test.py`. The existing `_run_from` helper at the
+top of the file builds the artifacts, so this test needs its own variant that can set
+the flag — add both:
+
+```python
+async def _run_writing(
+    src: pathlib.Path,
+    out: pathlib.Path,
+    sandbox: SandboxBase,
+    dependency_cache: DependencyCache,
+    symlink: bool = True,
+) -> GradingArtifacts:
+    artifacts = GradingArtifacts()
+    artifacts.inputs.append(
+        GradingFileInput(src=src, dest=pathlib.Path('executable.py'))
+    )
+    artifacts.outputs.append(
+        GradingFileOutput(
+            src=pathlib.Path('box-out.txt'), dest=out, symlink=symlink
+        )
+    )
+    await steps_with_caching.run(
+        f'{sys.executable} executable.py',
+        params=SandboxParams(stdout_file=pathlib.Path('box-out.txt')),
+        sandbox=sandbox,
+        artifacts=artifacts,
+        dependency_cache=dependency_cache,
+        metadata=RunLogMetadata(),
+    )
+    return artifacts
+
+
+async def test_output_is_a_symlink_into_storage_by_default(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    src = cleandir / 'executable.py'
+    src.write_text('print(7)')
+
+    await _run_writing(src, pathlib.Path('out.txt'), sandbox, dependency_cache)
+
+    assert (cleandir / 'out.txt').is_symlink()
+
+
+async def test_output_with_symlink_disabled_is_a_real_file(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    # A visualization is opened by a browser, which types a symlink by its
+    # target -- and a storage blob is named by its digest, with no extension.
+    src = cleandir / 'executable.py'
+    src.write_text('print(7)')
+
+    await _run_writing(
+        src, pathlib.Path('out.txt'), sandbox, dependency_cache, symlink=False
+    )
+
+    out = cleandir / 'out.txt'
+    assert not out.is_symlink()
+    assert out.is_file()
+    assert out.read_text().strip() == '7'
+
+
+async def test_output_with_symlink_disabled_stays_a_real_file_when_cached(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    # The second run is a cache hit, which materializes through the same
+    # function -- the file it restores must be a copy too.
+    src = cleandir / 'executable.py'
+    src.write_text('print(7)')
+
+    await _run_writing(
+        src, pathlib.Path('first.txt'), sandbox, dependency_cache, symlink=False
+    )
+    await _run_writing(
+        src, pathlib.Path('second.txt'), sandbox, dependency_cache, symlink=False
+    )
+
+    second = cleandir / 'second.txt'
+    assert not second.is_symlink()
+    assert second.read_text().strip() == '7'
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/grading/caching_test.py -k symlink -v`
+
+Expected: the two `symlink=False` tests FAIL. Pydantic's `extra` handling on
+`GradingFileOutput` decides the shape of the failure — either a
+`ValidationError` for an unknown `symlink` field, or (if extras are ignored)
+an `AssertionError` on `not out.is_symlink()`. The default-behaviour test
+should already PASS; if it does not, stop — the test backend is not
+symlinking and the rest of the plan needs rechecking.
+
+**Step 3: Add the field**
+
+In `rbx/grading/steps.py`, inside `GradingFileOutput`, after the `hash` field:
+
+```python
+    # Whether the destination may be a symlink into the storage. Turn this off
+    # for an artifact something outside rbx opens by path: a symlink is typed
+    # by its target, and a storage blob is named by its digest, so it has no
+    # extension to type it by.
+    symlink: bool = True
+```
+
+**Step 4: Honour it where the file is materialized**
+
+In `rbx/grading/caching.py`, in `_copy_hashed_files`, change the condition
+guarding the symlink branch:
+
+```python
+            if (
+                output.symlink
+                and (
+                    path_to_symlink := await cacher.path_for_symlink(
+                        output.digest.value
+                    )
+                )
+                is not None
+            ):
+                # Use a symlink to the file in the persistent cache, if available.
+                output.dest.unlink(missing_ok=True)
+                output.dest.parent.mkdir(parents=True, exist_ok=True)
+                output.dest.symlink_to(path_to_symlink)
+            else:
+                # Otherwise, copy it.
+```
+
+Note the copy branch calls `output.dest.open('wb')` without creating the
+parent directory, while the symlink branch does `mkdir`. Check whether the
+copy branch needs the same `output.dest.parent.mkdir(parents=True,
+exist_ok=True)`; `run_visualizer` already creates the visualization directory
+itself, but the branch is now reachable for outputs that do not. Add the
+`mkdir` to the copy branch if it is missing.
+
+**Step 5: Note the integrity gap**
+
+In `_maybe_check_integrity`, extend the existing comment so the early return
+does not read as an oversight:
+
+```python
+    if output.dest is None or not output.dest.is_symlink() or not output.dest.is_file():
+        # Only makes sense if the file EXISTS and IS A SYMLINK pointing to an
+        # EXISTING storage file.
+        # If the storage file ceases to exist, we can simply evict from the cache.
+        # An output that opted out of symlinking (`symlink=False`) is a copy
+        # and is deliberately not checked: the check is about a storage blob
+        # changing under a link, and a copy has no link to change under it.
+        return
+```
+
+**Step 6: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/grading/caching_test.py -v`
+
+Expected: PASS, including the pre-existing tests in that file.
+
+**Step 7: Commit**
+
+```bash
+git add rbx/grading/steps.py rbx/grading/caching.py tests/rbx/grading/caching_test.py
+git commit -m "feat(grading): let an output opt out of being a symlink"
+```
+
+---
+
+### Task 2: Visualizations opt out
+
+**Files:**
+- Modify: `rbx/box/visualizers.py:337-345` (the `outputs=[...]` of `run_visualizer`)
+- Test: `tests/rbx/box/test_visualizers.py:153` (`test_run_visualizer_passes_sandbox_args_and_outputs`)
+
+**Step 1: Write the failing assertion**
+
+In `tests/rbx/box/test_visualizers.py`, in
+`test_run_visualizer_passes_sandbox_args_and_outputs`, after the existing
+`outputs[0].dest` assertion:
+
+```python
+    # Not a symlink: a browser types a visualization by the extension of the
+    # file the path resolves to, and a storage blob has none.
+    assert outputs[0].symlink is False
+```
+
+**Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/test_visualizers.py::test_run_visualizer_passes_sandbox_args_and_outputs -v`
+
+Expected: FAIL — `assert True is False`.
+
+**Step 3: Set the flag**
+
+In `rbx/box/visualizers.py`, in the `outputs` list passed to `run_item`:
+
+```python
+        outputs=[
+            GradingFileOutput(
+                src=sandbox_path,
+                dest=visualization_path,
+                optional=True,
+                # A visualization is opened by whatever handles its extension
+                # -- a browser, the editor, the VS Code panel's <iframe>. A
+                # symlink is typed by its target, and the storage blob it
+                # would point at is named by its digest.
+                symlink=False,
+            ),
+        ],
+```
+
+**Step 4: Run it to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/test_visualizers.py -v`
+
+Expected: PASS, whole file.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/visualizers.py tests/rbx/box/test_visualizers.py
+git commit -m "fix(visualizers): write visualizations as real files"
+```
+
+---
+
+### Task 3: Verify end to end against a real package
+
+Unit tests cannot see the thing that was actually broken — how a browser types
+the file. Do this by hand.
+
+**Step 1: Rebuild a package that has an HTML visualizer**
+
+```bash
+cd ~/Dev/rbx-vscode-contest/apples
+rm -rf build
+uv run --project ~/Dev/robox.io rbx build --visualize
+```
+
+**Step 2: Confirm the artifact is a real file**
+
+```bash
+ls -l build/tests/main/visualization/
+file build/tests/main/visualization/1-gen-000.html
+```
+
+Expected: a regular file (no `->` in `ls -l`, mode starts `-rw`), reported as
+`HTML document text`.
+
+**Step 3: Confirm a browser parses it**
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new \
+  --disable-gpu --dump-dom \
+  "file://$PWD/build/tests/main/visualization/1-gen-000.html" | head -c 120
+```
+
+Expected: starts with `<!DOCTYPE html>` and the page's own markup. A
+`<pre style="word-wrap: break-word...">` wrapper means it is still being typed
+as plain text and the fix did not take.
+
+**Step 4: Confirm the txt visualization still works**
+
+```bash
+ls -l build/tests/samples/visualization/
+```
+
+Expected: `1-gen-000.txt`, also a regular file. The group-level `.txt`
+visualizer must keep working — it is the case the VS Code panel offers to open
+in an editor.
+
+**Step 5: Confirm the VS Code panel renders it**
+
+Launch the extension on that contest and open the testset panel's gallery:
+
+```bash
+cd ~/Dev/robox.io && ./run-extension.sh -f ~/Dev/rbx-vscode-contest
+```
+
+Expected: the `main` group's cells draw the page (headline `7 + 8 = 15` and a
+row of apples), not its source. The `samples` cell still shows the "Open .txt
+in editor" affordance.
+
+**Step 6: Check the disk cost is what the design claimed**
+
+```bash
+du -sh ~/Dev/rbx-vscode-contest/apples/build/tests
+```
+
+Expected: kilobytes for this package. Worth a sentence in the PR if it is not.
+
+---
+
+### Task 4: Ship it
+
+**Step 1: Run the touched tests together**
+
+Run: `uv run pytest tests/rbx/grading/caching_test.py tests/rbx/box/test_visualizers.py -v`
+
+Expected: PASS. Do not run the full suite — see the note in memory about
+spurious sandbox wall timeouts.
+
+**Step 2: Lint and format**
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+```
+
+**Step 3: Commit the design and the plan**
+
+```bash
+git add docs/plans/2026-08-24-visualization-symlink-design.md \
+        docs/plans/2026-08-24-visualization-symlink.md
+git commit -m "docs(plans): design for writing visualizations as real files"
+```
+
+**Step 4: Push and open the PR**
+
+```bash
+git push -u origin worktree-viz-artifact-no-symlink
+gh pr create --base main --title "fix(visualizers): write visualizations as real files, not symlinks"
+```
+
+The PR body should carry the measured table from the design doc — the two
+`file://` cases and what Chrome does with each — because that is the fact that
+makes the change obviously right, and it is not visible from the diff.

--- a/rbx/box/visualizers.py
+++ b/rbx/box/visualizers.py
@@ -344,6 +344,13 @@ async def run_visualizer(
                 src=sandbox_path,
                 dest=visualization_path,
                 optional=True,
+                # A visualization is opened by whatever handles its extension:
+                # a browser, the editor, the VS Code panel's <iframe>. A symlink
+                # is typed by its target, and the storage blob it would point at
+                # is named by its digest -- so a symlinked .html renders as its
+                # own source. This is the one artifact rbx hands to somebody
+                # else, so it is written as a real file.
+                symlink=False,
             ),
         ],
     )

--- a/rbx/grading/caching.py
+++ b/rbx/grading/caching.py
@@ -138,6 +138,9 @@ def _maybe_check_integrity(output: GradingFileOutput, integrity_digest: str):
         # Only makes sense if the file EXISTS and IS A SYMLINK pointing to an
         # EXISTING storage file.
         # If the storage file ceases to exist, we can simply evict from the cache.
+        # An output that opted out of symlinking (`symlink=False`) is a copy and
+        # is deliberately not checked here: this guards a storage blob changing
+        # under a link, and a copy has no link to change under it.
         return
     if output.digest is None:
         return
@@ -277,14 +280,24 @@ async def _copy_hashed_files(artifact_list: List[GradingArtifacts], cacher: File
                 continue
             assert output.digest.value is not None
             if (
-                path_to_symlink := await cacher.path_for_symlink(output.digest.value)
-            ) is not None:
+                output.symlink
+                and (
+                    path_to_symlink := await cacher.path_for_symlink(
+                        output.digest.value
+                    )
+                )
+                is not None
+            ):
                 # Use a symlink to the file in the persistent cache, if available.
                 output.dest.unlink(missing_ok=True)
                 output.dest.parent.mkdir(parents=True, exist_ok=True)
                 output.dest.symlink_to(path_to_symlink)
             else:
-                # Otherwise, copy it.
+                # Otherwise, copy it. This is also how an output that opted out
+                # of symlinking is materialized, so it has to stand on its own:
+                # the destination directory may not exist yet.
+                output.dest.unlink(missing_ok=True)
+                output.dest.parent.mkdir(parents=True, exist_ok=True)
                 with await cacher.get_file(output.digest.value) as fobj:
                     with output.dest.open('wb') as f:
                         copyfileobj(fobj, f, maxlen=output.maxlen)

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -191,6 +191,11 @@ class GradingFileOutput(BaseModel):
     intermediate: bool = False
     # Whether to track file through its hash (disable for optimization).
     hash: bool = True
+    # Whether the destination may be a symlink into the storage. Turn this off
+    # for an artifact something outside rbx opens by path: a symlink is typed by
+    # its target, and a storage blob is named by its digest, so it has no
+    # extension to be typed by.
+    symlink: bool = True
     # Whether to touch the file before the command runs.
     touch: bool = False
 
@@ -397,7 +402,8 @@ async def _process_output_artifacts(
         dst.parent.mkdir(parents=True, exist_ok=True)
 
         if (
-            output_artifact.digest is not None
+            output_artifact.symlink
+            and output_artifact.digest is not None
             and output_artifact.digest.value is not None
             and (
                 path_to_symlink := await sandbox.file_cacher.path_for_symlink(
@@ -411,7 +417,11 @@ async def _process_output_artifacts(
             dst.parent.mkdir(parents=True, exist_ok=True)
             dst.symlink_to(path_to_symlink)
         else:
-            # File is not in the persistent cache, copy it.
+            # File is not in the persistent cache, or the artifact asked not to
+            # be a symlink -- copy it. The unlink matters in the second case:
+            # dst may be a symlink left by an earlier run, and opening that
+            # 'wb' would write through it, into the storage blob.
+            dst.unlink(missing_ok=True)
             with dst.open('wb') as f:
                 with sandbox.get_file(output_artifact.src) as sb_f:
                     copyfileobj(

--- a/tests/rbx/box/test_visualizers.py
+++ b/tests/rbx/box/test_visualizers.py
@@ -178,6 +178,9 @@ async def test_run_visualizer_passes_sandbox_args_and_outputs(mock_run_item):
     assert len(outputs) == 1
     assert outputs[0].src == pathlib.Path('visualization.svg')
     assert outputs[0].dest == pathlib.Path('visualization/test.svg')
+    # Not a symlink: whatever opens a visualization types it by the extension
+    # of the file the path resolves to, and a storage blob has none.
+    assert outputs[0].symlink is False
 
     # Single input: host input file mapped onto sandbox `input.txt`.
     inputs = kwargs['inputs']

--- a/tests/rbx/grading/caching_test.py
+++ b/tests/rbx/grading/caching_test.py
@@ -160,3 +160,86 @@ async def test_cache_misses_when_a_later_hashed_output_is_gone_from_storage(
     for output in second.outputs:
         assert output.digest is not None and output.digest.value is not None
         assert await file_cacher.exists(output.digest.value)
+
+
+async def _run_writing(
+    src: pathlib.Path,
+    out: pathlib.Path,
+    sandbox: SandboxBase,
+    dependency_cache: DependencyCache,
+    symlink: bool = True,
+) -> GradingArtifacts:
+    artifacts = GradingArtifacts()
+    artifacts.inputs.append(
+        GradingFileInput(src=src, dest=pathlib.Path('executable.py'))
+    )
+    artifacts.outputs.append(
+        GradingFileOutput(src=pathlib.Path('box-out.txt'), dest=out, symlink=symlink)
+    )
+    await steps_with_caching.run(
+        f'{sys.executable} executable.py',
+        params=SandboxParams(stdout_file=pathlib.Path('box-out.txt')),
+        sandbox=sandbox,
+        artifacts=artifacts,
+        dependency_cache=dependency_cache,
+        metadata=RunLogMetadata(),
+    )
+    return artifacts
+
+
+async def test_output_is_a_symlink_into_storage_by_default(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    src = cleandir / 'executable.py'
+    src.write_text('print(7)')
+
+    await _run_writing(src, pathlib.Path('out.txt'), sandbox, dependency_cache)
+
+    assert (cleandir / 'out.txt').is_symlink()
+
+
+async def test_output_with_symlink_disabled_is_a_real_file(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    # A visualization is opened by a browser, which types a symlink by its
+    # target -- and a storage blob is named by its digest, with no extension.
+    src = cleandir / 'executable.py'
+    src.write_text('print(7)')
+
+    await _run_writing(
+        src, pathlib.Path('out.txt'), sandbox, dependency_cache, symlink=False
+    )
+
+    out = cleandir / 'out.txt'
+    assert not out.is_symlink()
+    assert out.is_file()
+    assert out.read_text().strip() == '7'
+
+
+async def test_output_with_symlink_disabled_stays_a_real_file_when_cached(
+    cleandir: pathlib.Path,
+    dependency_cache: DependencyCache,
+    sandbox: SandboxBase,
+    file_cacher: FileCacher,
+):
+    # The second run is a cache hit, which materializes through the same
+    # function -- the file it restores must be a copy too.
+    src = cleandir / 'executable.py'
+    src.write_text('print(7)')
+
+    await _run_writing(
+        src, pathlib.Path('first.txt'), sandbox, dependency_cache, symlink=False
+    )
+    await _run_writing(
+        src, pathlib.Path('second.txt'), sandbox, dependency_cache, symlink=False
+    )
+
+    second = cleandir / 'second.txt'
+    assert not second.is_symlink()
+    assert second.read_text().strip() == '7'


### PR DESCRIPTION
A visualization under `build/tests/<group>/visualization/` was a symlink into
the package's content store:

```
build/tests/main/visualization/1-gen-000.html
  -> .rbx/.storage/1be329cf1b722b5bff15ce7d43e520dd41d45b63
```

The link carries the extension the setter declared. The blob it points at is
named by its digest and carries none — and everything that types a file by its
extension resolves the link first. Measured with Chrome on macOS:

| `file://` target | Chrome renders |
|---|---|
| `link.html` → extension-less blob | plain text, wrapped in `<pre>` |
| `link.html` → `blob.html` | parsed HTML |

`mdls` agrees: the symlink `link.html` is typed `public.data`, not
`public.html`, so `open` does not route it to a browser as a page either. This
is neither a Chrome nor a VS Code quirk — both resolve the link and type the
target.

It bites wherever a visualization is handed over as a path: the editor
extension's testset panel draws HTML visualizations in an `<iframe>`, which
honours the wrong `Content-Type` where an `<img>` is rescued by content
sniffing — which is exactly why SVG visualizations rendered and HTML ones
showed their own source.

### The change

`GradingFileOutput` gains `symlink: bool = True`, mirroring the field
`GradingFileInput` already has, and `run_visualizer` sets it to `False`.

Both places that materialize an output honour it — the one that copies a fresh
run out of the sandbox (`steps.py`) and the one that restores a cache hit
(`caching.py`) — so a visualization is a real file whether it was just drawn or
came back from the cache. Both copy branches now `unlink` first: without it, a
dest left as a symlink by an earlier run would be opened `'wb'` and written
*through*, into the storage blob.

### Why only visualizations

Symlinks are load-bearing elsewhere: `digest_from_symlink()` reads an input's
digest off the link instead of hashing the file, and testsets are large.
Crucially it is consulted for **inputs only**, and a visualization is terminal
— nothing feeds one back into rbx. So this costs the cache nothing, and
`*.in`/`*.out` keep their links (verified in the rebuilt package).

The cost is duplicated bytes for visualizations alone: 128K of `build/tests`
for the two-problem package I tested on.

One deliberate gap, commented in place: `_maybe_check_integrity` skips
non-symlink dests, so a copied visualization is no longer tamper-checked. That
check guards a storage blob changing under a link, and a copy has no link.

### Verification

- `uv run pytest tests/rbx/grading tests/rbx/box/test_visualizers.py` — 426 passed.
- New caching tests cover all three states: the default still symlinks,
  `symlink=False` yields a real file, and it is still a real file after a cache
  hit.
- End to end on a real package: rebuilt, `ls -l` shows regular files, and
  Chrome's `--dump-dom` now returns `<!DOCTYPE html>` and the page's markup
  instead of a `<pre>` wrapper. `.in`/`.out`/`.err` are still symlinks.

Design and plan: `docs/plans/2026-08-24-visualization-symlink-design.md`.

Not yet verified by me: the testset panel itself, which lives on an unmerged
branch — the mechanism above says it follows, but it is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MAMn2LnHNrHzAgmrkGmXd