### PR TITLE
fix(vscode): honor the preset's buildDir instead of assuming build/

### DIFF
--- a/rbx/box/global_package.py
+++ b/rbx/box/global_package.py
@@ -12,7 +12,7 @@ from rbx.grading.judge.sandbox import SandboxBase
 from rbx.grading.judge.sandboxes.stupid_sandbox import StupidSandbox
 from rbx.grading.judge.storage import FilesystemStorage, Storage
 
-CACHE_STEP_VERSION = 5
+CACHE_STEP_VERSION = 6
 
 # How long to wait for other rbx processes to let go of a cache before giving
 # up on wiping it.

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -5,3 +5,5 @@ esbuild.mjs
 tsconfig.json
 **/*.map
 **/*.ts
+out-test/**
+esbuild.test.mjs

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rbx-vscode",
   "displayName": "rbx",
   "description": "Browse rbx testcases and solution verdicts without leaving the editor.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "rsalesc",
   "license": "MIT",
   "icon": "resources/icon.png",

--- a/vscode/src/discovery.ts
+++ b/vscode/src/discovery.ts
@@ -10,13 +10,19 @@ import * as vscode from 'vscode';
 
 import { PROBLEM_MANIFEST, PackageLayout, packageLayout } from './rbx/layout';
 
+// `**/build/**` is a guess, not a rule: the build directory is named by the
+// preset (see rbx/environment.ts) and may be called something else. It is only
+// here to keep the scan cheap -- rbx never writes a `problem.rbx.yml` into a
+// build directory, so nothing is lost when the guess misses.
 const EXCLUDE = '{**/node_modules/**,**/.git/**,**/.rbx/**,**/build/**}';
 
 export async function discoverPackages(): Promise<PackageLayout[]> {
   const matches = await vscode.workspace.findFiles(`**/${PROBLEM_MANIFEST}`, EXCLUDE);
   const roots = matches.map((uri) => path.dirname(uri.fsPath));
   const unique = Array.from(new Set(roots)).sort();
-  return unique.map(packageLayout);
+  // Wrapped rather than passed by reference: `packageLayout` takes an optional
+  // second argument, and `Array.map` would hand it the index.
+  return unique.map((root) => packageLayout(root));
 }
 
 /** Label for a package node: its directory name, or its path when ambiguous. */

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -17,7 +17,8 @@ import { registerDecorations } from './decorations';
 import { registerDiagnostics } from './diagnostics';
 import { initLog, log } from './log';
 import { CONTEST_FILE_GLOB, CONTEST_MANIFEST, isContestVariantFile } from './rbx/contest';
-import { BUILD_DIR, CACHE_DIR, PROBLEM_MANIFEST, TESTSET_MANIFEST } from './rbx/layout';
+import { resetBuildDirs, resolveBuildDir } from './rbx/environment';
+import { CACHE_DIR, PROBLEM_MANIFEST, TESTSET_MANIFEST } from './rbx/layout';
 import { RunDataProvider } from './runData';
 import { RunViewProvider } from './runView';
 import { registerSolutionLens } from './solutionLens';
@@ -44,21 +45,47 @@ function cacheRootOf(fsPath: string): string | undefined {
 }
 
 /**
+ * The package a `testset.yml` belongs to, or undefined if it belongs to none.
+ *
+ * The build directory is named by the active preset and can be nested, so the
+ * manifest's own path does not say how far up the package root is. Rather than
+ * guess a depth, each ancestor is asked whether *its* build directory is the
+ * one this manifest sits in -- which is the same question `testsetPath` answers
+ * in the other direction, so the watcher and the reader cannot disagree.
+ *
+ * Bounded to a few levels because `buildDir` is a build directory, not an
+ * arbitrary path, and an unbounded walk would make every stray `testset.yml`
+ * in the workspace cost a preset lookup per ancestor.
+ */
+function testsetRootOf(fsPath: string): string | undefined {
+  if (path.basename(fsPath) !== TESTSET_MANIFEST) {
+    return undefined;
+  }
+  let dir = path.dirname(fsPath);
+  for (let depth = 0; depth < 4; depth++) {
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    if (path.join(parent, resolveBuildDir(parent)) === path.dirname(fsPath)) {
+      return parent;
+    }
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
  * Map any watched path back to the package it belongs to.
  *
  * Two spellings reach the debounce: run artifacts under `.rbx`, and the testset
- * manifest `rbx build` writes at `<pkg>/build/testset.yml`. They feed the same
+ * manifest `rbx build` writes at `<pkg>/<build>/testset.yml`. They feed the same
  * pending set because they invalidate the same store -- a package is reloaded
  * whole, and which of its two producers moved is not a distinction the reload
  * makes.
  */
 function packageRootOf(fsPath: string): string | undefined {
-  const cached = cacheRootOf(fsPath);
-  if (cached !== undefined) {
-    return cached;
-  }
-  const suffix = `${path.sep}${BUILD_DIR}${path.sep}${TESTSET_MANIFEST}`;
-  return fsPath.endsWith(suffix) ? fsPath.slice(0, -suffix.length) : undefined;
+  return cacheRootOf(fsPath) ?? testsetRootOf(fsPath);
 }
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -177,7 +204,12 @@ export function activate(context: vscode.ExtensionContext): void {
   // about when a build has settled -- when it lands, everything it names is
   // already on disk. It joins the same debounce as the artifacts above, so a
   // build finishing while a run is in flight still costs one reload.
-  watch(`**/${BUILD_DIR}/${TESTSET_MANIFEST}`);
+  //
+  // The glob cannot name the build directory, because its name comes from the
+  // preset and differs per workspace; `packageRootOf` is what decides whether a
+  // given `testset.yml` is one of ours, and a stray one maps to no package and
+  // is dropped.
+  watch(`**/${TESTSET_MANIFEST}`);
 
   // A fourth glob, for a different question: the three above ask *what
   // changed*, this one asks *what is running*. `skeleton.yml` is written when
@@ -232,6 +264,29 @@ export function activate(context: vscode.ExtensionContext): void {
     manifests,
     vscode.workspace.onDidChangeWorkspaceFolders(rediscover),
   );
+
+  // The preset decides where the build directory is, so editing it moves every
+  // path the Tests view and the testcase panes are built from. Nothing else
+  // above notices: the packages are unchanged, only the name of a directory
+  // inside them, and a stale `PackageLayout` would keep pointing at the old one
+  // until the window was reloaded.
+  //
+  // Both spellings are watched for the same reason `findPresetDir` reads both:
+  // an installed preset lives in `.local.rbx/`, a preset under development is a
+  // checkout with a bare `preset.rbx.yml`. The environment file is named by the
+  // preset and so cannot be globbed by name -- watching the directory catches
+  // it whatever it is called.
+  const presets = vscode.workspace.createFileSystemWatcher(
+    `{**/preset.rbx.yml,**/.local.rbx/**}`,
+  );
+  const repoint = () => {
+    resetBuildDirs();
+    rediscover();
+  };
+  presets.onDidCreate(repoint);
+  presets.onDidChange(repoint);
+  presets.onDidDelete(repoint);
+  context.subscriptions.push(presets);
 
   // The dropdown's letters, order and colours come from `contest.rbx.yml`, and
   // nothing above watches it: renaming `A` to `B`, adding a colour, reordering

--- a/vscode/src/rbx/diagnostics.test.ts
+++ b/vscode/src/rbx/diagnostics.test.ts
@@ -7,7 +7,7 @@ import type { PackageRunView } from './nodes';
 import type { CompilationEntry } from './model';
 import type { CompilationFinding, PackageRun } from './store';
 
-const PKG: PackageLayout = { root: '/w/a' };
+const PKG: PackageLayout = { buildDir: 'build', root: '/w/a' };
 
 function finding(path: string, over: Partial<CompilationEntry> = {}): CompilationFinding {
   return {
@@ -135,7 +135,7 @@ test('every entry knows where the compiler output went', () => {
 
 test('findings from several packages are all reported', () => {
   const other: PackageRunView = {
-    pkg: { root: '/w/b' },
+    pkg: { buildDir: 'build', root: '/w/b' },
     run: {
       skeleton: {
       solutions: [],

--- a/vscode/src/rbx/environment.test.ts
+++ b/vscode/src/rbx/environment.test.ts
@@ -1,0 +1,122 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { test } from 'node:test';
+
+import { DEFAULT_BUILD_DIR, resetBuildDirs, resolveBuildDir } from './environment';
+
+/**
+ * Real files, not a mocked fs: what is under test is agreement with rbx about
+ * where a name lives on disk, and a fake that answers whatever the test says
+ * would agree with itself rather than with rbx.
+ */
+function tree(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rbx-env-'));
+  for (const [relative, contents] of Object.entries(files)) {
+    const target = path.join(root, ...relative.split('/'));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, contents);
+  }
+  resetBuildDirs();
+  return root;
+}
+
+const PRESET = 'name: p\nenv: env.rbx.yml\n';
+
+test('a package with no preset above it builds into rbx\'s default', () => {
+  const root = tree({ 'prob/problem.rbx.yml': 'name: prob\n' });
+  assert.strictEqual(resolveBuildDir(path.join(root, 'prob')), DEFAULT_BUILD_DIR);
+});
+
+test('a renamed buildDir reaches a package nested under the preset', () => {
+  const root = tree({
+    '.local.rbx/preset.rbx.yml': PRESET,
+    '.local.rbx/env.rbx.yml': 'buildDir: "build.rbx"\n',
+    'problems/seq/problem.rbx.yml': 'name: seq\n',
+  });
+  assert.strictEqual(resolveBuildDir(path.join(root, 'problems', 'seq')), 'build.rbx');
+});
+
+test('an environment that says nothing about buildDir keeps the default', () => {
+  const root = tree({
+    '.local.rbx/preset.rbx.yml': PRESET,
+    '.local.rbx/env.rbx.yml': 'sandbox: "stupid"\n',
+    'prob/problem.rbx.yml': 'name: prob\n',
+  });
+  assert.strictEqual(resolveBuildDir(path.join(root, 'prob')), DEFAULT_BUILD_DIR);
+});
+
+test('a preset with no env at all keeps the default', () => {
+  const root = tree({
+    '.local.rbx/preset.rbx.yml': 'name: p\n',
+    'prob/problem.rbx.yml': 'name: prob\n',
+  });
+  assert.strictEqual(resolveBuildDir(path.join(root, 'prob')), DEFAULT_BUILD_DIR);
+});
+
+test('a preset under development is read from its bare manifest', () => {
+  // No `.local.rbx` anywhere: this is a preset checkout, which rbx falls back
+  // to in `find_nested_preset`.
+  const root = tree({
+    'preset.rbx.yml': PRESET,
+    'env.rbx.yml': 'buildDir: "out"\n',
+    'problem/problem.rbx.yml': 'name: prob\n',
+  });
+  assert.strictEqual(resolveBuildDir(path.join(root, 'problem')), 'out');
+});
+
+test('an installed preset above wins over a bare manifest below it', () => {
+  // rbx looks for every `.local.rbx` before it considers a bare manifest, so a
+  // preset checkout vendored inside a contest must not capture the contest's
+  // problems.
+  const root = tree({
+    '.local.rbx/preset.rbx.yml': PRESET,
+    '.local.rbx/env.rbx.yml': 'buildDir: "build.rbx"\n',
+    'vendor/preset.rbx.yml': PRESET,
+    'vendor/env.rbx.yml': 'buildDir: "out"\n',
+    'vendor/prob/problem.rbx.yml': 'name: prob\n',
+  });
+  assert.strictEqual(resolveBuildDir(path.join(root, 'vendor', 'prob')), 'build.rbx');
+});
+
+test('unparseable yaml is treated as a package with no preset', () => {
+  const root = tree({
+    '.local.rbx/preset.rbx.yml': PRESET,
+    '.local.rbx/env.rbx.yml': 'buildDir: "[unclosed\n',
+    'prob/problem.rbx.yml': 'name: prob\n',
+  });
+  assert.strictEqual(resolveBuildDir(path.join(root, 'prob')), DEFAULT_BUILD_DIR);
+});
+
+test('an absolute buildDir is refused rather than escaping the package', () => {
+  const root = tree({
+    '.local.rbx/preset.rbx.yml': PRESET,
+    '.local.rbx/env.rbx.yml': `buildDir: "${path.join(path.sep, 'tmp', 'elsewhere')}"\n`,
+    'prob/problem.rbx.yml': 'name: prob\n',
+  });
+  assert.strictEqual(resolveBuildDir(path.join(root, 'prob')), DEFAULT_BUILD_DIR);
+});
+
+test('a buildDir that is not a string is refused', () => {
+  const root = tree({
+    '.local.rbx/preset.rbx.yml': PRESET,
+    '.local.rbx/env.rbx.yml': 'buildDir: 3\n',
+    'prob/problem.rbx.yml': 'name: prob\n',
+  });
+  assert.strictEqual(resolveBuildDir(path.join(root, 'prob')), DEFAULT_BUILD_DIR);
+});
+
+test('resetBuildDirs is what lets an edited preset move the build directory', () => {
+  const root = tree({
+    '.local.rbx/preset.rbx.yml': PRESET,
+    '.local.rbx/env.rbx.yml': 'buildDir: "build.rbx"\n',
+    'prob/problem.rbx.yml': 'name: prob\n',
+  });
+  const pkg = path.join(root, 'prob');
+  assert.strictEqual(resolveBuildDir(pkg), 'build.rbx');
+  fs.writeFileSync(path.join(root, '.local.rbx', 'env.rbx.yml'), 'buildDir: "out"\n');
+  assert.strictEqual(resolveBuildDir(pkg), 'build.rbx', 'cached until told otherwise');
+  resetBuildDirs();
+  assert.strictEqual(resolveBuildDir(pkg), 'out');
+});

