### PR TITLE
feat(moj): add `--upload` to `rbx package moj`

### DIFF
--- a/docs/plans/2026-08-24-moj-package-upload-design.md
+++ b/docs/plans/2026-08-24-moj-package-upload-design.md
@@ -1,0 +1,125 @@
+# `rbx package moj --upload`: design
+
+Issue [#755](https://github.com/rsalesc/rbx/issues/755).
+
+`rbx package moj` builds a MOJ package and leaves it on disk. This adds `-u` /
+`--upload`, which builds the package exactly as before and then uploads it to the
+judge through the `moj` CLI -- the same CLI `rbx time --runner moj` already shells
+out to. The difference from every other MOJ flow in rbx is what the upload is
+*for*: `rbx time` uploads a throwaway probe to a private `rbxt-` problem, while
+this uploads a package meant to be used.
+
+## Where the built directory comes from
+
+`moj upload <id> <dir>` wants the package **tree**, but `run_packager` builds into
+a `TemporaryDirectory` and hands back only the `.zip`.
+
+Unzipping that archive is not an option. `MojPackager` `chmod`s the checker
+(`packager.py:1195`) and every `scripts/<lang>/` file (`packager.py:1337`) to
+`0o755`, and Python's `zipfile.extract` does not restore mode bits -- the judge
+would receive a package whose `compile.sh` and `run.sh` are not executable, which
+fails on the server rather than locally.
+
+So `run_packager` grows an optional `into_dir: Optional[pathlib.Path]`. When set,
+`packager.package()` builds there instead of into the temp dir; nothing else
+changes and no other packager is touched. The `moj` command owns its own
+`TemporaryDirectory` and passes it in, which keeps the command's flow linear --
+build, then upload -- rather than nesting the upload inside a callback.
+
+## Resolving the problem id
+
+A new `rbx/box/packaging/moj/upload.py`, a sibling of the packager, mirroring
+`polygon/upload.py`.
+
+```
+login = await cli.whoami()          # existing; fails with "run `moj login`"
+org   = env.extensions.moj.org or login
+slug  = package_basename().lower()  # "<short>-<name>", or "<name>" outside a contest
+id    = f'{org}#{slug}'
+```
+
+`package_basename()` is already the shared naming rule, so the id on the server
+matches the artifact name on disk. MOJ's slug rule is stricter than rbx's: rbx
+names allow uppercase and contest short names *are* uppercase letters, while MOJ
+requires `^[a-z0-9][a-z0-9._-]{1,80}$`. Hence the lowercasing.
+
+Two guards, both about failures that are otherwise confusing far from their cause:
+
+- Validate the slug and the org (`^[A-Za-z0-9][A-Za-z0-9._-]{1,63}$`) against
+  MOJ's own rules, read off the CLI's `cmd_new`. A lowercased rbx name
+  essentially always passes, but a server-side 400 on a slug says much less than
+  we can say here.
+- **Refuse a slug beginning with `rbxt-`.** That prefix is what `is_rbxt_id` uses
+  to tell a throwaway timing problem from a real one. A problem legitimately
+  named `rbxt-foo` would otherwise put a real package under an id that
+  `rbx time --runner moj` believes it owns and may overwrite.
+
+When `org` is absent the upload still happens -- under the setter's own login --
+but it is warned about first: the problem lands in your **private personal org**,
+visible to nobody else, and `extensions.moj.org` in `env.rbx.yml` is how it goes
+somewhere shared.
+
+## The env-level `moj` extension
+
+`Extensions` in `rbx/box/extensions.py` carries only `boca` today; `moj` exists
+solely as a *language*-level extension. Add `MojExtension(RejectsRemovedFields)`
+to `packaging/moj/extension.py` with one optional field, `org`, and wire it as
+`Extensions.moj`. This is a schema change, so `docs/schemas` regenerates.
+
+## The command
+
+```
+rbx package moj -u [--calibrate]
+```
+
+The build is unchanged: verification, `--language` and `--calibrate` all behave
+exactly as they do today, into a temp dir. Then:
+
+1. `cli.whoami()`, resolve the id, warn if it is the personal org, print the
+   target.
+2. `cli.upload(id, dir)`. The server creates the problem when it does not exist --
+   that is how `rbx time --runner moj` bootstraps its `rbxt-` problems -- so
+   "create if missing" costs nothing. `display_title` and `languages` already ride
+   along in the `.moj-meta.json` the packager writes, which `moj upload` requires.
+3. Under `--calibrate` only: `cli.calibrate(id)`, and say it was queued.
+
+There is **no confirmation prompt**. `-u` is itself the opt-in, as it is for BOCA
+and Polygon.
+
+The calibration is **not waited on**. `MojRunner._wait_for_calibration` exists
+because a timing run cannot proceed on uncalibrated limits; a setter uploading a
+package has nothing to block on, and a bounded poll here would only convert a
+long server-side job into a long foreground one. `moj check <id>` reports the
+state whenever they want it.
+
+**`.moj-id` is never written.** The one at the package root is the binding
+`rbx time --runner moj` reads: a real published id landing there makes
+`ensure_moj_id` return a non-`rbxt-` id, and the runner then refuses to run at
+all. Uploading from a temp dir keeps this safe for free, and the CLI excludes
+`.moj-id` from the tar in any case.
+
+## Non-goals
+
+Stated because each would otherwise read as a bug.
+
+- **Publishing.** `moj upload` neither publishes nor unpublishes: the server
+  ignores `public` from a tar, and only `/problems/set-public` moves it. A newly
+  created problem stays private until it is published by hand.
+- **Creating the org.** `moj upload` creates the *problem*, not the *org*. An
+  upload to an org that does not exist fails; rbx surfaces the CLI's message and
+  names `moj mkdir <org>`. A pre-flight `moj org list`, to raise that before
+  paying for a full build, is a possible follow-up rather than part of this.
+- **Contest-level fan-out.** There is no `rbx contest package moj`, so this is
+  single-problem only.
+
+## Testing
+
+Following the split already established in
+`tests/rbx/box/runners/moj/test_cli.py`:
+
+- Id resolution, the lowercasing, both validation refusals and the `rbxt-`
+  refusal are pure unit tests.
+- The upload's argv goes through the stub `moj` binary, so the assertion comes
+  from a process that was really spawned.
+- One packaging test that `into_dir` yields a tree with its `0o755` scripts
+  intact -- the regression the directory-over-zip decision exists to prevent.

--- a/docs/plans/2026-08-24-moj-package-upload.md
+++ b/docs/plans/2026-08-24-moj-package-upload.md
@@ -246,7 +246,6 @@ from unittest import mock
 from rbx.box.packaging.moj.upload import resolve_problem_id
 
 
-@pytest.mark.asyncio
 async def test_resolve_warns_when_uploading_to_the_personal_org(capsys):
     with (
         mock.patch('rbx.box.packaging.moj.upload.cli.whoami', return_value='alice'),
@@ -260,7 +259,6 @@ async def test_resolve_warns_when_uploading_to_the_personal_org(capsys):
     assert 'personal org' in capsys.readouterr().out
 
 
-@pytest.mark.asyncio
 async def test_resolve_does_not_warn_when_an_org_is_configured(capsys):
     with (
         mock.patch('rbx.box.packaging.moj.upload.cli.whoami', return_value='alice'),
@@ -451,7 +449,6 @@ def test_moj_command_takes_an_upload_flag():
 In `test_upload.py`, drive the real stub binary so the argv assertion comes from a process that was actually spawned. Reuse the `_stub_moj` helper from `tests/rbx/box/runners/moj/test_cli.py` — copy it, or lift it into a shared conftest and import it from both.
 
 ```python
-@pytest.mark.asyncio
 async def test_upload_shells_out_to_moj_upload(monkeypatch, tmp_path):
     log = _stub_moj(monkeypatch, tmp_path, 'exit 0')
     directory = tmp_path / 'package'
@@ -462,7 +459,6 @@ async def test_upload_shells_out_to_moj_upload(monkeypatch, tmp_path):
     assert log.read_text().split() == ['upload', 'unicamp#a-aplusb', str(directory)]
 
 
-@pytest.mark.asyncio
 async def test_upload_queues_a_calibration_when_asked(monkeypatch, tmp_path):
     log = _stub_moj(monkeypatch, tmp_path, 'exit 0')
     directory = tmp_path / 'package'

--- a/docs/plans/2026-08-24-moj-package-upload.md
+++ b/docs/plans/2026-08-24-moj-package-upload.md
@@ -1,0 +1,649 @@
+# `rbx package moj --upload` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `-u` / `--upload` to `rbx package moj`, which builds the package as it does today and then uploads it to MOJ through the `moj` CLI, under `<org>#<slug>`.
+
+**Architecture:** `run_packager` grows an optional `into_dir` so the caller can keep the built *tree* (the zip loses the `0o755` bits the judge needs). A new `rbx/box/packaging/moj/upload.py` resolves `<org>#<slug>` from `moj whoami` plus a new env-level `extensions.moj.org`, and drives the existing `rbx.box.runners.moj.cli` wrapper. The design and its rationale are in [`2026-08-24-moj-package-upload-design.md`](2026-08-24-moj-package-upload-design.md) — read it before starting.
+
+**Tech Stack:** Python 3, Typer, Pydantic v2, pytest. The `moj` CLI is shelled out to; tests stub it with a shell script, exactly as `tests/rbx/box/runners/moj/test_cli.py` already does. Nothing here touches the network.
+
+**Before you start:** run `uv sync`. Run tests with `uv run pytest <path>`; run only the files you touch — a full run is slow and produces spurious sandbox wall timeouts.
+
+---
+
+## Task 1: The env-level `moj` extension
+
+Today `rbx/box/extensions.py` has an env-level extension only for `boca`; `moj` exists solely as a *language*-level one. This adds `MojExtension`, holding the single optional `org` field.
+
+**Files:**
+- Modify: `rbx/box/packaging/moj/extension.py`
+- Modify: `rbx/box/extensions.py:11-15`
+- Test: `tests/rbx/box/packaging/moj/test_extension.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+import pytest
+from pydantic import ValidationError
+
+from rbx.box.extensions import Extensions
+from rbx.box.packaging.moj.extension import MojExtension
+
+
+def test_org_defaults_to_none():
+    # Absent means "upload under my own login"; see `resolve_problem_id`.
+    assert MojExtension().org is None
+
+
+def test_org_is_read_off_the_environment_extensions():
+    extensions = Extensions.model_validate({'moj': {'org': 'unicamp'}})
+    assert extensions.moj is not None
+    assert extensions.moj.org == 'unicamp'
+
+
+def test_unknown_field_is_rejected():
+    # `extra='forbid'`, as every other extension: a typo in `env.rbx.yml` must
+    # fail loudly rather than be silently ignored at upload time.
+    with pytest.raises(ValidationError):
+        MojExtension.model_validate({'orgs': 'unicamp'})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/packaging/moj/test_extension.py -v`
+Expected: FAIL with `ImportError: cannot import name 'MojExtension'`.
+
+**Step 3: Write minimal implementation**
+
+In `rbx/box/packaging/moj/extension.py`, above `MojLanguageExtension`:
+
+```python
+class MojExtension(RejectsRemovedFields):
+    """Environment-level extensions for MOJ packaging."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    org: typing.Optional[str] = Field(
+        default=None,
+        description='The MOJ org to upload the package to, as `<org>#<problem>`. '
+        'Leave unset to upload under your own login, which is a private personal '
+        'org nobody else can see.',
+    )
+```
+
+In `rbx/box/extensions.py`, import `MojExtension` alongside `MojLanguageExtension` and add to `Extensions`:
+
+```python
+    moj: Optional[MojExtension] = Field(
+        default=None, description='Environment-level extensions for MOJ packaging.'
+    )
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/packaging/moj/test_extension.py -v`
+Expected: 3 passed.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/packaging/moj/extension.py rbx/box/extensions.py tests/rbx/box/packaging/moj/test_extension.py
+git commit -m "feat(moj): add an env-level moj extension with an org field
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Building and validating the problem id
+
+The id is `<org>#<slug>`. MOJ's slug rule is stricter than rbx's — rbx names allow uppercase and contest short names *are* uppercase letters, while MOJ requires lowercase — so the basename is lowercased. Keep this a **pure function**: it takes the login, the configured org and the package basename, and needs no loaded package or environment, which is what makes it cheap to test exhaustively.
+
+The two regexes are MOJ's own, read off `cmd_new` in the `moj` CLI.
+
+**Files:**
+- Create: `rbx/box/packaging/moj/upload.py`
+- Test: `tests/rbx/box/packaging/moj/test_upload.py` (create)
+
+**Step 1: Write the failing test**
+
+```python
+import pytest
+
+from rbx.box.packaging.moj.upload import build_problem_id
+from rbx.box.runners.moj.cli import MojCliError
+
+
+def test_uses_the_configured_org():
+    assert build_problem_id('alice', 'unicamp', 'a-aplusb') == 'unicamp#a-aplusb'
+
+
+def test_falls_back_to_the_login_when_no_org_is_configured():
+    assert build_problem_id('alice', None, 'a-aplusb') == 'alice#a-aplusb'
+
+
+def test_lowercases_the_slug():
+    # rbx allows uppercase in a problem name and contest short names ARE
+    # uppercase letters, but MOJ slugs are lowercase-only.
+    assert build_problem_id('alice', None, 'A-APlusB') == 'alice#a-aplusb'
+
+
+def test_rejects_a_slug_that_is_not_a_legal_moj_slug():
+    with pytest.raises(MojCliError, match='problem name'):
+        build_problem_id('alice', None, 'a+b')
+
+
+def test_rejects_an_illegal_org():
+    with pytest.raises(MojCliError, match='org'):
+        build_problem_id('alice', 'not an org', 'aplusb')
+
+
+def test_refuses_a_slug_that_looks_like_an_rbx_timing_problem():
+    # `rbxt-` marks a throwaway problem `rbx time --runner moj` created and may
+    # overwrite. A real package must never land on an id that looks like one.
+    with pytest.raises(MojCliError, match='rbxt-'):
+        build_problem_id('alice', None, 'rbxt-aplusb')
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/packaging/moj/test_upload.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'rbx.box.packaging.moj.upload'`.
+
+**Step 3: Write minimal implementation**
+
+Create `rbx/box/packaging/moj/upload.py`:
+
+```python
+"""Uploading a built MOJ package to the judge.
+
+Unlike `rbx time --runner moj`, which uploads a throwaway probe to a private
+`rbxt-` problem, this uploads a package meant to be used. It goes through the
+same CLI wrapper -- `rbx.box.runners.moj.cli` -- so credentials never pass
+through rbx and the session `moj login` established is reused.
+"""
+
+import re
+from typing import Optional
+
+from rbx.box.runners.moj.cli import MojCliError
+from rbx.box.runners.moj.problem_id import RBXT_PREFIX
+
+# MOJ's own rules, read off `cmd_new` in the CLI, which mirrors what the server's
+# `/problems/create` enforces. Checked here so an illegal name fails by name
+# rather than as a server-side 400 long after the build was paid for.
+_ORG_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._-]{1,63}$')
+_SLUG_RE = re.compile(r'^[a-z0-9][a-z0-9._-]{1,80}$')
+
+
+def build_problem_id(login: str, org: Optional[str], basename: str) -> str:
+    """The `<org>#<slug>` this package uploads to.
+
+    Pure on purpose: everything that needs a loaded package or a live CLI lives
+    in `resolve_problem_id`, so the naming rules can be tested on their own.
+    """
+    resolved_org = org or login
+    if not _ORG_RE.match(resolved_org):
+        raise MojCliError(
+            f'`{resolved_org}` is not a valid MOJ org: an org is 2-64 characters '
+            f'of `[A-Za-z0-9._-]` and cannot start with a punctuation character. '
+            f'Set `extensions.moj.org` in your `env.rbx.yml`.'
+        )
+
+    # Lowercased rather than refused: rbx names legally contain uppercase and a
+    # contest short name always does, so refusing would reject the common case.
+    slug = basename.lower()
+    if not _SLUG_RE.match(slug):
+        raise MojCliError(
+            f'`{slug}` is not a valid MOJ problem name: it must be 2-81 '
+            f'characters of `[a-z0-9._-]` and cannot start with a punctuation '
+            f'character. Rename the problem in your `problem.rbx.yml`.'
+        )
+    if slug.startswith(RBXT_PREFIX):
+        raise MojCliError(
+            f'`{slug}` starts with `{RBXT_PREFIX}`, which marks the throwaway '
+            f'problems `rbx time --runner moj` creates and may overwrite without '
+            f'asking. Rename the problem in your `problem.rbx.yml`.'
+        )
+
+    return f'{resolved_org}#{slug}'
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/packaging/moj/test_upload.py -v`
+Expected: 6 passed.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/packaging/moj/upload.py tests/rbx/box/packaging/moj/test_upload.py
+git commit -m "feat(moj): build and validate the upload problem id
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Resolving the id against the live CLI, and the personal-org warning
+
+`resolve_problem_id` is the thin, impure half: it asks `moj whoami` for the login, reads `extensions.moj.org`, takes the basename from the packager's own naming rule, and warns when the upload is heading for the setter's private personal org.
+
+Note `BasePackager.package_basename` (`rbx/box/packaging/packager.py:74-80`) is `<short>-<name>` inside a contest and `<name>` outside one — reuse it rather than re-deriving, so the remote id matches the local artifact name.
+
+**Files:**
+- Modify: `rbx/box/packaging/moj/upload.py`
+- Test: `tests/rbx/box/packaging/moj/test_upload.py`
+
+**Step 1: Write the failing test**
+
+Append. `whoami` and the configured org are patched; nothing spawns a process here.
+
+```python
+from unittest import mock
+
+from rbx.box.packaging.moj.upload import resolve_problem_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_warns_when_uploading_to_the_personal_org(capsys):
+    with (
+        mock.patch('rbx.box.packaging.moj.upload.cli.whoami', return_value='alice'),
+        mock.patch(
+            'rbx.box.packaging.moj.upload._configured_org', return_value=None
+        ),
+    ):
+        problem_id = await resolve_problem_id('a-aplusb')
+
+    assert problem_id == 'alice#a-aplusb'
+    assert 'personal org' in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_resolve_does_not_warn_when_an_org_is_configured(capsys):
+    with (
+        mock.patch('rbx.box.packaging.moj.upload.cli.whoami', return_value='alice'),
+        mock.patch(
+            'rbx.box.packaging.moj.upload._configured_org', return_value='unicamp'
+        ),
+    ):
+        problem_id = await resolve_problem_id('a-aplusb')
+
+    assert problem_id == 'unicamp#a-aplusb'
+    assert 'personal org' not in capsys.readouterr().out
+```
+
+`cli.whoami` is async, so patch it with an `AsyncMock` (or `mock.patch(..., new_callable=mock.AsyncMock, return_value='alice')`) if a plain `return_value` does not await cleanly.
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/packaging/moj/test_upload.py -v`
+Expected: FAIL with `ImportError: cannot import name 'resolve_problem_id'`.
+
+**Step 3: Write minimal implementation**
+
+Add to `rbx/box/packaging/moj/upload.py`:
+
+```python
+from rbx import console
+from rbx.box import environment
+from rbx.box.packaging.moj.extension import MojExtension
+from rbx.box.runners.moj import cli
+
+
+def _configured_org() -> Optional[str]:
+    """`extensions.moj.org` from `env.rbx.yml`, if it is set."""
+    return environment.get_extension_or_default('moj', MojExtension).org
+
+
+async def resolve_problem_id(basename: str) -> str:
+    """The remote problem this package uploads to, warning if it is private.
+
+    `basename` is the packager's own `package_basename()`, so the id on the
+    server matches the artifact name on disk.
+    """
+    login = await cli.whoami()
+    org = _configured_org()
+    problem_id = build_problem_id(login, org, basename)
+
+    if org is None:
+        # Not an error -- uploading under your own login is a perfectly good way
+        # to try the flow -- but it is invisible to everyone else, and finding
+        # that out from a co-setter is worse than hearing it here.
+        console.console.print(
+            f'[warning]No `extensions.moj.org` is set, so this package is going '
+            f'to [item]{problem_id}[/item] -- your private personal org, which '
+            f'nobody else can see.[/warning]\n'
+            f'[warning]Set `extensions.moj.org` in your `env.rbx.yml` to upload '
+            f'it somewhere shared.[/warning]'
+        )
+    return problem_id
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/packaging/moj/test_upload.py -v`
+Expected: 8 passed.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/packaging/moj/upload.py tests/rbx/box/packaging/moj/test_upload.py
+git commit -m "feat(moj): resolve the upload id and warn on a personal org
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Let `run_packager` build into a caller-owned directory
+
+`run_packager` (`rbx/box/packaging/packager.py:276-293`) builds into a `TemporaryDirectory` that is gone by the time it returns, and hands back only the `.zip`. `moj upload` wants the tree, and the tree cannot be recovered from the zip: `MojPackager` `chmod`s the checker (`packager.py:1195`) and every `scripts/<lang>/` file (`packager.py:1337`) to `0o755`, and `zipfile.extract` does not restore mode bits.
+
+**Files:**
+- Modify: `rbx/box/packaging/packager.py:208-293`
+- Test: `tests/rbx/box/packaging/moj/test_packager.py`
+
+**Step 1: Write the regression guard**
+
+The packager is exercised directly here, as the rest of that file already does — `run_packager` itself needs a full verification run. This asserts the property the whole decision exists for: the tree keeps its executable bits.
+
+```python
+import stat
+
+
+def test_package_writes_executable_scripts_into_the_tree(tmp_path, ...):
+    # Fill in `...` from the existing fixtures in this file (see the tests around
+    # `MojPackager(...)` for how one is constructed).
+    build_path = tmp_path / 'build'
+    into_path = tmp_path / 'package'
+    build_path.mkdir()
+
+    packager.package(build_path, into_path, [])
+
+    scripts = list((into_path / 'scripts').rglob('*.sh'))
+    assert scripts, 'expected per-language scripts in the package tree'
+    for script in scripts:
+        assert script.stat().st_mode & stat.S_IXUSR, f'{script} is not executable'
+```
+
+**Step 2: Run it**
+
+Run: `uv run pytest tests/rbx/box/packaging/moj/test_packager.py -k executable -v`
+Expected: **PASS** — `package()` already chmods. This is a regression guard, not a red test: it fails if anyone later routes the upload through the zip. Say so in the commit message, so a reader does not mistake it for TDD gone wrong.
+
+**Step 3: Write the implementation**
+
+In `run_packager`, replace the unconditional temp dir with an optional caller-owned one:
+
+```python
+async def run_packager(
+    packager_cls: Type[BasePackager],
+    verification: environment.VerificationParam,
+    samples_only: bool = False,
+    skip_packaging: bool = False,
+    into_dir: Optional[pathlib.Path] = None,
+    **kwargs,
+) -> Optional[pathlib.Path]:
+```
+
+and, at the packaging step:
+
+```python
+    console.console.print(f'Packaging problem for [item]{packager.name()}[/item]...')
+    with contextlib.ExitStack() as stack:
+        # `into_dir` lets a caller keep the built *tree*, not just the archive:
+        # `moj upload` uploads the directory, and the zip cannot stand in for it
+        # because unzipping drops the 0o755 bits the judge's scripts need.
+        if into_dir is None:
+            into_dir = pathlib.Path(stack.enter_context(tempfile.TemporaryDirectory()))
+        stack.enter_context(limits_info.use_profile(packager_cls.name()))
+        result_path = packager.package(
+            package.get_build_path(), into_dir, built_statements
+        )
+```
+
+Add `import contextlib` at the top. Leave everything after this block untouched.
+
+**Step 4: Verify nothing regressed**
+
+Run: `uv run pytest tests/rbx/box/packaging -x -q`
+Expected: the suite passes unchanged — `into_dir` defaults to the old behaviour.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/packaging/packager.py tests/rbx/box/packaging/moj/test_packager.py
+git commit -m "feat(packaging): let run_packager build into a caller-owned dir
+
+The MOJ upload needs the package tree, not the zip: unzipping drops the
+0o755 bits the judge's per-language scripts need. The new test is a
+regression guard for that, and passes before the change.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: The `-u` flag
+
+Wire it together. The build is unchanged; the upload is appended.
+
+**Files:**
+- Modify: `rbx/box/packaging/main.py` (the `moj` command)
+- Modify: `rbx/box/packaging/moj/upload.py`
+- Modify: `rbx/box/packaging/packager.py:74-80` (make `package_basename` a classmethod)
+- Test: `tests/rbx/box/packaging/moj/test_cli.py`
+- Test: `tests/rbx/box/packaging/moj/test_upload.py`
+
+**Step 1: Write the failing tests**
+
+In `test_cli.py`, following the shape already there:
+
+```python
+def test_moj_command_takes_an_upload_flag():
+    result = CliRunner().invoke(app, ['moj', '--help'])
+    assert result.exit_code == 0
+    assert '--upload' in _plain(result.output)
+```
+
+In `test_upload.py`, drive the real stub binary so the argv assertion comes from a process that was actually spawned. Reuse the `_stub_moj` helper from `tests/rbx/box/runners/moj/test_cli.py` — copy it, or lift it into a shared conftest and import it from both.
+
+```python
+@pytest.mark.asyncio
+async def test_upload_shells_out_to_moj_upload(monkeypatch, tmp_path):
+    log = _stub_moj(monkeypatch, tmp_path, 'exit 0')
+    directory = tmp_path / 'package'
+    directory.mkdir()
+
+    await upload_package('unicamp#a-aplusb', directory, calibrate=False)
+
+    assert log.read_text().split() == ['upload', 'unicamp#a-aplusb', str(directory)]
+
+
+@pytest.mark.asyncio
+async def test_upload_queues_a_calibration_when_asked(monkeypatch, tmp_path):
+    log = _stub_moj(monkeypatch, tmp_path, 'exit 0')
+    directory = tmp_path / 'package'
+    directory.mkdir()
+
+    await upload_package('unicamp#a-aplusb', directory, calibrate=True)
+
+    # Queued and NOT waited on: no `check` poll follows it.
+    argv = log.read_text().split()
+    assert argv[-2:] == ['calibrate', 'unicamp#a-aplusb']
+    assert 'check' not in argv
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/packaging/moj/test_upload.py tests/rbx/box/packaging/moj/test_cli.py -v`
+Expected: FAIL — `--upload` is not in the help, and `upload_package` does not exist.
+
+**Step 3: Write minimal implementation**
+
+Add to `rbx/box/packaging/moj/upload.py`:
+
+```python
+import pathlib
+
+
+async def upload_package(
+    problem_id: str, directory: pathlib.Path, calibrate: bool
+) -> None:
+    """Upload the built tree, and optionally queue a calibration.
+
+    The server creates the problem when it does not exist -- that is how
+    `rbx time --runner moj` bootstraps its own -- so there is nothing to create
+    here first. What it does *not* create is the **org**: an upload to an org
+    that does not exist fails, and the CLI's own message is what says so.
+
+    The calibration is queued and **not waited on**. Calibrating is a long
+    server-side job, and a setter who has just uploaded has nothing to block on;
+    `moj check <id>` reports the state whenever they want it.
+    """
+    console.console.print(f'Uploading the package to [item]{problem_id}[/item]...')
+    await cli.upload(problem_id, directory)
+    console.console.print(
+        f'[success]Package uploaded to [item]{problem_id}[/item]![/success]'
+    )
+
+    if calibrate:
+        await cli.calibrate(problem_id)
+        console.console.print(
+            f'[status]Calibration queued for [item]{problem_id}[/item]. It runs on '
+            f'the judge; check on it with [item]moj check {problem_id}[/item].'
+            f'[/status]'
+        )
+```
+
+In `rbx/box/packaging/main.py`, add the option to the `moj` command, before `language`:
+
+```python
+    upload: bool = typer.Option(
+        False,
+        '--upload',
+        '-u',
+        help='If set, will upload the package to MOJ.',
+    ),
+```
+
+and replace the `await run_packager(...)` call at the end of the command with:
+
+```python
+    if not upload:
+        await run_packager(
+            MojPackager,
+            verification=verification,
+            main_language=language,
+            timing_mode=timing_mode,
+        )
+        return
+
+    from rbx.box.packaging.moj.upload import resolve_problem_id, upload_package
+
+    # Resolved *before* the build: a missing `moj login`, or a name MOJ will not
+    # accept, should not cost a full verification run to find out about.
+    problem_id = await resolve_problem_id(MojPackager.package_basename())
+
+    with tempfile.TemporaryDirectory(prefix='rbx-moj-upload-') as tmp:
+        directory = pathlib.Path(tmp) / 'package'
+        await run_packager(
+            MojPackager,
+            verification=verification,
+            main_language=language,
+            timing_mode=timing_mode,
+            into_dir=directory,
+        )
+        await upload_package(problem_id, directory, calibrate=calibrate)
+```
+
+Add `import pathlib` and `import tempfile` to `main.py`.
+
+**`package_basename` must become callable without an instance.** It is an instance method at `packager.py:74` and does not touch `self`; make it a `@classmethod` and update its one call site at `packager.py:1358`. Mechanical, no behaviour change — say so in the commit message.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/packaging/moj -v`
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/packaging/main.py rbx/box/packaging/moj/upload.py rbx/box/packaging/packager.py tests/rbx/box/packaging/moj/
+git commit -m "feat(moj): add --upload to rbx package moj
+
+Closes #755.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Regenerate the completion spec
+
+A new CLI flag makes the completion drift test fail.
+
+**Files:**
+- Modify: `rbx/box/completion/_spec.py` (generated)
+
+**Step 1: Regenerate**
+
+```bash
+uv run python -m rbx.box.completion.serialize && uv run ruff format rbx/box/completion/_spec.py
+```
+
+Run the generator directly rather than through `mise run gen-completion-spec` — inside a worktree the mise task is a no-op.
+
+**Step 2: Verify**
+
+Run: `uv run pytest tests/rbx/box/completion -v`
+Expected: PASS. `git diff` should show `--upload` / `-u` on the `moj` command and nothing else.
+
+**Step 3: Check the schemas**
+
+`docs/schemas` is written as an import side effect and is not checked in, so there is most likely nothing to commit for the new extension field. Confirm with `git status`; if a schema file *is* tracked and changed, include it.
+
+**Step 4: Commit**
+
+```bash
+git add rbx/box/completion/_spec.py
+git commit -m "chore(completion): regenerate the spec for package moj --upload
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Final verification
+
+**Step 1: Lint and format**
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+```
+
+**Step 2: Run the touched suites**
+
+```bash
+uv run pytest tests/rbx/box/packaging tests/rbx/box/runners/moj tests/rbx/box/completion -q
+```
+
+Run only these. A full suite run is slow and produces spurious sandbox wall timeouts unrelated to this change.
+
+**Step 3: Eyeball the help**
+
+```bash
+uv run rbx package moj --help
+```
+
+Expected: `-u, --upload` listed, alongside the existing `--language` and `--calibrate`.
+
+---
+
+## Follow-ups, deliberately not in this plan
+
+- **Docs.** The docs site has no page for MOJ packaging at all — MOJ is not even in the backend table in `docs/setters/packaging/index.md` — so a section documenting only `-u` would be orphaned. The CLI reference (`docs/setters/reference/cli.md`) picks the flag up on the next docs build. A `docs/setters/packaging/moj.md` covering the backend as a whole is the real fix, and is its own piece of work.
+- **A pre-flight org check.** `moj org list` before the build would turn "the org does not exist" into a precise error instead of a failed upload after a full verification run.
+- **Publishing.** `moj upload` neither publishes nor unpublishes; a newly created problem stays private until published by hand.

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -1927,6 +1927,14 @@ SPEC = {
                             },
                         },
                         {
+                            'help': 'If set, will upload the package to MOJ.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--upload', '-u'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        },
+                        {
                             'help': 'If set, will build the statement in the given '
                             'language. Leave unset if you want to use the '
                             'language of the topmost statement.',

--- a/rbx/box/extensions.py
+++ b/rbx/box/extensions.py
@@ -3,7 +3,7 @@ from typing import Optional
 from pydantic import BaseModel, Field
 
 from rbx.box.packaging.boca.extension import BocaExtension, BocaLanguageExtension
-from rbx.box.packaging.moj.extension import MojLanguageExtension
+from rbx.box.packaging.moj.extension import MojExtension, MojLanguageExtension
 from rbx.box.packaging.polygon.extension import PolygonLanguageExtension
 
 
@@ -11,6 +11,10 @@ from rbx.box.packaging.polygon.extension import PolygonLanguageExtension
 class Extensions(BaseModel):
     boca: Optional[BocaExtension] = Field(
         default=None, description='Environment-level extensions for BOCA packaging.'
+    )
+
+    moj: Optional[MojExtension] = Field(
+        default=None, description='Environment-level extensions for MOJ packaging.'
     )
 
 

--- a/rbx/box/packaging/main.py
+++ b/rbx/box/packaging/main.py
@@ -1,3 +1,5 @@
+import pathlib
+import tempfile
 from typing import List, Optional
 
 import syncer
@@ -137,6 +139,12 @@ async def boca(
 @syncer.sync
 async def moj(
     verification: environment.VerificationParam,
+    upload: bool = typer.Option(
+        False,
+        '--upload',
+        '-u',
+        help='If set, will upload the package to MOJ.',
+    ),
     language: Optional[str] = typer.Option(
         None,
         '--language',
@@ -169,12 +177,33 @@ async def moj(
 
     # A MOJ package holds one statement, and its `display_title` resolves from
     # the same one, so the body and the rendered <h1> can never disagree.
-    await run_packager(
-        MojPackager,
-        verification=verification,
-        main_language=language,
-        timing_mode=timing_mode,
-    )
+    if not upload:
+        await run_packager(
+            MojPackager,
+            verification=verification,
+            main_language=language,
+            timing_mode=timing_mode,
+        )
+        return
+
+    from rbx.box.packaging.moj.upload import resolve_problem_id, upload_package
+
+    # Resolved *before* the build: a missing `moj login`, or a name MOJ will not
+    # accept, should not cost a full verification run to find out about.
+    problem_id = await resolve_problem_id(MojPackager.package_basename())
+
+    # The tree is what gets uploaded, so it has to outlive `run_packager` --
+    # which otherwise builds into a temp dir of its own and returns only the zip.
+    with tempfile.TemporaryDirectory(prefix='rbx-moj-upload-') as tmp:
+        directory = pathlib.Path(tmp) / 'package'
+        await run_packager(
+            MojPackager,
+            verification=verification,
+            main_language=language,
+            timing_mode=timing_mode,
+            into_dir=directory,
+        )
+        await upload_package(problem_id, directory, calibrate=calibrate)
 
 
 @app.command('pkg', help='Build a package for PKG.')

--- a/rbx/box/packaging/moj/extension.py
+++ b/rbx/box/packaging/moj/extension.py
@@ -30,6 +30,19 @@ MojLanguage = typing.Literal[
 ]
 
 
+class MojExtension(RejectsRemovedFields):
+    """Environment-level extensions for MOJ packaging."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    org: typing.Optional[str] = Field(
+        default=None,
+        description='The MOJ org to upload the package to, as `<org>#<problem>`. '
+        'Leave unset to upload under your own login, which is a private personal '
+        'org nobody else can see.',
+    )
+
+
 class MojLanguageExtension(RejectsRemovedFields):
     """Language-level extensions for MOJ packaging.
 

--- a/rbx/box/packaging/moj/upload.py
+++ b/rbx/box/packaging/moj/upload.py
@@ -1,0 +1,52 @@
+"""Uploading a built MOJ package to the judge.
+
+Unlike `rbx time --runner moj`, which uploads a throwaway probe to a private
+`rbxt-` problem, this uploads a package meant to be used. It goes through the
+same CLI wrapper -- `rbx.box.runners.moj.cli` -- so credentials never pass
+through rbx and the session `moj login` established is reused.
+"""
+
+import re
+from typing import Optional
+
+from rbx.box.runners.moj.cli import MojCliError
+from rbx.box.runners.moj.problem_id import RBXT_PREFIX
+
+# MOJ's own rules, read off `cmd_new` in the CLI, which mirrors what the server's
+# `/problems/create` enforces. Checked here so an illegal name fails by name
+# rather than as a server-side 400 long after the build was paid for.
+_ORG_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._-]{1,63}$')
+_SLUG_RE = re.compile(r'^[a-z0-9][a-z0-9._-]{1,80}$')
+
+
+def build_problem_id(login: str, org: Optional[str], basename: str) -> str:
+    """The `<org>#<slug>` this package uploads to.
+
+    Pure on purpose: everything that needs a loaded package or a live CLI lives
+    in `resolve_problem_id`, so the naming rules can be tested on their own.
+    """
+    resolved_org = org or login
+    if not _ORG_RE.match(resolved_org):
+        raise MojCliError(
+            f'`{resolved_org}` is not a valid MOJ org: an org is 2-64 characters '
+            f'of `[A-Za-z0-9._-]` and cannot start with a punctuation character. '
+            f'Set `extensions.moj.org` in your `env.rbx.yml`.'
+        )
+
+    # Lowercased rather than refused: rbx names legally contain uppercase and a
+    # contest short name always does, so refusing would reject the common case.
+    slug = basename.lower()
+    if not _SLUG_RE.match(slug):
+        raise MojCliError(
+            f'`{slug}` is not a valid MOJ problem name: it must be 2-81 '
+            f'characters of `[a-z0-9._-]` and cannot start with a punctuation '
+            f'character. Rename the problem in your `problem.rbx.yml`.'
+        )
+    if slug.startswith(RBXT_PREFIX):
+        raise MojCliError(
+            f'`{slug}` starts with `{RBXT_PREFIX}`, which marks the throwaway '
+            f'problems `rbx time --runner moj` creates and may overwrite without '
+            f'asking. Rename the problem in your `problem.rbx.yml`.'
+        )
+
+    return f'{resolved_org}#{slug}'

--- a/rbx/box/packaging/moj/upload.py
+++ b/rbx/box/packaging/moj/upload.py
@@ -6,6 +6,7 @@ same CLI wrapper -- `rbx.box.runners.moj.cli` -- so credentials never pass
 through rbx and the session `moj login` established is reused.
 """
 
+import pathlib
 import re
 from typing import Optional
 
@@ -83,3 +84,36 @@ async def resolve_problem_id(basename: str) -> str:
             f'it somewhere shared.[/warning]'
         )
     return problem_id
