### PR TITLE
fix(moj): stop warning about math in sample explanations (#762)

### DIFF
--- a/docs/setters/packaging/moj.md
+++ b/docs/setters/packaging/moj.md
@@ -90,11 +90,6 @@ A few things to keep in mind:
   externalization produces) is rasterized to PNG for you. That needs `pdftoppm`, from poppler; a
   statement with PDF figures and no poppler installed refuses to package, naming the figures.
 
-!!! warning "No math in sample explanations"
-    MOJ renders sample explanations without math support, so `$x$` inside an explanation reaches
-    the student literally. Nothing in the package can fix it -- {{rbx}} just warns you when an
-    explanation contains math.
-
 ## Test groups and scoring
 
 Test groups are supported, and translate into MOJ's own scoring file for problems that score by

--- a/rbx/box/packaging/moj/CLAUDE.md
+++ b/rbx/box/packaging/moj/CLAUDE.md
@@ -375,12 +375,6 @@ converts with `pdftoppm -png -r 300 -singlefile` after `materialize`. A statemen
 with no PDF figure never probes for poppler; one that has them and no poppler
 **refuses to package**, naming the figures. SVG passes through untouched.
 
-### Known limitation: no math in sample notes
-
-`gen-problem-json.sh` renders notes **without** `--mathml`, unlike the body, so
-math inside an explanation reaches the student as a literal `\(x\)`. Nothing in
-the package can fix it; rbx warns when a note contains math.
-
 ## Out of scope
 
 - **Interactive.** `task_types()` is `[BATCH]`. MOJ's arbiter protocol (test in

--- a/rbx/box/packaging/moj/statement.py
+++ b/rbx/box/packaging/moj/statement.py
@@ -16,10 +16,8 @@ facts worth carrying in your head:
 """
 
 import pathlib
-import re
 from typing import Dict, Mapping, Optional
 
-from rbx import console
 from rbx.box.packaging.moj import naming, statement_assets
 from rbx.box.statements import export
 from rbx.box.statements.markdown_export import check_moj_gate, tex_to_markdown
@@ -124,11 +122,6 @@ def build_enunciado(
     return '\n\n'.join(part.strip() for part in parts if part.strip()) + '\n'
 
 
-# Rendered notes go through pandoc WITHOUT `--mathml` (`gen-problem-json.sh`),
-# unlike the body, so any math in one reaches the student as a literal `\(x\)`.
-_MATH = re.compile(r'\$[^$\n]+\$')
-
-
 def sample_note_name(index: int) -> str:
     """The test name a sample explanation pairs with.
 
@@ -153,14 +146,6 @@ def build_notes(explanations: Mapping[int, str]) -> Dict[str, str]:
         name = sample_note_name(index)
         markdown = tex_to_markdown(content).strip()
         check_moj_gate(markdown, block_name=f'explanation for {name}')
-        if _MATH.search(markdown):
-            console.console.print(
-                f'[warning]The explanation for [item]{name}[/item] contains math, '
-                'but MOJ renders sample notes without MathML (unlike the statement '
-                'body), so it will reach the student as literal '
-                '[item]\\(…\\)[/item].[/warning]\n'
-                '[warning]Rewrite it without math if that matters.[/warning]'
-            )
         notes[name] = markdown + '\n'
     return notes
 

--- a/tests/rbx/box/packaging/moj/test_statement.py
+++ b/tests/rbx/box/packaging/moj/test_statement.py
@@ -101,13 +101,12 @@ def test_explanations_are_converted_to_markdown():
     assert '**bold**' in notes['sample001']
 
 
-def test_a_note_carrying_math_warns_but_ships(capsys):
-    """gen-problem-json.sh renders notes WITHOUT --mathml, unlike the body, so
-    math reaches the student as a literal \\(x\\). Nothing in the package can fix
-    it."""
+def test_a_note_carrying_math_ships_without_a_warning(capsys):
+    """MOJ supports math in sample notes, so a note carrying it is shipped
+    as-is and says nothing."""
     notes = statement.build_notes({0: 'The answer is $x + y$.'})
-    assert notes
-    assert 'math' in capsys.readouterr().out.lower()
+    assert '$x + y$' in notes['sample001']
+    assert capsys.readouterr().out == ''
 
 
 def test_layout_uses_docs_as_the_remap_base_for_both_slots():


### PR DESCRIPTION
Closes #762.

MOJ partially supports math in sample notes, so the warning was misleading. This drops:

- the CLI warning in `rbx/box/packaging/moj/statement.py` (and the now-unused `re`/`console` imports)
- the "No math in sample explanations" admonition in `docs/setters/packaging/moj.md`
- the matching "Known limitation" section in `rbx/box/packaging/moj/CLAUDE.md`

The test that asserted the warning now asserts the note ships as-is and nothing is printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01876KWf8jvMzdrr8pJgyFTz