### PR TITLE
fix(moj): always calibrate after `rbx package moj --upload`

### DIFF
--- a/docs/setters/packaging/moj.md
+++ b/docs/setters/packaging/moj.md
@@ -173,9 +173,10 @@ extensions:
 
 The org itself is *not* created for you: uploading to an org that doesn't exist fails.
 
-Combining `-u` with `--calibrate` also queues the calibration right after the upload. It's a long
-server-side job and {{rbx}} doesn't wait for it -- check on it with `moj check <org>#<problem>`
-whenever you want.
+Uploading also queues the calibration right after it, whether or not you passed `--calibrate`:
+a package is only judgeable once a judge has calibrated it, so there's nothing to gain from
+uploading one and leaving it uncalibrated. It's a long server-side job and {{rbx}} doesn't wait
+for it -- check on it with `moj check <org>#<problem>` whenever you want.
 
 ## Iterating faster with a single solution
 

--- a/rbx/box/packaging/main.py
+++ b/rbx/box/packaging/main.py
@@ -214,7 +214,7 @@ async def moj(
             reference_only=reference_only,
             into_dir=directory,
         )
-        await upload_package(problem_id, directory, calibrate=calibrate)
+        await upload_package(problem_id, directory)
 
 
 @app.command('pkg', help='Build a package for PKG.')

--- a/rbx/box/packaging/moj/upload.py
+++ b/rbx/box/packaging/moj/upload.py
@@ -100,10 +100,14 @@ async def resolve_problem_id(basename: str) -> str:
     return problem_id
 
 
-async def upload_package(
-    problem_id: str, directory: pathlib.Path, calibrate: bool
-) -> None:
-    """Upload the built tree, and optionally queue a calibration.
+async def upload_package(problem_id: str, directory: pathlib.Path) -> None:
+    """Upload the built tree and queue the calibration that follows it.
+
+    **Always both**, whatever settled the time limits. mojtools refuses to judge a
+    package with no `tl` file, and calibration is what writes one -- so an uploaded
+    package nobody calibrates is a package nobody can submit to, pinned limits
+    included. `--calibrate` decides whether the numbers calibration measures survive
+    `TLOVERRIDE`, not whether calibration runs.
 
     The **directory**, never the `.zip` beside it: `moj upload` tars what it is
     given, and an unzipped tree arrives with the judge's per-language scripts no
@@ -124,10 +128,9 @@ async def upload_package(
         f'[success]Package uploaded to [item]{problem_id}[/item]![/success]'
     )
 
-    if calibrate:
-        await cli.calibrate(problem_id)
-        console.console.print(
-            f'[status]Calibration queued for [item]{problem_id}[/item]. It runs on '
-            f'the judge; check on it with [item]moj check {problem_id}[/item].'
-            f'[/status]'
-        )
+    await cli.calibrate(problem_id)
+    console.console.print(
+        f'[status]Calibration queued for [item]{problem_id}[/item]. It runs on '
+        f'the judge; check on it with [item]moj check {problem_id}[/item].'
+        f'[/status]'
+    )

--- a/tests/rbx/box/packaging/moj/test_upload.py
+++ b/tests/rbx/box/packaging/moj/test_upload.py
@@ -104,23 +104,19 @@ async def test_resolve_does_not_warn_when_an_org_is_configured(capsys):
 # the argv a process really received. Nothing here touches the network.
 
 
-async def test_upload_shells_out_to_moj_upload(monkeypatch, tmp_path):
+async def test_upload_shells_out_to_moj_upload_and_queues_a_calibration(
+    monkeypatch, tmp_path
+):
     _stub_moj(monkeypatch, tmp_path, 'exit 0')
     directory = tmp_path / 'package'
     directory.mkdir()
 
-    await upload_package('unicamp#a-aplusb', directory, calibrate=False)
+    await upload_package('unicamp#a-aplusb', directory)
 
-    assert _stub_calls(tmp_path) == [['upload', 'unicamp#a-aplusb', str(directory)]]
-
-
-async def test_upload_queues_a_calibration_when_asked(monkeypatch, tmp_path):
-    _stub_moj(monkeypatch, tmp_path, 'exit 0')
-    directory = tmp_path / 'package'
-    directory.mkdir()
-
-    await upload_package('unicamp#a-aplusb', directory, calibrate=True)
-
+    # Both, whatever settled the limits: mojtools refuses to judge a package with no
+    # `tl` file, so a package nobody calibrates is a package nobody can submit to --
+    # pinned limits included. What `--calibrate` decides is whether the numbers
+    # calibration measures survive `TLOVERRIDE`, not whether it runs.
     calls = _stub_calls(tmp_path)
     assert calls == [
         ['upload', 'unicamp#a-aplusb', str(directory)],


### PR DESCRIPTION
## What

`rbx package moj --upload` now queues `moj calibrate` on **every** upload, not only under `--calibrate`.

## Why

mojtools refuses to judge a package with no `tl` file, and calibration is what writes one — so an uploaded package nobody calibrates is a package nobody can submit to. Queueing the calibration only under `--calibrate` left the pinned path (the default) uploading something unjudgeable.

`--calibrate` decides whether the numbers calibration measures survive `TLOVERRIDE`, not whether calibration runs, so `upload_package` no longer takes the flag at all.

## Changes

- `rbx/box/packaging/moj/upload.py` — `upload_package(problem_id, directory)` drops the `calibrate` parameter and always calls `cli.calibrate`, printing the "Calibration queued" status unconditionally. It is still queued and never waited on.
- `rbx/box/packaging/main.py` — call site updated; `calibrate` is now used solely to pick the timing mode.
- `tests/rbx/box/packaging/moj/test_upload.py` — the two upload tests collapse into one asserting `upload` then `calibrate` always, keeping the "no `check` poll follows it" assertion.
- `docs/setters/packaging/moj.md` — the paragraph tying the queued calibration to `--calibrate` now says uploading always queues it.

## Testing

- `uv run pytest tests/rbx/box/packaging/moj` — 178 passed, 4 skipped.
- `uv run ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hGCpzEcpR1G5jsSoYGn6y