### PR TITLE
perf(cli): defer textual imports out of module scope

### DIFF
--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -29,7 +29,6 @@ from rbx.box.contest.contest_package import (
 from rbx.box.contest.schema import Contest, ContestProblem
 from rbx.box.packaging import contest_main as packaging
 from rbx.box.schema import Package
-from rbx.box.ui.command_app import CommandEntry, start_command_app
 from rbx.box.yaml_validation import (
     YamlSyntaxError,
     YamlValidationError,
@@ -445,6 +444,8 @@ def _build_command_argvs_or_die(
 )
 @within_contest
 def each(ctx: typer.Context, keep_going: bool = KEEP_GOING_OPTION) -> None:
+    from rbx.box.ui.command_app import CommandEntry, start_command_app
+
     contest = find_contest_package_or_die()
     argvs, placeholder_prefix = _build_command_argvs_or_die(ctx.args)
     commands = [
@@ -514,6 +515,8 @@ def on(
         )
         subprocess.call(command, cwd=problems_of_interest[0].get_path(), shell=True)
         return
+
+    from rbx.box.ui.command_app import CommandEntry, start_command_app
 
     commands = [
         CommandEntry(

--- a/rbx/box/remote.py
+++ b/rbx/box/remote.py
@@ -13,7 +13,6 @@ from rbx.box.runners.moj import cli
 from rbx.box.runners.moj.cli import MojCliError
 from rbx.box.tooling.boca.scraper import BocaRun
 from rbx.box.tooling.moj import api
-from rbx.box.ui.review_app import start_review
 
 PathLike = Union[str, pathlib.Path]
 
@@ -378,6 +377,8 @@ def _try_cache(path: pathlib.Path, expander: Expander) -> Optional[pathlib.Path]
 
 
 def _expand_path(path: pathlib.Path) -> Optional[pathlib.Path]:
+    from rbx.box.ui.review_app import start_review
+
     if not cd.is_problem_package():
         console.console.print(
             f'Skipping expansion of {ref(path)} because we are not in a problem package.'

--- a/rbx/box/tooling/boca/main.py
+++ b/rbx/box/tooling/boca/main.py
@@ -5,7 +5,6 @@ import typer
 from rbx import annotations
 from rbx.box.tooling.boca.scrape import scrape_boca
 from rbx.box.tooling.boca.scraper import get_boca_scraper
-from rbx.box.tooling.boca.ui import run_app
 
 app = typer.Typer(no_args_is_help=True, cls=annotations.AliasGroup)
 
@@ -25,6 +24,8 @@ def view(
         help='Contest identifier to load (stored under app data).',
     ),
 ) -> None:
+    from rbx.box.tooling.boca.ui import run_app
+
     # Normalize empty input to None to let the UI apply default
     cid = (contest_id or '').strip() or None
     run_app(contest_id=cid)

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -389,7 +389,7 @@ class TestContestOn:
     ):
         with (
             mock.patch.object(contest_main.subprocess, 'call') as call,
-            mock.patch.object(contest_main, 'start_command_app') as start_app,
+            mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
         ):
             result = runner.invoke(contest_main.app, ['on', 'A', 'build'])
 
@@ -402,7 +402,7 @@ class TestContestOn:
     ):
         with (
             mock.patch.object(contest_main.subprocess, 'call') as call,
-            mock.patch.object(contest_main, 'start_command_app') as start_app,
+            mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
         ):
             result = runner.invoke(
                 contest_main.app, ['on', 'A', 'build', '::', 'run', '-s']
@@ -418,7 +418,7 @@ class TestContestOn:
     def test_keep_going_flag_precedes_the_problem_selector(
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
-        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+        with mock.patch('rbx.box.ui.command_app.start_command_app') as start_app:
             result = runner.invoke(
                 contest_main.app, ['on', '-k', 'A', 'build', '::', 'run']
             )
@@ -430,7 +430,7 @@ class TestContestOn:
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
         # `-k` here is `rbx run`'s business, not `rbx on`'s.
-        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+        with mock.patch('rbx.box.ui.command_app.start_command_app') as start_app:
             result = runner.invoke(
                 contest_main.app, ['on', 'A', 'build', '::', 'run', '-k']
             )
@@ -443,7 +443,7 @@ class TestContestOn:
     def test_empty_command_in_chain_is_an_error(
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
-        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+        with mock.patch('rbx.box.ui.command_app.start_command_app') as start_app:
             result = runner.invoke(contest_main.app, ['on', 'A', 'build', '::'])
 
         assert result.exit_code == 1
@@ -472,7 +472,7 @@ class TestContestEach:
     def test_each_queues_the_chain_in_every_problem(
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
-        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+        with mock.patch('rbx.box.ui.command_app.start_command_app') as start_app:
             result = runner.invoke(
                 contest_main.app, ['each', 'build', '::', 'package', 'build']
             )
@@ -486,7 +486,7 @@ class TestContestEach:
     def test_each_without_args_opens_an_empty_app(
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
-        with mock.patch.object(contest_main, 'start_command_app') as start_app:
+        with mock.patch('rbx.box.ui.command_app.start_command_app') as start_app:
             result = runner.invoke(contest_main.app, ['each'])
 
         assert result.exit_code == 0, result.output

--- a/tests/rbx/box/lazy_importing_main.py
+++ b/tests/rbx/box/lazy_importing_main.py
@@ -1,0 +1,7 @@
+import sys
+
+from rbx.box import main  # noqa
+
+if __name__ == '__main__':
+    for m in sys.modules:
+        print(m)

--- a/tests/rbx/box/lazy_importing_test.py
+++ b/tests/rbx/box/lazy_importing_test.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 from pathlib import Path
+from typing import List
 
 LAZY_MODULES = {
     'gitpython',
@@ -8,18 +9,40 @@ LAZY_MODULES = {
     'fastapi',
     'requests',
     'pydantic_xml',
+    'textual',
     'rbx.box.packaging.polygon.packager',
     'rbx.box.stresses',
 }
 
+# Modules that must not be loaded by `rbx.box.cli`, which every command pulls in.
+CLI_LAZY_MODULES = {
+    'textual',
+}
 
-def test_rich_not_imported_unnecessary():
-    file_path = Path(__file__).parent / 'lazy_importing_main.py'
+
+def _imported_modules(*args: str) -> List[str]:
     result = subprocess.run(
-        [sys.executable, '-m', 'coverage', 'run', str(file_path)],
+        [sys.executable, *args],
         capture_output=True,
         encoding='utf-8',
     )
+    assert result.returncode == 0, result.stderr
     modules = result.stdout.splitlines()
-    modules = [module for module in modules if module in LAZY_MODULES]
-    assert not modules
+    assert modules, (
+        f'expected the helper to print the imported modules: {result.stderr}'
+    )
+    return modules
+
+
+def test_rich_not_imported_unnecessary():
+    file_path = Path(__file__).parent / 'lazy_importing_main.py'
+    modules = _imported_modules('-m', 'coverage', 'run', str(file_path))
+    assert not [module for module in modules if module in LAZY_MODULES]
+
+
+def test_cli_does_not_import_textual():
+    modules = _imported_modules(
+        '-c',
+        'import sys; import rbx.box.cli; print("\\n".join(sys.modules))',
+    )
+    assert not [module for module in modules if module in CLI_LAZY_MODULES]


### PR DESCRIPTION
Closes #747.

Three module-scope imports reached `textual` on every `rbx` command, including `rbx --help`:

| Import site | Symbol | Moved into |
|---|---|---|
| `rbx/box/remote.py` | `start_review` | `_expand_path` |
| `rbx/box/contest/main.py` | `CommandEntry`, `start_command_app` | `each` / `on` |
| `rbx/box/tooling/boca/main.py` | `run_app` | `view` |

They had to move together — deferring any one of them left the other two pulling `textual` in, which is why the issue looked like a non-issue when tested one site at a time.

In `contest on`, the import sits after the single-command fast path, so the common `rbx contest on A build` case never touches textual either.

### Measured

`import rbx.box.cli`:

| | modules | warm import |
|---|---:|---:|
| before | 1,602 | ~535 ms |
| after | 1,289 | ~410 ms |

`python -c "import sys; import rbx.box.cli; print('textual' in sys.modules)"` prints `False`.

### Tests

- New `test_cli_does_not_import_textual` guards the acceptance criterion. Verified it fails if any of the three imports moves back to module scope.
- `tests/rbx/box/lazy_importing_main.py` is restored. The helper was lost in the `tests/` migration (8fa8468a), so the existing guard's subprocess had been failing and its assertion passing on empty output; the test now asserts a clean exit and non-empty output.
- `test_contest_main.py` patched `contest_main.start_command_app`, which is no longer a module attribute — repointed at `rbx.box.ui.command_app.start_command_app`.

`uv run pytest tests/rbx/box/lazy_importing_test.py tests/rbx/box/remote_test.py tests/rbx/box/contest/` → 235 passed.

Note: `import rbx.box.cli` still pulls `questionary` and `requests`. Those are separate items under #746 and are left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcqGa2hViFHF4HYiRNCGyT