+
+
+async def upload_package(
+    problem_id: str, directory: pathlib.Path, calibrate: bool
+) -> None:
+    """Upload the built tree, and optionally queue a calibration.
+
+    The **directory**, never the `.zip` beside it: `moj upload` tars what it is
+    given, and an unzipped tree arrives with the judge's per-language scripts no
+    longer executable (`zipfile.extract` does not restore mode bits).
+
+    The server creates the problem when it does not exist -- that is how
+    `rbx time --runner moj` bootstraps its own -- so there is nothing to create
+    here first. What it does *not* create is the **org**: an upload to an org
+    that does not exist fails, and the CLI's own message is what says so.
+
+    The calibration is queued and **not waited on**. Calibrating is a long
+    server-side job, and a setter who has just uploaded has nothing to block on;
+    `moj check <id>` reports the state whenever they want it.
+    """
+    console.console.print(f'Uploading the package to [item]{problem_id}[/item]...')
+    await cli.upload(problem_id, directory)
+    console.console.print(
+        f'[success]Package uploaded to [item]{problem_id}[/item]![/success]'
+    )
+
+    if calibrate:
+        await cli.calibrate(problem_id)
+        console.console.print(
+            f'[status]Calibration queued for [item]{problem_id}[/item]. It runs on '
+            f'the judge; check on it with [item]moj check {problem_id}[/item].'
+            f'[/status]'
+        )

