### PR TITLE
fix(moj): rename java sources to their public class in the jail

### DIFF
--- a/rbx/box/packaging/moj/CLAUDE.md
+++ b/rbx/box/packaging/moj/CLAUDE.md
@@ -307,6 +307,16 @@ Java and Kotlin build a **manifest jar** so `run.sh` is just `java -jar`. This f
 `lang/java/compile.sh`, which elects the main class by grepping for `main` and falling
 back to `ls *.class` — locale-dependent once javac emits nested `Main$X.class`.
 
+**Java sources are renamed to their public type inside the jail**, by
+`scripts/java/compile.sh`, before javac runs. javac is the only party that requires the
+two to agree: rbx names a solution file after the *solution*
+(`vinicius_fastIO.java` holding `public class Main`) and MOJ reads the name only to pick
+the language, so the mismatch is expected and would otherwise be a hard compile error —
+on a packaged solution during calibration, and equally on a contestant's submission
+whose file name is not their class. Doing it in the jail rather than at package time is
+what keeps both cases covered, and avoids the collision a host-side rename would create
+the moment two solutions both declare `public class Main`.
+
 ## Statements (`statement.py`, `statement_assets.py`)
 
 `statement_export_params()` forces externalize+demacro exactly as

--- a/rbx/box/packaging/moj/packager.py
+++ b/rbx/box/packaging/moj/packager.py
@@ -1305,9 +1305,9 @@ class MojPackager(BasePackager):
                     f'[error]Cannot package for MOJ: {solution.href()} and '
                     f'[item]{written[tag][basename]}[/item] would both be written to '
                     f'[item]sols/{tag}/{basename}[/item].[/error]\n'
-                    '[error]MOJ derives the language from the file name, and Java '
-                    'requires it to match the public class, so rbx will not rename '
-                    'them. Give one of them a different file name.[/error]'
+                    '[error]MOJ derives the language from the file name, so rbx ships '
+                    'each solution under its own name rather than renaming them. Give '
+                    'one of them a different file name.[/error]'
                 )
                 raise typer.Exit(1)
             written[tag][basename] = solution.path

--- a/rbx/resources/packagers/moj/scripts/java/compile.sh
+++ b/rbx/resources/packagers/moj/scripts/java/compile.sh
@@ -8,6 +8,29 @@ cd /tmp/rwdir
 
 SRC=$(ls *.java 2>/dev/null | head -1)
 [[ -n "$SRC" ]] || exit 1
+
+# javac is the only party here that insists a source file be named after the public
+# type it declares. Neither rbx nor MOJ does: rbx names a solution file after the
+# solution (`vinicius_fastIO.java` holding `public class Main`), and MOJ reads the
+# name only to pick the language. Left alone, that mismatch is a hard compile error --
+# for a packaged solution during calibration, and equally for a contestant who
+# submitted a file whose name is not their class. So rename each source to the type it
+# declares before javac ever sees it.
+#
+# Only a `public` declaration starting a line counts, which is the shape javac accepts
+# anyway; a `public class` inside a comment or a string virtually never starts one.
+for src in *.java; do
+  klass=$(sed -n -E \
+    's/^[[:space:]]*public[[:space:]]+([a-z]+[[:space:]]+)*(class|interface|enum|record)[[:space:]]+([A-Za-z_$][A-Za-z0-9_$]*).*/\3/p' \
+    "$src" | head -1)
+  [[ -n "$klass" ]] || continue
+  [[ "$klass.java" != "$src" ]] || continue
+  # A name already taken is a conflict only javac can explain; leave it to say so.
+  [[ -e "$klass.java" ]] && continue
+  mv -f "$src" "$klass.java" || exit 1
+  [[ "$SRC" == "$src" ]] && SRC="$klass.java"
+done
+
 klass=$(basename "$SRC" .java)
 [[ -n "$klass" ]] || klass=Main
 

--- a/tests/rbx/box/packaging/moj/test_java_compile_script.py
+++ b/tests/rbx/box/packaging/moj/test_java_compile_script.py
@@ -1,0 +1,164 @@
+"""Exercises the Java `compile.sh` template that ships inside a MOJ package.
+
+The script runs in MOJ's jail against hard-coded `/tmp` paths, so the fixture rewrites
+those onto a temp dir and puts stubbed `javac`/`jar` on PATH. The `javac` stub
+reproduces the one rule this script exists to satisfy -- a source declaring a public
+type must be named after it -- and fails outright on a source marked `SYNTAX_ERROR`, so
+a genuinely broken submission stays broken.
+"""
+
+import pathlib
+import subprocess
+
+import pytest
+
+from rbx.config import get_default_app_path
+
+JAVAC_STUB = r"""#!/bin/bash
+for src in "$@"; do
+  grep -q SYNTAX_ERROR "$src" && { echo "$src:1: error: ';' expected" >&2; exit 1; }
+  klass=$(sed -n -E 's/^[[:space:]]*public[[:space:]]+([a-z]+[[:space:]]+)*(class|interface) ([A-Za-z_$][A-Za-z0-9_$]*).*/\3/p' "$src" | head -1)
+  base=$(basename "$src" .java)
+  if [[ -n "$klass" && "$klass" != "$base" ]]; then
+    echo "$src:1: error: class $klass is public, should be declared in a file named $klass.java" >&2
+    exit 1
+  fi
+  touch "$base.class"
+done
+exit 0
+"""
+
+JAR_STUB = r"""#!/bin/bash
+# `jar cfm <jar> <manifest> <files...>`: keep the manifest around and emit a stand-in.
+cp "$3" manifest-seen.txt
+touch "$2"
+exit 0
+"""
+
+MAIN_CLASS = 'public class Main {\n  public static void main(String[] a) {}\n}\n'
+
+
+@pytest.fixture
+def jail(tmp_path: pathlib.Path):
+    """A stand-in for MOJ's jail. Returns a runner taking the sources to compile and
+    handing back `(process, rwdir, stdout_of_the_script)`."""
+    rwdir = tmp_path / 'rwdir'
+    rwdir.mkdir()
+
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    for name, body in [('javac', JAVAC_STUB), ('jar', JAR_STUB)]:
+        stub = bin_dir / name
+        stub.write_text(body)
+        stub.chmod(0o755)
+
+    template = (
+        get_default_app_path() / 'packagers' / 'moj' / 'scripts' / 'java' / 'compile.sh'
+    )
+    script = tmp_path / 'compile.sh'
+    script.write_text(
+        template.read_text()
+        .replace('/tmp/rwdir', str(rwdir))
+        .replace('/tmp/stderrlog', str(tmp_path / 'stderrlog'))
+        .replace('/tmp/out', str(tmp_path / 'out'))
+    )
+
+    def run(sources):
+        for name, content in sources.items():
+            (rwdir / name).write_text(content)
+        proc = subprocess.run(
+            ['bash', str(script)],
+            capture_output=True,
+            text=True,
+            env={'PATH': f'{bin_dir}:/usr/bin:/bin'},
+        )
+        return proc, rwdir, (tmp_path / 'out').read_text()
+
+    return run
+
+
+def _manifest(rwdir: pathlib.Path) -> str:
+    return (rwdir / 'manifest-seen.txt').read_text()
+
+
+def test_source_named_after_its_public_class_is_left_alone(jail):
+    proc, rwdir, out = jail({'Main.java': MAIN_CLASS})
+
+    assert proc.returncode == 0
+    assert 'BIN=prog.jar' in out
+    assert (rwdir / 'Main.java').is_file()
+    assert _manifest(rwdir) == 'Main-Class: Main\n'
+
+
+def test_source_named_after_the_solution_is_renamed_to_its_public_class(jail):
+    # The shape rbx ships: `sols/good/<solution>.java` declaring `public class Main`.
+    proc, rwdir, out = jail({'vinicius_gpt_fastIO.java': MAIN_CLASS})
+
+    assert proc.returncode == 0
+    assert 'BIN=prog.jar' in out
+    assert not (rwdir / 'vinicius_gpt_fastIO.java').exists()
+    assert (rwdir / 'Main.java').read_text() == MAIN_CLASS
+    # The entry point follows the file, so `java -jar` still finds it.
+    assert _manifest(rwdir) == 'Main-Class: Main\n'
+
+
+def test_rename_follows_a_public_class_that_is_not_called_main(jail):
+    proc, rwdir, out = jail(
+        {'sol.java': 'public class Solucao {\n  static void main(String[] a) {}\n}\n'}
+    )
+
+    assert proc.returncode == 0
+    assert 'BIN=prog.jar' in out
+    assert (rwdir / 'Solucao.java').is_file()
+    assert _manifest(rwdir) == 'Main-Class: Solucao\n'
+
+
+def test_source_with_no_public_class_keeps_its_name(jail):
+    # A package-private class needs no agreement with the file name, and renaming it
+    # would point the manifest at a class javac never emits.
+    proc, rwdir, out = jail(
+        {'sol.java': 'class Sol {\n  public static void main(String[] a) {}\n}\n'}
+    )
+
+    assert proc.returncode == 0
+    assert 'BIN=prog.jar' in out
+    assert (rwdir / 'sol.java').is_file()
+    assert _manifest(rwdir) == 'Main-Class: sol\n'
+
+
+def test_a_public_class_mentioned_in_a_comment_does_not_drive_the_rename(jail):
+    proc, rwdir, _ = jail(
+        {'Main.java': '// see public class Helper for the details\n' + MAIN_CLASS}
+    )
+
+    assert proc.returncode == 0
+    assert (rwdir / 'Main.java').is_file()
+    assert not (rwdir / 'Helper.java').exists()
+
+
+def test_helper_sources_are_renamed_too_without_stealing_the_entry_point(jail):
+    proc, rwdir, out = jail(
+        {'a_main.java': MAIN_CLASS, 'z_helper.java': 'public final class Helper {}\n'}
+    )
+
+    assert proc.returncode == 0
+    assert 'BIN=prog.jar' in out
+    assert (rwdir / 'Main.java').is_file()
+    assert (rwdir / 'Helper.java').is_file()
+    # `a_main.java` sorted first, so it stays the entry point under its new name.
+    assert _manifest(rwdir) == 'Main-Class: Main\n'
+
+
+def test_a_real_compile_error_still_fails(jail):
+    # Renaming must not paper over a source that simply does not compile.
+    proc, _, out = jail({'sol.java': 'public class Main { SYNTAX_ERROR }\n'})
+
+    assert proc.returncode != 0
+    assert 'BIN=' not in out
+
+
+def test_no_java_source_at_all_is_a_compile_error(jail):
+    proc, _, out = jail({})
+
+    assert proc.returncode != 0
+    assert 'BIN=' not in out


