### PR TITLE
perf(cli): defer the BOCA scraper stack out of the CLI import path

### DIFF
--- a/rbx/box/remote.py
+++ b/rbx/box/remote.py
@@ -11,7 +11,6 @@ from rbx.box import cd, environment, package
 from rbx.box.formatting import href, ref
 from rbx.box.runners.moj import cli
 from rbx.box.runners.moj.cli import MojCliError
-from rbx.box.tooling.boca.scraper import BocaRun
 from rbx.box.tooling.moj import api
 
 PathLike = Union[str, pathlib.Path]
@@ -73,14 +72,18 @@ class BocaExpander(Expander):
         return [str(self.get_boca_path(run_number, site_number)) + '.*']
 
     def expand(self, path: pathlib.Path) -> Optional[pathlib.Path]:
-        from rbx.box.tooling.boca import scraper as boca_upload
-
         match = self.get_match(str(path))
         if match is None:
             return None
         run_number, site_number = match
 
-        run = BocaRun.from_run_number(run_number, site_number)
+        # Imported here, and only here: the scraper pulls in `bs4`, `lxml`,
+        # `mechanize` and `dateparser`, and `remote` sits on the path every
+        # command walks -- so at module scope that stack would load for
+        # `rbx --help`.
+        from rbx.box.tooling.boca import scraper as boca_upload
+
+        run = boca_upload.BocaRun.from_run_number(run_number, site_number)
         boca_uploader = boca_upload.get_boca_scraper()
         boca_uploader.login()
         sol_path = boca_uploader.download_run(run, self.get_boca_folder())

--- a/rbx/box/tooling/boca/main.py
+++ b/rbx/box/tooling/boca/main.py
@@ -3,14 +3,19 @@ import pathlib
 import typer
 
 from rbx import annotations
-from rbx.box.tooling.boca.scrape import scrape_boca
-from rbx.box.tooling.boca.scraper import get_boca_scraper
 
 app = typer.Typer(no_args_is_help=True, cls=annotations.AliasGroup)
+
+# Every import of the scraper below is deferred into the command that needs it.
+# This module is reached from `rbx.box.cli` just to register the sub-app, and the
+# scraper pulls in `bs4`, `lxml`, `mechanize` and `dateparser` -- a web-scraping
+# stack no other command has any use for.
 
 
 @app.command('scrape', help='Scrape runs from BOCA.')
 def scrape() -> None:
+    from rbx.box.tooling.boca.scrape import scrape_boca
+
     scrape_boca(pathlib.Path())
 
 
@@ -33,6 +38,7 @@ def view(
 
 @app.command('submit', help='Submit solutions to BOCA.')
 def submit() -> None:
+    from rbx.box.tooling.boca.scraper import get_boca_scraper
     from rbx.box.tooling.boca.submitter import judge_all, submit_all_solutions
 
     judged_solutions = list(submit_all_solutions(get_boca_scraper(is_judge=True)))

--- a/tests/rbx/box/lazy_importing_test.py
+++ b/tests/rbx/box/lazy_importing_test.py
@@ -17,6 +17,11 @@ LAZY_MODULES = {
 # Modules that must not be loaded by `rbx.box.cli`, which every command pulls in.
 CLI_LAZY_MODULES = {
     'textual',
+    # The BOCA scraping stack, reachable only through a `@boca/...` expansion.
+    'bs4',
+    'lxml',
+    'mechanize',
+    'dateparser',
 }
 
 
@@ -40,7 +45,7 @@ def test_rich_not_imported_unnecessary():
     assert not [module for module in modules if module in LAZY_MODULES]
 
 
-def test_cli_does_not_import_textual():
+def test_cli_does_not_import_lazy_modules():
     modules = _imported_modules(
         '-c',
         'import sys; import rbx.box.cli; print("\\n".join(sys.modules))',


### PR DESCRIPTION
Closes #749.

`rbx.box.remote` imported `BocaRun` at module scope for a single use inside `BocaExpander.expand`, and `remote` sits on the path every command walks (`rbx.box.cli → compile → code → download → remote`). So a BOCA web-scraping stack loaded for `rbx --help`.

Moving that one import was not enough on its own: the `boca` Typer sub-app is a **second** path to the same modules, reached from `rbx.box.cli:64` purely to register the sub-app —

```
rbx/box/cli.py:64 → rbx/box/tooling/main.py:12 → rbx/box/tooling/boca/main.py:6 → scrape.py:6 → scraper.py
```

Both are deferred into the commands that need them now (`view` and `submit` already did this for the UI and the submitter).

### Measured

`import rbx.box.cli`, min of 6 warm runs:

| | Modules | Time |
|---|---:|---:|
| before | 1289 | 464 ms |
| after | **1157** | **367 ms** |

`bs4`, `lxml`, `mechanize`, `dateparser`, `soupsieve` and `html5lib` are all gone from the import path.

### Test

The existing `CLI_LAZY_MODULES` set in `tests/rbx/box/lazy_importing_test.py` already pins this shape of regression for `textual`; the four BOCA modules join it, and the test is renamed to `test_cli_does_not_import_lazy_modules` since it is no longer about textual alone. It fails on `main` with `assert not ['dateparser', 'mechanize', 'lxml', 'bs4']`.

`tests/rbx/box/lazy_importing_test.py`, `remote_test.py` and `tests/rbx/box/tooling` pass (106 tests); `ruff check`/`format` clean; `rbx tooling boca --help` still lists all three commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwwbPURyUJTRwEgUiKN9Yt