--- a/rbx/box/packaging/moj/upload.py
+++ b/rbx/box/packaging/moj/upload.py
@@ -9,6 +9,10 @@ through rbx and the session `moj login` established is reused.
 import re
 from typing import Optional
 
+from rbx import console
+from rbx.box import environment
+from rbx.box.packaging.moj.extension import MojExtension
+from rbx.box.runners.moj import cli
 from rbx.box.runners.moj.cli import MojCliError
 from rbx.box.runners.moj.problem_id import RBXT_PREFIX
 
@@ -50,3 +54,32 @@ def build_problem_id(login: str, org: Optional[str], basename: str) -> str:
         )
 
     return f'{resolved_org}#{slug}'
+
+
+def _configured_org() -> Optional[str]:
+    """`extensions.moj.org` from `env.rbx.yml`, if it is set."""
+    return environment.get_extension_or_default('moj', MojExtension).org
+
+
+async def resolve_problem_id(basename: str) -> str:
+    """The remote problem this package uploads to, warning if it is private.
+
+    `basename` is the packager's own `package_basename()`, so the id on the
+    server matches the artifact name on disk.
+    """
+    login = await cli.whoami()
+    org = _configured_org()
+    problem_id = build_problem_id(login, org, basename)
+
+    if org is None:
+        # Not an error -- uploading under your own login is a perfectly good way
+        # to try the flow -- but it is invisible to everyone else, and finding
+        # that out from a co-setter is worse than hearing it here.
+        console.console.print(
+            f'[warning]No `extensions.moj.org` is set, so this package is going '
+            f'to [item]{problem_id}[/item] -- your private personal org, which '
+            f'nobody else can see.[/warning]\n'
+            f'[warning]Set `extensions.moj.org` in your `env.rbx.yml` to upload '
+            f'it somewhere shared.[/warning]'
+        )
+    return problem_id

