### PR TITLE
build: keep node_modules out of the sdist and cap artifact size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,5 +172,10 @@ build_log.txt
 agents/
 
 .worktrees/
+# The VS Code extension is an npm project; hatchling only honours the *root*
+# .gitignore when excluding files from the sdist, so vscode/.gitignore's own
+# entry is not enough to keep node_modules out of a release.
+node_modules/
+
 # Built by `mise run vscode:vsix`, shipped in the wheel via hatch artifacts.
 rbx/resources/vscode/

--- a/mise.toml
+++ b/mise.toml
@@ -69,6 +69,9 @@ run = [
   "rm -rf dist/ rbx/resources/vscode/",
   "mise run vscode:vsix",
   "uv build",
+  # Guard against a stray directory being swept into a release; see
+  # [tool.rbx.dist] in pyproject.toml for the limits.
+  "python scripts/check_dist_size.py",
 ]
 
 [tasks.publish]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,11 +117,20 @@ exclude = ["rbx/testdata", "docs"]
 artifacts = ["rbx/resources/vscode/*.vsix"]
 
 [tool.hatch.build.targets.sdist]
-exclude = ["rbx/testdata", ".claude", ".worktrees", "docs"]
+exclude = ["rbx/testdata", ".claude", ".worktrees", "docs", "vscode/node_modules"]
 # Also here, not just on the wheel: `uv build` builds the sdist first and then
 # the wheel *from that sdist*, so a vsix dropped here never reaches the wheel
 # however the wheel target is configured.
 artifacts = ["rbx/resources/vscode/*.vsix"]
+
+[tool.rbx.dist]
+# Hard ceilings on the artifacts `mise run build` produces, enforced by
+# scripts/check_dist_size.py before anything is published. They are here to
+# catch a whole directory being swept into a release by accident: 1.2.0 shipped
+# a 23.8 MB sdist because vscode/node_modules was never excluded, and nothing
+# complained. Raise a limit only when the growth is understood and intended.
+max-wheel-mb = 5.0
+max-sdist-mb = 5.0
 
 [tool.ruff]
 extend-exclude = ["rbx/box/ui/_vendor"]

