### PR TITLE
feat(vscode): head each contest variant's block with its id

### DIFF
--- a/docs/plans/2026-08-24-vscode-contest-variants-design.md
+++ b/docs/plans/2026-08-24-vscode-contest-variants-design.md
@@ -1,0 +1,80 @@
+# VS Code: distinguishing contest variants in the problem selector
+
+Refs #745.
+
+## Problem
+
+The extension is a pure reader. It never spawns rbx and never learns which
+contest variant `-C`/`RBX_CONTEST` selected, so `contestIndex.ts` reads the
+canonical `contest.rbx.yml` *and* every sibling `contest.<id>.rbx.yml` and
+merges them first-wins in filename order. That union is the right default --
+a reader cannot know what the user will type in the terminal -- and it stays.
+
+What the union costs today is that the variants become indistinguishable once
+merged:
+
+- every variant collapses into one `<optgroup>` keyed by the contest root, so
+  nothing says whether a letter came from `div1` or `div2`;
+- `order` is counted per contest file, so div1's first problem and div2's first
+  problem both claim `0` and the sort falls through to label and root, which
+  interleaves the two variants' letters (`A`, `A`, `B`, `B`).
+
+A user running a two-division contest sees one jumbled list of letters with no
+way to tell the divisions apart.
+
+## Design
+
+Group by *contest file* rather than by contest root, and name the variant in
+the group heading.
+
+### Carry the variant id through the index
+
+`rbx/contest.ts` gains `contestVariantId(name)`, the inverse of the existing
+`isContestVariantFile`: the id for `contest.<id>.rbx.yml`, `undefined` for the
+canonical name. `ProblemIdentity` gains an optional `variantId`.
+
+`indexContests` already walks `contestFiles()` and knows each filename, so it
+stamps the id onto the identities that file produced. First-wins is untouched:
+a package named by both the canonical file and `div2` keeps the canonical
+identity, and therefore lands in the canonical group.
+
+### Group by (root, variant)
+
+`problems.ts` splits today's single `group` field -- which is both sort key and
+heading -- into the two things it was doing at once:
+
+- key: `contestRoot` plus `variantId ?? ''`;
+- heading: `basename(contestRoot)`, with ` (<id>)` appended for a variant.
+
+Canonical-first ordering falls out of the empty string sorting before any valid
+id, and the ids then sort in exactly the filename order `contestFiles()` merged
+in, so heading order and merge order cannot drift apart. Disjoint variants land
+as two contiguous blocks; overlapping ones read as "the canonical's problems,
+then what only `div2` adds", which is what first-wins actually produced.
+
+Grouping unconditionally, rather than only when the variants happen to be
+disjoint, keeps the dropdown's structure from reshuffling wholesale the moment
+someone adds one shared problem.
+
+### `order` stops colliding
+
+Each group is now exactly one contest file, so two problems can no longer claim
+the same `order` within a group. The `label`/`root` tie-breaks stay as
+belt-and-braces, but their comment -- which describes the merged-variants case
+outright -- no longer applies and is rewritten.
+
+## Deliberately unchanged
+
+- **The union itself.** Every variant's problems stay visible whichever one is
+  selected.
+- **"One group is no grouping".** A dispatcher holding a single
+  `contest.div1.rbx.yml` yields one group and renders headingless: there is no
+  second variant to distinguish it from, and the heading would be chrome for
+  nothing.
+- **`renderSelector`'s one-pass open/close**, which keys on the heading string
+  and so merges two same-named contest directories. That approximation predates
+  this change -- `compareGroups` documents it -- and is neither worsened nor
+  fixed here.
+- **Run artifacts.** The extension watches `<pkg>/.rbx/runs` and
+  `<pkg>/build/testset.yml`, both variant-invariant, and stay so under the split
+  planned in #753. Nothing outside the selector is variant-aware.

--- a/docs/tools/vscode.md
+++ b/docs/tools/vscode.md
@@ -72,6 +72,12 @@ naming problems by their contest letter and colour. It follows the problem that
 is *running*, so `rbx contest each run` walks the view along with it. The
 dropdown is hidden entirely when the workspace holds a single package.
 