--- a/rbx/box/packaging/packager.py
+++ b/rbx/box/packaging/packager.py
@@ -74,7 +74,11 @@ class BasePackager(ABC):
             res.add(statement.language)
         return list(res)
 
-    def package_basename(self):
+    @classmethod
+    def package_basename(cls):
+        # A classmethod because `rbx package moj --upload` resolves the remote
+        # problem id from this *before* the build, and so before there is an
+        # instance. It never used `self`.
         pkg = package.find_problem_package_or_die()
         shortname = naming.get_problem_shortname_or_require()
         if shortname is not None:

--- a/rbx/box/packaging/packager.py
+++ b/rbx/box/packaging/packager.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 import dataclasses
 import pathlib
 import shutil
@@ -210,6 +211,7 @@ async def run_packager(
     verification: environment.VerificationParam,
     samples_only: bool = False,
     skip_packaging: bool = False,
+    into_dir: Optional[pathlib.Path] = None,
     **kwargs,
 ) -> Optional[pathlib.Path]:
     from rbx.box import builder
@@ -273,12 +275,16 @@ async def run_packager(
     if skip_packaging:
         return None
     console.console.print(f'Packaging problem for [item]{packager.name()}[/item]...')
-    with (
-        tempfile.TemporaryDirectory() as td,
-        limits_info.use_profile(packager_cls.name()),
-    ):
+    with contextlib.ExitStack() as stack:
+        # `into_dir` lets a caller keep the built *tree*, not just the archive:
+        # `moj upload` uploads the directory, and the zip beside it cannot stand
+        # in for the tree because unzipping drops the 0o755 bits the judge's
+        # per-language scripts need.
+        if into_dir is None:
+            into_dir = pathlib.Path(stack.enter_context(tempfile.TemporaryDirectory()))
+        stack.enter_context(limits_info.use_profile(packager_cls.name()))
         result_path = packager.package(
-            package.get_build_path(), pathlib.Path(td), built_statements
+            package.get_build_path(), into_dir, built_statements
         )
 
     console.console.print(

--- a/tests/rbx/box/packaging/moj/test_cli.py
+++ b/tests/rbx/box/packaging/moj/test_cli.py
@@ -33,6 +33,14 @@ def test_moj_command_takes_a_language():
     assert '--language' in _plain(result.output)
 
 
+def test_moj_command_takes_an_upload_flag():
+    # Same spelling as `package boca` and `package polygon`, so `-u` means the
+    # same thing on every backend.
+    result = CliRunner().invoke(app, ['moj', '--help'])
+    assert result.exit_code == 0
+    assert '--upload' in _plain(result.output)
+
+
 def test_moj_command_has_no_legacy_boca_flag():
     # `--for-boca` belonged to the legacy BocaPackager subclass, which is gone.
     result = CliRunner().invoke(app, ['moj', '--help'])

--- a/tests/rbx/box/packaging/moj/test_extension.py
+++ b/tests/rbx/box/packaging/moj/test_extension.py
@@ -1,0 +1,23 @@
+import pytest
+from pydantic import ValidationError
+
+from rbx.box.extensions import Extensions
+from rbx.box.packaging.moj.extension import MojExtension
+
+
+def test_org_defaults_to_none():
+    # Absent means "upload under my own login"; see `resolve_problem_id`.
+    assert MojExtension().org is None
+
+
+def test_org_is_read_off_the_environment_extensions():
+    extensions = Extensions.model_validate({'moj': {'org': 'unicamp'}})
+    assert extensions.moj is not None
+    assert extensions.moj.org == 'unicamp'
+
+
+def test_unknown_field_is_rejected():
+    # `extra='forbid'`, as every other extension: a typo in `env.rbx.yml` must
+    # fail loudly rather than be silently ignored at upload time.
+    with pytest.raises(ValidationError):
+        MojExtension.model_validate({'orgs': 'unicamp'})

--- a/tests/rbx/box/packaging/moj/test_packager.py
+++ b/tests/rbx/box/packaging/moj/test_packager.py
@@ -1,6 +1,7 @@
 import fnmatch
 import json
 import shutil
+import stat
 import subprocess
 
 import pytest
@@ -87,6 +88,22 @@ def test_does_not_write_calibrated_files(moj_package):
     # A scripts/testlib.h would take precedence over the mojtools-vendored one.
     assert not (moj_package / 'scripts' / 'testlib.h').exists()
     assert not (moj_package / 'scripts' / 'rbx.h').exists()
+
+
+def test_scripts_in_the_package_tree_are_executable(moj_package):
+    """The judge runs these, so their mode bits are part of the package.
+
+    This is what forces `rbx package moj --upload` to hand `moj upload` the
+    built *tree* rather than the `.zip` beside it: `zipfile.extract` does not
+    restore mode bits, so a package rebuilt from the archive would arrive with
+    every `compile.sh` and `run.sh` non-executable -- and would fail on the
+    judge, not here.
+    """
+    scripts = sorted((moj_package / 'scripts').rglob('*.sh'))
+    assert scripts, 'expected per-language scripts in the package tree'
+    assert [
+        script for script in scripts if not script.stat().st_mode & stat.S_IXUSR
+    ] == []
 
 
 def test_writes_moj_meta_with_a_display_title(moj_package):

--- a/tests/rbx/box/packaging/moj/test_upload.py
+++ b/tests/rbx/box/packaging/moj/test_upload.py
@@ -1,0 +1,35 @@
+import pytest
+
+from rbx.box.packaging.moj.upload import build_problem_id
+from rbx.box.runners.moj.cli import MojCliError
+
+
+def test_uses_the_configured_org():
+    assert build_problem_id('alice', 'unicamp', 'a-aplusb') == 'unicamp#a-aplusb'
+
+
+def test_falls_back_to_the_login_when_no_org_is_configured():
+    assert build_problem_id('alice', None, 'a-aplusb') == 'alice#a-aplusb'
+
+
+def test_lowercases_the_slug():
+    # rbx allows uppercase in a problem name and contest short names ARE
+    # uppercase letters, but MOJ slugs are lowercase-only.
+    assert build_problem_id('alice', None, 'A-APlusB') == 'alice#a-aplusb'
+
+
+def test_rejects_a_slug_that_is_not_a_legal_moj_slug():
+    with pytest.raises(MojCliError, match='problem name'):
+        build_problem_id('alice', None, 'a+b')
+
+
+def test_rejects_an_illegal_org():
+    with pytest.raises(MojCliError, match='org'):
+        build_problem_id('alice', 'not an org', 'aplusb')
+
+
+def test_refuses_a_slug_that_looks_like_an_rbx_timing_problem():
+    # `rbxt-` marks a throwaway problem `rbx time --runner moj` created and may
+    # overwrite. A real package must never land on an id that looks like one.
+    with pytest.raises(MojCliError, match='rbxt-'):
+        build_problem_id('alice', None, 'rbxt-aplusb')

--- a/tests/rbx/box/packaging/moj/test_upload.py
+++ b/tests/rbx/box/packaging/moj/test_upload.py
@@ -1,6 +1,8 @@
+from unittest import mock
+
 import pytest
 
-from rbx.box.packaging.moj.upload import build_problem_id
+from rbx.box.packaging.moj.upload import build_problem_id, resolve_problem_id
 from rbx.box.runners.moj.cli import MojCliError
 
 
@@ -33,3 +35,41 @@ def test_refuses_a_slug_that_looks_like_an_rbx_timing_problem():
     # overwrite. A real package must never land on an id that looks like one.
     with pytest.raises(MojCliError, match='rbxt-'):
         build_problem_id('alice', None, 'rbxt-aplusb')
+
+
+# -- Resolving against the live CLI. -------------------------------------------
+#
+# `whoami` and the configured org are patched, so nothing here spawns a process
+# or reads an `env.rbx.yml`. Assertions are on the single word `personal` rather
+# than a phrase: rich wraps the warning at the console width, and a phrase can
+# straddle the break.
+
+
+async def test_resolve_warns_when_uploading_to_the_personal_org(capsys):
+    with (
+        mock.patch(
+            'rbx.box.packaging.moj.upload.cli.whoami',
+            new=mock.AsyncMock(return_value='alice'),
+        ),
+        mock.patch('rbx.box.packaging.moj.upload._configured_org', return_value=None),
+    ):
+        problem_id = await resolve_problem_id('a-aplusb')
+
+    assert problem_id == 'alice#a-aplusb'
+    assert 'personal' in capsys.readouterr().out
+
+
+async def test_resolve_does_not_warn_when_an_org_is_configured(capsys):
+    with (
+        mock.patch(
+            'rbx.box.packaging.moj.upload.cli.whoami',
+            new=mock.AsyncMock(return_value='alice'),
+        ),
+        mock.patch(
+            'rbx.box.packaging.moj.upload._configured_org', return_value='unicamp'
+        ),
+    ):
+        problem_id = await resolve_problem_id('a-aplusb')
+
+    assert problem_id == 'unicamp#a-aplusb'
+    assert 'personal' not in capsys.readouterr().out

--- a/tests/rbx/box/packaging/moj/test_upload.py
+++ b/tests/rbx/box/packaging/moj/test_upload.py
@@ -2,8 +2,13 @@ from unittest import mock
 
 import pytest
 
-from rbx.box.packaging.moj.upload import build_problem_id, resolve_problem_id
+from rbx.box.packaging.moj.upload import (
+    build_problem_id,
+    resolve_problem_id,
+    upload_package,
+)
 from rbx.box.runners.moj.cli import MojCliError
+from tests.rbx.box.runners.moj.test_cli import _stub_calls, _stub_moj
 
 
 def test_uses_the_configured_org():
@@ -73,3 +78,36 @@ async def test_resolve_does_not_warn_when_an_org_is_configured(capsys):
 
     assert problem_id == 'unicamp#a-aplusb'
     assert 'personal' not in capsys.readouterr().out
+
+
+# -- The upload itself. --------------------------------------------------------
+#
+# Driven through the stub binary rather than a fake, so the argv asserted on is
+# the argv a process really received. Nothing here touches the network.
+
+
+async def test_upload_shells_out_to_moj_upload(monkeypatch, tmp_path):
+    _stub_moj(monkeypatch, tmp_path, 'exit 0')
+    directory = tmp_path / 'package'
+    directory.mkdir()
+
+    await upload_package('unicamp#a-aplusb', directory, calibrate=False)
+
+    assert _stub_calls(tmp_path) == [['upload', 'unicamp#a-aplusb', str(directory)]]
+
+
+async def test_upload_queues_a_calibration_when_asked(monkeypatch, tmp_path):
+    _stub_moj(monkeypatch, tmp_path, 'exit 0')
+    directory = tmp_path / 'package'
+    directory.mkdir()
+
+    await upload_package('unicamp#a-aplusb', directory, calibrate=True)
+
+    calls = _stub_calls(tmp_path)
+    assert calls == [
+        ['upload', 'unicamp#a-aplusb', str(directory)],
+        ['calibrate', 'unicamp#a-aplusb'],
+    ]
+    # Queued, never waited on: no `check` poll follows it. A setter who has just
+    # uploaded has nothing to block on, and calibration is a long judge-side job.
+    assert not any('check' in call for call in calls)


### PR DESCRIPTION
Closes #755.

`rbx package moj -u` builds the package exactly as it does today — verification, `--language` and `--calibrate` all unchanged — and then uploads it to the judge through the `moj` CLI, the same wrapper `rbx time --runner moj` already drives. Credentials never pass through rbx; the session `moj login` established is reused.

```
rbx package moj -u [--calibrate]
```

The remote problem is `<org>#<slug>`, where `org` is the new `extensions.moj.org` in `env.rbx.yml` and `slug` is the packager's own `package_basename()` — `<short>-<name>` inside a contest, `<name>` outside one. `moj upload` creates the problem when it does not exist, and `.moj-meta.json` (which the packager already writes) carries the title and the language whitelist.

Design and rationale: [`docs/plans/2026-08-24-moj-package-upload-design.md`](docs/plans/2026-08-24-moj-package-upload-design.md). Plan: [`docs/plans/2026-08-24-moj-package-upload.md`](docs/plans/2026-08-24-moj-package-upload.md).

## Three decisions worth a second look

**The upload takes the built tree, not the zip.** `MojPackager` `chmod`s the checker and every `scripts/<lang>/` file to `0o755`, and `zipfile.extract` does not restore mode bits — a package rebuilt from the archive would reach the judge with `compile.sh` and `run.sh` non-executable, and fail there rather than here. So `run_packager` grows an optional `into_dir` and the command keeps the tree alive across the upload. `test_scripts_in_the_package_tree_are_executable` is the regression guard, and passes before the change.

**`.moj-id` is never written.** The one at the package root is the binding `rbx time --runner moj` reads: a real published id landing there makes `ensure_moj_id` return a non-`rbxt-` id and the runner refuse to run at all. Uploading from a temp dir keeps this safe for free, and the CLI excludes `.moj-id` from the tar anyway.

**A slug starting with `rbxt-` is refused.** That prefix is what `is_rbxt_id` uses to tell a throwaway timing problem from a real one, so a problem legitimately named `rbxt-foo` would otherwise land on an id the MOJ runner believes it owns and may overwrite.

## Behaviour details

- **No `extensions.moj.org`** → the upload goes to the setter's own login and warns that this is a private personal org nobody else can see.
- **Slugs are lowercased.** MOJ requires `^[a-z0-9][a-z0-9._-]{1,80}$`, while rbx names allow uppercase and contest short names *are* uppercase letters. Org and slug are both validated against MOJ's own rules (read off the CLI's `cmd_new`) before the build, so an illegal name fails by name instead of as a server-side 400 after a full verification run.
- **No confirmation prompt** — `-u` is the opt-in, same as BOCA and Polygon.
- **`--calibrate` queues a calibration and does not wait on it.** Calibrating is a long judge-side job; `moj check <id>` reports the state on demand.
- `package_basename` becomes a `classmethod` so the id can be resolved before the build. It never used `self`; every call site was already `self.package_basename()`.

## Not in this PR

- **Docs.** The docs site has no MOJ packaging page at all — MOJ is not even in the backend table in `docs/setters/packaging/index.md` — so a section covering only `-u` would be orphaned. The CLI reference picks the flag up on the next docs build. A `docs/setters/packaging/moj.md` covering the backend as a whole is the real fix.
- **A pre-flight org check.** `moj upload` creates the problem, not the org; an upload to an org that does not exist fails with the CLI's own message. `moj org list` before the build would turn that into a precise error.
- **Publishing.** `moj upload` neither publishes nor unpublishes — the server ignores `public` from a tar. A newly created problem stays private until published by hand.

## Testing

`523 passed, 4 skipped` across `tests/rbx/box/packaging` and `tests/rbx/box/runners/moj`; `936 passed` in `tests/rbx/box/completion`; `ruff check` and `ruff format --check` clean.

New tests: id building and every refusal as pure unit tests; the personal-org warning with `whoami` patched; the upload's argv driven through the stub `moj` binary, so it is asserted off a process that really ran. Nothing touches the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdzhushnJLYVDgLTiiXMHB
