### PR TITLE
feat(moj): fill the package author from vars.author

### DIFF
--- a/docs/setters/packaging/moj.md
+++ b/docs/setters/packaging/moj.md
@@ -90,22 +90,6 @@ A few things to keep in mind:
   externalization produces) is rasterized to PNG for you. That needs `pdftoppm`, from poppler; a
   statement with PDF figures and no poppler installed refuses to package, naming the figures.
 
-## Author
-
-Every MOJ package carries an `author` file, and MOJ refuses one that is empty. {{rbx}} fills it
-from the `author` package variable:
-
-```yaml title="problem.rbx.yml"
-vars:
-  author: "Ada Lovelace"
-```
-
-It is the same variable your statement can render as `\VAR{author}`, so the name in the package
-and the name in the statement never drift apart.
-
-A problem that declares no such variable packages anyway, with a placeholder author of
-`Unknown` -- MOJ needs *something* there, and you can still fix it on the server.
-
 ## Test groups and scoring
 
 Test groups are supported, and translate into MOJ's own scoring file for problems that score by

--- a/docs/setters/packaging/moj.md
+++ b/docs/setters/packaging/moj.md
@@ -90,6 +90,22 @@ A few things to keep in mind:
   externalization produces) is rasterized to PNG for you. That needs `pdftoppm`, from poppler; a
   statement with PDF figures and no poppler installed refuses to package, naming the figures.
 
+## Author
+
+Every MOJ package carries an `author` file, and MOJ refuses one that is empty. {{rbx}} fills it
+from the `author` package variable:
+
+```yaml title="problem.rbx.yml"
+vars:
+  author: "Ada Lovelace"
+```
+
+It is the same variable your statement can render as `\VAR{author}`, so the name in the package
+and the name in the statement never drift apart.
+
+A problem that declares no such variable packages anyway, with a placeholder author of
+`Unknown` -- MOJ needs *something* there, and you can still fix it on the server.
+
 ## Test groups and scoring
 
 Test groups are supported, and translate into MOJ's own scoring file for problems that score by

--- a/rbx/box/packaging/moj/CLAUDE.md
+++ b/rbx/box/packaging/moj/CLAUDE.md
@@ -386,6 +386,16 @@ converts with `pdftoppm -png -r 300 -singlefile` after `materialize`. A statemen
 with no PDF figure never probes for poppler; one that has them and no poppler
 **refuses to package**, naming the figures. SVG passes through untouched.
 
+## `author`
+
+MOJ hard-requires a non-empty `author` file. rbx has no first-class author field, so
+`_author()` reads the `author` package **var** -- the same one a statement renders as
+`\VAR{author}`, which is why it is a var rather than a new schema field: one place to
+say the name, and the package and the statement cannot drift. Any primitive is
+stringified (`vars` is untyped by design, and a name that parses as a number is still a
+name); an absent or blank-once-stripped var falls back to `Unknown`, since an empty
+`author: ""` must not travel through as an empty file that `validate-problem.sh` rejects.
+
 ## Out of scope
 
 - **Interactive.** `task_types()` is `[BATCH]`. MOJ's arbiter protocol (test in

--- a/rbx/box/packaging/moj/packager.py
+++ b/rbx/box/packaging/moj/packager.py
@@ -48,9 +48,16 @@ from rbx.box.statements.schema import (
 )
 from rbx.config import get_default_app_path, get_testlib
 
-# rbx has no author field, and MOJ hard-requires the file, so a visible placeholder
-# keeps validate-problem.sh green until the setter fills it in on the server.
-DEFAULT_AUTHOR = 'Unknown\n'
+# The package var the setter puts their name in. rbx has no first-class author field,
+# and `vars` is where a problem already carries free-form metadata the statement can
+# render (`\VAR{author}`), so MOJ's `author` file reads the same var rather than
+# introducing a second place to say the same thing.
+AUTHOR_VAR = 'author'
+
+# MOJ hard-requires the file, so a package with no `vars.author` still gets a visible
+# placeholder that keeps validate-problem.sh green until the setter fills it in on the
+# server.
+DEFAULT_AUTHOR = 'Unknown'
 
 # `ULIMITS[-f]` in KB, and deliberately a **fixed, generous** number rather than the
 # problem's `outputLimit`.