--- a/vscode/src/rbx/environment.ts
+++ b/vscode/src/rbx/environment.ts
@@ -1,0 +1,135 @@
+/**
+ * Where a package keeps its build directory, as rbx would resolve it.
+ *
+ * `buildDir` is an environment setting (`Environment.buildDir` in
+ * rbx/box/environment.py), so a preset is free to rename it -- and presets do:
+ * a preset shipping `buildDir: build.rbx` lets a checkout gitignore one glob.
+ * Hardcoding `build` here silently emptied the Tests view and pointed every
+ * testcase pane at a path that does not exist.
+ *
+ * Resolved by reading the same files rbx reads rather than by asking rbx, which
+ * the extension never does (design D2/D3): `presets.find_local_preset` walks up
+ * for `.local.rbx/preset.rbx.yml`, `Preset.env` names an environment file beside
+ * it, and `Environment.buildDir` is the answer. Every step is optional, and any
+ * step that is missing, unreadable or the wrong shape falls back to `build` --
+ * which is both rbx's default and what a package with no preset at all has.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { parse as parseYaml } from 'yaml';
+
+/** rbx's default when no environment says otherwise (`Environment.buildDir`). */
+export const DEFAULT_BUILD_DIR = 'build';
+
+const PRESET_MANIFEST = 'preset.rbx.yml';
+const LOCAL_PRESET_DIR = '.local.rbx';
+
+/**
+ * Cache keyed by package root.
+ *
+ * Resolution touches two small files per package and is asked for on every
+ * path build, so it is memoized rather than repeated. `resetBuildDirs` is what
+ * the watcher calls when a preset or environment file changes -- the whole map
+ * is dropped, because a preset lives above the packages it governs and one
+ * edit can move all of them at once.
+ */
+const cache = new Map<string, string>();
+
+export function resetBuildDirs(): void {
+  cache.clear();
+}
+
+function readYaml(filePath: string): unknown {
+  let text: string;
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+  try {
+    return parseYaml(text);
+  } catch {
+    // Caught half-written, or hand-edited into something invalid. The fallback
+    // is a directory that may not exist, which the views already render as
+    // "nothing built yet" -- the same as being genuinely unbuilt.
+    return undefined;
+  }
+}
+
+function stringField(raw: unknown, key: string): string | undefined {
+  if (typeof raw !== 'object' || raw === null) {
+    return undefined;
+  }
+  const value = (raw as Record<string, unknown>)[key];
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+/** Ancestors of `from`, nearest first, stopping at the filesystem root. */
+function* ancestors(from: string): Generator<string> {
+  let current = path.resolve(from);
+  for (;;) {
+    yield current;
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return;
+    }
+    current = parent;
+  }
+}
+
+/**
+ * The active preset's directory, mirroring `presets.find_local_preset`.
+ *
+ * Two spellings, in rbx's order: an installed preset lives in `.local.rbx/`
+ * beside the contest, and a preset being *developed* is a checkout with a bare
+ * `preset.rbx.yml` at its top. The nested form is only consulted when no
+ * installed one is found anywhere above, which is the order rbx uses.
+ */
+function findPresetDir(root: string): string | undefined {
+  for (const dir of ancestors(root)) {
+    if (fs.existsSync(path.join(dir, LOCAL_PRESET_DIR, PRESET_MANIFEST))) {
+      return path.join(dir, LOCAL_PRESET_DIR);
+    }
+  }
+  for (const dir of ancestors(root)) {
+    if (fs.existsSync(path.join(dir, PRESET_MANIFEST))) {
+      return dir;
+    }
+  }
+  return undefined;
+}
+
+function resolveUncached(root: string): string {
+  const presetDir = findPresetDir(root);
+  if (presetDir === undefined) {
+    return DEFAULT_BUILD_DIR;
+  }
+  const env = stringField(readYaml(path.join(presetDir, PRESET_MANIFEST)), 'env');
+  if (env === undefined) {
+    return DEFAULT_BUILD_DIR;
+  }
+  const buildDir = stringField(readYaml(path.join(presetDir, env)), 'buildDir');
+  if (buildDir === undefined) {
+    return DEFAULT_BUILD_DIR;
+  }
+  // An absolute `buildDir` would escape the package. rbx joins it onto the
+  // package root with pathlib, where an absolute right-hand side *replaces*
+  // the root -- a behaviour worth mirroring nowhere, so it is refused here.
+  return path.isAbsolute(buildDir) ? DEFAULT_BUILD_DIR : buildDir;
+}
+
+/**
+ * The build directory for a package, relative to its root.
+ *
+ * A relative path, not a bare name: nothing stops an environment from spelling
+ * it `out/build`, and callers join it onto the root themselves (`layout.ts`).
+ */
+export function resolveBuildDir(root: string): string {
+  const cached = cache.get(root);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const resolved = resolveUncached(root);
+  cache.set(root, resolved);
+  return resolved;
+}