### PR DESCRIPTION
## Problem

Packaging a problem with a Java solution whose file name doesn't match its public class fails at compile time:

```
vinicius_gpt_fastIO.java:8: error: class Main is public, should be declared in a file named Main.java
public class Main {
       ^
```

rbx deliberately does **not** rename solution files (`_write_solutions` documents this), and MOJ reads the file name only to pick the language. javac is the only party that requires the two to agree — so the mismatch is expected and was a hard compile error.

It hit two cases: a packaged solution during calibration, and a **contestant** whose submitted file name isn't their class (an unfair Compilation Error).

## Fix

`rbx/resources/packagers/moj/scripts/java/compile.sh` now renames each source to the public type it declares before javac runs, tracking the entry point so the jar manifest's `Main-Class` still follows it. Sources with no public type, or already matching, are untouched; a name collision is left for javac to explain.

Doing it **in the jail** rather than at package time is what covers the contestant case too, and it avoids the collision a host-side rename would create the moment two solutions both declare `public class Main` — which `_write_solutions` would then reject.

## Verification

Reproduced the original failure against a real JDK 24, then confirmed the fix end to end: `BIN=prog.jar`, and `echo 42 | java -jar prog.jar` → `hello 42`.

New `tests/rbx/box/packaging/moj/test_java_compile_script.py` runs the shipped script against a stubbed jail (8 cases: rename, no-rename, `public class` in a comment, helper sources, real compile error, no sources). MOJ packaging suite: 72 passed. Ruff clean.

Also updated the now-stale rationale in the `_write_solutions` collision error (it claimed Java requires the name to match) and documented the jail-side rename in `rbx/box/packaging/moj/CLAUDE.md`.

> [!NOTE]
> Existing MOJ problems carry the old script — they need `rbx package moj` + re-upload to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMM5uXB6wcb2ssatshnsn2