+A contest split into variants gets one block per variant, headed by the variant
+id. The extension never learns which variant you passed to `-C`, so it offers
+all of them at once: the canonical contest's problems first, then each variant's
+under its own heading. Two divisions that both start at `A` stay apart, and the
+heading says which `A` you are about to open.
+
 ## Opening a testcase
 
 <kbd>Enter</kbd> on a testcase -- or a click on it -- opens **two editor

--- a/vscode/src/contestIndex.test.ts
+++ b/vscode/src/contestIndex.test.ts
@@ -89,3 +89,30 @@ test('scans one contest once for every package under it', async () => {
     },
   );
 });
+
+test('names the variant each letter came from', async () => {
+  // The selector heads a variant's block with this id, so it has to survive the
+  // merge -- and the canonical, which wins the root it shares with div1, has to
+  // come back with none.
+  await withTree(
+    {
+      'contest.rbx.yml': 'problems:\n  - short_name: A\n    path: shared\n',
+      'contest.div1.rbx.yml': 'problems:\n  - short_name: Z\n    path: shared\n',
+      'contest.div2.rbx.yml': 'problems:\n  - short_name: B\n    path: only2\n',
+    },
+    async (root) => {
+      const index = await indexContests([path.join(root, 'shared'), path.join(root, 'only2')]);
+      assert.deepStrictEqual(
+        [...index].map(([key, identity]) => [
+          path.relative(root, key),
+          identity.shortName,
+          identity.variantId,
+        ]),
+        [
+          ['shared', 'A', undefined],
+          ['only2', 'B', 'div2'],
+        ],
+      );
+    },
+  );
+});

