### PR TITLE
test(timing): drive the dry-run estimation with asyncio.run

### DIFF
--- a/tests/rbx/box/test_timing_dry.py
+++ b/tests/rbx/box/test_timing_dry.py
@@ -152,7 +152,7 @@ def _stub_estimation(testing_pkg: testing_package.TestingPackage):
 def test_the_estimated_profile_is_not_written_when_dry():
     limits_path = package.get_limits_file('local')
 
-    estimated = asyncio.get_event_loop().run_until_complete(
+    estimated = asyncio.run(
         timing.compute_time_limits(check=False, detailed=False, dry=True)
     )
 
@@ -166,9 +166,7 @@ def test_the_estimated_profile_is_not_written_when_dry():
 def test_the_estimated_profile_is_written_when_not_dry():
     limits_path = package.get_limits_file('local')
 
-    estimated = asyncio.get_event_loop().run_until_complete(
-        timing.compute_time_limits(check=False, detailed=False)
-    )
+    estimated = asyncio.run(timing.compute_time_limits(check=False, detailed=False))
 
     assert estimated is not None
     assert limits_path.exists()


### PR DESCRIPTION
## Problem

Two tests failed on the Python 3.14 CI job ([run 32767749452](https://github.com/rsalesc/rbx/actions/runs/32767749452/job/97560966654)):

```
FAILED tests/rbx/box/test_timing_dry.py::test_the_estimated_profile_is_not_written_when_dry - RuntimeError: There is no current event loop in thread 'MainThread'.
FAILED tests/rbx/box/test_timing_dry.py::test_the_estimated_profile_is_written_when_not_dry - RuntimeError: There is no current event loop in thread 'MainThread'.
```

Both drove the coroutine with `asyncio.get_event_loop().run_until_complete(...)`. Python 3.14 no longer creates an implicit event loop, so that raises unless something else already set one. These tests passed before only when a `runner`-fixture test happened to land in the same xdist worker first and set a loop up — an ordering accident, which is why this surfaced now rather than earlier.

## Fix

Switched both to `asyncio.run(...)`, which is what the rest of the suite already uses (`package_digest_cache_test.py`, `checkers_communication_test.py`) and which does not depend on ambient loop state.

No production code touched. The `try`/`except RuntimeError` guards in the `runner` fixtures are already 3.14-correct and were left alone.

## Verification

- Reproduced the failure on unmodified code by running just the two tests in isolation.
- After the change, all 8 tests in `tests/rbx/box/test_timing_dry.py` pass on CPython 3.14.3.
- `ruff check` / `ruff format` clean; pre-commit and commitizen passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfzS9ESkPRfUNgBRdGArhf