### PR TITLE
feat(timing): add --dry to rbx time to rehearse without writing

### DIFF
--- a/docs/setters/profiling/estimating.md
+++ b/docs/setters/profiling/estimating.md
@@ -149,6 +149,21 @@ rbx time --runs=3
 Each testcase's timing becomes the **maximum** across its runs, which is the pessimistic reading
 and the right one for a limit.
 
+## Rehearsing without writing
+
+```bash
+rbx time --dry
+```
+
+Everything a normal run does — the measurement, the picker, the estimation, the upper-bound
+check — happens, and the profile it arrives at is printed instead of saved. Nothing on disk
+changes, so the [limits profile](profiles.md) you already have survives the rehearsal.
+
+That makes it the flag to reach for when the question is whether the estimation *works* —
+a ratio you just changed, a solution you just declared too slow, a remote judge you are trying
+for the first time — rather than what limit to commit to. It applies to every strategy, and to
+`--integrate` as well, which leaves `problem.rbx.yml` untouched under it.
+
 ## Sharing the report
 
 ```bash

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -173,6 +173,7 @@ rbx time [OPTIONS]
 | `--runner` | TEXT | Where to run the solutions being timed (local, moj). | `local` |
 | `--share` | TEXT | Capture the time report (run report + limits table) and copy it to the clipboard. Pass a format: --share png or --share text. | - |
 | `--skip-slow` | BOOLEAN | Skip checking the estimated limit against the solutions expected to be too slow. The limit is written with its upper bound unchecked. | `False` |
+| `--dry` | BOOLEAN | Run the whole estimation but write nothing to the disk: the limits profile is printed instead of saved. | `False` |
 
 
 ---

--- a/rbx/box/cli.py
+++ b/rbx/box/cli.py
@@ -807,6 +807,12 @@ async def time(
         help='Skip checking the estimated limit against the solutions expected to '
         'be too slow. The limit is written with its upper bound unchecked.',
     ),
+    dry: bool = typer.Option(
+        False,
+        '--dry',
+        help='Run the whole estimation but write nothing to the disk: the limits '
+        'profile is printed instead of saved.',
+    ),
 ):
     if share is not None and share not in ('png', 'text'):
         console.console.print(
@@ -834,7 +840,7 @@ async def time(
     )
     console.console.print()
     if integrate:
-        timing.integrate(profile)
+        timing.integrate(profile, dry=dry)
         return
 
     if auto:
@@ -881,7 +887,7 @@ async def time(
     formula: Optional[str] = None
 
     if choice == 'inherit':
-        timing.inherit_time_limits(profile=profile)
+        timing.inherit_time_limits(profile=profile, dry=dry)
         return
     elif choice == 'custom':
         timelimit = await questionary.text(
@@ -893,7 +899,7 @@ async def time(
                 '[error]No custom time limit provided. Exiting.[/error]'
             )
             raise typer.Exit(1)
-        timing.set_time_limit(int(timelimit), profile=profile)
+        timing.set_time_limit(int(timelimit), profile=profile, dry=dry)
         return
 
     if choice == 'estimate_custom':
@@ -928,6 +934,7 @@ async def time(
         share=share,
         skip_slow=skip_slow,
         runner=solution_runner,
+        dry=dry,
     )
     if estimated is None:
         # Every failure of the estimation -- an unsatisfiable range, a solution

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -401,6 +401,15 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': 'Run the whole estimation but write nothing to the disk: the '
+                    'limits profile is printed instead of saved.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--dry'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -1589,6 +1589,7 @@ async def compute_time_limits(
     share: Optional[str] = None,
     skip_slow: bool = False,
     runner: Optional['SolutionRunner'] = None,
+    dry: bool = False,
 ):
     if package.get_main_solution() is None:
         # An error, not a warning: with no accepted solution nothing bounds the
@@ -1629,12 +1630,21 @@ async def compute_time_limits(
         return None
 
     limits_path = package.get_limits_file(profile)
-    console.console.print(
-        f'[success]Writing the following timing profile to [item]{href(limits_path)}[/item].[/success]'
-    )
     limits = estimated_tl.to_limits()
-    limits_path.parent.mkdir(parents=True, exist_ok=True)
-    limits_path.write_text(utils.model_to_yaml(limits))
+    if dry:
+        # The estimation itself already ran in full -- exercising it is the
+        # whole point of a dry run -- so the profile it produced is still worth
+        # printing. Only the write is skipped.
+        console.console.print(
+            f'[warning]Dry run: not writing the timing profile to '
+            f'[item]{href(limits_path)}[/item].[/warning]'
+        )
+    else:
+        console.console.print(
+            f'[success]Writing the following timing profile to [item]{href(limits_path)}[/item].[/success]'
+        )
+        limits_path.parent.mkdir(parents=True, exist_ok=True)
+        limits_path.write_text(utils.model_to_yaml(limits))
 
     limits_info.render_limits_table(limits, title=f'Time limits ({profile})')
 
@@ -1656,9 +1666,15 @@ async def compute_time_limits(
     return estimated_tl
 
 
-def inherit_time_limits(profile: str = 'local'):
+def inherit_time_limits(profile: str = 'local', dry: bool = False):
     limits_path = package.get_limits_file(profile)
     limits = schema.LimitsProfile(inheritFromPackage=True)
+    if dry:
+        console.console.print(
+            f'[warning]Dry run: not writing the timing profile to '
+            f'[item]{href(limits_path)}[/item].[/warning]'
+        )
+        return
     limits_path.parent.mkdir(parents=True, exist_ok=True)
     limits_path.write_text(utils.model_to_yaml(limits))
 
@@ -1667,9 +1683,15 @@ def inherit_time_limits(profile: str = 'local'):
     )
 
 
-def set_time_limit(timelimit: int, profile: str = 'local'):
+def set_time_limit(timelimit: int, profile: str = 'local', dry: bool = False):
     limits = schema.LimitsProfile(timeLimit=timelimit)
     limits_path = package.get_limits_file(profile)
+    if dry:
+        console.console.print(
+            f'[warning]Dry run: not writing the timing profile to '
+            f'[item]{href(limits_path)}[/item].[/warning]'
+        )
+        return
     limits_path.parent.mkdir(parents=True, exist_ok=True)
     limits_path.write_text(utils.model_to_yaml(limits))
 
@@ -1678,7 +1700,7 @@ def set_time_limit(timelimit: int, profile: str = 'local'):
     )
 
 
-def integrate(profile: str = 'local'):
+def integrate(profile: str = 'local', dry: bool = False):
     limits_profile = limits_info.get_saved_limits_profile(profile)
     if limits_profile is None:
         console.console.print(
@@ -1712,6 +1734,14 @@ def integrate(profile: str = 'local'):
 
     dest_yml = package.find_problem_yaml()
     assert dest_yml is not None
+    if dry:
+        # `--integrate` writes the package, not the profile, but a dry run
+        # promises nothing reaches the disk -- so this write is skipped too.
+        console.console.print(
+            f'[warning]Dry run: not integrating limits profile [item]{profile}[/item] '
+            f'into the package.[/warning]'
+        )
+        return
     utils.save_ruyaml(dest_yml, ru, pkg)
 
     console.console.print(

--- a/tests/rbx/box/test_timing_dry.py
+++ b/tests/rbx/box/test_timing_dry.py
@@ -1,0 +1,174 @@
+"""`rbx time --dry` runs the whole flow but leaves the disk untouched.
+
+The flag exists to exercise the estimation -- the build, the runs, the picker,
+the upper-bound check -- without committing to what it produced, so every path
+of `rbx time` that would write something must become a no-op under it: the
+limits profile the estimation writes, the profile the `inherit` and `custom`
+strategies write, and the `problem.rbx.yml` that `--integrate` rewrites.
+"""
+
+import asyncio
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box import cli, package, timing
+from rbx.box.schema import ExpectedOutcome
+from rbx.box.testing import testing_package
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _skip_preset_check():
+    with mock.patch('rbx.box.presets.check_active_preset_compatibility'):
+        yield
+
+
+async def _build_ok(*args, **kwargs):
+    return True
+
+
+def test_dry_reaches_the_estimation(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    seen = {}
+
+    async def compute_time_limits(*args, **kwargs):
+        seen.update(kwargs)
+        return timing.TimingProfile(timeLimit=1000)
+
+    with (
+        mock.patch('rbx.box.builder.build', _build_ok),
+        mock.patch('rbx.box.timing.compute_time_limits', compute_time_limits),
+    ):
+        result = runner.invoke(cli.app, ['time', '--auto', '--dry'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['dry'] is True
+
+
+def test_the_estimation_writes_the_profile_unless_it_is_dry(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+):
+    seen = {}
+
+    async def compute_time_limits(*args, **kwargs):
+        seen.update(kwargs)
+        return timing.TimingProfile(timeLimit=1000)
+
+    with (
+        mock.patch('rbx.box.builder.build', _build_ok),
+        mock.patch('rbx.box.timing.compute_time_limits', compute_time_limits),
+    ):
+        result = runner.invoke(cli.app, ['time', '--auto'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['dry'] is False
+
+
+def test_inherit_writes_nothing_when_dry(
+    testing_pkg: testing_package.TestingPackage,
+):
+    limits_path = package.get_limits_file('local')
+
+    timing.inherit_time_limits(profile='local', dry=True)
+
+    assert not limits_path.exists()
+
+
+def test_a_custom_limit_writes_nothing_when_dry(
+    testing_pkg: testing_package.TestingPackage,
+):
+    limits_path = package.get_limits_file('local')
+
+    timing.set_time_limit(1234, profile='local', dry=True)
+
+    assert not limits_path.exists()
+
+
+def test_integrate_leaves_the_package_untouched_when_dry(
+    testing_pkg: testing_package.TestingPackage,
+):
+    # A saved profile the package does not carry yet: without --dry this would
+    # rewrite `problem.rbx.yml` with its time limit.
+    timing.set_time_limit(4242, profile='local')
+    before = testing_pkg.yml_path.read_text()
+
+    timing.integrate('local', dry=True)
+
+    assert testing_pkg.yml_path.read_text() == before
+
+
+def test_integrate_rewrites_the_package_when_not_dry(
+    testing_pkg: testing_package.TestingPackage,
+):
+    timing.set_time_limit(4242, profile='local')
+
+    timing.integrate('local')
+
+    assert package.find_problem_package_or_die().timeLimit == 4242
+
+
+@pytest.fixture
+def _stub_estimation(testing_pkg: testing_package.TestingPackage):
+    """The estimation, reduced to the profile it produced.
+
+    Everything `compute_time_limits` does before the write -- the inference run,
+    the grouping, the upper-bound check -- has its own tests; what is under test
+    here is only what happens to the profile afterwards.
+    """
+    testing_pkg.add_solution('sol.cpp', ExpectedOutcome.ACCEPTED)
+
+    async def run_for_inference(*args, **kwargs):
+        return mock.MagicMock()
+
+    async def build_estimation_context(*args, **kwargs):
+        return mock.MagicMock()
+
+    async def estimate_and_validate(*args, **kwargs):
+        return timing.TimingProfile(timeLimit=1000)
+
+    with (
+        mock.patch('rbx.box.timing._run_for_inference', run_for_inference),
+        mock.patch('rbx.box.timing.build_estimation_context', build_estimation_context),
+        mock.patch('rbx.box.timing._estimate_and_validate', estimate_and_validate),
+        mock.patch('rbx.box.timing.get_inference_solutions', return_value=[]),
+    ):
+        yield
+
+
+@pytest.mark.usefixtures('_stub_estimation')
+def test_the_estimated_profile_is_not_written_when_dry():
+    limits_path = package.get_limits_file('local')
+
+    estimated = asyncio.get_event_loop().run_until_complete(
+        timing.compute_time_limits(check=False, detailed=False, dry=True)
+    )
+
+    # The command still succeeds and still reports the limit it estimated --
+    # only the file is missing.
+    assert estimated is not None
+    assert not limits_path.exists()
+
+
+@pytest.mark.usefixtures('_stub_estimation')
+def test_the_estimated_profile_is_written_when_not_dry():
+    limits_path = package.get_limits_file('local')
+
+    estimated = asyncio.get_event_loop().run_until_complete(
+        timing.compute_time_limits(check=False, detailed=False)
+    )
+
+    assert estimated is not None
+    assert limits_path.exists()


### PR DESCRIPTION
Closes #739.

`rbx time --dry` runs the whole estimation — build, timing runs, language-group picker, estimation, upper-bound check — and prints the limits profile it arrived at instead of saving it. Nothing reaches the disk, so the profile you already have survives the rehearsal.

It covers every write path of the command, not just the estimate:

- the estimated profile (`compute_time_limits`)
- the `inherit` strategy's profile
- the `custom` strategy's profile
- `--integrate`, which leaves `problem.rbx.yml` untouched under `--dry`

Each of those prints a `Dry run: not writing …` line where it would otherwise have reported the write, and the estimated limits table is still rendered so the run is still readable.

`-p` was already optional (it defaults to `local`), and under `--dry` it stops mattering at all.

### Tests

New `tests/rbx/box/test_timing_dry.py`: the flag reaches the estimation, each strategy writes nothing under it, `--integrate` leaves the package byte-identical, and the non-dry counterparts still write.

### Docs

New "Rehearsing without writing" section in `docs/setters/profiling/estimating.md`, plus the regenerated CLI reference row and completion spec entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrfNuYt1qVipwiizdq2Xwf