### PR TITLE
feat(moj): switch to inline statement images as base64

### DIFF
--- a/rbx/box/packaging/moj/CLAUDE.md
+++ b/rbx/box/packaging/moj/CLAUDE.md
@@ -386,6 +386,37 @@ for `asset_roots[SAMPLE]`, where many files land in the directory).
 Note names come from `naming.testcase_name(..., is_sample=True)` rather than a
 hand-spelled `sample%03d`, so a note can never stop pairing with its test.
 
+### Figures: shipped as files, or inlined as base64
+
+`statement.INLINE_IMAGES_AS_BASE64` picks between the two shapes. A **code-level
+switch**, deliberately not a schema field: both produce a valid package, MOJ shows
+the reader the same statement either way, and nothing about a problem says which
+one it wants.
+
+`False` (the default) ships `docs/assets/fig.png` and leaves the document citing
+`![](assets/fig.png)` — the shape mojtools was built around, since
+`render-statement.sh` passes `--resource-path=<pkg>/docs` precisely so pandoc can
+find them, and it is the *renderer* that base64-embeds each figure into the HTML a
+student reads. The files stay inspectable in the tarball and a figure cited twice
+travels once.
+
+`True` rewrites each reference to a `data:` URI carrying the file's bytes and ships
+no image files at all (`statement_assets.base64_inliner` /
+`discard_assets`, driven by `statement.discard_inlined_assets`), so the statement
+renders identically wherever pandoc runs — no resource path, no files. It costs
+~4/3 the size, carries a twice-cited figure twice, and makes the raw Markdown
+unreadable by a human.
+
+Two ordering facts the switch depends on. The rewrite runs on **pandoc's AST**
+(`markdown_export.tex_to_markdown(..., rewrite_image_url=...)`), not over the
+emitted Markdown, so a multi-kilobyte replacement is escaped and wrapped by
+pandoc's own writer rather than by a regex. And it reads the **materialized**
+figure, so `build_enunciado`/`build_notes` are called after `materialize` and
+`rasterize_pdf_assets` — a TikZ figure is inlined as the rasterized PNG, never the
+PDF the statement was authored against. Their `docs_root` is `docs/` for the body
+*and* for the notes, for the same reason the remap base is (below); without it the
+references are left alone whatever the switch says.
+
 ### PDF figures need poppler
 
 MOJ renders to HTML and base64-embeds every image, so an `<img src="fig.pdf">` is

--- a/rbx/box/packaging/moj/CLAUDE.md
+++ b/rbx/box/packaging/moj/CLAUDE.md
@@ -393,19 +393,20 @@ switch**, deliberately not a schema field: both produce a valid package, MOJ sho
 the reader the same statement either way, and nothing about a problem says which
 one it wants.
 
-`False` (the default) ships `docs/assets/fig.png` and leaves the document citing
+`True` (the default) rewrites each reference to a `data:` URI carrying the file's
+bytes and ships no image files at all (`statement_assets.base64_inliner` /
+`discard_assets`, driven by `statement.discard_inlined_assets`), so the statement
+renders identically wherever pandoc runs — no resource path, no files. That is why
+it is the default: it removes the one thing about a MOJ statement that depends on
+files landing where the renderer expects them. It costs ~4/3 the size, carries a
+twice-cited figure twice, and makes the raw Markdown unreadable by a human.
+
+`False` ships `docs/assets/fig.png` and leaves the document citing
 `![](assets/fig.png)` — the shape mojtools was built around, since
 `render-statement.sh` passes `--resource-path=<pkg>/docs` precisely so pandoc can
 find them, and it is the *renderer* that base64-embeds each figure into the HTML a
 student reads. The files stay inspectable in the tarball and a figure cited twice
 travels once.
-
-`True` rewrites each reference to a `data:` URI carrying the file's bytes and ships
-no image files at all (`statement_assets.base64_inliner` /
-`discard_assets`, driven by `statement.discard_inlined_assets`), so the statement
-renders identically wherever pandoc runs — no resource path, no files. It costs
-~4/3 the size, carries a twice-cited figure twice, and makes the raw Markdown
-unreadable by a human.
 
 Two ordering facts the switch depends on. The rewrite runs on **pandoc's AST**
 (`markdown_export.tex_to_markdown(..., rewrite_image_url=...)`), not over the

--- a/rbx/box/packaging/moj/packager.py
+++ b/rbx/box/packaging/moj/packager.py
@@ -721,10 +721,14 @@ class MojPackager(BasePackager):
         rasterize_pdf_assets(bundle, into_path)
 
         try:
+            # `docs_root` is what an inlining build reads the figures out of, so
+            # both calls come after materialize + rasterize above.
             body = moj_statement.build_enunciado(
-                bundle.blocks, language=main_statement.language
+                bundle.blocks,
+                language=main_statement.language,
+                docs_root=docs_path,
             )
-            notes = moj_statement.build_notes(bundle.explanations)
+            notes = moj_statement.build_notes(bundle.explanations, docs_root=docs_path)
         except MojGateError as e:
             console.console.print(
                 f'[error]Cannot package this statement for MOJ.[/error]\n'
@@ -737,6 +741,10 @@ class MojPackager(BasePackager):
             note_path = into_path / moj_statement.note_path(name)
             note_path.parent.mkdir(parents=True, exist_ok=True)
             note_path.write_text(content)
+
+        # Last, and only in the inlining mode: the documents that were just
+        # written carry the figures themselves, so the files are dead weight.
+        moj_statement.discard_inlined_assets(bundle, into_path)
 
     def _write_conf(self, into_path: pathlib.Path) -> None:
         pkg = package.find_problem_package_or_die()

--- a/rbx/box/packaging/moj/statement.py
+++ b/rbx/box/packaging/moj/statement.py
@@ -16,7 +16,7 @@ facts worth carrying in your head:
 """
 
 import pathlib
-from typing import Dict, Mapping, Optional
+from typing import Callable, Dict, Mapping, Optional
 
 import typer
 
@@ -43,6 +43,57 @@ _HEADINGS = {
 # MOJ is a Brazilian judge and its own tooling is Portuguese, so an
 # unrecognized language falls back to it rather than to English.
 _DEFAULT_HEADING_LANGUAGE = 'pt'
+
+# How the statement's figures travel to MOJ. A code-level switch on purpose: both
+# shapes are valid packages, MOJ shows the reader the same statement either way,
+# and nothing about a problem says which one it wants -- so this is a decision
+# about the packager, not a knob for `problem.rbx.yml`.
+#
+# `False` (the default) ships the image files beside the documents and leaves the
+# references pointing at them:
+#
+#     docs/enunciado.md      ![](assets/fig.png)
+#     docs/assets/fig.png
+#
+# which is the shape mojtools was built around -- `render-statement.sh` passes
+# `--resource-path=<pkg>/docs` precisely so pandoc can find them, and it is the
+# renderer, not rbx, that base64-embeds each figure into the HTML a student
+# reads. Keeping the files also keeps them inspectable in the tarball, keeps the
+# Markdown readable in MOJ's editor, and lets one figure cited twice be sent once.
+#
+# `True` inlines each figure into the document as a `data:` URI and ships no
+# image files at all. The statement then renders identically anywhere pandoc runs
+# -- with no resource path, in a preview, pasted somewhere else entirely -- which
+# is what makes it worth having: it removes the one thing about a MOJ statement
+# that depends on files landing where the renderer expects them. The cost is
+# blunt: base64 is ~4/3 the size, a figure cited from both the body and a note is
+# carried twice, and the raw Markdown stops being readable by a human.
+INLINE_IMAGES_AS_BASE64 = False
+
+
+def _image_rewriter(
+    docs_root: Optional[pathlib.Path],
+) -> Optional[Callable[[str], str]]:
+    """The image-reference rewrite these documents need, if any.
+
+    ``None`` -- the untouched references -- whenever the packager is shipping the
+    files, and also whenever the caller passed no ``docs_root``: inlining reads
+    the *materialized* figures, so a caller with no directory to read them from
+    could only be handed a document citing images it never shipped.
+    """
+    if not INLINE_IMAGES_AS_BASE64 or docs_root is None:
+        return None
+    return statement_assets.base64_inliner(docs_root)
+
+
+def discard_inlined_assets(bundle: export.StatementBundle, root: pathlib.Path) -> None:
+    """Drop the materialized asset files once the documents carry them inline.
+
+    A no-op in the shipping-files mode, so the packager may call it
+    unconditionally and this module stays the only place that reads the switch.
+    """
+    if INLINE_IMAGES_AS_BASE64:
+        statement_assets.discard_assets(bundle, root)
 
 
 def _headings(language: Optional[str]) -> Dict[str, str]:
@@ -133,12 +184,16 @@ def moj_layout() -> statement_assets.RasterizingLayout:
     )
 
 
-def _convert(blocks: Mapping[str, str], name: str) -> str:
+def _convert(
+    blocks: Mapping[str, str],
+    name: str,
+    rewrite_image_url: Optional[Callable[[str], str]] = None,
+) -> str:
     """Convert one block to Markdown and check it against MOJ's gate."""
     content = (blocks.get(name) or '').strip()
     if not content:
         return ''
-    markdown = tex_to_markdown(content).strip()
+    markdown = tex_to_markdown(content, rewrite_image_url=rewrite_image_url).strip()
     check_moj_gate(markdown, block_name=name)
     return markdown
 
@@ -148,24 +203,32 @@ def build_enunciado(
     *,
     language: Optional[str],
     title: Optional[str] = None,
+    docs_root: Optional[pathlib.Path] = None,
 ) -> str:
     """Render `docs/enunciado.md` from a bundle's blocks.
 
     `title` is accepted and deliberately unused: it documents that the caller's
     title has a home (`display_title` in `.moj-meta.json`) and that this
     document is not it.
+
+    `docs_root` is the materialized `docs/` the body's image references resolve
+    against, and is what `INLINE_IMAGES_AS_BASE64` needs to read the figures.
+    Optional so a caller with no package on disk -- a test converting blocks, a
+    statement with no images -- keeps working; without it the references are left
+    as the bundle wrote them whatever the switch says.
     """
     del title  # See the docstring: MOJ injects the <h1> from display_title.
 
     headings = _headings(language)
-    parts = [_convert(blocks, 'legend')]
+    rewrite = _image_rewriter(docs_root)
+    parts = [_convert(blocks, 'legend', rewrite)]
 
     # Emitted unconditionally, empty block or not: these two headings ARE the
     # release gate, grepped out of the raw file by validate-problem.sh.
-    parts.append(f'## {headings["input"]}\n\n{_convert(blocks, "input")}')
-    parts.append(f'## {headings["output"]}\n\n{_convert(blocks, "output")}')
+    parts.append(f'## {headings["input"]}\n\n{_convert(blocks, "input", rewrite)}')
+    parts.append(f'## {headings["output"]}\n\n{_convert(blocks, "output", rewrite)}')
 
-    notes = _convert(blocks, 'notes')
+    notes = _convert(blocks, 'notes', rewrite)
     if notes:
         parts.append(f'## {headings["notes"]}\n\n{notes}')
 
@@ -186,15 +249,25 @@ def sample_note_name(index: int) -> str:
     )
 
 
