### PR TITLE
perf(moj): cache the submission listing between downloads

### DIFF
--- a/rbx/box/remote.py
+++ b/rbx/box/remote.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import re
 from abc import ABC, abstractmethod
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import typer
 
@@ -138,6 +138,21 @@ class MojExpander(Expander):
             )
         return contest, subid
 
+    # The listing cache, beside the sources it names, under the package's own
+    # `.remote/moj/<contest>/` -- so `rbx clean` wipes it with everything else and
+    # no state of MOJ's outlives the cache it belongs to. The name cannot collide
+    # with a downloaded source: those are always `<32 hex digits>.<ext>`.
+    LISTING_CACHE_NAME = 'listing.json'
+
+    def __init__(self) -> None:
+        # Per process, and this class is instantiated once into
+        # `REGISTERED_EXPANDERS`: several `@moj/...` references in one `rbx run`
+        # share a single listing and a single `moj contest whoami` subprocess
+        # between them, rather than paying for both once each.
+        self._listings: Dict[str, Dict[str, api.SubmissionRow]] = {}
+        self._refetched: Set[str] = set()
+        self._whoamis: Dict[str, cli.ContestWhoami] = {}
+
     def get_moj_folder(self, contest: str) -> pathlib.Path:
         return self.get_remote_path(pathlib.Path('moj') / contest)
 
@@ -148,23 +163,147 @@ class MojExpander(Expander):
         contest, subid = match
         return [str(self.get_moj_folder(contest) / subid) + '.*']
 
-    def expand(self, path: pathlib.Path) -> Optional[pathlib.Path]:
+    def _whoami(self, contest: str) -> cli.ContestWhoami:
+        """Who this machine is inside `contest`, asked at most once per process.
+
+        This is a *subprocess*, and the single most expensive thing an expansion
+        does -- which is why the fast path below skips it entirely and why the
+        slow path shares one answer across every reference in the same run.
+        """
+        if contest not in self._whoamis:
+            self._whoamis[contest] = cli.contest_whoami(contest)
+        return self._whoamis[contest]
+
+    def _listing_path(self, contest: str) -> pathlib.Path:
+        return self.get_moj_folder(contest) / self.LISTING_CACHE_NAME
+
+    def _read_listing(self, contest: str) -> Dict[str, api.SubmissionRow]:
+        """The last listing rbx read for this contest, or an empty one."""
+        if contest in self._listings:
+            return self._listings[contest]
+
+        rows: Dict[str, api.SubmissionRow] = {}
+        path = self._listing_path(contest)
+        if path.is_file():
+            try:
+                rows = api.CachedListing.model_validate_json(path.read_text()).rows
+            except (OSError, ValueError):
+                # A cache is a hint, so every way of failing to read one means the
+                # same thing: there is no hint. Written by an older rbx, truncated
+                # by an interrupted run, unreadable -- all of it reads as empty and
+                # costs one listing call to rebuild.
+                rows = {}
+        self._listings[contest] = rows
+        return rows
+
+    def _write_listing(self, contest: str, rows: Dict[str, api.SubmissionRow]) -> None:
+        path = self._listing_path(contest)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Through a temporary file: two rbx processes downloading from the same
+        # contest at once must not leave half a listing behind for a third to read.
+        tmp = path.with_suffix('.json.tmp')
+        tmp.write_text(api.CachedListing(rows=rows).model_dump_json())
+        tmp.replace(path)
+
+    def _forget(self, contest: str, subid: str) -> None:
+        """Drop one row, after it turned out not to describe a download."""
+        rows = dict(self._read_listing(contest))
+        if rows.pop(subid, None) is None:
+            return
+        self._listings[contest] = rows
+        self._write_listing(contest, rows)
+
+    def _cached_row(self, contest: str, subid: str) -> Optional[api.SubmissionRow]:
+        """A row good enough to download from, or `None` to go and ask MOJ.
+
+        Two conditions, and the second carries the argument. A **pending** row
+        says nothing durable -- its verdict is still moving, and MOJ archives the
+        source only once it has stopped -- so it is never served from cache and
+        always costs a fresh listing. A **settled** row, on the other hand, is a
+        set of facts about a submission that has already been judged: its language
+        and its epoch cannot change afterwards, and they are the whole of what the
+        download needs. There is nothing for a TTL to protect.
+        """
+        row = self._read_listing(contest).get(subid)
+        if row is None or row.is_pending:
+            return None
+        return row
+
+    def _fetch_listing(self, contest: str, token: str) -> Dict[str, api.SubmissionRow]:
+        """The listing as MOJ has it now, kept for the next reference.
+
+        Once per contest per process. A second lookup missing milliseconds after a
+        full listing came back is not going to be answered by asking for it again;
+        anything genuinely new since then arrives with the next `rbx` invocation.
+        """
+        if contest in self._refetched:
+            return self._read_listing(contest)
+
+        who = self._whoami(contest)
+        rows = api.list_submissions(
+            contest, token, any_submission=who.can_read_any_submission
+        )
+        self._listings[contest] = rows
+        self._refetched.add(contest)
+        self._write_listing(contest, rows)
+        return rows
+
+    def _download(
+        self, contest: str, token: str, row: api.SubmissionRow
+    ) -> pathlib.Path:
         from rbx.box.packaging.moj import moj_language_utils
 