@@ -652,8 +659,23 @@ class MojPackager(BasePackager):
             json.dumps(meta, ensure_ascii=False, indent=2) + '\n'
         )
 
+    def _author(self) -> str:
+        """The `author` file's contents, taken from `vars.author`.
+
+        Any primitive var is accepted and stringified -- `vars` is untyped by design,
+        and a name that happens to parse as a number is still a name. A var that is
+        absent, or that is blank once stripped, falls back to `DEFAULT_AUTHOR`: MOJ
+        requires the file to be non-empty, so an empty `author: ""` must not travel
+        through as an empty file.
+        """
+        author = package.find_problem_package_or_die().expanded_vars.get(AUTHOR_VAR)
+        if author is None:
+            return DEFAULT_AUTHOR
+        author = str(author).strip()
+        return author or DEFAULT_AUTHOR
+
     def _write_metadata(self, into_path: pathlib.Path) -> None:
-        (into_path / 'author').write_text(DEFAULT_AUTHOR)
+        (into_path / 'author').write_text(self._author() + '\n')
         (into_path / 'tags').write_text('')
         self._write_moj_meta(into_path)
         self._write_statement(into_path)

--- a/tests/rbx/box/packaging/moj/test_packager.py
+++ b/tests/rbx/box/packaging/moj/test_packager.py
@@ -64,6 +64,43 @@ def test_writes_the_mandatory_metadata_files(moj_package):
     assert (moj_package / 'tags').exists()
 
 
+def test_writes_the_author_from_vars(testing_pkg, tmp_path):
+    minimal_package(testing_pkg)
+    testing_pkg.yml.vars = {'author': 'Ada Lovelace'}
+    testing_pkg.save()
+
+    moj_package = run_packager(
+        testing_pkg, tmp_path, build_entries(tmp_path, ['samples'])
+    )
+
+    assert (moj_package / 'author').read_text() == 'Ada Lovelace\n'
+
+
+def test_falls_back_to_a_placeholder_author_without_the_var(testing_pkg, tmp_path):
+    # MOJ requires a non-empty `author`, so a package that never declared one still
+    # has to produce something validate-problem.sh accepts.
+    minimal_package(testing_pkg)
+    testing_pkg.save()
+
+    moj_package = run_packager(
+        testing_pkg, tmp_path, build_entries(tmp_path, ['samples'])
+    )
+
+    assert (moj_package / 'author').read_text() == 'Unknown\n'
+
+
+def test_falls_back_to_a_placeholder_author_for_a_blank_var(testing_pkg, tmp_path):
+    minimal_package(testing_pkg)
+    testing_pkg.yml.vars = {'author': '   '}
+    testing_pkg.save()
+
+    moj_package = run_packager(
+        testing_pkg, tmp_path, build_entries(tmp_path, ['samples'])
+    )
+
+    assert (moj_package / 'author').read_text() == 'Unknown\n'
+
+
 def test_falls_back_to_the_dummy_statement_without_statements(moj_package):
     # MOJ requires the two headings, so a package that declares no statement at
     # all must still produce a valid enunciado.md.


### PR DESCRIPTION
MOJ hard-requires a non-empty `author` file, and rbx always wrote `Unknown` into it.

This reads the `author` **package var** instead — the same var a statement renders as `\VAR{author}`, so the name in the package and the name in the statement cannot drift apart:

```yaml title="problem.rbx.yml"
vars:
  author: "Ada Lovelace"
```

Any primitive is stringified (`vars` is untyped by design, and a name that parses as a number is still a name). A var that is absent, or blank once stripped, falls back to the `Unknown` placeholder — an empty `author: ""` must not travel through as an empty file that `validate-problem.sh` rejects.

Also documented in `docs/setters/packaging/moj.md` and `rbx/box/packaging/moj/CLAUDE.md`, with tests for the three cases (var present / absent / blank).

Verified: `uv run pytest tests/rbx/box/packaging/moj/` → 171 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013st32U3G2vyDrtDmAi7q9L