--- a/scripts/check_dist_size.py
+++ b/scripts/check_dist_size.py
@@ -1,0 +1,194 @@
+"""Fail the build when a release artifact is bigger than we allow it to be.
+
+Run by `mise run build` right after `uv build`, so every path that produces
+artifacts -- `build`, `publish`, `release` -- is guarded before anything
+reaches PyPI.
+
+The check exists because size regressions here are silent and one-directional:
+1.2.0 shipped a 23.8 MB sdist, 90% of which was `vscode/node_modules` swept in
+by accident. Nothing failed, nothing warned, and the only symptom was a slow
+`pip download`. A hard ceiling turns that class of mistake into a build error.
+
+When an artifact is over its limit the report names the directories responsible
+rather than just the number, so the failure points at the cause. Limits live in
+`[tool.rbx.dist]` in pyproject.toml and are meant to be edited -- but
+deliberately, when growth is understood, never to silence a red build.
+"""
+
+import argparse
+import dataclasses
+import pathlib
+import sys
+import tarfile
+import zipfile
+from typing import Dict, List, Optional, Sequence, Tuple
+
+try:  # pragma: no cover - exercised by whichever interpreter runs the build
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+MB = 1024 * 1024
+
+# Kind -> the pyproject key holding its ceiling, and the fallback used when
+# pyproject says nothing. The fallbacks are a backstop for a malformed config,
+# not the source of truth -- pyproject is.
+LIMIT_KEYS: Dict[str, str] = {'wheel': 'max-wheel-mb', 'sdist': 'max-sdist-mb'}
+DEFAULT_LIMITS: Dict[str, float] = {'wheel': 5.0, 'sdist': 5.0}
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@dataclasses.dataclass
+class Violation:
+    path: pathlib.Path
+    kind: str
+    size: int
+    limit_mb: float
+    offenders: List[Tuple[str, int]]
+    total_uncompressed: int
+
+
+def load_limits(pyproject: pathlib.Path) -> Dict[str, float]:
+    """Read the per-kind ceilings (in MB) out of `[tool.rbx.dist]`."""
+    limits = dict(DEFAULT_LIMITS)
+    if not pyproject.is_file():
+        return limits
+    with pyproject.open('rb') as f:
+        data = tomllib.load(f)
+    table = data.get('tool', {}).get('rbx', {}).get('dist', {})
+    for kind, key in LIMIT_KEYS.items():
+        value = table.get(key)
+        if isinstance(value, (int, float)) and value > 0:
+            limits[kind] = float(value)
+    return limits
+
+
+def kind_of(path: pathlib.Path) -> Optional[str]:
+    if path.name.endswith('.whl'):
+        return 'wheel'
+    if path.name.endswith('.tar.gz'):
+        return 'sdist'
+    return None
+
+
+def entries(path: pathlib.Path) -> List[Tuple[str, int]]:
+    """List `(name, uncompressed_size)` for every file inside an artifact."""
+    kind = kind_of(path)
+    if kind == 'wheel':
+        with zipfile.ZipFile(path) as zf:
+            return [(i.filename, i.file_size) for i in zf.infolist() if not i.is_dir()]
+    with tarfile.open(path) as tf:
+        # Strip the `name-version/` prefix every sdist wraps its content in, so
+        # offenders read as repository paths.
+        return [
+            (m.name.split('/', 1)[1] if '/' in m.name else m.name, m.size)
+            for m in tf.getmembers()
+            if m.isfile()
+        ]
+
+
+def top_offenders(
+    files: Sequence[Tuple[str, int]], depth: int = 2, limit: int = 6
+) -> List[Tuple[str, int]]:
+    """Aggregate files into their top `depth` path components, largest first."""
+    totals: Dict[str, int] = {}
+    for name, size in files:
+        parts = name.split('/')
+        key = '/'.join(parts[:depth]) if len(parts) > depth else name
+        totals[key] = totals.get(key, 0) + size
+    ranked = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
+    return ranked[:limit]
+
+
+def check_artifact(path: pathlib.Path, limits: Dict[str, float]) -> Optional[Violation]:
+    kind = kind_of(path)
+    if kind is None:
+        return None
+    size = path.stat().st_size
+    limit_mb = limits[kind]
+    if size <= limit_mb * MB:
+        return None
+    files = entries(path)
+    return Violation(
+        path=path,
+        kind=kind,
+        size=size,
+        limit_mb=limit_mb,
+        offenders=top_offenders(files),
+        total_uncompressed=sum(s for _, s in files),
+    )
+
+
+def _mib(n: int) -> str:
+    return f'{n / MB:.2f} MiB'
+
+
+def format_violation(v: Violation) -> str:
+    rule = '=' * 72
+    lines = [
+        '',
+        rule,
+        f'  RELEASE BLOCKED: {v.path.name} is {_mib(v.size)}, '
+        f'over the {v.limit_mb:.2f} MB limit',
+        rule,
+        '',
+        f'  Unpacked it holds {_mib(v.total_uncompressed)}. Biggest contents:',
+        '',
+    ]
+    for name, size in v.offenders:
+        share = size / v.total_uncompressed * 100 if v.total_uncompressed else 0.0
+        lines.append(f'    {_mib(size):>12}  {share:5.1f}%  {name}')
+    lines += [
+        '',
+        '  If something in that list should not ship, exclude it in',
+        f'  [tool.hatch.build.targets.{v.kind}] in pyproject.toml.',
+        '',
+        f'  If this growth is intended, raise {LIMIT_KEYS[v.kind]} in',
+        '  [tool.rbx.dist] -- and say why in the commit message.',
+        rule,
+        '',
+    ]
+    return '\n'.join(lines)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description='Fail the build when a release artifact exceeds its size limit.'
+    )
+    parser.add_argument(
+        'dist',
+        nargs='?',
+        default=str(REPO_ROOT / 'dist'),
+        help='directory holding the built artifacts (default: ./dist)',
+    )
+    args = parser.parse_args(argv)
+
+    dist = pathlib.Path(args.dist)
+    limits = load_limits(REPO_ROOT / 'pyproject.toml')
+    artifacts = sorted(p for p in dist.glob('*') if kind_of(p) is not None)
+
+    if not artifacts:
+        # Passing on an empty dist/ would make the guard quietly useless the
+        # first time someone reorders the build steps.
+        print(
+            f'No wheel or sdist found in {dist}/ -- nothing to check.', file=sys.stderr
+        )
+        return 1
+
+    violations = [v for v in (check_artifact(p, limits) for p in artifacts) if v]
+    for v in violations:
+        print(format_violation(v), file=sys.stderr)
+
+    if violations:
+        return 1
+
+    for p in artifacts:
+        kind = kind_of(p)
+        assert kind is not None
+        print(f'{p.name}: {_mib(p.stat().st_size)} (limit {limits[kind]:.2f} MB) OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/rbx/test_check_dist_size.py
+++ b/tests/rbx/test_check_dist_size.py
@@ -1,0 +1,166 @@
+import pathlib
+import tarfile
+import zipfile
+
+import pytest
+
+from scripts import check_dist_size
+
+MB = check_dist_size.MB
+
+
+def _wheel(path: pathlib.Path, files: dict) -> pathlib.Path:
+    target = path / 'pkg-1.0.0-py3-none-any.whl'
+    with zipfile.ZipFile(target, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for name, size in files.items():
+            zf.writestr(name, b'\0' * size)
+    return target
+
+
+def _sdist(path: pathlib.Path, files: dict) -> pathlib.Path:
+    target = path / 'pkg-1.0.0.tar.gz'
+    src = path / 'src'
+    src.mkdir(exist_ok=True)
+    with tarfile.open(target, 'w:gz') as tf:
+        for name, size in files.items():
+            blob = src / 'blob'
+            blob.write_bytes(b'\0' * size)
+            tf.add(blob, arcname=f'pkg-1.0.0/{name}')
+    return target
+
+
+def test_load_limits_reads_the_pyproject_table(tmp_path):
+    (tmp_path / 'pyproject.toml').write_text(
+        '[tool.rbx.dist]\nmax-wheel-mb = 12.5\nmax-sdist-mb = 30\n'
+    )
+
+    assert check_dist_size.load_limits(tmp_path / 'pyproject.toml') == {
+        'wheel': 12.5,
+        'sdist': 30.0,
+    }
+
+
+def test_load_limits_falls_back_when_the_table_is_absent(tmp_path):
+    (tmp_path / 'pyproject.toml').write_text('[tool.ruff]\n')
+
+    assert (
+        check_dist_size.load_limits(tmp_path / 'pyproject.toml')
+        == check_dist_size.DEFAULT_LIMITS
+    )
+
+
+@pytest.mark.parametrize('value', ['"big"', '0', '-3'])
+def test_load_limits_ignores_unusable_values(tmp_path, value):
+    (tmp_path / 'pyproject.toml').write_text(
+        f'[tool.rbx.dist]\nmax-wheel-mb = {value}\n'
+    )
+
+    limits = check_dist_size.load_limits(tmp_path / 'pyproject.toml')
+
+    assert limits['wheel'] == check_dist_size.DEFAULT_LIMITS['wheel']
+
+
+def test_the_real_pyproject_declares_both_limits():
+    limits = check_dist_size.load_limits(check_dist_size.REPO_ROOT / 'pyproject.toml')
+
+    assert limits == {'wheel': 5.0, 'sdist': 5.0}
+
+
+def test_kind_of_recognizes_wheels_and_sdists():
+    assert check_dist_size.kind_of(pathlib.Path('a-1.0-py3-none-any.whl')) == 'wheel'
+    assert check_dist_size.kind_of(pathlib.Path('a-1.0.tar.gz')) == 'sdist'
+    assert check_dist_size.kind_of(pathlib.Path('a-1.0.zip')) is None
+
+
+def test_entries_strips_the_sdist_prefix(tmp_path):
+    sdist = _sdist(tmp_path, {'rbx/box/cli.py': 10, 'README.md': 4})
+
+    assert dict(check_dist_size.entries(sdist)) == {
+        'rbx/box/cli.py': 10,
+        'README.md': 4,
+    }
+
+
+def test_entries_reports_uncompressed_wheel_sizes(tmp_path):
+    wheel = _wheel(tmp_path, {'rbx/big.bin': 5000, 'rbx/small.py': 12})
+
+    assert dict(check_dist_size.entries(wheel)) == {
+        'rbx/big.bin': 5000,
+        'rbx/small.py': 12,
+    }
+
+
+def test_top_offenders_aggregates_by_directory_largest_first():
+    files = [
+        ('vscode/node_modules/a', 800),
+        ('vscode/node_modules/b', 700),
+        ('vscode/src/main.ts', 50),
+        ('rbx/box/cli.py', 300),
+    ]
+
+    assert check_dist_size.top_offenders(files) == [
+        ('vscode/node_modules', 1500),
+        ('rbx/box', 300),
+        ('vscode/src', 50),
+    ]
+
+
+def test_top_offenders_keeps_shallow_paths_whole():
+    assert check_dist_size.top_offenders([('uv.lock', 9)]) == [('uv.lock', 9)]
+
+
+def test_an_artifact_under_its_limit_is_not_a_violation(tmp_path):
+    wheel = _wheel(tmp_path, {'rbx/cli.py': 1024})
+
+    assert check_dist_size.check_artifact(wheel, {'wheel': 5.0, 'sdist': 5.0}) is None
+
+
+def test_an_oversized_artifact_reports_its_biggest_directories(tmp_path):
+    # Stored, not deflated, so the archive on disk really does exceed the limit.
+    wheel = tmp_path / 'pkg-1.0.0-py3-none-any.whl'
+    with zipfile.ZipFile(wheel, 'w', zipfile.ZIP_STORED) as zf:
+        zf.writestr('vscode/node_modules/blob.bin', b'\0' * (3 * MB))
+        zf.writestr('rbx/box/cli.py', b'\0' * 1024)
+
+    violation = check_dist_size.check_artifact(wheel, {'wheel': 1.0, 'sdist': 5.0})
+
+    assert violation is not None
+    assert violation.kind == 'wheel'
+    assert violation.limit_mb == 1.0
+    assert violation.size > MB
+    assert violation.offenders[0][0] == 'vscode/node_modules'
+
+
+def test_the_failure_report_names_the_offender_and_the_escape_hatch(tmp_path):
+    wheel = tmp_path / 'pkg-1.0.0-py3-none-any.whl'
+    with zipfile.ZipFile(wheel, 'w', zipfile.ZIP_STORED) as zf:
+        zf.writestr('vscode/node_modules/blob.bin', b'\0' * (3 * MB))
+
+    violation = check_dist_size.check_artifact(wheel, {'wheel': 1.0, 'sdist': 5.0})
+    report = check_dist_size.format_violation(violation)
+
+    assert 'RELEASE BLOCKED' in report
+    assert 'vscode/node_modules' in report
+    assert 'max-wheel-mb' in report
+
+
+def test_main_passes_on_artifacts_within_limits(tmp_path, capsys):
+    _wheel(tmp_path, {'rbx/cli.py': 1024})
+    _sdist(tmp_path, {'rbx/cli.py': 1024})
+
+    assert check_dist_size.main([str(tmp_path)]) == 0
+    assert 'OK' in capsys.readouterr().out
+
+
+def test_main_fails_loudly_on_an_oversized_artifact(tmp_path, capsys):
+    wheel = tmp_path / 'pkg-1.0.0-py3-none-any.whl'
+    with zipfile.ZipFile(wheel, 'w', zipfile.ZIP_STORED) as zf:
+        zf.writestr('vscode/node_modules/blob.bin', b'\0' * (6 * MB))
+
+    assert check_dist_size.main([str(tmp_path)]) == 1
+    assert 'RELEASE BLOCKED' in capsys.readouterr().err
+
+
+def test_main_fails_when_there_is_nothing_to_check(tmp_path, capsys):
+    assert check_dist_size.main([str(tmp_path)]) == 1
+    assert 'nothing to check' in capsys.readouterr().err


### PR DESCRIPTION
## What happened

1.2.0 shipped a **23.8 MB sdist**. 90.4% of it is `vscode/node_modules`, swept in by accident — 6,404 files across 277 npm packages, including four macOS arm64 Mach-O binaries built on the release machine (`@vscode/vsce-sign`, `@vscode/vsce-sign-darwin-arm64`, `@esbuild/darwin-arm64`, `esbuild/bin/esbuild`).

The wheel was never affected: 411 files, zero `node_modules` entries.

## Root cause

Hatchling drops VCS-ignored files from the sdist, but it consults **only the repository-root `.gitignore`**. `node_modules/` is ignored by `vscode/.gitignore`, a nested ignore file, so the directory was treated as ordinary source.

This only reproduces where the extension has been built. A fresh clone or a CI runner that never ran `npm install` produces a ~3 MB sdist — which is exactly why it slipped through review and CI.

## The fix

- `vscode/node_modules` added to `[tool.hatch.build.targets.sdist]` `exclude`.
- `node_modules/` added to the **root** `.gitignore`, so the whole class is covered rather than this one instance.

Measured at the same commit (`aa77127`), with `vscode/node_modules` present on disk:

| Artifact | Before | After |
|---|---|---|
| sdist | 28.94 MB | **3.15 MB** |
| wheel | 1,543,633 B | **1,543,633 B** (identical) |

The wheel builds through the sdist chain and still carries `rbx/resources/vscode/rbx-vscode-0.1.0.vsix`, so `rbx vscode install` cannot regress.

## The conformance check

The regression was silent — nothing failed, nothing warned. `mise run build` now ends with `scripts/check_dist_size.py`, so every path that publishes (`build`, `publish`, `release`) is guarded before anything reaches PyPI.

Limits are editable in `pyproject.toml`, starting at 5 MB:

```toml
[tool.rbx.dist]
max-wheel-mb = 5.0
max-sdist-mb = 5.0
```

The failure report names the directories responsible rather than just the number. Run against the tarball actually published as 1.2.0:

```
========================================================================
  RELEASE BLOCKED: rbx_cp-1.2.0.tar.gz is 23.82 MiB, over the 5.00 MB limit
========================================================================

  Unpacked it holds 72.16 MiB. Biggest contents:

       62.31 MiB   86.4%  vscode/node_modules
        2.64 MiB    3.7%  tests/rbx
        2.49 MiB    3.5%  rbx/box
        1.32 MiB    1.8%  rbx/resources
        0.83 MiB    1.1%  tests/e2e
        0.68 MiB    0.9%  vscode/src

  If something in that list should not ship, exclude it in
  [tool.hatch.build.targets.sdist] in pyproject.toml.

  If this growth is intended, raise max-sdist-mb in
  [tool.rbx.dist] -- and say why in the commit message.
========================================================================
```

An empty `dist/` is treated as a failure too, so reordering the build steps can't quietly disable the guard.

## Verification

- 17 new tests in `tests/rbx/test_check_dist_size.py` — limit parsing (including malformed values), artifact introspection for both formats, offender ranking, report contents, and all three `main()` exit paths. All pass.
- `ruff check .` and `ruff format --check .` clean across 647 files.
- Checker run against the fixed artifacts: passes. Run against the published 1.2.0 tarball: fails as shown above.

## Note for the next release

1.2.0 is already on PyPI with the oversized sdist. This PR prevents a recurrence but does not change what is published — worth deciding separately whether to yank or simply supersede it.

## Not addressed

Nothing sensitive is in the tarball: swept for credentials, key material, `.env`, `.DS_Store`, caches, build logs — none present. After the fix, `tests/` plus `casts/fixtures` are ~1.25 MB of the remaining 3.0 MB; trimming them is a preference call, not a defect, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXwAoozyqHtr2A3dbs5Jws