+        source = api.download_source(contest, token, row)
+
+        # MOJ sends no filename with the source, so one is built. The extension
+        # comes from the language rbx would compile it with, falling back to MOJ's
+        # own id -- which is what its web UI names the download.
+        rbx_language = moj_language_utils.get_rbx_language_from_moj_language(
+            moj_language_utils.normalize_moj_language(row.lang)
+        )
+        extension = row.lang.lower()
+        if rbx_language is not None:
+            language = environment.get_language_or_nil(rbx_language)
+            if language is not None:
+                extension = language.extension
+
+        final_path = self.get_moj_folder(contest) / f'{row.subid}.{extension}'
+        final_path.parent.mkdir(parents=True, exist_ok=True)
+        final_path.write_text(source)
+        console.console.print(f'Downloaded {href(final_path)} from MOJ...')
+        return final_path
+
+    def expand(self, path: pathlib.Path) -> Optional[pathlib.Path]:
         match = self.get_match(str(path))
         if match is None:
             return None
         contest, subid = match
 
-        # Before the token is even read: this is what turns a missing session or a
-        # missing `moj-contest` into its own instruction, and it is also where the
-        # role comes from, which decides which listing below can be asked for.
-        who = cli.contest_whoami(contest)
         token = api.read_token(contest)
 
-        rows = api.list_submissions(
-            contest, token, any_submission=who.can_read_any_submission
-        )
+        # The fast path. A settled row already on disk answers everything the
+        # download asks of the listing, so neither the listing call -- which is the
+        # whole contest, and grows with it -- nor the `whoami` subprocess happens
+        # at all, and the source download is the only thing that touches MOJ.
+        row = self._cached_row(contest, subid)
+        if row is not None:
+            try:
+                return self._download(contest, token, row)
+            except MojCliError:
+                # The cached row did not describe a download after all: a session
+                # that may no longer read this submission, a token that has since
+                # expired, an archived source that has gone. Here that is a bare
+                # `404 source_notfound` (or a `401`) with nothing to act on; the
+                # path below has a sentence for every one of those cases. So the
+                # row goes, and the answer comes from MOJ.
+                self._forget(contest, subid)
+
+        # This is what turns a missing session or a missing `moj-contest` into its
+        # own instruction, and it is also where the role comes from, which decides
+        # which listing below can be asked for.
+        who = self._whoami(contest)
+
+        rows = self._fetch_listing(contest, token)
         row = rows.get(subid)
         if row is None:
             # Asked here rather than left to the download, which answers a bare
@@ -194,25 +333,7 @@ class MojExpander(Expander):
                 f'again in a moment.'
             )
 
