### PR TITLE
fix(deps): raise requests floor to 2.34 to silence chardet warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "pydantic>=2.11.7",
   "rich>=13.9.4",
   "pyyaml>=6.0.1",
-  "requests>=2.32.3",
+  "requests>=2.34.0",  # <2.34 warns on chardet>=6 via its compat check
   "latexbuild>=0.2.2",
   "pydantic-xml[lxml]>=2.11.0",
   "more-itertools>=10.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2822,7 +2822,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "questionary", specifier = ">=2.1.0" },
-    { name = "requests", specifier = ">=2.32.3" },
+    { name = "requests", specifier = ">=2.34.0" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "ruamel-yaml", specifier = ">=0.18.14" },
     { name = "ruyaml", specifier = ">=0.91.0" },
@@ -2999,7 +2999,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -3007,9 +3007,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`requests` runs an import-time compatibility check that asserts `chardet < 6.0.0`. Environments that resolved `requests 2.32.x` alongside `chardet 6+` printed a `RequestsDependencyWarning` on **every** `rbx` invocation:

```
requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (7.0.1)/charset_normalizer (3.4.5) doesn't match a supported version!
```

The urllib3 part of the message is a red herring — only the chardet bound fails; the warning text just prints all three versions.

`requests 2.34` widened that bound to `< 8.0.0`, so the root fix is raising our floor rather than capping `chardet`.

## Changes

- `requests>=2.32.3` -> `requests>=2.34.0` in `pyproject.toml`, relocked (`uv.lock`: 2.32.5 -> 2.34.2).

## Verification

- Clean venv install of this branch imports `requests` silently with `chardet 7.6.0` / `urllib3 2.7.0`.
- Confirmed `chardet.detect()` (used in `rbx/box/statements/latex.py:25`) behaves correctly under chardet 7.
- `tests/rbx/box/lazy_importing_test.py`, `tests/rbx/box/tooling/moj/test_api.py`, `tests/rbx/box/statements/test_latex_tooling.py`: 31 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gDG2BqusGXSJajFgzpS1A