### PR TITLE
feat(moj): download a contestant's submission with `@moj/<contest>/<id>`

### DIFF
--- a/docs/plans/2026-08-24-moj-submission-download-design.md
+++ b/docs/plans/2026-08-24-moj-submission-download-design.md
@@ -1,0 +1,176 @@
+# Downloading a MOJ submission: `@moj/<cid>/<subid>`
+
+`@boca/<run>` pulls a contestant's submission out of BOCA and hands it to `rbx run`,
+`rbx stress` and `rbx download remote` as an ordinary solution path. MOJ has no
+counterpart. This design adds one.
+
+The shape is deliberately the same as BOCA's -- a new `Expander` in
+[`rbx/box/remote.py`](../../rbx/box/remote.py), the same review gate, the same cache
+directory. What differs is everything underneath, because MOJ is a REST API with roles
+rather than a scraped PHP form.
+
+## What MOJ actually offers
+
+Read from the **public OpenAPI spec** (`https://moj.naquadah.com.br/api/openapi.json`,
+221 paths, served by the Swagger page at `/api/`), the shipped CLI layers (`moj`,
+`moj-contest`, `moj-judges`, `moj-comp`, build `b6b0c21-20260821`), the contest
+front-end (`/contest/**/*.js`, `/shared/submission-links.js`) and live probes against
+`treino` on 2026-08-24.
+
+| Endpoint | What it gives |
+|---|---|
+| `GET /api/v1/submission/source?contest=&id=&time=` | The submission's source, `text/plain`. Bearer auth. |
+| `GET /api/v1/contest/history?contest=` | **Your own** submissions, 7-field TXT. |
+| `GET /api/v1/contest/allsubmissions?contest=` | **Everyone's**, 9-field TXT. Judge-gated. |
+| `GET /api/v1/auth/status?contest=` | `login` + the role booleans. |
+
+Verified behaviour of `/submission/source`:
+
+| Case | Response |
+|---|---|
+| No `Authorization` header | `401 auth_required` |
+| Unknown contest | `404 contest_notfound` |
+| Missing `id` | `400 id_missing` |
+| `id` not 32 lowercase hex | `400 id_invalid` |
+| Well-formed `id`, no such source | `404 source_notfound` |
+| Success | `200 text/plain`, **no `Content-Disposition`** |
+
+The id is an md5 digest: `handlers/submit.sh` "valida + gera id (md5)" and the daemon
+archives the source at `users/<login>/submissions/<id>.<ext>` (`FLOW.md`). The `time`
+parameter is the submission's epoch and is **optional** -- format validation passes
+without it -- but MOJ's own front-end always sends it, so rbx does too.
+
+### Who may read a submission
+
+Roles are a login suffix **inside a contest**: `.admin`, `.judge`, `.cjudge` (chief),
+`.staff`, `.cstaff`, `.mon`, `.animeitor`. A plain `.judge` is enough: `contest/judge/judge.js`
+lists every submission through `/contest/allsubmissions` and renders `srcLink()` -- the
+same `/submission/source` call -- for each row. What a plain judge loses is **identity,
+not code**: the server blanks `username`/`fullname`/`univ` for judge and monitor, and
+fills them only for admin and chief.
+
+Confirmed live with a non-judge account: `/contest/allsubmissions` and
+`/contest/review/list` both answer `403 judge_required`.
+
+**Not verified, deliberately:** whether a plain participant is refused a *stranger's*
+source given a valid id. `/submission/summary` documents itself as "same gate as the log;
+third-party ids omitted", so `/submission/source` is near-certainly gated the same way --
+but a positive result from probing it would be a MOJ vulnerability report, not an rbx
+feature, so it went untested. Nothing below depends on the answer: rbx gates on the
+listing lookup regardless.
+
+### Sessions are per contest, and `moj login` does not create them
+
+`lib/core.sh` -- shared by all four CLI layers -- keeps **one token per contest**:
+
+- `CFG = ${MOJ_CONFIG_DIR:-$HOME/.config/moj}`, mode 700
+- `$CFG/token-<contest>`, umask 077
+- `$CFG/hdr-<contest>`, literally `Authorization: Bearer <tok>`, for `curl -H @file`
+- Legacy fallback `$CFG/token` / `$CFG/hdr`, **`treino` only**
+- Base URL `${MOJ_URL:-https://moj.naquadah.com.br}`; `MOJ_HOST` overrides the `Host` header
+
+`moj login` writes `token-treino` and nothing else. The command that creates a contest
+session is **`moj-contest login <cid>`**, which is a *separate artifact* from `moj`:
+`moj contest …` delegates to a `moj-contest` executable beside the script or on `PATH`,
+and dies with an install command when there is none.
+
+No CLI layer wraps `/submission/*` or `/contest/history`. Those two calls must be made
+directly; everything else goes through `moj-contest`.
+
+## Design
+
+### Reference syntax
+
+`@moj/<cid>/<subid>`, with `@moj/<subid>` resolving the contest from `MOJ_CONTEST`.
+
+The contest is part of the reference because a reference gets committed into
+`problem.rbx.yml`, where it has to still mean something a month later on someone else's
+machine. `<subid>` is checked against `^[0-9a-f]{32}$` before any network call: it is
+MOJ's own validation, so matching it locally turns a typo into an immediate error instead
+of a round-trip.
+
+There is deliberately **no** `extensions.moj.contest` field for the shorthand.
+`MOJ_CONTEST` is MOJ's own convention and every CLI layer already honours it; a second
+source of truth for "which contest" is the ambient state the explicit form exists to
+avoid.
+
+### Preconditions
+
+1. `moj contest -c <cid> --json whoami`. With `--json` before the subcommand this returns
+   the raw `/auth/status` body:
+
+   ```json
+   {"success":true,"logged_in":true,"login":"rsalesc","name":"Roberto Sales",
+    "contest":"treino","is_admin":false,"is_judge":false,"is_chief":false, …}
+   ```
+
+   Two failure modes, both exit 1: `camada 'contest' não instalada: curl -fLO …` when the
+   layer is missing, and `faça 'moj-contest login' primeiro.` when there is no session.
+   The first already carries its own fix and is passed through untouched. The second is
+   **replaced**, because the command it names does not take the contest and so does not
+   actually help; rbx says `moj-contest login <cid>` instead.
+
+2. Read `is_judge` / `is_admin` / `is_chief` out of that JSON. This is what selects the
+   listing endpoint below -- which is why shelling out here is load-bearing rather than a
+   presence check that could be an HTTP call instead.
+
+### Fetching
+
+1. Judge, chief or admin → `GET /contest/allsubmissions?contest=<cid>`.
+   Otherwise → `GET /contest/history?contest=<cid>`.
+2. Find the row whose subid matches; take `lang` and `epoch` from it. **A miss is the
+   error**: rbx reports that `<subid>` is not visible to `<login>` in `<cid>`, rather than
+   letting the source call answer a bare `404 source_notfound`, which cannot tell "no such
+   submission" from "not yours".
+3. `GET /submission/source?contest=<cid>&id=<subid>&time=<epoch>`.
+
+Both raw calls use `requests` (already a dependency) with the bearer token read from the
+token file, honouring `MOJ_CONFIG_DIR`, `MOJ_URL` and `MOJ_HOST` exactly as `lib/core.sh`
+does.
+
+### Parsing the history lines
+
+Both listings are colon-separated, and **the verdict may itself contain colons** -- MOJ
+documents this and its own `contest/contest.js` slices from the end to survive it. The
+7-field form (`tempo:user:probid:lang:verdict:epoch:subid`) is end-anchored parseable; the
+9-field form appends `fullname:univ`, so it is not. MOJ's `judge.js` splits the 9-field
+form positionally (`v[4]` verdict, `v[6]` id) and would mis-read such a row.
+
+rbx anchors on the pair instead, scanning for `:(\d{9,}):([0-9a-f]{32})(?::|$)`. A
+10-digit epoch followed by a 32-hex digest is unmistakable, and `lang` is field 3 from the
+front -- unambiguous, because the verdict is the only variable-width field and it sits
+*after* `lang`. One parser serves both formats.
+
+### Naming the file
+
+The endpoint sends no filename, so rbx builds one: `<subid>.<ext>` under
+`.remote/moj/<cid>/`. The extension comes from MOJ's `lang` through the mapping that
+already exists for packaging -- `normalize_moj_language` → `get_rbx_language_from_moj_language`
+→ `Language.extension` -- falling back to the raw `lang` lowercased, which is what the MOJ
+web UI does.
+
+`cacheable_globs` returns `.remote/moj/<cid>/<subid>.*`, so a second run does not
+re-download. `needs_review()` is `True`, as for BOCA: this is untrusted third-party code
+entering the package, which is the whole reason that hook exists.
+
+### Layout
+
+| File | Change |
+|---|---|
+| `rbx/box/runners/moj/cli.py` | `MOJ_CONTEST_ARGV`, `contest_whoami(cid) -> ContestWhoami` |
+| `rbx/box/tooling/moj/api.py` | token/base-URL resolution, `list_submissions`, `download_source` |
+| `rbx/box/remote.py` | `MojExpander`, registered after `BocaExpander` |
+| `rbx/box/completion/completers.py` | `('@moj/', …)` prefix |
+
+The completer is not optional: `enum_consistency_test.py` asserts that its prefix list
+mirrors `REGISTERED_EXPANDERS`.
+
+## Testing
+
+Stub-binary tests for `contest_whoami` -- success, missing layer, missing session, missing
+`-c` -- mirroring the existing MOJ CLI stub tests. Unit tests for the line parser (both
+widths, colon-bearing verdicts, absent id) and the reference parser (valid, bad hex, wrong
+length, shorthand with and without `MOJ_CONTEST`). HTTP mocked with `mock.patch`.
+
+No live-API test in the suite, matching how the rest of the MOJ integration is tested; a
+manual end-to-end run against `treino` gates the work instead.

--- a/docs/plans/2026-08-24-moj-submission-download-design.md
+++ b/docs/plans/2026-08-24-moj-submission-download-design.md
@@ -40,6 +40,19 @@ archives the source at `users/<login>/submissions/<id>.<ext>` (`FLOW.md`). The `
 parameter is the submission's epoch and is **optional** -- format validation passes
 without it -- but MOJ's own front-end always sends it, so rbx does too.
 
+### A pending submission has no source yet
+
+Found by the end-to-end run, not by reading: the daemon archives the source at **step 5**
+of judging, *after* it has a verdict. Ask for a submission still showing
+`Not Answered Yet` and the server answers `404 source_notfound` -- byte for byte the reply
+for an id that does not exist, about a submission rbx has just listed from the same
+server.
+
+So the listing row carries its verdict, and rbx refuses a pending download by name rather
+than passing that 404 on. The pending vocabulary is `moj-comp`'s own `_watch_verdict` set
+(`Not Answered Yet`, `On queue`, `Running`, empty), matched case-insensitively because
+that loop lists `On queue` and `on queue` both.
+
 ### Who may read a submission
 
 Roles are a login suffix **inside a contest**: `.admin`, `.judge`, `.cjudge` (chief),
@@ -174,3 +187,26 @@ length, shorthand with and without `MOJ_CONTEST`). HTTP mocked with `mock.patch`
 
 No live-API test in the suite, matching how the rest of the MOJ integration is tested; a
 manual end-to-end run against `treino` gates the work instead.
+
+### What the live run confirmed (2026-08-24)
+
+Against `treino`, as `rsalesc` (a plain competitor there):
+
+| Path | Result |
+|---|---|
+| `moj contest --json -c treino whoami` | the raw `/auth/status` JSON, role flags included |
+| no session for a contest | rbx's own `moj-contest login <cid>` message |
+| `/contest/allsubmissions` as a non-judge | `403 judge_required`, surfaced with MOJ's wording |
+| well-formed id, no such submission | reported by rbx before the download is attempted |
+| malformed id | refused locally, no request made |
+| `MOJ_CONTEST` shorthand | resolves, end to end through `rbx download remote` |
+| pending submission | "still judging", not MOJ's `404` |
+| **judged submission** | **downloaded byte-identical, named `<subid>.cpp`** |
+
+The success path was verified by submitting a throwaway to `rsalesc#rbxt-3b302f1b` -- one
+of rbx's own private, disposable problems -- and downloading it back. Note the history row
+spells the language `CPP`, uppercase, which is why the extension is derived through
+`normalize_moj_language` rather than used as it arrives.
+
+Still unverified: the judge listing (`/contest/allsubmissions` with a judge account) and
+therefore a download of *someone else's* submission. No judge account was available.