--- a/vscode/src/rbx/layout.ts
+++ b/vscode/src/rbx/layout.ts
@@ -9,9 +9,9 @@
  * Verified against rbx as of 2026-08-14 by materializing a real package:
  *
  *   <pkg>/problem.rbx.yml
- *   <pkg>/build/tests/<group>/<stem>.in     generated input      (symlink)
- *   <pkg>/build/tests/<group>/<stem>.out    expected answer      (symlink)
- *   <pkg>/build/testset.yml                 TestsetManifest
+ *   <pkg>/<build>/tests/<group>/<stem>.in   generated input      (symlink)
+ *   <pkg>/<build>/tests/<group>/<stem>.out  expected answer      (symlink)
+ *   <pkg>/<build>/testset.yml               TestsetManifest
  *   <pkg>/.rbx/runs/skeleton.yml            SolutionReportSkeleton
  *   <pkg>/.rbx/runs/<i>/<group>/<stem>.eval Evaluation
  *   <pkg>/.rbx/runs/<i>/<group>/<stem>.out  solution stdout      (symlink)
@@ -21,6 +21,10 @@
  * Note the expected answer is `.out`, not `.ans`, and the cache directory is
  * `.rbx`, not `.box` -- the v1 design doc is wrong on both counts.
  *
+ * `<build>` is not literally `build`: it is `Environment.buildDir`, which a
+ * preset may rename (see `environment.ts`). Only `packageLayout` resolves it;
+ * every path below is built from what the layout already carries.
+ *
  * The `.in`/`.out`/`.err` artifacts are symlinks into `.rbx/.storage/<sha1>`,
  * which is content-addressed. That is load-bearing for the watcher: artifact
  * content is never rewritten in place, so a path we have already read can be