-def build_notes(explanations: Mapping[int, str]) -> Dict[str, str]:
-    """Render each sample explanation, keyed by the sample's test name."""
+def build_notes(
+    explanations: Mapping[int, str],
+    *,
+    docs_root: Optional[pathlib.Path] = None,
+) -> Dict[str, str]:
+    """Render each sample explanation, keyed by the sample's test name.
+
+    `docs_root` is `docs/`, exactly as in `build_enunciado` -- a note's images
+    resolve against it and not against `docs/notes/`, where the file itself
+    lands; see `moj_layout`.
+    """
     notes: Dict[str, str] = {}
+    rewrite = _image_rewriter(docs_root)
     for index in sorted(explanations):
         content = (explanations[index] or '').strip()
         if not content:
             continue
         name = sample_note_name(index)
-        markdown = tex_to_markdown(content).strip()
+        markdown = tex_to_markdown(content, rewrite_image_url=rewrite).strip()
         check_moj_gate(markdown, block_name=f'explanation for {name}')
         notes[name] = markdown + '\n'
     return notes

--- a/rbx/box/packaging/moj/statement.py
+++ b/rbx/box/packaging/moj/statement.py
@@ -49,8 +49,20 @@ _DEFAULT_HEADING_LANGUAGE = 'pt'
 # and nothing about a problem says which one it wants -- so this is a decision
 # about the packager, not a knob for `problem.rbx.yml`.
 #
