### PR TITLE
fix(moj): quote the contestant's file name in the jail scripts

### DIFF
--- a/rbx/box/packaging/moj/CLAUDE.md
+++ b/rbx/box/packaging/moj/CLAUDE.md
@@ -317,6 +317,22 @@ whose file name is not their class. Doing it in the jail rather than at package 
 what keeps both cases covered, and avoids the collision a host-side rename would create
 the moment two solutions both declare `public class Main`.
 
+**The contestant's file name reaches these scripts raw, so quote every expansion of it.**
+The judge materializes the submission under the name it was sent with, and that name
+becomes `BIN` — which every `run.sh` reads back by `source`ing the `binfile.sh`
+build-and-test.sh writes. A team once submitted `l(1).cpp` (the mark a browser sticks on
+a repeated download, which they never chose) and got a Compilation Error for code that
+passed as `l.cpp`; mojtools then made this a gate, `check-quoting.sh`
+([cd-moj/mojtools@2be585e](https://github.com/cd-moj/mojtools/commit/2be585ee4741040c870408bee2caea7a58104937)).
+Of the three families it names, two are ours: `$BIN` in `run.sh`, and the `BIN=` line a
+`compile.sh` prints when that line *is* the submitted name (only `py`, which runs the
+source; the compiled languages name their artifact themselves and print a literal). The
+third — a `make` recipe handed to `/bin/sh` — cannot happen here: these templates invoke
+the compiler directly on a quoted `"$SRC"` rather than generating a Makefile the way
+mojtools' `lang/*/compile.sh` do. `binfile.sh` is upstream's to escape (`printf 'BIN=%q'`).
+`tests/rbx/box/packaging/moj/test_resources.py` is the gate for both families, and
+`test_hostile_filename.py` compiles and runs a submission under such a name end to end.
+
 ## Statements (`statement.py`, `statement_assets.py`)
 
 `statement_export_params()` forces externalize+demacro exactly as

--- a/rbx/resources/packagers/moj/scripts/c/run.sh
+++ b/rbx/resources/packagers/moj/scripts/c/run.sh
@@ -6,4 +6,8 @@ cd /tmp/dir
 # problem's limits into the jail. It defines BIN, MOJ_MEMLIMITMB and MOJ_STACKKB.
 source binfile.sh
 
-exec ./$BIN < /tmp/in > /tmp/out
+# Quote every expansion of BIN: it carries the name the CONTESTANT submitted, which the
+# judge materializes verbatim -- `l(1).cpp`, the mark a browser sticks on a repeated
+# download, is a real report. Unquoted it reaches the shell raw and kills the run.
+
+exec ./"$BIN" < /tmp/in > /tmp/out

--- a/rbx/resources/packagers/moj/scripts/cpp/run.sh
+++ b/rbx/resources/packagers/moj/scripts/cpp/run.sh
@@ -6,4 +6,8 @@ cd /tmp/dir
 # problem's limits into the jail. It defines BIN, MOJ_MEMLIMITMB and MOJ_STACKKB.
 source binfile.sh
 
-exec ./$BIN < /tmp/in > /tmp/out
+# Quote every expansion of BIN: it carries the name the CONTESTANT submitted, which the
+# judge materializes verbatim -- `l(1).cpp`, the mark a browser sticks on a repeated
+# download, is a real report. Unquoted it reaches the shell raw and kills the run.
+
+exec ./"$BIN" < /tmp/in > /tmp/out

--- a/rbx/resources/packagers/moj/scripts/py/compile.sh
+++ b/rbx/resources/packagers/moj/scripts/py/compile.sh
@@ -16,4 +16,7 @@ PY=python3; command -v pypy3 >/dev/null 2>&1 && PY=pypy3
 
 # Syntax check, so a syntax error is a Compilation Error rather than a Runtime Error.
 $PY -m py_compile "$BINF" || exit 1
-echo BIN=$BINF
+# printf, not `echo BIN=$BINF`: this is the one BIN line here that is the contestant's own
+# filename, and an unquoted expansion would collapse its whitespace before build-and-test.sh
+# ever gets to escape it into binfile.sh.
+printf 'BIN=%s\n' "$BINF"

--- a/rbx/resources/packagers/moj/scripts/py/run.sh
+++ b/rbx/resources/packagers/moj/scripts/py/run.sh
@@ -6,5 +6,9 @@ cd /tmp/dir
 # problem's limits into the jail. It defines BIN, MOJ_MEMLIMITMB and MOJ_STACKKB.
 source binfile.sh
 
-command -v pypy3 >/dev/null 2>&1 && exec pypy3 ./$BIN < /tmp/in > /tmp/out
-exec python3 ./$BIN < /tmp/in > /tmp/out
+# Quote every expansion of BIN: it carries the name the CONTESTANT submitted, which the
+# judge materializes verbatim -- `l(1).cpp`, the mark a browser sticks on a repeated
+# download, is a real report. Unquoted it reaches the shell raw and kills the run.
+
+command -v pypy3 >/dev/null 2>&1 && exec pypy3 ./"$BIN" < /tmp/in > /tmp/out
+exec python3 ./"$BIN" < /tmp/in > /tmp/out

--- a/tests/rbx/box/packaging/moj/test_hostile_filename.py
+++ b/tests/rbx/box/packaging/moj/test_hostile_filename.py
@@ -1,0 +1,95 @@
+"""Compiles and runs a submission whose *filename* is hostile to the shell.
+
+The judge materializes the source under the name the contestant sent, so `l(1).py` --
+the mark a browser sticks on a repeated download -- reaches these templates verbatim and
+flows into BIN. Upstream mojtools took a Compilation Error from exactly that name
+(cd-moj/mojtools@2be585e); the fixture below walks the same path rbx's templates take,
+including the `printf 'BIN=%q'` build-and-test.sh uses to write `binfile.sh`.
+"""
+
+import pathlib
+import shlex
+import subprocess
+
+import pytest
+
+from rbx.config import get_default_app_path
+
+HOSTILE = 'OlaMundo(1).py'
+SOURCE = 'print(input().strip().upper())\n'
+
+
+def _template(language: str, script: str) -> str:
+    return (
+        get_default_app_path() / 'packagers' / 'moj' / 'scripts' / language / script
+    ).read_text()
+
+
+@pytest.fixture
+def jail(tmp_path: pathlib.Path):
+    """A stand-in for MOJ's jail, wired the way build-and-test.sh wires the real one:
+    compile in a writable dir, carry BIN across in `binfile.sh`, then run."""
+    rwdir = tmp_path / 'rwdir'
+    rwdir.mkdir()
+
+    def compile_and_run(filename: str, source: str, stdin: str):
+        (rwdir / filename).write_text(source)
+
+        compile_out = tmp_path / 'compile.out'
+        compile_sh = tmp_path / 'compile.sh'
+        compile_sh.write_text(
+            _template('py', 'compile.sh')
+            .replace('{{rbxFlags}}', '')
+            .replace('/tmp/rwdir', str(rwdir))
+            .replace('/tmp/stderrlog', str(tmp_path / 'compile.err'))
+            .replace('/tmp/out', str(compile_out))
+        )
+        compiled = subprocess.run(['bash', str(compile_sh)], capture_output=True)
+        if compiled.returncode != 0:
+            return compiled, compile_out.read_text(), None
+
+        # build-and-test.sh: the BIN line becomes a `source`d assignment, escaped.
+        bin_name = compile_out.read_text().partition('BIN=')[2].strip('\n')
+        (rwdir / 'binfile.sh').write_text(
+            f'BIN={shlex.quote(bin_name)}\nMOJ_MEMLIMITMB=256\nMOJ_STACKKB=131072\n'
+        )
+
+        run_out = tmp_path / 'run.out'
+        (tmp_path / 'in').write_text(stdin)
+        run_sh = tmp_path / 'run.sh'
+        run_sh.write_text(
+            _template('py', 'run.sh')
+            .replace('/tmp/dir', str(rwdir))
+            .replace('/tmp/stderrlog', str(tmp_path / 'run.err'))
+            .replace('/tmp/in', str(tmp_path / 'in'))
+            .replace('/tmp/out', str(run_out))
+        )
+        ran = subprocess.run(['bash', str(run_sh)], capture_output=True)
+        assert ran.returncode == 0, (tmp_path / 'run.err').read_text()
+        return compiled, compile_out.read_text(), run_out.read_text()
+
+    return compile_and_run
+
+
+def test_python_submission_with_a_browser_mangled_name_compiles_and_runs(jail):
+    _, compile_out, run_out = jail(HOSTILE, SOURCE, 'ola\n')
+
+    # BIN carries the parentheses through untouched -- and, quoted, they stay data.
+    assert compile_out == f'BIN={HOSTILE}\n'
+    assert run_out == 'OLA\n'
+
+
+def test_python_submission_with_a_spaced_name_compiles_and_runs(jail):
+    _, compile_out, run_out = jail('minha sol.py', SOURCE, 'ola\n')
+
+    assert compile_out == 'BIN=minha sol.py\n'
+    assert run_out == 'OLA\n'
+
+
+def test_a_syntax_error_is_still_a_compilation_error(jail):
+    compiled, compile_out, run_out = jail(HOSTILE, 'def (\n', '')
+
+    # The hostile name must not turn a broken submission into a passing one.
+    assert compiled.returncode != 0
+    assert 'BIN=' not in compile_out
+    assert run_out is None

--- a/tests/rbx/box/packaging/moj/test_java_compile_script.py
+++ b/tests/rbx/box/packaging/moj/test_java_compile_script.py
@@ -149,6 +149,19 @@ def test_helper_sources_are_renamed_too_without_stealing_the_entry_point(jail):
     assert _manifest(rwdir) == 'Main-Class: Main\n'
 
 
+def test_a_browser_mangled_file_name_is_renamed_like_any_other(jail):
+    # `OlaMundo(1).java` is what a browser hands back on a repeated download. mojtools
+    # excludes java from its hostile-name battery, since javac demands the file match
+    # the public type -- but the rename here happens before javac ever sees it, so the
+    # name that would be a legitimate Compilation Error upstream compiles fine.
+    proc, rwdir, out = jail({'OlaMundo(1).java': MAIN_CLASS})
+
+    assert proc.returncode == 0
+    assert 'BIN=prog.jar' in out
+    assert (rwdir / 'Main.java').read_text() == MAIN_CLASS
+    assert _manifest(rwdir) == 'Main-Class: Main\n'
+
+
 def test_a_real_compile_error_still_fails(jail):
     # Renaming must not paper over a source that simply does not compile.
     proc, _, out = jail({'sol.java': 'public class Main { SYNTAX_ERROR }\n'})

--- a/tests/rbx/box/packaging/moj/test_resources.py
+++ b/tests/rbx/box/packaging/moj/test_resources.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 
 import pytest
@@ -29,7 +30,7 @@ def test_compile_templates_emit_the_bin_contract():
     for template in TEMPLATES:
         text = (_scripts() / template / 'compile.sh').read_text()
         # No BIN= line on stdout means Compilation Error, per build-and-test.sh.
-        assert 'echo BIN=' in text
+        assert re.search(r"(echo BIN=|printf 'BIN=)", text)
         assert 'cd /tmp/rwdir' in text
 
 
@@ -61,6 +62,49 @@ def test_templates_are_valid_bash(template):
         path = _scripts() / template / script
         proc = subprocess.run(['bash', '-n', str(path)], capture_output=True, text=True)
         assert proc.returncode == 0, f'{path}: {proc.stderr}'
+
+
+# -- the contestant's filename never reaches a shell unquoted -----------------------
+#
+# mojtools' own gate for this is `check-quoting.sh` (cd-moj/mojtools@2be585e), written
+# after a team submitted `l(1).cpp` -- the mark a browser sticks on a repeated download
+# -- and got a Compilation Error for code that passed as `l.cpp`. The judge materializes
+# the source under the name the contestant sent, so that name flows into BIN and, from
+# there, into scripts these templates replace. Two of the three families upstream lists
+# are ours: `$BIN` in the run scripts, and the BIN line a compile script prints when it
+# is the submitted filename. The third (a `make` recipe handed to `/bin/sh`) does not
+# exist here -- these templates invoke the compiler directly.
+
+
+@pytest.mark.parametrize('template', TEMPLATES)
+def test_run_templates_never_expand_bin_unquoted(template):
+    text = (_scripts() / template / 'run.sh').read_text()
+    unquoted = [
+        line
+        for line in text.splitlines()
+        if not line.lstrip().startswith('#')
+        # Strip the quoted forms, then anything left mentioning BIN is a raw expansion.
+        and re.search(r'\$\{?BIN\b', re.sub(r'"\$\{?BIN[^"]*"', '', line))
+    ]
+    assert not unquoted, f'unquoted $BIN in {template}/run.sh: {unquoted}'
+
+
+@pytest.mark.parametrize('template', TEMPLATES)
+def test_compile_templates_never_print_an_unquoted_bin_name(template):
+    text = (_scripts() / template / 'compile.sh').read_text()
+    bin_lines = [
+        line
+        for line in text.splitlines()
+        if not line.lstrip().startswith('#') and re.search(r'\bBIN=', line)
+    ]
+    assert bin_lines, f'{template}/compile.sh prints no BIN line'
+    for line in bin_lines:
+        # Either a literal artifact name (`echo BIN=main`) or a quoted printf. An
+        # `echo BIN=$VAR` would word-split the contestant's filename before
+        # build-and-test.sh ever escapes it into binfile.sh.
+        assert re.fullmatch(r'echo BIN=[A-Za-z0-9._-]+', line.strip()) or re.match(
+            r"printf 'BIN=%s\\n' \"\$\w+\"", line.strip()
+        ), f'{template}/compile.sh: unquoted BIN line: {line!r}'
 
 
 def test_compare_stub_is_valid_bash():


### PR DESCRIPTION
Brings the MOJ packager's in-jail scripts into conformance with [cd-moj/mojtools@2be585e](https://github.com/cd-moj/mojtools/commit/2be585ee4741040c870408bee2caea7a58104937).

The judge materializes a submission under the name the contestant sent, so that name becomes `BIN` and reaches every `run.sh` through the `binfile.sh` build-and-test.sh writes. A team submitted `l(1).cpp` — the mark a browser sticks on a repeated download, which they never chose — and got a **Compilation Error** for code that passed as `l.cpp`. Upstream turned that into a gate (`check-quoting.sh`) over three code families.

### Where rbx stood on each family

| Family | Status here |
|---|---|
| `make` recipe handed to `/bin/sh` | **Not applicable.** These templates invoke the compiler directly on a quoted `"$SRC"` rather than generating a Makefile. |
| `$BIN` in `run.sh` | **Non-conformant** in `c`, `cpp`, `py` (`exec ./$BIN`). `java`/`kt` were already quoted (`-jar "$BIN"`). |
| `binfile.sh` escaping | Upstream's to write. But `py/compile.sh` printed `echo BIN=$BINF` — the one `BIN=` line that *is* the submitted name — word-splitting it before upstream ever got to escape it. |

### Changes

- `c/run.sh`, `cpp/run.sh`, `py/run.sh`: `./"$BIN"`, with the reason in a comment so the fix survives the next copy-paste between languages (which is how upstream's bug spread).
- `py/compile.sh`: `printf 'BIN=%s\n' "$BINF"`, mirroring what upstream did for `lang/java/compile.sh`.
- `rbx/box/packaging/moj/CLAUDE.md`: the doctrine, including why family 1 cannot happen here.

### Tests

- `test_resources.py`: a static gate mirroring `check-quoting.sh` for both applicable families, parametrized over every emitted language.
- `test_hostile_filename.py` (new): compiles and runs a Python submission named `OlaMundo(1).py` and `minha sol.py` end to end through the real `compile.sh` → `binfile.sh` (escaped with `shlex.quote`, as build-and-test.sh does) → `run.sh` path, and checks a syntax error is still a Compilation Error under a hostile name.
- `test_java_compile_script.py`: java under `OlaMundo(1).java`. Upstream excludes java from its hostile battery by definition (`javac` demands the file match the public type); rbx's in-jail rename runs before `javac`, so the name that is a legitimate CE upstream compiles fine here.

Verified by mutation: reverting the two fixes makes 3 of the new tests fail. Full MOJ suite: 195 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD28EQZfHWpk3zXkBKYuKs