--- a/vscode/src/contestIndex.ts
+++ b/vscode/src/contestIndex.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import {
   CONTEST_MANIFEST,
   ProblemIdentity,
+  contestVariantId,
   isContestVariantFile,
   parseContest,
   problemIdentities,
@@ -85,7 +86,14 @@ export async function indexContests(
     scanned.add(contestRoot);
     for (const file of await contestFiles(contestRoot)) {
       const contest = parseContest(await readYamlFile(file));
-      const identities = problemIdentities(contestRoot, contest);
+      // The id comes from the filename rather than the parsed contest: a
+      // variant file does not name itself, and `contestFiles` has just sorted
+      // these by that very name.
+      const identities = problemIdentities(
+        contestRoot,
+        contest,
+        contestVariantId(path.basename(file)),
+      );
       for (const [key, identity] of identities) {
         // First file to name a root wins; canonical is read first.
         if (!index.has(key)) {

--- a/vscode/src/rbx/contest.test.ts
+++ b/vscode/src/rbx/contest.test.ts
@@ -3,7 +3,9 @@ import { test } from 'node:test';
 import { parse as parseYaml } from 'yaml';
 
 import {
+  CONTEST_MANIFEST,
   ParsedContest,
+  contestVariantId,
   isContestVariantFile,
   parseContest,
   problemIdentities,
@@ -188,4 +190,46 @@ problems:
     parsed.problems.map((p) => p.shortName),
     ['B'],
   );
+});
+
+test('reads the id out of a variant file name, and none out of the canonical', () => {
+  assert.strictEqual(contestVariantId('contest.div1.rbx.yml'), 'div1');
+  assert.strictEqual(contestVariantId('contest.d-i_v2.rbx.yml'), 'd-i_v2');
+  // The canonical file is not a variant of itself, however the affixes overlap.
+  assert.strictEqual(contestVariantId(CONTEST_MANIFEST), undefined);
+  // Same rejections as `isContestVariantFile`, which is defined in its terms.
+  assert.strictEqual(contestVariantId('contest.div1.bak.rbx.yml'), undefined);
+  assert.strictEqual(contestVariantId('contest.1div.rbx.yml'), undefined);
+  assert.strictEqual(contestVariantId('problem.rbx.yml'), undefined);
+});
+
+test('stamps the variant id on every identity that file names', () => {
+  const identities = problemIdentities(
+    '/c',
+    contest(`
+problems:
+  - short_name: A
+  - short_name: B
+`),
+    'div2',
+  );
+  assert.deepStrictEqual(
+    [...identities.values()].map((identity) => [identity.shortName, identity.variantId]),
+    [
+      ['A', 'div2'],
+      ['B', 'div2'],
+    ],
+  );
+});
+
+test('a canonical identity carries no variant key at all', () => {
+  // Absent, not present-and-undefined: the field is optional, and callers
+  // compare whole identities.
+  const identities = problemIdentities('/c', contest('problems:\n  - short_name: A\n'));
+  assert.deepStrictEqual(identities.get('/c/A'), {
+    shortName: 'A',
+    color: undefined,
+    order: 0,
+    contestRoot: '/c',
+  });
 });

--- a/vscode/src/rbx/contest.ts
+++ b/vscode/src/rbx/contest.ts
@@ -35,13 +35,31 @@ export const CONTEST_FILE_GLOB = `${VARIANT_PREFIX.slice(0, -1)}*${VARIANT_SUFFI
  * `contest.div1.rbx.yml` and its stale letters would win.
  */
 export function isContestVariantFile(name: string): boolean {
-  return (
-    name.startsWith(VARIANT_PREFIX) &&
-    name.endsWith(VARIANT_SUFFIX) &&
+  return contestVariantId(name) !== undefined;
+}
+
+/**
+ * The variant id `name` carries, or undefined for the canonical file.
+ *
+ * The inverse of `isContestVariantFile`, and the only definition of the two:
+ * a name that yields no id is not a variant file, so the two answers can never
+ * disagree about a `contest.div1.bak.rbx.yml`.
+ *
+ * Undefined also comes back for a name that is not a contest file at all. The
+ * caller has already found the file by that point -- `contestFiles` builds the
+ * list itself -- so "not a variant" and "not ours" want the same handling.
+ */
+export function contestVariantId(name: string): string | undefined {
+  if (
+    !name.startsWith(VARIANT_PREFIX) ||
+    !name.endsWith(VARIANT_SUFFIX) ||
     // The affixes overlap on the canonical name itself, whose id is empty.
-    name !== CONTEST_MANIFEST &&
-    VARIANT_ID.test(name.slice(VARIANT_PREFIX.length, -VARIANT_SUFFIX.length))
-  );
+    name === CONTEST_MANIFEST
+  ) {
+    return undefined;
+  }
+  const id = name.slice(VARIANT_PREFIX.length, -VARIANT_SUFFIX.length);
+  return VARIANT_ID.test(id) ? id : undefined;
 }
 
 /** One problem as its contest declares it. */
@@ -139,6 +157,15 @@ export interface ProblemIdentity {
   readonly color?: string;
   readonly order: number;
   /**
+   * The variant file that named this problem, or undefined for the canonical.
+   *
+   * `order` is counted per contest file, so it only orders a problem among the
+   * others from the same file; this is the rest of that key. It is also what
+   * lets the selector head a variant's block with the id the user passes to
+   * `-C`, which is the only place the extension ever says a variant's name.
+   */
+  readonly variantId?: string;
+  /**
    * The contest root that named this problem, for grouping.
    *
    * Carried rather than re-derived from the package root: a contest is free to
@@ -159,6 +186,7 @@ export interface ProblemIdentity {
 export function problemIdentities(
   contestRoot: string,
   contest: ParsedContest,
+  variantId?: string,
 ): Map<string, ProblemIdentity> {
   const identities = new Map<string, ProblemIdentity>();
   for (const problem of contest.problems) {
@@ -171,6 +199,10 @@ export function problemIdentities(
         shortName: problem.shortName,
         color: problem.color,
         order: problem.order,
+        // Spread rather than set outright: the field is optional, and a
+        // canonical identity carrying an explicit `variantId: undefined` would
+        // not deep-equal one that never had the key.
+        ...(variantId === undefined ? {} : { variantId }),
         contestRoot,
       });
     }

--- a/vscode/src/rbx/problems.test.ts
+++ b/vscode/src/rbx/problems.test.ts
@@ -239,3 +239,126 @@ test('a contest that names nothing usable costs its packages their letters only'
     ]);
   }
 });
+
+/** An identity a variant file named, rather than the canonical contest. */
+const variant = (
+  shortName: string,
+  order: number,
+  variantId: string,
+  contestRoot = '/c',
+) => ({
+  shortName,
+  order,
+  color: undefined,
+  variantId,
+  contestRoot,
+});
+
+test('names the variant in the heading, and heads the canonical bare', () => {
+  const choices = problemChoices(
+    ['/c/A', '/c/X'],
+    new Map([
+      ['/c/A', identity('A', 0)],
+      ['/c/X', variant('A', 0, 'div2')],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => [c.label, c.group]),
+    [
+      ['A', 'c'],
+      ['A', 'c (div2)'],
+    ],
+  );
+});
+
+test('keeps each variant whole instead of interleaving them by letter', () => {
+  // The case the union used to jumble: two disjoint divisions whose letters
+  // both start at A and whose `order` both start at 0. Sorting on order alone
+  // would read A, A, B, B with nothing saying which division either A is.
+  const choices = problemChoices(
+    ['/c/1a', '/c/1b', '/c/2a', '/c/2b'],
+    new Map([
+      ['/c/1a', variant('A', 0, 'div1')],
+      ['/c/1b', variant('B', 1, 'div1')],
+      ['/c/2a', variant('A', 0, 'div2')],
+      ['/c/2b', variant('B', 1, 'div2')],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => `${c.group}/${c.label}`),
+    ['c (div1)/A', 'c (div1)/B', 'c (div2)/A', 'c (div2)/B'],
+  );
+});
+
+test('puts the canonical block ahead of every variant', () => {
+  // Not alphabetical luck: `canonical` would sort after `beta` on the heading
+  // text, and the canonical block still has to come first.
+  const choices = problemChoices(
+    ['/c/z', '/c/b'],
+    new Map([
+      ['/c/b', variant('A', 0, 'beta')],
+      ['/c/z', identity('Z', 0)],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.group),
+    ['c', 'c (beta)'],
+  );
+});
+
+test('leaves a lone variant unheaded, like any single group', () => {
+  // A dispatcher with one variant has nothing to distinguish it from, so the
+  // heading would be chrome naming the only thing on offer.
+  const choices = problemChoices(
+    ['/c/A', '/c/B'],
+    new Map([
+      ['/c/A', variant('A', 0, 'div1')],
+      ['/c/B', variant('B', 1, 'div1')],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.group),
+    [undefined, undefined],
+  );
+});
+
+test('two contests in same-named directories keep their variants apart', () => {
+  // The headings collide -- they always have, and `renderSelector` merges them
+  // -- but the sort key is the full root, so neither contest's block is split
+  // in half by the other's.
+  const choices = problemChoices(
+    ['/x/c/A', '/y/c/A'],
+    new Map([
+      ['/x/c/A', variant('A', 0, 'div1', '/x/c')],
+      ['/y/c/A', variant('A', 0, 'div1', '/y/c')],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.root),
+    ['/x/c/A', '/y/c/A'],
+  );
+});
+
+test('orders a contest ahead of a longer-named one, variants and all', () => {
+  // The NUL in the group key is what makes this work: comparing `c (div2)`
+  // against `c2` as plain text would put the variant last, splitting `c` in
+  // half around a contest that has no business between its blocks.
+  const choices = problemChoices(
+    ['/r/c2/A', '/r/c/A', '/r/c/B'],
+    new Map([
+      ['/r/c2/A', identity('A', 0, undefined, '/r/c2')],
+      ['/r/c/A', identity('A', 0, undefined, '/r/c')],
+      ['/r/c/B', variant('B', 0, 'div2', '/r/c')],
+    ]),
+    () => '',
+  );
+  assert.deepStrictEqual(
+    choices.map((c) => c.group),
+    ['c', 'c (div2)', 'c2'],
+  );
+});

--- a/vscode/src/rbx/problems.ts
+++ b/vscode/src/rbx/problems.ts
@@ -43,8 +43,33 @@ interface ContestedEntry {
   readonly root: string;
   readonly label: string;
   readonly color?: string;
-  readonly group: string;
+  /** Orders the groups and decides where one ends; never shown. */
+  readonly groupKey: string;
+  /** What the `<optgroup>` heading reads; never ordered by. */
+  readonly groupLabel: string;
   readonly order: number;
+}
+
+/**
+ * The two halves of a group: what sorts it, and what it reads as.
+ *
+ * One string used to do both, back when a group was a contest root and its
+ * heading was that root's basename. A variant's heading now names the variant
+ * too, and the id sorts differently from the text around it, so the sort key
+ * has to stay the raw pair.
+ */
+function groupOf(identity: ProblemIdentity): { key: string; label: string } {
+  const base = path.basename(identity.contestRoot);
+  return identity.variantId === undefined
+    ? // The canonical's empty id sorts before every valid one (they must start
+      // with a letter), which is what puts its block first without a special
+      // case. The separator keeps `/a` + `bc` from keying the same as `/ab` +
+      // `c`, neither of which can contain it.
+      { key: `${identity.contestRoot}\u0000`, label: base }
+    : {
+        key: `${identity.contestRoot}\u0000${identity.variantId}`,
+        label: `${base} (${identity.variantId})`,
+      };
 }
 
 /** A package no contest named: nothing orders it but its own path. */
@@ -67,12 +92,21 @@ function compare(a: string, b: string): number {
 }
 
 /**
- * Order two contests the way their headings read.
+ * Order two groups the way their headings read.
  *
- * By basename first, because that is the whole of what the `<optgroup>` shows:
- * ordering by the full root would print `beta` above `alpha` for `/z/alpha` and
- * `/a/beta`. The full root then settles two contests in same-named directories,
- * whose headings collide anyway but must at least not shuffle.
+ * By the key's last segment first, because that is the contest directory's own
+ * name -- what heads the `<optgroup>` -- with the variant id after the NUL:
+ * ordering by the whole key would print `beta` above `alpha` for `/z/alpha` and
+ * `/a/beta`. Since the NUL sorts below every character a name may hold, this
+ * one comparison orders by contest name and then by variant, which is what puts
+ * `c` before `c2` and the canonical `c` before `c (div2)` alike.
+ *
+ * The whole key then settles two contests in same-named directories, whose
+ * headings collide anyway but must at least not shuffle.
+ *
+ * Variants sort among themselves by id, which is the filename order
+ * `contestFiles` merged in, so the blocks read in the order first-wins
+ * resolved them.
  */
 function compareGroups(a: string, b: string): number {
   return compare(path.basename(a), path.basename(b)) || compare(a, b);
@@ -95,6 +129,10 @@ export function problemChoices(
       // name says which problem it actually is. A package that declares no
       // name keeps the bare letter rather than growing an empty separator.
       const declared = name(root);
+      // The contest file that named the problem, not the problem's parent: a
+      // contest may nest its problems, so the root's parent directory is
+      // neither the contest's name nor unique across contests.
+      const group = groupOf(identity);
       contested.push({
         root,
         label:
@@ -102,26 +140,23 @@ export function problemChoices(
             ? identity.shortName
             : `${identity.shortName}${NAME_SEPARATOR}${declared}`,
         color: identity.color,
-        // The contest that named the problem, not the problem's parent: a
-        // contest may nest its problems, and the intermediate directory is
-        // neither the contest's name nor unique across contests.
-        group: identity.contestRoot,
+        groupKey: group.key,
+        groupLabel: group.label,
         order: identity.order,
       });
     }
   }
 
   contested.sort((a, b) => {
-    const group = compareGroups(a.group, b.group);
+    const group = compareGroups(a.groupKey, b.groupKey);
     if (group !== 0) {
       return group;
     }
-    // `order` is counted per contest file, and `indexContests` merges a
-    // dispatcher's variants (`contest.div1.rbx.yml`, `contest.div2.rbx.yml`)
-    // into one index, so two problems in the same group really can both claim
-    // order 1. Falling through to the label and then the root keeps the
-    // dropdown from reshuffling with whatever order discovery happened to
-    // yield -- these tie-breaks are not redundant.
+    // A group is one contest file and `order` is counted per file, so within a
+    // group it decides outright -- a dispatcher's variants no longer share one.
+    // The tie-breaks stay for the file that names one directory twice, where
+    // `problemIdentities` keeps the first block's letter but the second entry
+    // still counted an order of its own.
     return a.order - b.order || compare(a.label, b.label) || compare(a.root, b.root);
   });
   loose.sort((a, b) => compare(a.root, b.root));
@@ -131,7 +166,7 @@ export function problemChoices(
   // count as a group of their own even though they render without a heading --
   // a contest sitting flush against a run of bare folder names is the case a
   // heading most needs to explain.
-  const groups = new Set(contested.map((entry) => entry.group));
+  const groups = new Set(contested.map((entry) => entry.groupKey));
   const grouped = groups.size + (loose.length > 0 ? 1 : 0) > 1;
 
   // Mapped per array rather than over the concatenation: only a contested
@@ -144,7 +179,7 @@ export function problemChoices(
       root: entry.root,
       label: entry.label,
       color: entry.color,
-      group: grouped ? path.basename(entry.group) : undefined,
+      group: grouped ? entry.groupLabel : undefined,
     })),
     ...loose.map((entry) => ({
       root: entry.root,


### PR DESCRIPTION
Closes #745.

## What #745 asked

"Understand how the VS Code extension behaves with variants." The audit found
that variants reach exactly one place: the problem selector. The extension is a
pure reader -- it never spawns rbx, never reads `-C`/`RBX_CONTEST` -- and the
run artifacts it watches (`<pkg>/.rbx/runs`, `<pkg>/build/testset.yml`) are
variant-invariant, and stay so under the split planned in #753.

So `contestIndex.ts` reads the canonical `contest.rbx.yml` *and* every sibling
`contest.<id>.rbx.yml` and merges them first-wins. That union is deliberate and
stays. What it cost was telling the variants apart afterwards:

- every variant collapsed into one `<optgroup>` keyed by the contest root, so
  nothing said whether a letter came from `div1` or `div2`;
- `order` is counted per contest file, so both divisions' first problems claimed
  `0` and the sort fell through to label and root, interleaving them as
  `A`, `A`, `B`, `B`.

## What this does

Groups by *contest file* rather than contest root.

```
mycontest (div1)        mycontest
  A · Two Sum             A · Two Sum      <- canonical block, bare heading
  B · Knapsack            B · Knapsack
mycontest (div2)        mycontest (div2)
  A · Warmup              A · Warmup       <- only what div2 adds
  B · Two Sum
```

- `contestVariantId(name)` is the new inverse of `isContestVariantFile`, and now
  the only definition of the two, so they cannot disagree about a
  `contest.div1.bak.rbx.yml`.
- `ProblemIdentity` gains an optional `variantId`, stamped on by `indexContests`
  from the filename it is already iterating. First-wins is untouched: a package
  both the canonical and `div2` name keeps the canonical identity and block.
- `problems.ts` splits the one `group` field into a sort key
  (`<root>\0<variantId>`) and a heading (`<basename> (<id>)`). The canonical's
  empty id sorts its block first with no special case, and the NUL makes one
  basename comparison order by contest name and then by variant -- which is what
  keeps `c (div2)` from landing after `c2`.
- Each group is now one contest file, so `order` no longer collides inside one.
  The `label`/`root` tie-breaks stay, but as belt-and-braces.

`commands.ts`'s "switch problem" quick-pick shows `problem.group` as its
description, so it gets the variant-qualified heading for free.

## Deliberately unchanged

- **The union.** Every variant's problems stay visible whichever one is selected.
- **"One group is no grouping".** A dispatcher holding a single
  `contest.div1.rbx.yml` renders headingless: nothing to distinguish it from.
- **`renderSelector`'s one-pass open/close**, which keys on the heading string
  and merges two same-named contest directories. That approximation predates
  this change and is neither worsened nor fixed here.

## Testing

`npm test` in `vscode/`: **439 pass, 0 fail** (10 new). Covers id extraction and
its rejections, the id surviving the merge, canonical-before-variants, disjoint
divisions staying contiguous, the lone-variant heading suppression, and the
`c` / `c (div2)` / `c2` ordering the NUL separator exists for.

`npm run typecheck` reports 159 errors both with and without this change -- all
pre-existing, in webview test files missing node type declarations. `prettier
--check` likewise flags the same six files before and after, so nothing was
reformatted. `npm run lint` cannot run here (eslint is not installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfVUkW1XFa21FDpjZTnQh8