-# `False` (the default) ships the image files beside the documents and leaves the
-# references pointing at them:
+# `True` (the default) inlines each figure into the document as a `data:` URI and
+# ships no image files at all:
+#
+#     docs/enunciado.md      ![](data:image/png;base64,iVBORw0KGgo…)
+#
+# The statement then renders identically anywhere pandoc runs -- with no resource
+# path, in a preview, pasted somewhere else entirely -- which is what makes it the
+# default: it removes the one thing about a MOJ statement that depends on files
+# landing where the renderer expects them. The cost is blunt: base64 is ~4/3 the
+# size, a figure cited from both the body and a note is carried twice, and the raw
+# Markdown stops being readable by a human.
+#
+# `False` ships the image files beside the documents and leaves the references
+# pointing at them:
 #
 #     docs/enunciado.md      ![](assets/fig.png)
 #     docs/assets/fig.png
@@ -60,15 +72,7 @@ _DEFAULT_HEADING_LANGUAGE = 'pt'
 # renderer, not rbx, that base64-embeds each figure into the HTML a student
 # reads. Keeping the files also keeps them inspectable in the tarball, keeps the
 # Markdown readable in MOJ's editor, and lets one figure cited twice be sent once.
-#
-# `True` inlines each figure into the document as a `data:` URI and ships no
-# image files at all. The statement then renders identically anywhere pandoc runs
-# -- with no resource path, in a preview, pasted somewhere else entirely -- which
-# is what makes it worth having: it removes the one thing about a MOJ statement
-# that depends on files landing where the renderer expects them. The cost is
-# blunt: base64 is ~4/3 the size, a figure cited from both the body and a note is
-# carried twice, and the raw Markdown stops being readable by a human.
-INLINE_IMAGES_AS_BASE64 = False
+INLINE_IMAGES_AS_BASE64 = True
 
 
 def _image_rewriter(

--- a/rbx/box/packaging/moj/statement_assets.py
+++ b/rbx/box/packaging/moj/statement_assets.py
@@ -15,10 +15,11 @@ The conversion is split in two, and the split is load-bearing:
 - ``rasterize_pdf_assets`` does the actual conversion, after materialization.
 """
 
+import base64
 import dataclasses
 import pathlib
 import subprocess
-from typing import List
+from typing import Callable, List
 
 import typer
 
@@ -126,6 +127,91 @@ def rasterize_pdf_assets(bundle: export.StatementBundle, root: pathlib.Path) -> 
         # Shipping it would mean a broken <img> in the rendered statement.
         if dest != produced and dest.is_file():
             dest.unlink()
+
+
+# --- Base64 inlining -------------------------------------------------------
+#
+# The alternative to shipping the image files beside the documents: the
+# statement carries every figure inside itself, as a `data:` URI, and
+# `docs/assets` (and friends) are not written at all. Which one a package gets
+# is `statement.INLINE_IMAGES_AS_BASE64`; the argument for each is there.
+
+
+# The suffixes a statement figure can reach MOJ with, mapped to the MIME type the
+# data URI must declare. Spelled out rather than read off `mimetypes`, whose table
+# is platform- and registry-dependent (`.svg` in particular is routinely missing
+# on a bare container) -- the set is small and closed anyway, since PDFs have
+# already been rasterized by the time inlining runs.
+_MIME_TYPES = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
+    '.webp': 'image/webp',
+    '.bmp': 'image/bmp',
+    '.tif': 'image/tiff',
+    '.tiff': 'image/tiff',
+}
+
+_DEFAULT_MIME_TYPE = 'application/octet-stream'
+
+
+def data_uri(path: pathlib.Path) -> str:
+    """The ``data:`` URI carrying ``path``'s bytes."""
+    mime = _MIME_TYPES.get(path.suffix.lower(), _DEFAULT_MIME_TYPE)
+    payload = base64.b64encode(path.read_bytes()).decode('ascii')
+    return f'data:{mime};base64,{payload}'
+
+
+def base64_inliner(base: pathlib.Path) -> Callable[[str], str]:
+    """A ``rewrite_image_url`` that replaces a reference with the file's own bytes.
+
+    ``base`` is the directory the document's references resolve against -- for
+    every MOJ document the materialized ``docs/``, since that is what
+    ``gen-problem-json.sh`` hands pandoc as ``--resource-path``. So this must run
+    AFTER ``materialize`` and ``rasterize_pdf_assets``: what it reads is the
+    placed file, which for a TikZ figure is the rasterized PNG rather than the
+    PDF the statement was authored against.
+
+    A reference that does not name a file under ``base`` is left exactly as it
+    is -- an absolute URL, an already-inlined ``data:`` URI, a path that escapes
+    ``base`` -- rather than being reported: none of them is this function's to
+    rewrite, and a broken local reference is already MOJ's renderer's to
+    complain about, in the same words it would have used without inlining.
+    """
+
+    def rewrite(url: str) -> str:
+        if not url or '://' in url or url.startswith('data:'):
+            return url
+        target = base / url
+        if not target.is_file():
+            return url
+        return data_uri(target)
+
+    return rewrite
+
+
+def discard_assets(bundle: export.StatementBundle, root: pathlib.Path) -> None:
+    """Remove every materialized asset under ``root``, and the dirs left empty.
+
+    The other half of inlining: the bytes now live inside the documents, so the
+    files beside them are dead weight in the tarball. Only the destinations the
+    bundle itself chose are removed, and a directory goes only if it comes out
+    empty, so nothing else the packager wrote is in the blast radius.
+    """
+    directories = set()
+    for bundled in bundle.assets:
+        dest = root / bundled.dest
+        if dest.is_file():
+            dest.unlink()
+        directories.add(dest.parent)
+
+    # Deepest first, so a parent emptied by its own children also goes.
+    for directory in sorted(directories, key=lambda d: len(d.parts), reverse=True):
+        while directory != root and directory.is_dir() and not any(directory.iterdir()):
+            directory.rmdir()
+            directory = directory.parent
 
 
 def _fail(bundled: export.BundledAsset, result: subprocess.CompletedProcess) -> None:

--- a/rbx/box/statements/markdown_export.py
+++ b/rbx/box/statements/markdown_export.py
@@ -26,7 +26,7 @@ changed its Markdown writer, not that the expectation was wrong.
 
 import json
 import re
-from typing import Any
+from typing import Any, Callable, Optional
 
 from rbx import tooling
 
@@ -40,33 +40,47 @@ class MojGateError(ValueError):
     """
 
 
-def _clear_image_alts(node: Any) -> None:
-    """Empty the alt inlines of every ``Image`` in a pandoc AST, in place.
+def _fix_images(node: Any, rewrite_url: Optional[Callable[[str], str]]) -> None:
+    """Normalize every ``Image`` in a pandoc AST, in place.
 
-    A pandoc ``Image`` is ``{'t': 'Image', 'c': [attr, [inlines], [url, title]]}``
-    and the alt inlines are that middle element.
+    A pandoc ``Image`` is ``{'t': 'Image', 'c': [attr, [inlines], [url, title]]}``:
+    the alt inlines are that middle element, and the url is the first of the last.
+    The alt is always cleared; ``rewrite_url``, when given, replaces the url --
+    which is how a consumer that ships no image files at all (MOJ, inlining
+    base64) gets one.
     """
     if isinstance(node, list):
         for child in node:
-            _clear_image_alts(child)
+            _fix_images(child, rewrite_url)
         return
     if not isinstance(node, dict):
         return
     if node.get('t') == 'Image' and isinstance(node.get('c'), list):
         node['c'][1] = []
+        if rewrite_url is not None:
+            target = node['c'][2]
+            target[0] = rewrite_url(target[0])
         return
     for value in node.values():
-        _clear_image_alts(value)
+        _fix_images(value, rewrite_url)
 
 
-def tex_to_markdown(tex: str) -> str:
-    """Convert one Polygon-TeX block to Markdown."""
+def tex_to_markdown(
+    tex: str, *, rewrite_image_url: Optional[Callable[[str], str]] = None
+) -> str:
+    """Convert one Polygon-TeX block to Markdown.
+
+    ``rewrite_image_url`` maps each image reference to what the document should
+    cite instead. It runs on the AST rather than over the emitted Markdown so a
+    replacement may be arbitrary text -- a multi-kilobyte ``data:`` URI included,
+    which pandoc's writer then escapes and wraps correctly on its own.
+    """
     import pypandoc
 
     tooling.PANDOC.ensure()
 
     ast = json.loads(pypandoc.convert_text(tex, 'json', format='latex'))
-    _clear_image_alts(ast)
+    _fix_images(ast, rewrite_image_url)
     return pypandoc.convert_text(json.dumps(ast), 'markdown', format='json')
 
 

--- a/tests/rbx/box/packaging/moj/test_packager.py
+++ b/tests/rbx/box/packaging/moj/test_packager.py
@@ -7,6 +7,7 @@ import subprocess
 import pytest
 import typer
 
+from rbx.box.packaging.moj import statement as moj_statement
 from rbx.box.packaging.moj.packager import JudgeCalibrated, MojPackager
 from rbx.box.schema import ScoreType, TaskType
 from rbx.box.statements.schema import ConversionType, StatementType
@@ -687,6 +688,10 @@ def test_points_problems_emit_a_score_file(testing_pkg, tmp_path):
 
 
 def test_package_writes_a_real_enunciado(testing_pkg, tmp_path, monkeypatch):
+    # Pinned to the shipping-files mode, which is what makes the DERIVED REFERENCE
+    # observable: inlining replaces it with the figure's bytes, so a wrong remap
+    # would show up only as a figure that failed to inline.
+    monkeypatch.setattr(moj_statement, 'INLINE_IMAGES_AS_BASE64', False)
     minimal_package(testing_pkg)
     with_statements(testing_pkg, monkeypatch, PT_BLOCKS)
 
@@ -705,7 +710,37 @@ def test_package_writes_a_real_enunciado(testing_pkg, tmp_path, monkeypatch):
     assert (into_path / 'docs' / 'assets' / 'fig.png').exists()
 
 
+def test_package_inlines_the_figures_and_ships_no_asset_files(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The default. The figure travels inside the documents, so the files the
+    references used to point at are not in the tarball at all."""
+    minimal_package(testing_pkg)
+    with_statements(
+        testing_pkg,
+        monkeypatch,
+        PT_BLOCKS,
+        explanations={0: 'Veja \\includegraphics{diagram}.'},
+    )
+
+    into_path = run_packager(
+        testing_pkg, tmp_path, build_entries(tmp_path, ['samples'])
+    )
+
+    text = (into_path / 'docs' / 'enunciado.md').read_text()
+    note = (into_path / 'docs' / 'notes' / 'sample001.md').read_text()
+    assert 'data:image/png;base64,' in text
+    assert 'data:image/png;base64,' in note
+    assert '](assets/' not in text
+    assert '](samples/' not in note
+    assert not (into_path / 'docs' / 'assets').exists()
+    assert not (into_path / 'docs' / 'samples').exists()
+
+
 def test_package_writes_sample_notes_by_test_name(testing_pkg, tmp_path, monkeypatch):
+    # See the note in test_package_writes_a_real_enunciado: the reference this
+    # asserts on is what inlining replaces.
+    monkeypatch.setattr(moj_statement, 'INLINE_IMAGES_AS_BASE64', False)
     minimal_package(testing_pkg)
     with_statements(
         testing_pkg,

--- a/tests/rbx/box/packaging/moj/test_statement.py
+++ b/tests/rbx/box/packaging/moj/test_statement.py
@@ -137,11 +137,26 @@ def inlining(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(statement, 'INLINE_IMAGES_AS_BASE64', True)
 
 
+@pytest.fixture
+def shipping_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(statement, 'INLINE_IMAGES_AS_BASE64', False)
+
+
+def test_the_default_is_to_inline(docs_with_figure: pathlib.Path):
+    """Pinned rather than left implicit: which mode a package gets is the whole
+    point of the switch, and every other test here sets it explicitly."""
+    doc = statement.build_enunciado(
+        FIGURE_BLOCKS, language='pt-br', docs_root=docs_with_figure
+    )
+    assert 'data:image/png;base64,' in doc
+
+
 def test_shipping_files_keeps_the_reference_pointing_at_the_file(
+    shipping_files,
     docs_with_figure: pathlib.Path,
 ):
-    """The default: the image travels as its own file and the document cites it,
-    which is the shape render-statement.sh's --resource-path exists for."""
+    """The image travels as its own file and the document cites it, which is the
+    shape render-statement.sh's --resource-path exists for."""
     doc = statement.build_enunciado(
         FIGURE_BLOCKS, language='pt-br', docs_root=docs_with_figure
     )
@@ -222,6 +237,7 @@ def test_discarding_inlined_assets_removes_the_files_and_their_dirs(
 
 
 def test_discarding_is_a_no_op_when_the_files_are_what_ships(
+    shipping_files,
     tmp_path: pathlib.Path,
 ):
     (tmp_path / 'docs' / 'assets').mkdir(parents=True)

--- a/tests/rbx/box/packaging/moj/test_statement.py
+++ b/tests/rbx/box/packaging/moj/test_statement.py
@@ -1,5 +1,6 @@
 """Assembling `docs/enunciado.md` and `docs/notes/<sample>.md` for MOJ."""
 
+import base64
 import pathlib
 
 import pytest
@@ -107,6 +108,143 @@ def test_a_note_carrying_math_ships_without_a_warning(capsys):
     notes = statement.build_notes({0: 'The answer is $x + y$.'})
     assert '$x + y$' in notes['sample001']
     assert capsys.readouterr().out == ''
+
+
+# A 1x1 PNG, so an inlined payload is a real image rather than invented bytes.
+PNG_BYTES = base64.b64decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmM'
+    'IQAAAABJRU5ErkJggg=='
+)
+
+FIGURE_BLOCKS = {
+    'legend': 'See it:\n\n\\includegraphics{assets/fig.png}',
+    'input': 'A single line.',
+    'output': 'A single line.',
+}
+
+
+@pytest.fixture
+def docs_with_figure(tmp_path: pathlib.Path) -> pathlib.Path:
+    """A materialized `docs/` holding the one figure the blocks below cite."""
+    docs = tmp_path / 'docs'
+    (docs / 'assets').mkdir(parents=True)
+    (docs / 'assets' / 'fig.png').write_bytes(PNG_BYTES)
+    return docs
+
+
+@pytest.fixture
+def inlining(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(statement, 'INLINE_IMAGES_AS_BASE64', True)
+
+
+def test_shipping_files_keeps_the_reference_pointing_at_the_file(
+    docs_with_figure: pathlib.Path,
+):
+    """The default: the image travels as its own file and the document cites it,
+    which is the shape render-statement.sh's --resource-path exists for."""
+    doc = statement.build_enunciado(
+        FIGURE_BLOCKS, language='pt-br', docs_root=docs_with_figure
+    )
+    assert '(assets/fig.png)' in doc
+    assert 'data:image/png;base64,' not in doc
+
+
+def test_inlining_carries_the_figure_inside_the_document(
+    inlining, docs_with_figure: pathlib.Path
+):
+    doc = statement.build_enunciado(
+        FIGURE_BLOCKS, language='pt-br', docs_root=docs_with_figure
+    )
+    assert f'data:image/png;base64,{base64.b64encode(PNG_BYTES).decode()}' in doc
+    assert '(assets/fig.png)' not in doc
+
+
+def test_inlining_carries_a_note_figure_too(inlining, docs_with_figure: pathlib.Path):
+    notes = statement.build_notes(
+        {0: 'Look:\n\n\\includegraphics{assets/fig.png}'},
+        docs_root=docs_with_figure,
+    )
+    assert 'data:image/png;base64,' in notes['sample001']
+
+
+def test_inlining_without_a_docs_root_leaves_the_references_alone(inlining):
+    """Nothing on disk to read, so rewriting could only cite files the caller is
+    not shipping."""
+    doc = statement.build_enunciado(FIGURE_BLOCKS, language='pt-br')
+    assert '(assets/fig.png)' in doc
+
+
+def test_inlining_leaves_a_reference_it_cannot_resolve(
+    inlining, docs_with_figure: pathlib.Path
+):
+    """A missing file, an absolute URL: not this rewrite's to fix, and MOJ's own
+    renderer complains about the first in the same words either way."""
+    doc = statement.build_enunciado(
+        {
+            'legend': (
+                '\\includegraphics{assets/missing.png}\n\n'
+                '\\includegraphics{https://example.com/f.png}'
+            ),
+        },
+        language='pt-br',
+        docs_root=docs_with_figure,
+    )
+    assert '(assets/missing.png)' in doc
+    assert '(https://example.com/f.png)' in doc
+
+
+def test_discarding_inlined_assets_removes_the_files_and_their_dirs(
+    inlining, tmp_path: pathlib.Path
+):
+    (tmp_path / 'docs' / 'assets').mkdir(parents=True)
+    (tmp_path / 'docs' / 'assets' / 'fig.png').write_bytes(PNG_BYTES)
+    (tmp_path / 'docs' / 'enunciado.md').write_text('kept\n')
+    bundle = export.StatementBundle(
+        blocks={},
+        explanations={},
+        assets=[
+            export.BundledAsset(
+                asset=export.ResolvedAsset(
+                    scope=export.AssetScope.STATEMENT,
+                    source=tmp_path / 'docs' / 'assets' / 'fig.png',
+                    rel=pathlib.PurePosixPath('fig.png'),
+                ),
+                dest=pathlib.PurePosixPath('docs/assets/fig.png'),
+            )
+        ],
+        remaps={},
+    )
+
+    statement.discard_inlined_assets(bundle, tmp_path)
+
+    assert not (tmp_path / 'docs' / 'assets').exists()
+    assert (tmp_path / 'docs' / 'enunciado.md').is_file()
+
+
+def test_discarding_is_a_no_op_when_the_files_are_what_ships(
+    tmp_path: pathlib.Path,
+):
+    (tmp_path / 'docs' / 'assets').mkdir(parents=True)
+    (tmp_path / 'docs' / 'assets' / 'fig.png').write_bytes(PNG_BYTES)
+    bundle = export.StatementBundle(
+        blocks={},
+        explanations={},
+        assets=[
+            export.BundledAsset(
+                asset=export.ResolvedAsset(
+                    scope=export.AssetScope.STATEMENT,
+                    source=tmp_path / 'docs' / 'assets' / 'fig.png',
+                    rel=pathlib.PurePosixPath('fig.png'),
+                ),
+                dest=pathlib.PurePosixPath('docs/assets/fig.png'),
+            )
+        ],
+        remaps={},
+    )
+
+    statement.discard_inlined_assets(bundle, tmp_path)
+
+    assert (tmp_path / 'docs' / 'assets' / 'fig.png').is_file()
 
 
 def test_layout_uses_docs_as_the_remap_base_for_both_slots():


### PR DESCRIPTION
MOJ statements shipped their figures as files beside the documents (`docs/assets/fig.png`, cited as `![](assets/fig.png)`) — the shape mojtools was built around, since `render-statement.sh` passes `--resource-path=<pkg>/docs` precisely so pandoc can find them, and it is the *renderer* that base64-embeds each figure into the HTML a student reads.

This makes the other shape the default: the document carries each figure inside itself as a `data:` URI and the package ships no image files at all. It renders identically wherever pandoc runs — no resource path, nothing that depends on files landing where the renderer expects them. The cost is ~4/3 the size, a twice-cited figure travelling twice, and raw Markdown a human can no longer read.

Both are valid packages and nothing about a problem says which one it wants, so the choice is a **code-level constant**, `statement.INLINE_IMAGES_AS_BASE64`, deliberately not a schema field. It now defaults to `True`; setting it to `False` restores the previous file-shipping behavior.

## How it works

- `markdown_export.tex_to_markdown(..., rewrite_image_url=...)` does the swap on **pandoc's JSON AST**, beside the existing alt-clearing — not over the emitted Markdown. A multi-kilobyte replacement is then escaped and wrapped by pandoc's own writer rather than by a regex.
- `statement_assets.base64_inliner(docs_root)` reads the **materialized** figure, so `build_enunciado` / `build_notes` are called after `materialize` and `rasterize_pdf_assets`: a TikZ figure inlines as the rasterized PNG, never the PDF it was authored against. `docs_root` is `docs/` for the body *and* for the notes, for the same reason the remap base is.
- `statement_assets.discard_assets` then removes the now-dead files and any directory left empty. `statement.discard_inlined_assets` is a no-op in file mode, so `statement.py` stays the only place that reads the switch.
- A reference the inliner cannot resolve — a missing file, an absolute URL, an already-inlined `data:` URI — is left exactly as it is.

## Testing

9 new tests in `tests/rbx/box/packaging/moj/test_statement.py`: the default, both modes on a body figure, a note figure, the no-`docs_root` case, unresolvable references, and the file discarding in each mode.

In `test_packager.py`, the two tests asserting the derived reference are **pinned to the shipping-files mode** rather than rewritten — inlining replaces that reference with the figure's bytes, so a wrong remap would otherwise surface only as a figure that failed to inline. A new test covers the default end to end: data URIs in the body and the note, and no `docs/assets` or `docs/samples` in the tarball.

`uv run pytest tests/rbx/box/packaging/moj tests/rbx/box/statements` → 564 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GYE11W1WRLXgStpyf5hD7