-        source = api.download_source(contest, token, row)
-
-        # MOJ sends no filename with the source, so one is built. The extension
-        # comes from the language rbx would compile it with, falling back to MOJ's
-        # own id -- which is what its web UI names the download.
-        rbx_language = moj_language_utils.get_rbx_language_from_moj_language(
-            moj_language_utils.normalize_moj_language(row.lang)
-        )
-        extension = row.lang.lower()
-        if rbx_language is not None:
-            language = environment.get_language_or_nil(rbx_language)
-            if language is not None:
-                extension = language.extension
-
-        final_path = self.get_moj_folder(contest) / f'{subid}.{extension}'
-        final_path.parent.mkdir(parents=True, exist_ok=True)
-        final_path.write_text(source)
-        console.console.print(f'Downloaded {href(final_path)} from MOJ...')
-        return final_path
+        return self._download(contest, token, row)
 
 
 REGISTERED_EXPANDERS: List['Expander'] = [

--- a/rbx/box/tooling/moj/api.py
+++ b/rbx/box/tooling/moj/api.py
@@ -71,6 +71,18 @@ class SubmissionRow(BaseModel):
         return self.verdict.strip().lower() in PENDING_VERDICTS
 
 
+class CachedListing(BaseModel):
+    """A listing as it was last read from MOJ, on its way to and from disk.
+
+    An envelope rather than a bare dict so that the file carries a shape a future
+    field can be added to, and so that reading one back is a single validation
+    that either yields rows or raises -- a half-written or older file has to read
+    as *no cache*, never as a partial one.
+    """
+
+    rows: Dict[str, SubmissionRow] = {}
+
+
 def config_dir() -> pathlib.Path:
     """`CFG` in `lib/core.sh`."""
     override = os.environ.get('MOJ_CONFIG_DIR')

--- a/tests/rbx/box/remote_test.py
+++ b/tests/rbx/box/remote_test.py
@@ -633,3 +633,183 @@ class TestMojExpander:
 
         assert 'still judging' in str(exc_info.value)
         assert not downloaded
+
+    # -- Reusing the listing. --------------------------------------------------
+
+    def _rows(self, *subids: str, verdict: str = 'Accepted'):
+        return {
+            subid: api.SubmissionRow(
+                subid=subid, lang='cpp', epoch=1755000000, verdict=verdict
+            )
+            for subid in subids
+        }
+
+    def _serve(self, monkeypatch, rows, who=None, source='x\n'):
+        """One fake MOJ, counting what each expansion actually asks of it."""
+        asked = {'listing': 0, 'whoami': 0, 'source': 0}
+
+        def fake_whoami(contest):
+            asked['whoami'] += 1
+            return who if who is not None else self._who(is_judge=True)
+
+        def fake_list(contest, token, any_submission):
+            asked['listing'] += 1
+            return dict(rows)
+
+        def fake_source(contest, token, row):
+            asked['source'] += 1
+            return source(row) if callable(source) else source
+
+        monkeypatch.setattr(remote.cli, 'contest_whoami', fake_whoami)
+        monkeypatch.setattr(remote.api, 'read_token', lambda c: 'tok')
+        monkeypatch.setattr(remote.api, 'list_submissions', fake_list)
+        monkeypatch.setattr(remote.api, 'download_source', fake_source)
+        return asked
+
+    def _listing_cache(self) -> pathlib.Path:
+        return (
+            package.get_problem_remote_dir()
+            / 'moj'
+            / 'sbc2026'
+            / remote.MojExpander.LISTING_CACHE_NAME
+        )
+
+    def test_a_listing_answers_every_submission_it_carries(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """The whole listing is kept, not just the row that was asked for.
+
+        A fresh expander downloads the second one on purpose: what makes it free
+        is the file on disk, so it has to outlive the process that wrote it.
+        """
+        other = 'a' * 32
+        asked = self._serve(monkeypatch, self._rows(_SUB, other))
+
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{other}'))
+
+        assert asked['listing'] == 1
+        assert asked['source'] == 2
+
+    def test_a_cached_row_costs_neither_a_listing_nor_a_subprocess(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """`whoami` is a subprocess, and a settled row needs nothing it answers."""
+        asked = self._serve(monkeypatch, self._rows(_SUB))
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+        before = dict(asked)
+
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert asked['listing'] == before['listing']
+        assert asked['whoami'] == before['whoami']
+        assert asked['source'] == before['source'] + 1
+
+    def test_a_pending_row_is_never_served_from_the_cache(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """Its verdict is still moving, and the source only exists once it stops."""
+        pending = self._serve(monkeypatch, self._rows(_SUB, verdict='On queue'))
+        with pytest.raises(MojCliError):
+            remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+        assert pending['listing'] == 1
+
+        judged = self._serve(monkeypatch, self._rows(_SUB))
+        result = remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert result is not None
+        assert judged['listing'] == 1
+
+    def test_a_submission_the_cache_does_not_carry_is_asked_for(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """A miss is the whole reason the server still gets asked."""
+        other = 'a' * 32
+        first = self._serve(monkeypatch, self._rows(other))
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{other}'))
+        assert first['listing'] == 1
+
+        second = self._serve(monkeypatch, self._rows(other, _SUB))
+        result = remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert result is not None
+        assert second['listing'] == 1
+
+    def test_a_miss_asks_the_server_once_per_run(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """A second miss milliseconds later is not a different question."""
+        asked = self._serve(monkeypatch, self._rows('a' * 32))
+        expander = remote.MojExpander()
+
+        for _ in range(2):
+            with pytest.raises(MojCliError):
+                expander.expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert asked['listing'] == 1
+        assert asked['whoami'] == 1
+
+    def test_a_cached_row_that_no_longer_downloads_falls_back_to_the_listing(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """The refusal MOJ gives here has no name; the listing path has one.
+
+        A source download that fails against a cached row says only `404
+        source_notfound` -- which is what MOJ answers for a submission that was
+        never yours as much as for one that never existed. So the row is dropped
+        and the question is put to the listing, which knows how to say it.
+        """
+        self._serve(monkeypatch, self._rows(_SUB))
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        def refuse(row):
+            raise MojCliError('MOJ answered 404 for `/submission/source`.')
+
+        asked = self._serve(monkeypatch, {}, who=self._who('ana'), source=refuse)
+
+        with pytest.raises(MojCliError) as exc_info:
+            remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        message = str(exc_info.value)
+        assert 'has no submission' in message
+        assert 'ana' in message
+        assert asked['listing'] == 1
+        # And the row is gone, so the next run does not pay for it again.
+        assert _SUB not in self._listing_cache().read_text()
+
+    def test_an_unreadable_cache_reads_as_no_cache(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """Half-written, older, corrupt -- all of it means "ask MOJ"."""
+        asked = self._serve(monkeypatch, self._rows(_SUB))
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+        self._listing_cache().write_text('{"rows": {"broken')
+
+        result = remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert result is not None
+        assert asked['listing'] == 2
+
+    def test_a_row_that_failed_to_download_is_dropped_even_if_moj_is_down(
+        self, testing_pkg: testing_package.TestingPackage, monkeypatch
+    ):
+        """Otherwise a poisoned row costs a doomed request on every later run.
+
+        The listing that would have replaced it cannot be fetched either -- the
+        network is the thing that is broken -- so nothing else is going to take
+        the bad row out of the cache.
+        """
+        self._serve(monkeypatch, self._rows(_SUB))
+        remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+        assert _SUB in self._listing_cache().read_text()
+
+        def unreachable(*args, **kwargs):
+            raise MojCliError('Could not reach MOJ at `https://moj.example`.')
+
+        self._serve(monkeypatch, {}, source=unreachable)
+        monkeypatch.setattr(remote.api, 'list_submissions', unreachable)
+
+        with pytest.raises(MojCliError):
+            remote.MojExpander().expand(pathlib.Path(f'@moj/sbc2026/{_SUB}'))
+
+        assert _SUB not in self._listing_cache().read_text()


### PR DESCRIPTION
Every `@moj/<contest>/<subid>` expansion listed the contest's submissions from scratch, and ran `moj contest whoami` — a subprocess — to decide which listing endpoint it was allowed to ask for. The listing grows with the contest: a 5000-submission `allsubmissions` is ~166 KB gzipped, of which 80 KB is md5 ids that don't compress, and it was paid once per reference.

### What this does

The listing is now kept whole under the package's own `.remote/moj/<contest>/listing.json`, so a listing fetched to download submission A also answers B, C and D — the second download costs one source request and nothing else. `rbx clean` wipes it with the rest of the package cache.

- **A row is served only when it is present *and* settled.** A pending verdict is still moving, and MOJ archives the source only once it has stopped, so a pending row always costs a fresh listing. Everything the download takes from a settled row — language, epoch — is a fact about a submission that has already been judged, which is why there is no TTL here.
- **A miss goes to the server exactly as before**, and at most once per contest per run: a second miss milliseconds after a full listing came back is not a different question.
- **`whoami` is memoized per run**, and skipped entirely on a cache hit — nothing on that path needs the role.
- **A cached row that fails to download falls back to the full path.** The failure there is a bare `404 source_notfound`, which cannot tell "no such submission" from "not yours"; the listing path has a sentence for each, and #772's error messages are preserved rather than regressed. The row is dropped on the way, so a poisoned row does not cost a doomed request on every later run.

### Why not `/submission/log`

The original question was whether `/submission/log` could replace the listing outright, since the language is the only thing the listing is read for. Probed live: the log does carry it (`<title>Report — … (cpp) — …` and a `Linguagem` / `Arquivo: e2e.cpp` table), but it is the wrong lever.

- It is gated in the mode that matters. Per the spec, *"dono vê conforme o SHOWLOG efetivo: explícito manda, ausente = oculto em modo icpc"* — a contestant's own log is hidden by default under ICPC mode.
- Failure is silent: an unknown id returns **HTTP 200** with a 143-byte `Report indisponível para esta submissão.` stub. One response for "no such submission", "not yours", "still judging" and "SHOWLOG off".
- It is not reliably cheaper. The log embeds the input + diff of *every* test — O(this problem's test data), unbounded, with no truncation marker.

`/submission/summary` (181 bytes, O(1), `{}` for an invisible id) was the other candidate, but it carries no `lang`, and nothing structured does — checked across all 221 paths of the OpenAPI spec. So the listing stays, and gets cached instead.

### Tests

8 new tests in `tests/rbx/box/remote_test.py`; 102 pass across `remote_test.py` and `tests/rbx/box/tooling/moj/`. Each new test was mutation-checked — disabling the fast path, the fallback, the once-per-run cap or the row eviction each fails a specific one.

### No docs change

The behaviour is invisible from the outside: a re-download of the same id was already short-circuited by the file cache, and nothing observable changes for a new one.