@@ -28,22 +32,23 @@
  */
 import * as path from 'path';
 
+import { resolveBuildDir } from './environment';
+
 export const PROBLEM_MANIFEST = 'problem.rbx.yml';
 export const CACHE_DIR = '.rbx';
-export const BUILD_DIR = 'build';
 /**
  * The manifest `rbx build` writes last, describing the testset it just built.
  *
- * It sits under `build/` rather than `.rbx/` on purpose (design D2): a fresh
- * build rewrites `build/tests` and this file together, so the two cannot drift,
- * and `rbx clean` -- which wipes `.rbx` -- can never orphan it.
+ * It sits under the build directory rather than `.rbx/` on purpose (design D2):
+ * a fresh build rewrites `<build>/tests` and this file together, so the two
+ * cannot drift, and `rbx clean` -- which wipes `.rbx` -- can never orphan it.
  */
 export const TESTSET_MANIFEST = 'testset.yml';
 
 /** Artifact suffixes, as they appear on disk. */
 export const enum Ext {
   Input = '.in',
-  /** Both the expected answer (under build/tests) and solution stdout (under runs). */
+  /** Both the expected answer (under `<build>/tests`) and solution stdout (under runs). */
   Output = '.out',
   Stderr = '.err',
   Eval = '.eval',
@@ -55,10 +60,26 @@ export const enum Ext {
 export interface PackageLayout {
   /** Absolute path to the directory containing problem.rbx.yml. */
   readonly root: string;
+  /**
+   * Build directory, relative to `root`.
+   *
+   * Carried on the layout rather than read at every join: it comes from the
+   * active preset's environment (`environment.ts`), so it is a fact about the
+   * package, and resolving it once per package is what keeps a single view
+   * from mixing paths built before and after a preset edit.
+   */
+  readonly buildDir: string;
 }
 
-export function packageLayout(root: string): PackageLayout {
-  return { root };
+/**
+ * Describe a package rooted at `root`.
+ *
+ * `buildDir` is resolved from the active preset unless a caller names one,
+ * which only tests do -- everywhere else the answer is whatever rbx would use,
+ * and asking for it here is what stops each call site inventing a default.
+ */
+export function packageLayout(root: string, buildDir?: string): PackageLayout {
+  return { root, buildDir: buildDir ?? resolveBuildDir(root) };
 }
 
 export function manifestPath(pkg: PackageLayout): string {
@@ -107,7 +128,12 @@ export function compilationLogPath(pkg: PackageLayout, relative: string): string
  * exists nowhere.
  */
 export function testsDir(pkg: PackageLayout): string {
-  return path.join(pkg.root, BUILD_DIR, 'tests');
+  return path.join(buildPath(pkg), 'tests');
+}
+
+/** Absolute path to the package's build directory. */
+export function buildPath(pkg: PackageLayout): string {
+  return path.join(pkg.root, pkg.buildDir);
 }
 
 /**
@@ -118,7 +144,7 @@ export function testsDir(pkg: PackageLayout): string {
  * glob rather than a heuristic about when a build has settled.
  */
 export function testsetPath(pkg: PackageLayout): string {
-  return path.join(pkg.root, BUILD_DIR, TESTSET_MANIFEST);
+  return path.join(buildPath(pkg), TESTSET_MANIFEST);
 }
 
 /**

--- a/vscode/src/rbx/nodes.test.ts
+++ b/vscode/src/rbx/nodes.test.ts
@@ -41,7 +41,7 @@ function run(solutions: readonly SolutionRun[]): PackageRun {
   };
 }
 
-const PKG: PackageLayout = { root: '/w/a' };
+const PKG: PackageLayout = { buildDir: 'build', root: '/w/a' };
 
 const ONE: PackageRunView = {
   pkg: PKG,
@@ -72,7 +72,7 @@ test('two packages laid out alike never share a row id', () => {
   // resolves a context-menu command through a map of ids, and the client keeps
   // a selection across a switch of problem. Two packages laid out identically
   // -- which is what a contest's problems are -- must not collide there.
-  const ids = (root: string): string[] => flattenNodes({ pkg: { root }, run: ONE.run }).map(nodeId);
+  const ids = (root: string): string[] => flattenNodes({ pkg: { buildDir: 'build', root }, run: ONE.run }).map(nodeId);
   const here = ids('/w/a');
   const there = ids('/w/b');
   assert.strictEqual(here.length, there.length);

--- a/vscode/src/rbx/testsetViewModel.test.ts
+++ b/vscode/src/rbx/testsetViewModel.test.ts
@@ -309,7 +309,7 @@ test('a tests row naming an entry that is not there is ignored, not drawn', () =
 test('nodes and rows share one walk, so every row id resolves to a node', () => {
   const { rows } = buildTestsetViewModel(TESTSET);
   const nodes = new Map(
-    testsetNodes({ root: '/w/a' }, TESTSET).map((node) => [testsetNodeId(node), node]),
+    testsetNodes({ buildDir: 'build', root: '/w/a' }, TESTSET).map((node) => [testsetNodeId(node), node]),
   );
   assert.deepStrictEqual([...nodes.keys()], rows.map((row) => row.id));
   const node = nodes.get('main::1-gen-001');
@@ -322,7 +322,7 @@ test('nodes and rows share one walk, so every row id resolves to a node', () => 
 });
 
 test('no manifest is no nodes', () => {
-  assert.deepStrictEqual(testsetNodes({ root: '/w/a' }, undefined), []);
+  assert.deepStrictEqual(testsetNodes({ buildDir: 'build', root: '/w/a' }, undefined), []);
 });
 
 test('every testcase row opens the two panes, and no group row opens anything', () => {

--- a/vscode/src/rbx/viewModel.test.ts
+++ b/vscode/src/rbx/viewModel.test.ts
@@ -19,7 +19,7 @@ import { Row, buildViewModel } from './viewModel';
 // declared INCORRECT that fails in the wrong places. Those three are what a
 // naive encoding folds into one red row.
 
-const PKG: PackageLayout = { root: '/w/a' };
+const PKG: PackageLayout = { buildDir: 'build', root: '/w/a' };
 
 function testcase(stem: string, outcome?: string, over: Partial<TestcaseRun> = {}): TestcaseRun {
   return {

--- a/vscode/src/testsetView.ts
+++ b/vscode/src/testsetView.ts
@@ -234,7 +234,7 @@ export class TestsetViewProvider implements vscode.WebviewViewProvider {
     const pkg = selected === undefined ? undefined : packageLayout(selected);
     const testset = pkg === undefined ? undefined : await this.data.testset(pkg);
     this.nodes = new Map(
-      testsetNodes(pkg ?? { root: '' }, testset).map((node) => [testsetNodeId(node), node]),
+      testsetNodes(pkg ?? packageLayout(''), testset).map((node) => [testsetNodeId(node), node]),
     );
     const built = testset !== undefined;
     const posted = this.posted;


### PR DESCRIPTION
## Problem

The extension hardcoded `BUILD_DIR = 'build'` (`vscode/src/rbx/layout.ts`), but `buildDir` is an environment setting (`Environment.buildDir`) that a preset is free to rename. Under a preset shipping `buildDir: build.rbx`, everything the extension read out of the build directory pointed at a path that does not exist:

- **Tests view empty** — read `build/testset.yml`; the real file is `build.rbx/testset.yml`.
- **Testcase input/expected panes "not found"** — `inputPath`/`answerPath` pointed into `build/tests/`.
- **`rbx build` never refreshed the editor** — the watcher glob `**/build/testset.yml` never matched, so a build reached the views only on a window reload.

Verified against a real package by running the extension's own `ArtifactStore` over it: before, `testset` did not load and inputs resolved under `build/`; after, both are correct. (The Run *tree* was unaffected — it is built from `skeleton.yml` under `.rbx/` — which is why only the panes looked broken there.)

## Fix

New `vscode/src/rbx/environment.ts` resolves the build directory the way rbx does, by reading the same files rather than invoking rbx (design D2/D3):

1. walk up for `.local.rbx/preset.rbx.yml`, falling back to a bare `preset.rbx.yml` for a preset under development — mirroring `presets.find_local_preset`;
2. follow `Preset.env`;
3. read `Environment.buildDir`.

Every step is optional; anything missing, unreadable, mistyped or absolute falls back to `build`, which is both rbx's default and what a package with no preset has.

- `PackageLayout` carries `buildDir`, resolved once per package, so a single view cannot mix paths from before and after a preset edit.
- The testset watcher globs `**/testset.yml` and asks each ancestor whether *its* build directory is the one the manifest sits in — the same question `testsetPath` answers in the other direction, so watcher and reader cannot disagree. Works for a nested `buildDir` too.
- A new watcher on preset/`.local.rbx` files drops the resolution cache and repoints every package, since a preset governs all the packages beneath it.

## Also here

- `CACHE_STEP_VERSION` 5 → 6, so caches are invalidated on upgrade.
- `npm run vsix` was bundling `out-test/` whenever anyone had run the tests first (2.13 MB → 142 KB). Added it to `.vscodeignore`.
- Extension version bumped to 0.1.1 — `rbx vscode install` reads the bundled version from the vsix filename, so it needs the bump to see an upgrade.

## Testing

- `tsc --noEmit` clean.
- 418/418 extension unit tests pass, including 10 new ones in `environment.test.ts` covering: no preset, a renamed `buildDir`, an env that omits it, a preset with no `env`, a preset under development, an installed preset outranking a vendored one, unparseable YAML, an absolute `buildDir`, a non-string `buildDir`, and cache invalidation.
- `tests/rbx/box/test_cache_dirs.py` and `tests/rbx/box/cache_process_safety_test.py` pass (9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pac6wpPFJvsJVfnmdTUWiu