--- a/docs/plans/2026-08-24-moj-submission-download.md
+++ b/docs/plans/2026-08-24-moj-submission-download.md
@@ -1,0 +1,330 @@
+# `@moj/<cid>/<subid>` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let `rbx run`, `rbx stress` and `rbx download remote` take `@moj/<cid>/<subid>` and pull that contestant's source out of MOJ, the way `@boca/<run>` already does for BOCA.
+
+**Architecture:** A new `MojExpander` in `rbx/box/remote.py`. Preconditions and the caller's role come from shelling out to `moj contest -c <cid> --json whoami`; the two calls no CLI layer wraps -- the submission listing and the source download -- go over raw HTTP with the bearer token the `moj-contest` session left in `~/.config/moj/token-<cid>`.
+
+**Tech Stack:** Python 3, `requests` (already a dependency), `pydantic` v2 for the whoami model, `pytest` with a stub shell script standing in for the CLI.
+
+Design: [`2026-08-24-moj-submission-download-design.md`](2026-08-24-moj-submission-download-design.md).
+
+---
+
+## Things that will bite you
+
+**`--json` placement.** `moj --json contest whoami` **silently loses the flag**: `moj` consumes `--json` into a shell variable, then `exec`s `moj-contest` without it, and `RAW` is not exported. The working invocation is `moj contest --json -c <cid> whoami` -- flag *after* the layer name. Verified live on 2026-08-24. This means `contest_whoami` must call `_run_moj` and parse the JSON itself; it must **not** use `_run_moj_json`, which prepends a global `--json`.
+
+**Two failure modes, two different fixes.** `moj contest …` with no `moj-contest` on `PATH` exits 1 with `moj: camada 'contest' não instalada: curl -fLO https://moj.naquadah.com.br/moj-contest && chmod +x moj-contest`. With no session it exits 1 with `moj-contest: faça 'moj-contest login' primeiro.` The first message already carries its fix and is passed through. The second names a command that does not take a contest, so rbx replaces it with `moj-contest login <cid>`.
+
+**Colon-bearing verdicts.** Do not split history lines positionally. See Task 3.
+
+---
+
+## Task 1: `contest_whoami` in the CLI wrapper
+
+**Files:**
+- Modify: `rbx/box/runners/moj/cli.py`
+- Test: `tests/rbx/box/runners/moj/test_cli.py`
+
+**Step 1: Write the failing tests**
+
+Add to `test_cli.py`, next to the other stub-based tests. The canned body:
+
+```python
+_CONTEST_WHOAMI = (
+    '{"success":true,"logged_in":true,"login":"ana.judge","name":"Ana A",'
+    '"contest":"sbc2026","is_admin":false,"is_judge":true,"is_chief":false}\n'
+)
+```
+
+Four tests:
+
+```python
+async def test_contest_whoami_reads_the_role_flags(monkeypatch, tmp_path):
+    _stub_moj(monkeypatch, tmp_path, f"cat <<'EOF'\n{_CONTEST_WHOAMI}EOF\n")
+
+    who = await cli.contest_whoami('sbc2026')
+
+    assert who.login == 'ana.judge'
+    assert who.can_read_any_submission
+    # The flag goes AFTER `contest`: `moj --json contest ...` loses it entirely.
+    assert _stub_calls(tmp_path) == [['contest', '--json', '-c', 'sbc2026', 'whoami']]
+
+
+async def test_contest_whoami_says_how_to_log_in_when_there_is_no_session(
+    monkeypatch, tmp_path
+):
+    _stub_moj(
+        monkeypatch,
+        tmp_path,
+        "echo \"moj-contest: faça 'moj-contest login' primeiro.\" >&2\nexit 1\n",
+    )
+
+    with pytest.raises(MojCliError) as e:
+        await cli.contest_whoami('sbc2026')
+    # The CLI's own hint omits the contest, and so cannot be followed.
+    assert 'moj-contest login sbc2026' in str(e.value)
+
+
+async def test_contest_whoami_passes_through_the_missing_layer_message(
+    monkeypatch, tmp_path
+):
+    _stub_moj(
+        monkeypatch,
+        tmp_path,
+        "echo \"moj: camada 'contest' nao instalada: curl -fLO "
+        'https://moj.naquadah.com.br/moj-contest\\" >&2\nexit 1\n',
+    )
+
+    with pytest.raises(MojCliError) as e:
+        await cli.contest_whoami('sbc2026')
+    assert 'curl -fLO' in str(e.value)
+    assert 'moj-contest login' not in str(e.value)
+
+
+async def test_contest_whoami_refuses_output_that_is_not_json(monkeypatch, tmp_path):
+    _stub_moj(monkeypatch, tmp_path, "echo 'contest: sbc2026  login: ana'\n")
+
+    with pytest.raises(MojCliError):
+        await cli.contest_whoami('sbc2026')
+```
+
+**Step 2: Run to verify they fail**
+
+`uv run pytest tests/rbx/box/runners/moj/test_cli.py -k contest_whoami -v` → FAIL, `module 'cli' has no attribute 'contest_whoami'`.
+
+**Step 3: Implement**
+
+In `cli.py`:
+
+```python
+class ContestWhoami(BaseModel):
+    """`/auth/status` for one contest, as `moj contest --json whoami` relays it."""
+
+    model_config = ConfigDict(extra='ignore')
+
+    login: str
+    contest: Optional[str] = None
+    is_admin: bool = False
+    is_judge: bool = False
+    is_chief: bool = False
+
+    @property
+    def can_read_any_submission(self) -> bool:
+        """Whether this session may list submissions other than its own.
+
+        A plain `.judge` is enough: the contest's own judge screen lists every
+        submission through `/contest/allsubmissions` and links each one's source.
+        What a plain judge loses is the *identity* behind a row, not the code.
+        """
+        return self.is_judge or self.is_chief or self.is_admin
+```
+
+and, defaulting every flag to `False` so an older server that omits one reads as
+"no access" rather than failing to parse:
+
+```python
+_NO_SESSION_RE = re.compile(r'\blogin\b.*\bprimeiro\b', re.IGNORECASE)
+
+
+async def contest_whoami(contest: str) -> ContestWhoami:
+    try:
+        out = await _run_moj(['contest', '--json', '-c', contest, 'whoami'])
+    except MojNotInstalledError:
+        raise
+    except MojCliError as e:
+        if _NO_SESSION_RE.search(str(e)):
+            raise MojCliError(
+                f'There is no `moj` session for the contest `{contest}`.\n'
+                f'Log in with `moj-contest login {contest}` and try again.\n'
+                f'Note this is a *different* session from the one `moj login` '
+                f'creates, which only ever covers `treino`.'
+            ) from e
+        raise
+    try:
+        return ContestWhoami.model_validate(json.loads(out))
+    except (json.JSONDecodeError, ValidationError) as e:
+        raise MojCliError(
+            f'Could not read the output of `{MOJ_BINARY} contest --json -c '
+            f'{contest} whoami` as an auth status.\n{out.strip()}'
+        ) from e
+```
+
+`--json` goes after `contest` deliberately; comment it at the call site.
+
+**Step 4: Run to verify they pass**
+
+`uv run pytest tests/rbx/box/runners/moj/test_cli.py -v`
+
+**Step 5: Commit**
+
+```bash
+git add rbx/box/runners/moj/cli.py tests/rbx/box/runners/moj/test_cli.py
+git commit -m "feat(moj): read a contest session's role via \`moj contest whoami\`"
+```
+
+---
+
+## Task 2: Session file and base URL
+
+**Files:**
+- Create: `rbx/box/tooling/moj/__init__.py`, `rbx/box/tooling/moj/api.py`
+- Test: `tests/rbx/box/tooling/moj/__init__.py`, `tests/rbx/box/tooling/moj/test_api.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_token_comes_from_the_per_contest_file(monkeypatch, tmp_path):
+    monkeypatch.setenv('MOJ_CONFIG_DIR', str(tmp_path))
+    (tmp_path / 'token-sbc2026').write_text('tok-abc')
+
+    assert api.read_token('sbc2026') == 'tok-abc'
+
+
+def test_treino_falls_back_to_the_legacy_unsuffixed_token(monkeypatch, tmp_path):
+    # `lib/core.sh` keeps this fallback for `treino` and nothing else.
+    monkeypatch.setenv('MOJ_CONFIG_DIR', str(tmp_path))
+    (tmp_path / 'token').write_text('tok-legacy')
+
+    assert api.read_token('treino') == 'tok-legacy'
+    with pytest.raises(MojCliError):
+        api.read_token('sbc2026')
+
+
+def test_a_missing_token_says_which_login_command_makes_one(monkeypatch, tmp_path):
+    monkeypatch.setenv('MOJ_CONFIG_DIR', str(tmp_path))
+
+    with pytest.raises(MojCliError) as e:
+        api.read_token('sbc2026')
+    assert 'moj-contest login sbc2026' in str(e.value)
+
+
+def test_base_url_honours_moj_url(monkeypatch):
+    monkeypatch.setenv('MOJ_URL', 'http://localhost:8080/')
+    assert api.base_url() == 'http://localhost:8080'
+```
+
+**Step 2: Run to verify they fail.**
+
+**Step 3: Implement** in `api.py` -- mirroring `lib/core.sh`: `CFG = ${MOJ_CONFIG_DIR:-$HOME/.config/moj}`, `MOJ_URL` default `https://moj.naquadah.com.br` with trailing slashes stripped, and a `MOJ_HOST` header override. Token is `.strip()`ed (the CLI writes it with `printf`, no newline, but a hand-edited file may have one).
+
+**Step 4: Run. Step 5: Commit.**
+
+---
+
+## Task 3: The history line parser
+
+**Files:** same `api.py` / `test_api.py`.
+
+This is the part most likely to be got wrong, so it is its own task with its own tests.
+
+Both listings are colon-separated and **the verdict may contain colons**. The 7-field form is `tempo:user:probid:lang:verdict:epoch:subid`; the 9-field form appends `fullname:univ`, so it cannot be read from either end. Anchor on the `epoch:subid` pair instead -- a 10-digit number followed by a 32-hex digest -- and take `lang` as field 3 from the front, which is safe because the verdict is the only variable-width field and sits after it.
+
+**Step 1: Write the failing tests**
+
+```python
+_SUB = 'd89e6b7735c675fd7b50b3354ba64097'
+
+def test_parses_the_seven_field_own_history_form():
+    line = f'1755000000:ana:A:cpp:Accepted:1755000000:{_SUB}'
+    row = api.parse_submission_line(line)
+    assert row == api.SubmissionRow(subid=_SUB, lang='cpp', epoch=1755000000)
+
+
+def test_parses_the_nine_field_judge_form_with_trailing_identity():
+    line = f'1755000000:ana:A:py:Wrong Answer:1755000000:{_SUB}:Ana A:UFPB'
+    assert api.parse_submission_line(line).lang == 'py'
+
+
+def test_survives_a_verdict_containing_a_colon():
+    # MOJ documents this; its own judge.js splits positionally and gets it wrong.
+    line = f'1755000000:ana:A:java:Judge Error: No_Servers:1755000000:{_SUB}:Ana:U'
+    row = api.parse_submission_line(line)
+    assert row.subid == _SUB
+    assert row.lang == 'java'
+
+
+def test_returns_none_for_a_line_with_no_submission_id():
+    assert api.parse_submission_line('1755000000:ana:A:cpp:On queue::') is None
+```
+
+**Step 2: Run to verify they fail.**
+
+**Step 3: Implement**
+
+```python
+_ROW_RE = re.compile(r':(\d{9,}):([0-9a-f]{32})(?::|$)')
+
+
+def parse_submission_line(line: str) -> Optional[SubmissionRow]:
+    match = _ROW_RE.search(line)
+    if match is None:
+        return None
+    fields = line.split(':')
+    if len(fields) < 4:
+        return None
+    return SubmissionRow(
+        subid=match.group(2), lang=fields[3], epoch=int(match.group(1))
+    )
+```
+
+**Step 4: Run. Step 5: Commit.**
+
+---
+
+## Task 4: `list_submissions` and `download_source`
+
+**Files:** same `api.py` / `test_api.py`.
+
+`list_submissions(contest, token, any_submission: bool)` GETs `/contest/allsubmissions` when `any_submission`, `/contest/history` otherwise, and returns `Dict[str, SubmissionRow]` keyed by subid. `download_source(contest, token, row)` GETs `/submission/source?contest=&id=&time=`.
+
+Both send `Authorization: Bearer <token>`, add `Host` when `MOJ_HOST` is set, and raise `MojCliError` carrying the server's `error.message` when the body is the JSON error envelope. HTTP is mocked with `mock.patch('requests.get')`.
+
+Tests: the judge path hits `allsubmissions`; the non-judge path hits `history`; a 401/403/404 surfaces the server's message; a successful source download returns the text verbatim.
+
+Commit.
+
+---
+
+## Task 5: `MojExpander`
+
+**Files:**
+- Modify: `rbx/box/remote.py`, `rbx/box/completion/completers.py`
+- Test: `tests/rbx/box/test_remote.py` (create if absent), `tests/rbx/box/completion/enum_consistency_test.py:31-32`
+
+Reference grammar: `@moj/<cid>/<subid>` or `@moj/<subid>` with the contest from `MOJ_CONTEST`. `<subid>` must match `^[0-9a-f]{32}$` -- MOJ's own check, done locally so a typo costs no round-trip.
+
+`expand()`:
+1. Parse the ref; a bad one returns `None` (not this expander's).
+2. `await cli.contest_whoami(cid)`.
+3. `list_submissions(...)`; a subid that is not there errors with "not visible to `<login>` in `<cid>`" rather than letting the source call answer a bare `404`.
+4. `download_source(...)`, write to `.remote/moj/<cid>/<subid>.<ext>`.
+
+Extension: `normalize_moj_language` → `get_rbx_language_from_moj_language` → `Language.extension`, falling back to the raw `lang` lowercased.
+
+`needs_review()` returns `True` and `cacheable_globs` returns `.remote/moj/<cid>/<subid>.*`, both as BOCA does.
+
+Then update `_SOLUTION_PREFIXES` with `('@moj/', 'download a MOJ submission, e.g. @moj/<contest>/<id>')` and both assertions in `enum_consistency_test.py`.
+
+Commit.
+
+---
+
+## Task 6: Docs
+
+- `docs/setters/cheatsheet.md:38,56` -- a `@moj/` row beside each `@boca/` one.
+- `docs/setters/packaging/moj.md` -- a section on downloading a submission: the ref grammar, that it needs `moj-contest login <cid>` (*not* `moj login`), and that a judge sees everyone's code while everyone else sees only their own.
+
+Follow [`docs/plans/docs-writing-style-guide.md`](docs-writing-style-guide.md). Do not commit a regenerated `docs/setters/reference/cli.md`.
+
+Commit.
+
+---
+
+## Task 7: Verify
+
+1. `uv run pytest tests/rbx/box/runners/moj tests/rbx/box/tooling/moj tests/rbx/box/completion -v`
+2. `uv run ruff check . && uv run ruff format --check .`
+3. Manual end-to-end against `treino` with the live session, confirming the error path for an id that does not exist and the success path for one that does.

--- a/docs/setters/cheatsheet.md
+++ b/docs/setters/cheatsheet.md
@@ -36,6 +36,7 @@ Where a command has a page of its own, the :material-open-in-new: next to it tak
 | Run against a timing profile [:material-open-in-new:](/setters/profiling#using-profiles-when-running-solutions) | `rbx run -p icpc` |
 | Copy the run report to the clipboard [:material-open-in-new:](/setters/running#sharing-a-report) | `rbx run --share png` |
 | Run a submission downloaded from {{boca}} | `rbx run @boca/123` |
+| Run a submission downloaded from {{moj}} [:material-open-in-new:](/setters/packaging/moj#downloading-a-submission) | `rbx run @moj/<contest>/<id>` |
 | Run all solutions interactively [:material-open-in-new:](/setters/running#running-tests-with-custom-inputs) | `rbx irun` |
 | Choose solutions and run interactively | `rbx irun -c` |
 | Run solutions in a single testcase | `rbx irun -t samples/0` |
@@ -54,6 +55,7 @@ Where a command has a page of its own, the :material-open-in-new: next to it tak
 | Download {{tgen}} to the current folder | `rbx download tgen` |
 | Download a built-in {{testlib}} checker [:material-open-in-new:](/setters/grading/checkers) | `rbx download checker wcmp.cpp` |
 | Download a {{boca}} submission into the package | `rbx download remote @boca/123` |
+| Download a {{moj}} submission into the package [:material-open-in-new:](/setters/packaging/moj#downloading-a-submission) | `rbx download remote @moj/<contest>/<id>` |
 | Generate the `rbx.h` header in the package [:material-open-in-new:](/generators-and-rbx-h) | `rbx header` |
 | Build all statements [:material-open-in-new:](/setters/statements) | `rbx statements build` |
 | Build a specific variant [:material-open-in-new:](/setters/statements#keeping-two-recipes-for-one-language) | `rbx statements build <variant>` |

--- a/docs/setters/packaging/moj.md
+++ b/docs/setters/packaging/moj.md
@@ -239,6 +239,59 @@ Warnings go to stderr in this mode, and a problem that couldn't be read is repor
 instead of taking a line -- so whatever consumes the output never sees a problem pointing at an
 empty id.
 
+## Downloading a submission
+
+When a contestant's solution does something your testset didn't expect, you usually want to run
+it here rather than read it on the contest page. Point any command that takes a solution at
+`@moj/<contest>/<submission>` and {{rbx}} downloads the source into the package:
+
+```bash
+rbx run @moj/sbc2026/d89e6b7735c675fd7b50b3354ba64097
+rbx download remote @moj/sbc2026/d89e6b7735c675fd7b50b3354ba64097
+```
+
+The submission id is the 32-character hexadecimal string MOJ shows beside the submission. The
+downloaded file lands under the package's remote cache and, as with any downloaded code,
+{{rbx}} shows it to you for review before running it.
+
+If you work in one contest at a time, set `MOJ_CONTEST` and drop the contest from the reference:
+
+```bash
+export MOJ_CONTEST=sbc2026
+rbx run @moj/d89e6b7735c675fd7b50b3354ba64097
+```
+
+Prefer the long form in `problem.rbx.yml`. A reference you commit is read months later on
+someone else's machine, where nothing says which contest was meant.
+
+### Logging in to a contest
+
+Downloading needs a session **for that contest**, which is not the one `moj login` creates --
+that one covers the training area alone. Contest accounts are handed out by whoever runs the
+contest, and they log in through a second CLI, `moj-contest`:
+
+```bash
+moj-contest login sbc2026
+```
+
+Install it alongside `moj` if you don't have it yet:
+
+```bash
+curl -fLO https://moj.naquadah.com.br/moj-contest && chmod +x moj-contest
+```
+
+As with uploading, {{rbx}} reuses the session that command establishes and never handles your
+credentials.
+
+### What you're allowed to download
+
+**Judges see every submission in the contest.** If your contest account is a judge, a chief
+judge or an admin, any submission id in that contest downloads.
+
+**Everyone else sees only their own.** A submission id that isn't yours is reported as not found
+rather than downloaded, and {{rbx}} says which of the two cases it hit -- reading someone else's
+code needs a judge account, not a different reference.
+
 ## Troubleshooting
 
 ### My problem has a tight `outputLimit`, but MOJ doesn't enforce it

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ extra:
   codeforces: "[Codeforces](https://codeforces.com)"
   polygon: "[Polygon](https://polygon.codeforces.com)"
   boca: "[BOCA](https://github.com/cassiopc/boca)"
+  moj: "[MOJ](https://moj.naquadah.com.br)"
   testlib: "[testlib](https://codeforces.com/testlib)"
   jngen: "[jngen](https://github.com/ifsmirnov/jngen)"
   tgen: "[tgen](https://github.com/brunomaletta/tgen)"

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -82,7 +82,8 @@ def complete_problem(ctx: CompletionContext, incomplete: str) -> List[Completion
 # `@boca/` trails it (the order the engine emits, preserved by the shell scripts).
 _MAIN_PREFIX = ('@main', 'first accepted solution')
 _BOCA_PREFIX = ('@boca/', 'download a BOCA submission, e.g. @boca/123')
-_SOLUTION_PREFIXES = (_MAIN_PREFIX, _BOCA_PREFIX)
+_MOJ_PREFIX = ('@moj/', 'download a MOJ submission, e.g. @moj/<contest>/<id>')
+_SOLUTION_PREFIXES = (_MAIN_PREFIX, _BOCA_PREFIX, _MOJ_PREFIX)
 
 
 def _expand_solution_paths(root: Path, sol: dict):
@@ -119,6 +120,7 @@ def complete_solutions(ctx: CompletionContext, incomplete: str) -> List[Completi
                     seen.add(value)
                     items.append(CompletionItem(value, help=help_text))
     items.append(CompletionItem(_BOCA_PREFIX[0], help=_BOCA_PREFIX[1]))
+    items.append(CompletionItem(_MOJ_PREFIX[0], help=_MOJ_PREFIX[1]))
     return items
 
 

--- a/rbx/box/remote.py
+++ b/rbx/box/remote.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import re
 from abc import ABC, abstractmethod
@@ -6,9 +7,12 @@ from typing import List, Optional, Tuple, Union
 import typer
 
 from rbx import console, utils
-from rbx.box import cd, package
+from rbx.box import cd, environment, package
 from rbx.box.formatting import href, ref
+from rbx.box.runners.moj import cli
+from rbx.box.runners.moj.cli import MojCliError
 from rbx.box.tooling.boca.scraper import BocaRun
+from rbx.box.tooling.moj import api
 from rbx.box.ui.review_app import start_review
 
 PathLike = Union[str, pathlib.Path]
@@ -85,9 +89,126 @@ class BocaExpander(Expander):
         return sol_path
 
 
+class MojExpander(Expander):
+    """`@moj/<contest>/<submission>` -- a submission downloaded from MOJ.
+
+    The contest is part of the reference because a reference gets committed into
+    `problem.rbx.yml`, where it has to still mean something next month on someone
+    else's machine. `@moj/<submission>` is accepted as a shorthand and resolves the
+    contest from `MOJ_CONTEST`, the same variable every `moj` CLI layer reads.
+
+    Reaching MOJ needs a session **for that contest**, which `moj login` does not
+    create -- it covers `treino` alone. `moj-contest login <contest>` is the one
+    that does, and every failure here says so.
+    """
+
+    # `@moj/<contest>/<subid>` or `@moj/<subid>`. The contest is whatever MOJ
+    # accepts as a contest id, minus the `/` that separates the two.
+    MOJ_REGEX = re.compile(r'^@moj/(?:([^/]+)/)?([^/]+)$')
+
+    def needs_review(self) -> bool:
+        return True
+
+    def get_match(self, path_str: str) -> Optional[Tuple[str, str]]:
+        """`(contest, subid)`, or `None` when this is not a MOJ reference.
+
+        A malformed *submission id* raises rather than returning `None`: it is
+        unambiguously addressed to this expander, and falling through would report
+        it as "not a valid expansion", which says nothing about the real mistake.
+        The server's own rule is the one applied, so a typo costs no round-trip.
+        """
+        match = self.MOJ_REGEX.match(path_str)
+        if match is None:
+            return None
+
+        contest = match.group(1) or os.environ.get('MOJ_CONTEST')
+        if not contest:
+            raise MojCliError(
+                f'`{path_str}` does not say which MOJ contest it belongs to.\n'
+                f'Write it as `@moj/<contest>/{match.group(2)}`, or set '
+                f'`MOJ_CONTEST` in your environment.'
+            )
+
+        subid = match.group(2)
+        if not api.SUBID_RE.match(subid):
+            raise MojCliError(
+                f'`{subid}` is not a MOJ submission id: an id is exactly 32 '
+                f'lowercase hexadecimal characters.\nYou can copy one from the '
+                f'contest page, next to the submission.'
+            )
+        return contest, subid
+
+    def get_moj_folder(self, contest: str) -> pathlib.Path:
+        return self.get_remote_path(pathlib.Path('moj') / contest)
+
+    def cacheable_globs(self, path: pathlib.Path) -> List[str]:
+        match = self.get_match(str(path))
+        if match is None:
+            return []
+        contest, subid = match
+        return [str(self.get_moj_folder(contest) / subid) + '.*']
+
+    def expand(self, path: pathlib.Path) -> Optional[pathlib.Path]:
+        from rbx.box.packaging.moj import moj_language_utils
+
+        match = self.get_match(str(path))
+        if match is None:
+            return None
+        contest, subid = match
+
+        # Before the token is even read: this is what turns a missing session or a
+        # missing `moj-contest` into its own instruction, and it is also where the
+        # role comes from, which decides which listing below can be asked for.
+        who = cli.contest_whoami(contest)
+        token = api.read_token(contest)
+
+        rows = api.list_submissions(
+            contest, token, any_submission=who.can_read_any_submission
+        )
+        row = rows.get(subid)
+        if row is None:
+            # Asked here rather than left to the download, which answers a bare
+            # `404 source_notfound` that cannot tell "no such submission" from
+            # "not yours" -- and those have very different fixes.
+            scope = (
+                'this contest' if who.can_read_any_submission else 'your submissions'
+            )
+            raise MojCliError(
+                f'MOJ has no submission `{subid}` among {scope} in `{contest}`.\n'
+                f'You are logged in as `{who.login}`.'
+                + (
+                    ''
+                    if who.can_read_any_submission
+                    else "\nReading someone else's submission needs a judge "
+                    'account in that contest.'
+                )
+            )
+
+        source = api.download_source(contest, token, row)
+
+        # MOJ sends no filename with the source, so one is built. The extension
+        # comes from the language rbx would compile it with, falling back to MOJ's
+        # own id -- which is what its web UI names the download.
+        rbx_language = moj_language_utils.get_rbx_language_from_moj_language(
+            moj_language_utils.normalize_moj_language(row.lang)
+        )
+        extension = row.lang.lower()
+        if rbx_language is not None:
+            language = environment.get_language_or_nil(rbx_language)
+            if language is not None:
+                extension = language.extension
+
+        final_path = self.get_moj_folder(contest) / f'{subid}.{extension}'
+        final_path.parent.mkdir(parents=True, exist_ok=True)
+        final_path.write_text(source)
+        console.console.print(f'Downloaded {href(final_path)} from MOJ...')
+        return final_path
+
+
 REGISTERED_EXPANDERS: List['Expander'] = [
     MainExpander(),
     BocaExpander(),
+    MojExpander(),
 ]
 
 

--- a/rbx/box/remote.py
+++ b/rbx/box/remote.py
@@ -184,6 +184,16 @@ class MojExpander(Expander):
                 )
             )
 
+        if row.is_pending:
+            # The judging daemon archives the source only once it has a verdict,
+            # so downloading now would answer `404 source_notfound` -- the same
+            # reply as for an id that does not exist, about one just listed.
+            raise MojCliError(
+                f'MOJ is still judging submission `{subid}` (`{row.verdict}`).\n'
+                f'Its source is only downloadable once it has a verdict; try '
+                f'again in a moment.'
+            )
+
         source = api.download_source(contest, token, row)
 
         # MOJ sends no filename with the source, so one is built. The extension

--- a/rbx/box/runners/moj/cli.py
+++ b/rbx/box/runners/moj/cli.py
@@ -34,6 +34,7 @@ import json
 import pathlib
 import re
 import shlex
+import subprocess
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -341,34 +342,70 @@ async def _run_moj(args: Sequence[str]) -> str:
     except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
         # Caught at the spawn call specifically, so that a `FileNotFoundError`
         # raised by something deeper cannot be mislabelled as a missing CLI.
-        raise MojNotInstalledError(
-            f'Could not run `{MOJ_BINARY}`: the MOJ CLI is not installed, or is '
-            f'not on your `PATH`. Install it and run `moj login` before using '
-            f'the MOJ runner.'
-        ) from e
+        raise _not_installed_error(e) from e
 
     stdout, stderr = await process.communicate()
-    out = stdout.decode(errors='replace')
-    err = stderr.decode(errors='replace')
+    return _stdout_or_raise(
+        args,
+        process.returncode,
+        stdout.decode(errors='replace'),
+        stderr.decode(errors='replace'),
+    )
 
-    if process.returncode != 0:
-        # Both streams: the CLI's `die()` writes to stderr, but not every failure
-        # path goes through it, and a failure whose reason we dropped is a failure
-        # the setter cannot act on.
-        detail = '\n'.join(part.strip() for part in (err, out) if part.strip())
-        message = (
-            f'Command `{MOJ_BINARY} {shlex.join(args)}` failed with exit code '
-            f'{process.returncode}.'
+
+def _not_installed_error(e: BaseException) -> MojNotInstalledError:
+    """The failure to *spawn* the CLI, which is never a failure of the command."""
+    return MojNotInstalledError(
+        f'Could not run `{MOJ_BINARY}`: the MOJ CLI is not installed, or is '
+        f'not on your `PATH`. Install it and run `moj login` before using '
+        f'the MOJ runner.'
+    )
+
+
+def _stdout_or_raise(
+    args: Sequence[str], returncode: Optional[int], out: str, err: str
+) -> str:
+    """What the CLI printed, or the reason it failed.
+
+    Shared by the async and the sync spawners so that the two cannot disagree
+    about what a failure means -- the 429 in particular, which decides whether a
+    caller waits or gives up.
+    """
+    if returncode == 0:
+        return out
+
+    # Both streams: the CLI's `die()` writes to stderr, but not every failure
+    # path goes through it, and a failure whose reason we dropped is a failure
+    # the setter cannot act on.
+    detail = '\n'.join(part.strip() for part in (err, out) if part.strip())
+    message = (
+        f'Command `{MOJ_BINARY} {shlex.join(args)}` failed with exit code {returncode}.'
+    )
+    full = f'{message}\n{detail}' if detail else message
+    status = _HTTP_STATUS_RE.search(detail)
+    if status is not None and status.group(1) == _QUEUE_FULL_STATUS:
+        # Raised as its own type so a caller can wait it out. Everything else
+        # here is a mistake to report; this one is a queue to sit behind.
+        raise MojQueueFullError(full)
+    raise MojCliError(full)
+
+
+def _run_moj_sync(args: Sequence[str]) -> str:
+    """`_run_moj`, for the callers that cannot await.
+
+    Solution-path expansion (`rbx.box.remote`) is synchronous, and is itself
+    called from inside async code -- `compile.any` does -- so it can neither
+    `await` nor start a loop of its own. A second spawner is the small price;
+    the error handling above is shared, which is the part worth not duplicating.
+    """
+    try:
+        process = subprocess.run(
+            [MOJ_BINARY, *args], capture_output=True, text=True, errors='replace'
         )
-        full = f'{message}\n{detail}' if detail else message
-        status = _HTTP_STATUS_RE.search(detail)
-        if status is not None and status.group(1) == _QUEUE_FULL_STATUS:
-            # Raised as its own type so a caller can wait it out. Everything else
-            # here is a mistake to report; this one is a queue to sit behind.
-            raise MojQueueFullError(full)
-        raise MojCliError(full)
+    except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
+        raise _not_installed_error(e) from e
 
-    return out
+    return _stdout_or_raise(args, process.returncode, process.stdout, process.stderr)
 
 
 async def _run_moj_json(args: Sequence[str]) -> Any:
@@ -503,7 +540,7 @@ class ContestWhoami(BaseModel):
 _NO_SESSION_RE = re.compile(r'\blogin\b.*\bprimeiro\b', re.IGNORECASE)
 
 
-async def contest_whoami(contest: str) -> ContestWhoami:
+def contest_whoami(contest: str) -> ContestWhoami:
     """Who this machine is inside `contest`, and what it is allowed to read.
 
     Contest sessions are **not** the session `moj login` creates. That one covers
@@ -511,12 +548,16 @@ async def contest_whoami(contest: str) -> ContestWhoami:
     (`$CFG/token-<contest>`) and its own login command. Which is why a missing
     session here cannot be reported the way the rest of this module reports one.
 
+    Synchronous, alone among the wrappers here, because its caller is: solution
+    paths expand synchronously, from inside async code, so there is neither a
+    loop to await on nor room to start one.
+
     `--json` goes **after** `contest`, and that is load-bearing: `moj` parses the
     global flag into a shell variable and then `exec`s `moj-contest` without it,
     so `moj --json contest whoami` prints prose and parses as nothing.
     """
     try:
-        out = await _run_moj(['contest', '--json', '-c', contest, 'whoami'])
+        out = _run_moj_sync(['contest', '--json', '-c', contest, 'whoami'])
     except MojNotInstalledError:
         # No `moj` at all. Its own message installs the right thing; so does the
         # one for a missing `contest` *layer*, which arrives as a plain

--- a/rbx/box/runners/moj/cli.py
+++ b/rbx/box/runners/moj/cli.py
@@ -36,7 +36,7 @@ import re
 import shlex
 from typing import Any, Dict, List, Optional, Sequence, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from rbx.box.exception import RbxException
 
@@ -466,3 +466,83 @@ async def testrun(ref: Union[str, pathlib.Path], solution: pathlib.Path) -> str:
 async def testrun_status(run: str) -> TestrunStatus:
     """The state of a queued testrun. Poll until `done`, and bound the wait."""
     return TestrunStatus.model_validate(await _run_moj_json(['testrun-status', run]))
+
+
+class ContestWhoami(BaseModel):
+    """`/auth/status` for one contest, as `moj contest --json whoami` relays it.
+
+    Every role flag defaults to `False` rather than being required: a server that
+    predates one of them has to read as *no* access. The opposite default would
+    turn a missing field into a permission.
+    """
+
+    model_config = ConfigDict(extra='ignore')
+
+    login: str
+    contest: Optional[str] = None
+    is_admin: bool = False
+    is_judge: bool = False
+    is_chief: bool = False
+
+    @property
+    def can_read_any_submission(self) -> bool:
+        """Whether this session may list submissions other than its own.
+
+        A plain `.judge` is enough. The contest's own judge screen lists every
+        submission through `/contest/allsubmissions` and links each one's source;
+        what a plain judge loses is the *identity* behind a row -- the server
+        blanks `username`/`fullname`/`univ` for judge and monitor -- and never the
+        code. Chief and admin get the identities too, which rbx does not need.
+        """
+        return self.is_judge or self.is_chief or self.is_admin
+
+
+# The CLI's `need_login`: `die "faça '$MOJ_TOOL login' primeiro."`. Matched on the
+# two words that survive a rewording rather than on the sentence, and case-folded,
+# since the only cost of a false positive is a *better* message than the CLI's.
+_NO_SESSION_RE = re.compile(r'\blogin\b.*\bprimeiro\b', re.IGNORECASE)
+
+
+async def contest_whoami(contest: str) -> ContestWhoami:
+    """Who this machine is inside `contest`, and what it is allowed to read.
+
+    Contest sessions are **not** the session `moj login` creates. That one covers
+    `treino` and only `treino`; a contest gets its own account, its own token file
+    (`$CFG/token-<contest>`) and its own login command. Which is why a missing
+    session here cannot be reported the way the rest of this module reports one.
+
+    `--json` goes **after** `contest`, and that is load-bearing: `moj` parses the
+    global flag into a shell variable and then `exec`s `moj-contest` without it,
+    so `moj --json contest whoami` prints prose and parses as nothing.
+    """
+    try:
+        out = await _run_moj(['contest', '--json', '-c', contest, 'whoami'])
+    except MojNotInstalledError:
+        # No `moj` at all. Its own message installs the right thing; so does the
+        # one for a missing `contest` *layer*, which arrives as a plain
+        # `MojCliError` below and is likewise passed through.
+        raise
+    except MojCliError as e:
+        if _NO_SESSION_RE.search(str(e)):
+            raise MojCliError(
+                f'There is no MOJ session for the contest `{contest}`.\n'
+                f'Log in with `moj-contest login {contest}`, then try again.\n'
+                f'Note this is a different session from the one `moj login` '
+                f'creates: that one only ever covers `treino`.'
+            ) from e
+        raise
+
+    try:
+        parsed = json.loads(out)
+    except json.JSONDecodeError as e:
+        raise MojCliError(
+            f'Could not read the output of `{MOJ_BINARY} contest --json -c '
+            f'{contest} whoami` as JSON.\n{out.strip()}'
+        ) from e
+    try:
+        return ContestWhoami.model_validate(parsed)
+    except ValidationError as e:
+        raise MojCliError(
+            f'`{MOJ_BINARY} contest --json -c {contest} whoami` returned JSON '
+            f'without a login in it.\n{out.strip()}'
+        ) from e

--- a/rbx/box/tooling/moj/api.py
+++ b/rbx/box/tooling/moj/api.py
@@ -42,12 +42,33 @@ TREINO = 'treino'
 _TIMEOUT_S = 30
 
 
+# The verdicts that mean the judge has not finished. Taken from `moj-comp`'s own
+# `_watch_verdict`, which polls until the verdict leaves this set, and matched
+# case-insensitively because it lists `On queue` and `on queue` both.
+#
+# An empty verdict counts: the same loop treats it as still in flight.
+PENDING_VERDICTS = frozenset({'', 'not answered yet', 'on queue', 'running', 'judging'})
+
+
 class SubmissionRow(BaseModel):
     """One line of a MOJ history listing, reduced to what a download needs."""
 
     subid: str
     lang: str
     epoch: int
+    verdict: str = ''
+
+    @property
+    def is_pending(self) -> bool:
+        """Whether the judge is still working on this submission.
+
+        Worth knowing before a download, because the source is archived by the
+        judging daemon *after* it produces a verdict (`FLOW.md`, step 5). Ask for
+        a pending submission's source and MOJ answers `404 source_notfound` --
+        the same reply it gives for an id that does not exist, about one that
+        plainly does and that rbx has just listed.
+        """
+        return self.verdict.strip().lower() in PENDING_VERDICTS
 
 
 def config_dir() -> pathlib.Path:
@@ -162,11 +183,18 @@ def parse_submission_line(line: str) -> Optional[SubmissionRow]:
     match = _ROW_RE.search(line)
     if match is None:
         return None
-    fields = line.split(':')
-    if len(fields) < 4:
+
+    # Everything before the anchored pair is `tempo:user:probid:lang:verdict`,
+    # and the verdict is whatever is left once the four fixed fields are taken --
+    # which is how a verdict carrying colons survives being read.
+    fields = line[: match.start()].split(':')
+    if len(fields) < 5:
         return None
     return SubmissionRow(
-        subid=match.group(2), lang=fields[3], epoch=int(match.group(1))
+        subid=match.group(2),
+        lang=fields[3],
+        epoch=int(match.group(1)),
+        verdict=':'.join(fields[4:]),
     )
 
 

--- a/rbx/box/tooling/moj/api.py
+++ b/rbx/box/tooling/moj/api.py
@@ -1,0 +1,207 @@
+"""The two MOJ API calls no `moj` CLI layer wraps.
+
+Everything else rbx asks of MOJ goes through the judge's own CLI, so that
+credentials never pass through rbx (`rbx.box.runners.moj.cli`). Listing a
+contest's submissions and downloading one's source are the exceptions: `moj`,
+`moj-contest`, `moj-judges` and `moj-comp` between them expose no command that
+reaches `/contest/history`, `/contest/allsubmissions` or `/submission/source`.
+
+So these two go over HTTP, reusing the bearer token the CLI's own session left on
+disk. The layout is read off `lib/core.sh`, the core shared by all four layers,
+and this module mirrors it exactly -- including `MOJ_CONFIG_DIR`, `MOJ_URL` and
+`MOJ_HOST`, so that a setter pointing their CLI at a dev server points rbx at it
+too, and the legacy unsuffixed token file that exists for `treino` alone.
+
+**rbx never writes here.** It reads the token a `moj-contest login` created; it
+cannot create one, and says so when there is none.
+"""
+
+import os
+import pathlib
+import re
+from typing import Dict, Optional
+
+import requests
+from pydantic import BaseModel
+
+from rbx.box.runners.moj.cli import MojCliError
+
+# Mirrors `lib/core.sh`: `MOJ_URL="${MOJ_URL:-https://moj.naquadah.com.br}"`.
+DEFAULT_MOJ_URL = 'https://moj.naquadah.com.br'
+
+# Every path below is relative to this. The spec's own `servers` entry.
+API_PREFIX = '/api/v1'
+
+# `CONTEST="${MOJ_CONTEST:-treino}"` in the CLI -- and the one contest whose token
+# file may be unsuffixed, from before sessions were per-contest.
+TREINO = 'treino'
+
+# How long a single call may take. The listings are plain TXT and the sources are
+# capped at 1 MB server-side (`SUBMIT_MAX_KB`), so nothing here is a long read;
+# what this actually bounds is a hung or wrong `MOJ_URL`.
+_TIMEOUT_S = 30
+
+
+class SubmissionRow(BaseModel):
+    """One line of a MOJ history listing, reduced to what a download needs."""
+
+    subid: str
+    lang: str
+    epoch: int
+
+
+def config_dir() -> pathlib.Path:
+    """`CFG` in `lib/core.sh`."""
+    override = os.environ.get('MOJ_CONFIG_DIR')
+    if override:
+        return pathlib.Path(override)
+    return pathlib.Path.home() / '.config' / 'moj'
+
+
+def base_url() -> str:
+    """The server the CLI would talk to, without a trailing slash."""
+    return (os.environ.get('MOJ_URL') or DEFAULT_MOJ_URL).rstrip('/')
+
+
+def _headers(token: str) -> Dict[str, str]:
+    headers = {'Authorization': f'Bearer {token}'}
+    # `HDR=(-H "Host: $MOJ_HOST")` in the CLI: how a setter points a real client
+    # at a local instance behind the production vhost.
+    host = os.environ.get('MOJ_HOST')
+    if host:
+        headers['Host'] = host
+    return headers
+
+
+def read_token(contest: str) -> str:
+    """The bearer token of the session `moj-contest login <contest>` created.
+
+    `token_file` in `lib/core.sh`, including its one fallback: `treino` may still
+    be sitting in an unsuffixed `token` from before sessions were per-contest, and
+    no other contest ever may.
+    """
+    cfg = config_dir()
+    candidates = [cfg / f'token-{contest}']
+    if contest == TREINO:
+        candidates.append(cfg / 'token')
+
+    for candidate in candidates:
+        if candidate.is_file():
+            token = candidate.read_text().strip()
+            if token:
+                return token
+
+    raise MojCliError(
+        f'There is no MOJ session for the contest `{contest}`: no token file in '
+        f'`{cfg}`.\nLog in with `moj-contest login {contest}` and try again.'
+    )
+
+
+def _get(path: str, contest: str, token: str, **params: str) -> requests.Response:
+    """GET one API path, turning MOJ's error envelope into a readable failure."""
+    url = f'{base_url()}{API_PREFIX}{path}'
+    try:
+        response = requests.get(
+            url,
+            params={'contest': contest, **params},
+            headers=_headers(token),
+            timeout=_TIMEOUT_S,
+        )
+    except requests.RequestException as e:
+        raise MojCliError(f'Could not reach MOJ at `{url}`: {e}') from e
+
+    if response.ok:
+        return response
+
+    # `{"success":false,"error":{"message":..,"code":..}}` on every handled
+    # failure; an nginx error page on the rest, which `.json()` refuses.
+    message = None
+    try:
+        body = response.json()
+        if isinstance(body, dict):
+            error = body.get('error')
+            if isinstance(error, dict):
+                message = error.get('message')
+            message = message or body.get('message')
+    except ValueError:
+        pass
+
+    detail = f': {message}' if message else ''
+    raise MojCliError(
+        f'MOJ answered {response.status_code} for `{path}`{detail}.\n'
+        f'Contest `{contest}`, server `{base_url()}`.'
+    )
+
+
+# The `<epoch>:<subid>` pair, which is what makes a history line parseable at all.
+#
+# Both listings are colon-separated, and **the verdict may contain colons** -- MOJ
+# documents this, and its own `contest.js` slices from the end to survive it. That
+# works for the 7-field own-history form (`…:epoch:subid`) but not for the 9-field
+# judge form, which appends `fullname:univ`; MOJ's `judge.js` splits *that* one
+# positionally and would misread a colon-bearing verdict.
+#
+# Anchoring on the pair sidesteps the whole question: a >=9-digit epoch followed by
+# a 32-hex md5 digest is unmistakable in either form. `lang` is then field 3 from
+# the front, which is safe because the verdict is the only variable-width field and
+# it sits *after* `lang`.
+_ROW_RE = re.compile(r':(\d{9,}):([0-9a-f]{32})(?::|$)')
+
+# The submission id as MOJ issues it: `submit.sh` "valida + gera id (md5)". Checked
+# before any request, because it is the server's own check (`400 id_invalid`) and
+# matching it locally turns a typo into an instant error instead of a round-trip.
+SUBID_RE = re.compile(r'^[0-9a-f]{32}$')
+
+
+def parse_submission_line(line: str) -> Optional[SubmissionRow]:
+    """One listing line, or `None` when it carries no submission id.
+
+    A line without one is normal rather than broken: a submission still queued has
+    no id in the aggregated views, and blank lines end the payload.
+    """
+    match = _ROW_RE.search(line)
+    if match is None:
+        return None
+    fields = line.split(':')
+    if len(fields) < 4:
+        return None
+    return SubmissionRow(
+        subid=match.group(2), lang=fields[3], epoch=int(match.group(1))
+    )
+
+
+def list_submissions(
+    contest: str, token: str, any_submission: bool
+) -> Dict[str, SubmissionRow]:
+    """The submissions this session can see, keyed by id.
+
+    `any_submission` picks the endpoint, and the two are not interchangeable:
+    `/contest/allsubmissions` is judge-gated and answers `403 judge_required` to
+    anyone else, while `/contest/history` is every session's own and covers a
+    judge's own submissions too.
+    """
+    path = '/contest/allsubmissions' if any_submission else '/contest/history'
+    text = _get(path, contest, token).text
+
+    rows: Dict[str, SubmissionRow] = {}
+    for line in text.splitlines():
+        row = parse_submission_line(line.strip())
+        if row is not None:
+            rows[row.subid] = row
+    return rows
+
+
+def download_source(contest: str, token: str, row: SubmissionRow) -> str:
+    """The source of one submission, as `text/plain`.
+
+    `time` is the submission's epoch. The server treats it as optional -- format
+    validation passes without it -- but every MOJ front-end sends it, and matching
+    them costs nothing and keeps rbx on the path the server actually serves.
+    """
+    return _get(
+        '/submission/source',
+        contest,
+        token,
+        id=row.subid,
+        time=str(row.epoch),
+    ).text

--- a/tests/rbx/box/completion/completers_test.py
+++ b/tests/rbx/box/completion/completers_test.py
@@ -157,7 +157,7 @@ def test_solutions_completer_expands_globs_to_actual_files(tmp_path):
     assert by_value['sols/main.cpp'].help == 'ac'  # outcome carries to each match
 
 
-def test_solutions_completer_orders_main_first_boca_last(tmp_path):
+def test_solutions_completer_orders_main_first_remote_prefixes_last(tmp_path):
     (tmp_path / 'problem.rbx.yml').write_text(
         'solutions:\n  - path: sols/z.cpp\n  - path: sols/a.cpp\n'
     )
@@ -168,6 +168,8 @@ def test_solutions_completer_orders_main_first_boca_last(tmp_path):
     values = [
         i.value for i in completers.complete_solutions(_ctx(package_root=tmp_path), '')
     ]
+    # `@main` leads because it is the one a setter picks blind; the download
+    # prefixes trail because neither can enumerate anything to complete *to*.
     assert values[0] == '@main'
-    assert values[-1] == '@boca/'
-    assert set(values[1:-1]) == {'sols/z.cpp', 'sols/a.cpp'}
+    assert values[-2:] == ['@boca/', '@moj/']
+    assert set(values[1:-2]) == {'sols/z.cpp', 'sols/a.cpp'}

--- a/tests/rbx/box/completion/enum_consistency_test.py
+++ b/tests/rbx/box/completion/enum_consistency_test.py
@@ -26,7 +26,7 @@ def test_solution_prefixes_cover_registered_expanders():
     from rbx.box.remote import REGISTERED_EXPANDERS
 
     expander_names = {type(e).__name__ for e in REGISTERED_EXPANDERS}
-    assert expander_names == {'MainExpander', 'BocaExpander'}
+    assert expander_names == {'MainExpander', 'BocaExpander', 'MojExpander'}
 
     prefixes = {p for p, _ in completers._SOLUTION_PREFIXES}  # noqa: SLF001
-    assert prefixes == {'@main', '@boca/'}
+    assert prefixes == {'@main', '@boca/', '@moj/'}

--- a/tests/rbx/box/remote_test.py
+++ b/tests/rbx/box/remote_test.py
@@ -474,7 +474,9 @@ class TestMojExpander:
     def test_expand_downloads_the_source_under_the_right_extension(
         self, testing_pkg: testing_package.TestingPackage, monkeypatch
     ):
-        row = api.SubmissionRow(subid=_SUB, lang='cpp', epoch=1755000000)
+        row = api.SubmissionRow(
+            subid=_SUB, lang='cpp', epoch=1755000000, verdict='Accepted'
+        )
         monkeypatch.setattr(
             remote.cli, 'contest_whoami', lambda c: self._who(is_judge=True)
         )
@@ -502,7 +504,9 @@ class TestMojExpander:
         which one can be asked at all.
         """
         seen = {}
-        row = api.SubmissionRow(subid=_SUB, lang='cpp', epoch=1755000000)
+        row = api.SubmissionRow(
+            subid=_SUB, lang='cpp', epoch=1755000000, verdict='Accepted'
+        )
 
         def fake_list(contest, token, any_submission):
             seen['any'] = any_submission
@@ -523,7 +527,9 @@ class TestMojExpander:
         self, testing_pkg: testing_package.TestingPackage, monkeypatch
     ):
         seen = {}
-        row = api.SubmissionRow(subid=_SUB, lang='cpp', epoch=1755000000)
+        row = api.SubmissionRow(
+            subid=_SUB, lang='cpp', epoch=1755000000, verdict='Accepted'
+        )
 
         def fake_list(contest, token, any_submission):
             seen['any'] = any_submission
@@ -568,7 +574,9 @@ class TestMojExpander:
         self, testing_pkg: testing_package.TestingPackage, monkeypatch
     ):
         """What MOJ's web UI names the download, when rbx claims no such language."""
-        row = api.SubmissionRow(subid=_SUB, lang='Kt', epoch=1755000000)
+        row = api.SubmissionRow(
+            subid=_SUB, lang='Kt', epoch=1755000000, verdict='Accepted'
+        )
         monkeypatch.setattr(
             remote.cli, 'contest_whoami', lambda c: self._who(is_judge=True)
         )
@@ -591,3 +599,37 @@ class TestMojExpander:
     def test_the_download_needs_review(self):
         """Third-party code entering the package, exactly as with BOCA."""
         assert remote.MojExpander().needs_review()
+
+    def test_a_submission_still_being_judged_is_not_downloaded(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """Observed live on 2026-08-24, and the reason this check exists.
+
+        MOJ archives the source only after the judging daemon produces a verdict,
+        so asking for a pending one gets `404 source_notfound` -- byte for byte
+        the reply for an id that does not exist, about a submission rbx has just
+        listed. Saying "still judging" is the difference between waiting a moment
+        and hunting for a wrong id.
+        """
+        downloaded = []
+        row = api.SubmissionRow(
+            subid=_SUB, lang='cpp', epoch=1755000000, verdict='Not Answered Yet'
+        )
+        monkeypatch.setattr(
+            remote.cli, 'contest_whoami', lambda c: self._who(is_judge=True)
+        )
+        monkeypatch.setattr(remote.api, 'read_token', lambda c: 'tok')
+        monkeypatch.setattr(
+            remote.api, 'list_submissions', lambda c, t, any_submission: {_SUB: row}
+        )
+        monkeypatch.setattr(
+            remote.api,
+            'download_source',
+            lambda c, t, r: downloaded.append(r) or 'x\n',
+        )
+
+        with pytest.raises(MojCliError) as exc_info:
+            remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert 'still judging' in str(exc_info.value)
+        assert not downloaded

--- a/tests/rbx/box/remote_test.py
+++ b/tests/rbx/box/remote_test.py
@@ -5,9 +5,15 @@ import pytest
 import typer
 
 from rbx.box import package, remote
+from rbx.box.runners.moj import cli
+from rbx.box.runners.moj.cli import MojCliError
 from rbx.box.schema import ExpectedOutcome
 from rbx.box.testing import testing_package
 from rbx.box.tooling.boca.scraper import BocaRun
+from rbx.box.tooling.moj import api
+
+# A submission id as MOJ issues one: an md5 digest.
+_SUB = 'd89e6b7735c675fd7b50b3354ba64097'
 
 
 class TestExpander:
@@ -382,3 +388,206 @@ class TestBocaRegex:
         match = remote.BocaExpander.BOCA_REGEX.match('@main')
 
         assert match is None
+
+
+class TestMojExpander:
+    """`@moj/<contest>/<submission>`."""
+
+    def _who(self, login: str = 'ana.judge', **flags):
+        return cli.ContestWhoami(login=login, **flags)
+
+    # -- Parsing the reference. ------------------------------------------------
+
+    def test_get_match_reads_the_contest_and_the_submission(self):
+        expander = remote.MojExpander()
+
+        assert expander.get_match(f'@moj/sbc2026/{_SUB}') == ('sbc2026', _SUB)
+
+    def test_get_match_falls_back_to_moj_contest(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv('MOJ_CONTEST', 'sbc2026')
+        expander = remote.MojExpander()
+
+        assert expander.get_match(f'@moj/{_SUB}') == ('sbc2026', _SUB)
+
+    def test_the_explicit_contest_wins_over_the_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A reference committed to `problem.rbx.yml` has to mean one thing."""
+        monkeypatch.setenv('MOJ_CONTEST', 'somewhere-else')
+        expander = remote.MojExpander()
+
+        assert expander.get_match(f'@moj/sbc2026/{_SUB}') == ('sbc2026', _SUB)
+
+    def test_the_shorthand_without_moj_contest_says_what_is_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv('MOJ_CONTEST', raising=False)
+        expander = remote.MojExpander()
+
+        with pytest.raises(MojCliError) as exc_info:
+            expander.get_match(f'@moj/{_SUB}')
+        assert 'MOJ_CONTEST' in str(exc_info.value)
+
+    def test_a_malformed_id_is_refused_rather_than_ignored(self):
+        """Refused, not passed over: the reference is plainly addressed here.
+
+        Returning `None` would make the engine report "not a valid expansion",
+        which describes the outcome and not the mistake. And the id rule is the
+        server's own -- MOJ answers `400 id_invalid` -- so checking it locally
+        costs a round-trip rather than buying one.
+        """
+        expander = remote.MojExpander()
+
+        with pytest.raises(MojCliError) as exc_info:
+            expander.get_match('@moj/sbc2026/123')
+        assert '32' in str(exc_info.value)
+
+    def test_an_uppercase_digest_is_not_a_submission_id(self):
+        """MOJ generates the id with `md5`, and matches it lowercase."""
+        expander = remote.MojExpander()
+
+        with pytest.raises(MojCliError):
+            expander.get_match(f'@moj/sbc2026/{_SUB.upper()}')
+
+    def test_get_match_ignores_other_expanders_references(self):
+        expander = remote.MojExpander()
+
+        assert expander.get_match('@boca/123') is None
+        assert expander.get_match('@main') is None
+        assert expander.get_match('sols/main.cpp') is None
+
+    # -- Caching. --------------------------------------------------------------
+
+    def test_cacheable_globs_cover_any_extension(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        """The extension is only known after the listing, so the glob spans them."""
+        expander = remote.MojExpander()
+
+        globs = expander.cacheable_globs(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert len(globs) == 1
+        assert globs[0].endswith(f'moj/sbc2026/{_SUB}.*')
+
+    # -- Downloading. ----------------------------------------------------------
+
+    def test_expand_downloads_the_source_under_the_right_extension(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        row = api.SubmissionRow(subid=_SUB, lang='cpp', epoch=1755000000)
+        monkeypatch.setattr(
+            remote.cli, 'contest_whoami', lambda c: self._who(is_judge=True)
+        )
+        monkeypatch.setattr(remote.api, 'read_token', lambda c: 'tok')
+        monkeypatch.setattr(
+            remote.api, 'list_submissions', lambda c, t, any_submission: {_SUB: row}
+        )
+        monkeypatch.setattr(
+            remote.api, 'download_source', lambda c, t, r: 'int main(){}\n'
+        )
+
+        result = remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert result is not None
+        assert result.name == f'{_SUB}.cpp'
+        assert result.read_text() == 'int main(){}\n'
+
+    def test_a_judge_is_asked_for_every_submission(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """The two listing endpoints are not interchangeable.
+
+        `/contest/allsubmissions` answers `403 judge_required` to a competitor, and
+        `/contest/history` never carries anyone else's rows -- so the role decides
+        which one can be asked at all.
+        """
+        seen = {}
+        row = api.SubmissionRow(subid=_SUB, lang='cpp', epoch=1755000000)
+
+        def fake_list(contest, token, any_submission):
+            seen['any'] = any_submission
+            return {_SUB: row}
+
+        monkeypatch.setattr(
+            remote.cli, 'contest_whoami', lambda c: self._who(is_judge=True)
+        )
+        monkeypatch.setattr(remote.api, 'read_token', lambda c: 'tok')
+        monkeypatch.setattr(remote.api, 'list_submissions', fake_list)
+        monkeypatch.setattr(remote.api, 'download_source', lambda c, t, r: 'x\n')
+
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert seen['any'] is True
+
+    def test_a_competitor_is_asked_only_for_their_own(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        seen = {}
+        row = api.SubmissionRow(subid=_SUB, lang='cpp', epoch=1755000000)
+
+        def fake_list(contest, token, any_submission):
+            seen['any'] = any_submission
+            return {_SUB: row}
+
+        monkeypatch.setattr(remote.cli, 'contest_whoami', lambda c: self._who('ana'))
+        monkeypatch.setattr(remote.api, 'read_token', lambda c: 'tok')
+        monkeypatch.setattr(remote.api, 'list_submissions', fake_list)
+        monkeypatch.setattr(remote.api, 'download_source', lambda c, t, r: 'x\n')
+
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert seen['any'] is False
+
+    def test_an_unknown_id_is_reported_before_the_download(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """The download would answer a bare 404 that cannot say which case it is."""
+        downloaded = []
+        monkeypatch.setattr(remote.cli, 'contest_whoami', lambda c: self._who('ana'))
+        monkeypatch.setattr(remote.api, 'read_token', lambda c: 'tok')
+        monkeypatch.setattr(
+            remote.api, 'list_submissions', lambda c, t, any_submission: {}
+        )
+        monkeypatch.setattr(
+            remote.api,
+            'download_source',
+            lambda c, t, r: downloaded.append(r) or 'x\n',
+        )
+
+        with pytest.raises(MojCliError) as exc_info:
+            remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        message = str(exc_info.value)
+        assert _SUB in message
+        assert 'ana' in message
+        # A competitor is told what would let them read someone else's.
+        assert 'judge account' in message
+        assert not downloaded
+
+    def test_an_unknown_language_falls_back_to_mojs_own_id(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """What MOJ's web UI names the download, when rbx claims no such language."""
+        row = api.SubmissionRow(subid=_SUB, lang='Kt', epoch=1755000000)
+        monkeypatch.setattr(
+            remote.cli, 'contest_whoami', lambda c: self._who(is_judge=True)
+        )
+        monkeypatch.setattr(remote.api, 'read_token', lambda c: 'tok')
+        monkeypatch.setattr(
+            remote.api, 'list_submissions', lambda c, t, any_submission: {_SUB: row}
+        )
+        monkeypatch.setattr(remote.api, 'download_source', lambda c, t, r: 'fun main\n')
+
+        result = remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert result is not None
+        assert result.name == f'{_SUB}.kt'
+
+    def test_expand_ignores_a_reference_that_is_not_ours(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        assert remote.MojExpander().expand(pathlib.Path('@boca/123')) is None
+
+    def test_the_download_needs_review(self):
+        """Third-party code entering the package, exactly as with BOCA."""
+        assert remote.MojExpander().needs_review()

--- a/tests/rbx/box/runners/moj/test_cli.py
+++ b/tests/rbx/box/runners/moj/test_cli.py
@@ -823,7 +823,7 @@ _CONTEST_WHOAMI = (
 )
 
 
-async def test_contest_whoami_reads_the_role_flags(
+def test_contest_whoami_reads_the_role_flags(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ):
     """The argv is the assertion here as much as the parse is.
@@ -836,14 +836,14 @@ async def test_contest_whoami_reads_the_role_flags(
     """
     _stub_moj(monkeypatch, tmp_path, f"cat <<'EOF'\n{_CONTEST_WHOAMI}EOF\n")
 
-    who = await cli.contest_whoami('sbc2026')
+    who = cli.contest_whoami('sbc2026')
 
     assert who.login == 'ana.judge'
     assert who.can_read_any_submission
     assert _stub_calls(tmp_path) == [['contest', '--json', '-c', 'sbc2026', 'whoami']]
 
 
-async def test_contest_whoami_denies_any_submission_to_a_plain_competitor(
+def test_contest_whoami_denies_any_submission_to_a_plain_competitor(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ):
     _stub_moj(
@@ -853,22 +853,22 @@ async def test_contest_whoami_denies_any_submission_to_a_plain_competitor(
         '"is_chief":false}\nEOF\n',
     )
 
-    assert not (await cli.contest_whoami('sbc2026')).can_read_any_submission
+    assert not cli.contest_whoami('sbc2026').can_read_any_submission
 
 
-async def test_contest_whoami_treats_absent_role_flags_as_no_access(
+def test_contest_whoami_treats_absent_role_flags_as_no_access(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ):
     """A server that predates a flag must read as "no access", never as access."""
     _stub_moj(monkeypatch, tmp_path, 'cat <<\'EOF\'\n{"login":"ana"}\nEOF\n')
 
-    who = await cli.contest_whoami('sbc2026')
+    who = cli.contest_whoami('sbc2026')
 
     assert who.login == 'ana'
     assert not who.can_read_any_submission
 
 
-async def test_contest_whoami_says_how_to_log_in_when_there_is_no_session(
+def test_contest_whoami_says_how_to_log_in_when_there_is_no_session(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ):
     """The CLI's own hint names a command that cannot be followed.
@@ -886,11 +886,11 @@ async def test_contest_whoami_says_how_to_log_in_when_there_is_no_session(
     )
 
     with pytest.raises(MojCliError) as exc_info:
-        await cli.contest_whoami('sbc2026')
+        cli.contest_whoami('sbc2026')
     assert 'moj-contest login sbc2026' in str(exc_info.value)
 
 
-async def test_contest_whoami_passes_the_missing_layer_message_through(
+def test_contest_whoami_passes_the_missing_layer_message_through(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ):
     """`moj-contest` is a separate artifact, and moj's own error installs it.
@@ -908,12 +908,12 @@ async def test_contest_whoami_passes_the_missing_layer_message_through(
     )
 
     with pytest.raises(MojCliError) as exc_info:
-        await cli.contest_whoami('sbc2026')
+        cli.contest_whoami('sbc2026')
     assert 'curl -fLO' in str(exc_info.value)
     assert 'moj-contest login sbc2026' not in str(exc_info.value)
 
 
-async def test_contest_whoami_refuses_output_that_is_not_json(
+def test_contest_whoami_refuses_output_that_is_not_json(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ):
     """The prose form is what a dropped `--json` produces, and it is not a login."""
@@ -924,4 +924,4 @@ async def test_contest_whoami_refuses_output_that_is_not_json(
     )
 
     with pytest.raises(MojCliError):
-        await cli.contest_whoami('sbc2026')
+        cli.contest_whoami('sbc2026')

--- a/tests/rbx/box/runners/moj/test_cli.py
+++ b/tests/rbx/box/runners/moj/test_cli.py
@@ -809,3 +809,119 @@ async def test_another_failure_that_mentions_a_queue_is_not_a_full_queue(
     with pytest.raises(cli.MojCliError) as exc_info:
         await cli.testrun('alice#rbxt-deadbeef', tmp_path / 'sol.cpp')
     assert not isinstance(exc_info.value, cli.MojQueueFullError)
+
+
+# -- contest whoami: the contest-scoped session, through the `contest` layer. ---
+
+# What `moj contest --json -c <cid> whoami` really prints: with `--json` the CLI's
+# `out` relays `/auth/status` untouched. Confirmed live on 2026-08-24 against
+# `treino`; the role flags below are the ones a judge account carries.
+_CONTEST_WHOAMI = (
+    '{"success":true,"logged_in":true,"login":"ana.judge","name":"Ana A",'
+    '"contest":"sbc2026","is_admin":false,"is_judge":true,"is_staff":false,'
+    '"is_cstaff":false,"is_chief":false,"is_animeitor":false}\n'
+)
+
+
+async def test_contest_whoami_reads_the_role_flags(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    """The argv is the assertion here as much as the parse is.
+
+    `moj --json contest whoami` **silently loses the flag** -- `moj` consumes it
+    into a shell variable and then `exec`s `moj-contest` without it -- and the
+    prose that comes back instead parses as nothing at all. So the flag has to sit
+    after `contest`, and a refactor that "tidies" it back to the front has to fail
+    here rather than in front of a setter.
+    """
+    _stub_moj(monkeypatch, tmp_path, f"cat <<'EOF'\n{_CONTEST_WHOAMI}EOF\n")
+
+    who = await cli.contest_whoami('sbc2026')
+
+    assert who.login == 'ana.judge'
+    assert who.can_read_any_submission
+    assert _stub_calls(tmp_path) == [['contest', '--json', '-c', 'sbc2026', 'whoami']]
+
+
+async def test_contest_whoami_denies_any_submission_to_a_plain_competitor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    _stub_moj(
+        monkeypatch,
+        tmp_path,
+        'cat <<\'EOF\'\n{"login":"ana","is_admin":false,"is_judge":false,'
+        '"is_chief":false}\nEOF\n',
+    )
+
+    assert not (await cli.contest_whoami('sbc2026')).can_read_any_submission
+
+
+async def test_contest_whoami_treats_absent_role_flags_as_no_access(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    """A server that predates a flag must read as "no access", never as access."""
+    _stub_moj(monkeypatch, tmp_path, 'cat <<\'EOF\'\n{"login":"ana"}\nEOF\n')
+
+    who = await cli.contest_whoami('sbc2026')
+
+    assert who.login == 'ana'
+    assert not who.can_read_any_submission
+
+
+async def test_contest_whoami_says_how_to_log_in_when_there_is_no_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    """The CLI's own hint names a command that cannot be followed.
+
+    `moj-contest login` without a contest exits asking for one, so relaying that
+    message unchanged sends the setter around a loop. rbx names the contest.
+    """
+    _stub_moj(
+        monkeypatch,
+        tmp_path,
+        """
+        echo "moj-contest: faca 'moj-contest login' primeiro." >&2
+        exit 1
+        """,
+    )
+
+    with pytest.raises(MojCliError) as exc_info:
+        await cli.contest_whoami('sbc2026')
+    assert 'moj-contest login sbc2026' in str(exc_info.value)
+
+
+async def test_contest_whoami_passes_the_missing_layer_message_through(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    """`moj-contest` is a separate artifact, and moj's own error installs it.
+
+    Rewriting this one would replace a working `curl` command with a `login` hint
+    for a CLI that is not there yet -- the wrong fix, in the wrong order.
+    """
+    _stub_moj(
+        monkeypatch,
+        tmp_path,
+        """
+        echo "moj: camada 'contest' nao instalada: curl -fLO https://moj.naquadah.com.br/moj-contest" >&2
+        exit 1
+        """,
+    )
+
+    with pytest.raises(MojCliError) as exc_info:
+        await cli.contest_whoami('sbc2026')
+    assert 'curl -fLO' in str(exc_info.value)
+    assert 'moj-contest login sbc2026' not in str(exc_info.value)
+
+
+async def test_contest_whoami_refuses_output_that_is_not_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    """The prose form is what a dropped `--json` produces, and it is not a login."""
+    _stub_moj(
+        monkeypatch,
+        tmp_path,
+        "echo 'contest: sbc2026  login: ana  nome: Ana  admin: nao'\n",
+    )
+
+    with pytest.raises(MojCliError):
+        await cli.contest_whoami('sbc2026')

--- a/tests/rbx/box/tooling/moj/test_api.py
+++ b/tests/rbx/box/tooling/moj/test_api.py
@@ -138,7 +138,7 @@ def test_parses_the_seven_field_own_history_form():
     line = f'1755000000:ana:A:cpp:Accepted:1755000000:{_SUB}'
 
     assert api.parse_submission_line(line) == api.SubmissionRow(
-        subid=_SUB, lang='cpp', epoch=1755000000
+        subid=_SUB, lang='cpp', epoch=1755000000, verdict='Accepted'
     )
 
 
@@ -310,3 +310,48 @@ def test_moj_host_is_sent_when_set(monkeypatch: pytest.MonkeyPatch, get_calls):
     api.list_submissions('sbc2026', 'tok', any_submission=False)
 
     assert calls[0]['headers']['Host'] == 'moj.local'
+
+
+def test_the_verdict_is_read_off_the_line():
+    line = f'1755000000:ana:A:cpp:Wrong Answer:1755000000:{_SUB}'
+
+    row = api.parse_submission_line(line)
+
+    assert row is not None
+    assert row.verdict == 'Wrong Answer'
+    assert not row.is_pending
+
+
+def test_a_colon_bearing_verdict_is_kept_whole():
+    line = f'1755000000:ana:A:java:Judge Error: No_Servers:1755000000:{_SUB}:Ana:U'
+
+    row = api.parse_submission_line(line)
+
+    assert row is not None
+    assert row.verdict == 'Judge Error: No_Servers'
+
+
+@pytest.mark.parametrize(
+    'verdict', ['Not Answered Yet', 'On queue', 'on queue', 'Running', '']
+)
+def test_a_submission_still_being_judged_is_pending(verdict: str):
+    """Observed live: a fresh submission sits at `Not Answered Yet`.
+
+    Its source is not archived until the judging daemon has a verdict, so this
+    is what stands between a setter and a `404` that reads as "no such id".
+    """
+    line = f'1755000000:ana:A:cpp:{verdict}:1755000000:{_SUB}'
+
+    row = api.parse_submission_line(line)
+
+    assert row is not None
+    assert row.is_pending
+
+
+def test_an_accepted_submission_is_not_pending():
+    line = f'1755000000:ana:A:cpp:Accepted:1755000000:{_SUB}'
+
+    row = api.parse_submission_line(line)
+
+    assert row is not None
+    assert not row.is_pending

--- a/tests/rbx/box/tooling/moj/test_api.py
+++ b/tests/rbx/box/tooling/moj/test_api.py
@@ -1,0 +1,312 @@
+"""The two MOJ API calls rbx makes directly.
+
+Nothing here touches the network: `requests.get` is replaced wholesale, and the
+assertions are about the URL and parameters rbx *would* have requested. The wire
+shapes those assertions encode -- the error envelope, the two listing widths, the
+`400 id_invalid` rule -- were read off MOJ's published OpenAPI spec and confirmed
+against the live server on 2026-08-24.
+"""
+
+import pathlib
+from typing import Any, Dict, List, Optional
+from unittest import mock
+
+import pytest
+
+from rbx.box.runners.moj.cli import MojCliError
+from rbx.box.tooling.moj import api
+
+# A submission id as MOJ issues one: an md5 digest, not a number.
+_SUB = 'd89e6b7735c675fd7b50b3354ba64097'
+_OTHER_SUB = '6ac4364288283cda5c5f8732eae6f144'
+
+
+class _Response:
+    """Just enough of `requests.Response` for `_get` to work on."""
+
+    def __init__(
+        self, status_code: int = 200, text: str = '', json_body: Optional[Any] = None
+    ):
+        self.status_code = status_code
+        self.text = text
+        self._json_body = json_body
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    def json(self) -> Any:
+        if self._json_body is None:
+            raise ValueError('not json')
+        return self._json_body
+
+
+@pytest.fixture
+def get_calls():
+    """Yields `(calls, holder)` with `requests.get` patched out.
+
+    `calls` accumulates what rbx asked for; assigning `holder['response']` sets
+    what comes back, so a test that only cares about the request can ignore it.
+    """
+    holder: Dict[str, Any] = {'response': _Response()}
+    calls: List[Dict[str, Any]] = []
+
+    def fake(url, params=None, headers=None, timeout=None):
+        calls.append({'url': url, 'params': params or {}, 'headers': headers or {}})
+        response = holder['response']
+        return response(url, params or {}) if callable(response) else response
+
+    with mock.patch.object(api.requests, 'get', fake):
+        yield calls, holder
+
+
+# -- The session on disk. ------------------------------------------------------
+
+
+def test_token_comes_from_the_per_contest_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    monkeypatch.setenv('MOJ_CONFIG_DIR', str(tmp_path))
+    (tmp_path / 'token-sbc2026').write_text('tok-abc')
+
+    assert api.read_token('sbc2026') == 'tok-abc'
+
+
+def test_treino_falls_back_to_the_legacy_unsuffixed_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    """`lib/core.sh` keeps this fallback for `treino`, and for nothing else.
+
+    A contest reading someone's stale `treino` token would authenticate as the
+    wrong account against the wrong contest -- so the fallback stays narrow.
+    """
+    monkeypatch.setenv('MOJ_CONFIG_DIR', str(tmp_path))
+    (tmp_path / 'token').write_text('tok-legacy')
+
+    assert api.read_token('treino') == 'tok-legacy'
+    with pytest.raises(MojCliError):
+        api.read_token('sbc2026')
+
+
+def test_the_suffixed_token_wins_over_the_legacy_one(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    monkeypatch.setenv('MOJ_CONFIG_DIR', str(tmp_path))
+    (tmp_path / 'token').write_text('tok-legacy')
+    (tmp_path / 'token-treino').write_text('tok-current')
+
+    assert api.read_token('treino') == 'tok-current'
+
+
+def test_a_missing_token_says_which_login_command_makes_one(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    monkeypatch.setenv('MOJ_CONFIG_DIR', str(tmp_path))
+
+    with pytest.raises(MojCliError) as exc_info:
+        api.read_token('sbc2026')
+    assert 'moj-contest login sbc2026' in str(exc_info.value)
+
+
+def test_an_empty_token_file_is_no_session_at_all(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    """An empty file would otherwise send `Bearer ` and fail as a 401 later."""
+    monkeypatch.setenv('MOJ_CONFIG_DIR', str(tmp_path))
+    (tmp_path / 'token-sbc2026').write_text('\n')
+
+    with pytest.raises(MojCliError):
+        api.read_token('sbc2026')
+
+
+def test_base_url_honours_moj_url_and_drops_its_trailing_slash(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv('MOJ_URL', 'http://localhost:8080/')
+    assert api.base_url() == 'http://localhost:8080'
+
+
+def test_base_url_defaults_to_the_production_server(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv('MOJ_URL', raising=False)
+    assert api.base_url() == api.DEFAULT_MOJ_URL
+
+
+# -- The line parser. ----------------------------------------------------------
+
+
+def test_parses_the_seven_field_own_history_form():
+    line = f'1755000000:ana:A:cpp:Accepted:1755000000:{_SUB}'
+
+    assert api.parse_submission_line(line) == api.SubmissionRow(
+        subid=_SUB, lang='cpp', epoch=1755000000
+    )
+
+
+def test_parses_the_nine_field_judge_form_with_trailing_identity():
+    """`/contest/allsubmissions` appends `fullname:univ` after the id."""
+    line = f'1755000000:ana:A:py:Wrong Answer:1755000000:{_SUB}:Ana A:UFPB'
+
+    row = api.parse_submission_line(line)
+
+    assert row is not None
+    assert row.subid == _SUB
+    assert row.lang == 'py'
+
+
+def test_survives_a_verdict_containing_a_colon():
+    """MOJ documents that the verdict may carry colons.
+
+    Its own `judge.js` splits the 9-field form positionally (`v[4]` verdict,
+    `v[6]` id) and reads this line as a submission whose id is `No_Servers`.
+    Anchoring on the `epoch:subid` pair is what makes rbx immune.
+    """
+    line = f'1755000000:ana:A:java:Judge Error: No_Servers:1755000000:{_SUB}:Ana:U'
+
+    row = api.parse_submission_line(line)
+
+    assert row is not None
+    assert row.subid == _SUB
+    assert row.lang == 'java'
+    assert row.epoch == 1755000000
+
+
+def test_returns_none_for_a_pending_line_with_no_submission_id():
+    assert api.parse_submission_line('1755000000:ana:A:cpp:On queue::') is None
+
+
+def test_returns_none_for_a_blank_line():
+    assert api.parse_submission_line('') is None
+
+
+def test_does_not_mistake_a_short_hex_run_for_a_submission_id():
+    """32 characters exactly -- the server's own rule, and `400 id_invalid` below."""
+    short = 'd89e6b7735c675fd7b50b3354ba640'
+    assert (
+        api.parse_submission_line(f'1755000000:ana:A:cpp:AC:1755000000:{short}') is None
+    )
+
+
+# -- Listing. ------------------------------------------------------------------
+
+
+def test_a_judge_lists_every_submission(get_calls):
+    calls, holder = get_calls
+    holder['response'] = _Response(
+        text=(
+            f'1755000000:ana:A:cpp:Accepted:1755000000:{_SUB}:Ana A:UFPB\n'
+            f'1755000100:bob:B:py:Wrong Answer:1755000100:{_OTHER_SUB}:Bob B:UFPE\n'
+        )
+    )
+
+    rows = api.list_submissions('sbc2026', 'tok', any_submission=True)
+
+    assert set(rows) == {_SUB, _OTHER_SUB}
+    assert rows[_OTHER_SUB].lang == 'py'
+    assert calls[0]['url'].endswith('/api/v1/contest/allsubmissions')
+    assert calls[0]['params']['contest'] == 'sbc2026'
+    assert calls[0]['headers']['Authorization'] == 'Bearer tok'
+
+
+def test_a_competitor_lists_only_their_own(get_calls):
+    """The judge endpoint answers `403 judge_required` to them, so it is not tried."""
+    calls, holder = get_calls
+    holder['response'] = _Response(
+        text=f'1755000000:ana:A:cpp:Accepted:1755000000:{_SUB}\n'
+    )
+
+    rows = api.list_submissions('sbc2026', 'tok', any_submission=False)
+
+    assert set(rows) == {_SUB}
+    assert calls[0]['url'].endswith('/api/v1/contest/history')
+
+
+def test_listing_skips_lines_that_carry_no_id(get_calls):
+    _, holder = get_calls
+    holder['response'] = _Response(
+        text=(
+            '\n'
+            '1755000000:ana:A:cpp:On queue::\n'
+            f'1755000100:ana:A:cpp:Accepted:1755000100:{_SUB}\n'
+        )
+    )
+
+    assert set(api.list_submissions('sbc2026', 'tok', any_submission=False)) == {_SUB}
+
+
+def test_a_denied_listing_surfaces_the_servers_own_message(get_calls):
+    _, holder = get_calls
+    holder['response'] = _Response(
+        status_code=403,
+        json_body={
+            'success': False,
+            'error': {'message': 'Judge/monitor only', 'code': 'judge_required'},
+        },
+    )
+
+    with pytest.raises(MojCliError) as exc_info:
+        api.list_submissions('sbc2026', 'tok', any_submission=True)
+    assert 'Judge/monitor only' in str(exc_info.value)
+    assert '403' in str(exc_info.value)
+
+
+def test_a_non_json_error_page_still_names_the_status(get_calls):
+    """nginx serves 502/504 as HTML, and `.json()` refuses it.
+
+    The status alone is thin, but it beats an empty message -- which is the bug
+    MOJ's own `_api_fail` was patched to stop producing.
+    """
+    _, holder = get_calls
+    holder['response'] = _Response(status_code=502, text='<html>502</html>')
+
+    with pytest.raises(MojCliError) as exc_info:
+        api.list_submissions('sbc2026', 'tok', any_submission=True)
+    assert '502' in str(exc_info.value)
+
+
+# -- Source download. ----------------------------------------------------------
+
+
+def test_download_sends_the_id_and_the_epoch(get_calls):
+    calls, holder = get_calls
+    holder['response'] = _Response(text='int main() { return 0; }\n')
+    row = api.SubmissionRow(subid=_SUB, lang='cpp', epoch=1755000000)
+
+    source = api.download_source('sbc2026', 'tok', row)
+
+    assert source == 'int main() { return 0; }\n'
+    assert calls[0]['url'].endswith('/api/v1/submission/source')
+    assert calls[0]['params'] == {
+        'contest': 'sbc2026',
+        'id': _SUB,
+        'time': '1755000000',
+    }
+
+
+def test_download_surfaces_a_missing_source(get_calls):
+    _, holder = get_calls
+    holder['response'] = _Response(
+        status_code=404,
+        json_body={
+            'success': False,
+            'error': {
+                'message': 'Submission source not found',
+                'code': 'source_notfound',
+            },
+        },
+    )
+    row = api.SubmissionRow(subid=_SUB, lang='cpp', epoch=1755000000)
+
+    with pytest.raises(MojCliError) as exc_info:
+        api.download_source('sbc2026', 'tok', row)
+    assert 'Submission source not found' in str(exc_info.value)
+
+
+def test_moj_host_is_sent_when_set(monkeypatch: pytest.MonkeyPatch, get_calls):
+    """How a setter points a real client at a local instance."""
+    calls, holder = get_calls
+    monkeypatch.setenv('MOJ_HOST', 'moj.local')
+    holder['response'] = _Response(text='')
+
+    api.list_submissions('sbc2026', 'tok', any_submission=False)
+
+    assert calls[0]['headers']['Host'] == 'moj.local'


### PR DESCRIPTION
The MOJ counterpart of `@boca/<run>`: `rbx run`, `rbx stress` and `rbx download remote` now take a MOJ submission reference and pull the contestant's source into the package, behind the same review gate.

```bash
rbx run @moj/sbc2026/d89e6b7735c675fd7b50b3354ba64097
rbx download remote @moj/sbc2026/d89e6b7735c675fd7b50b3354ba64097

# or, with MOJ_CONTEST set
rbx run @moj/d89e6b7735c675fd7b50b3354ba64097
```

Design: [`docs/plans/2026-08-24-moj-submission-download-design.md`](docs/plans/2026-08-24-moj-submission-download-design.md).

## The reference carries the contest

`@moj/<contest>/<submission>`, because a reference gets committed into `problem.rbx.yml`, where it has to still mean something next month on someone else's machine. `@moj/<submission>` is accepted as a shorthand and resolves the contest from `MOJ_CONTEST`, the variable every `moj` CLI layer already reads. The id is checked against `^[0-9a-f]{32}$` before any request — that is the server's own rule (`400 id_invalid`), so matching it locally turns a typo into an instant error instead of a round-trip.

## `moj-contest` is a real dependency, not a presence check

Contest sessions are **not** the one `moj login` creates — that covers the training area alone. `moj-contest login <cid>` is what makes one, and it ships as a separate artifact from `moj`.

`moj contest -c <cid> --json whoami` runs before anything else and hands back the role flags, which **pick the listing endpoint**: `/contest/allsubmissions` for a judge, chief or admin, `/contest/history` for everyone else. The two are not interchangeable — the first answers `403 judge_required` to a competitor — so without that call rbx would have to guess and retry.

Two failure modes, two treatments:

- **Missing layer** → moj's own message passes through untouched; it already carries `curl -fLO .../moj-contest`.
- **Missing session** → replaced. The CLI says `moj-contest login` with no contest, which exits asking for one; rbx names it.

`--json` goes *after* `contest`, and a test pins the argv: `moj --json contest whoami` silently drops the flag (moj parses it into a shell variable, then execs the layer without it) and returns prose that parses as nothing.

## What still had to go over HTTP

No CLI layer — `moj`, `moj-contest`, `moj-judges` or `moj-comp` — exposes any command reaching `/contest/history`, `/contest/allsubmissions` or `/submission/source`. Those three go over HTTP in `rbx/box/tooling/moj/api.py`, reusing the bearer token the CLI's own session left on disk. rbx only ever *reads* it; the layout mirrors `lib/core.sh`, `MOJ_CONFIG_DIR` / `MOJ_URL` / `MOJ_HOST` and the `treino`-only legacy token file included.

## Parsing the history lines

Both listings are colon-separated and **the verdict may contain colons**. The 7-field own-history form is end-anchored parseable; the 9-field judge form appends `fullname:univ`, so it is not. MOJ's own `judge.js` splits that one positionally and reads `Judge Error: No_Servers` as a submission whose id is `No_Servers`.

rbx anchors on the `<epoch>:<subid>` pair instead — a 10-digit number followed by a 32-hex digest is unmistakable in either form — and one parser serves both.

## A pending submission has no source yet

Found by the end-to-end run rather than by reading. MOJ archives the source at **step 5** of judging, after the daemon has a verdict, so a submission still showing `Not Answered Yet` answers `404 source_notfound` — byte for byte the reply for an id that does not exist, about one rbx has just listed from the same server. The listing row now carries its verdict and a pending download is refused by name, before the doomed request.

## Verified live (2026-08-24, against `treino`)

| Path | Result |
|---|---|
| `moj contest --json -c treino whoami` | raw `/auth/status` JSON, role flags included |
| no session for a contest | rbx's own `moj-contest login <cid>` message |
| `/contest/allsubmissions` as a non-judge | `403 judge_required`, surfaced with MOJ's wording |
| well-formed id, no such submission | reported before the download is attempted |
| malformed id | refused locally, no request made |
| `MOJ_CONTEST` shorthand | resolves end to end |
| pending submission | "still judging", not MOJ's `404` |
| **judged submission** | **downloaded byte-identical, named `<subid>.cpp`** |

The success path was checked by submitting a throwaway to `rsalesc#rbxt-3b302f1b` — one of rbx's own private, disposable problems — and downloading it back. The history row spells the language `CPP` uppercase, which is why the extension is derived through `normalize_moj_language` rather than used as it arrives.

**Not verified:** the judge listing with a real judge account, and therefore a download of *someone else's* submission — no judge account was available. Recorded as open in the design doc.

## Tests

1208 pass across `tests/rbx/box/{tooling/moj,remote_test.py,completion,runners/moj}`. Stub-binary tests for `contest_whoami` (argv, both failure modes, non-JSON output); unit tests for the line parser (both widths, colon-bearing verdicts, pending verdicts) and the reference parser; HTTP mocked throughout. No live-API test in the suite, matching the rest of the MOJ integration.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jg7wtXN3sfG1aa7vHtXJLS
