### PR TITLE
perf(cli): defer the iso639 import out of module scope

### DIFF
--- a/rbx/box/lang.py
+++ b/rbx/box/lang.py
@@ -1,11 +1,14 @@
 import functools
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List
 
-import iso639
+if TYPE_CHECKING:
+    import iso639
 
 
 @functools.cache
-def _get_lowercase_name_mapping() -> Dict[str, iso639.Lang]:
+def _get_lowercase_name_mapping() -> Dict[str, 'iso639.Lang']:
+    import iso639
+
     res = {}
     for lang in iso639.iter_langs():
         res[lang.name.lower()] = lang
@@ -20,6 +23,8 @@ def _get_lang_name(lang: str) -> str:
 
 
 def code_to_lang(lang: str) -> str:
+    import iso639
+
     return iso639.Lang(lang).name.lower()
 
 
@@ -29,10 +34,14 @@ def code_to_langs(langs: List[str]) -> List[str]:
 
 @functools.cache
 def is_valid_lang_code(lang: str) -> bool:
+    import iso639
+
     return iso639.is_language(lang)
 
 
 def lang_to_code(lang: str) -> str:
+    import iso639
+
     return iso639.Lang(_get_lang_name(lang)).pt1
 
 

--- a/tests/rbx/box/lazy_importing_test.py
+++ b/tests/rbx/box/lazy_importing_test.py
@@ -17,6 +17,7 @@ LAZY_MODULES = {
 # Modules that must not be loaded by `rbx.box.cli`, which every command pulls in.
 CLI_LAZY_MODULES = {
     'textual',
+    'iso639',
 }
 
 
@@ -40,7 +41,7 @@ def test_rich_not_imported_unnecessary():
     assert not [module for module in modules if module in LAZY_MODULES]
 
 
-def test_cli_does_not_import_textual():
+def test_cli_does_not_import_heavy_modules():
     modules = _imported_modules(
         '-c',
         'import sys; import rbx.box.cli; print("\\n".join(sys.modules))',


### PR DESCRIPTION
Closes #750.

`rbx/box/lang.py` imported `iso639` at module scope, and `iso639` builds its full language database at import time (~19ms). `lang.py` is reached from `rbx.box.schema` through the statement schema, so **every** `rbx` invocation paid for it -- only to have a validator available for a statement language field most commands never look at.

## Change

Move the `import iso639` into each function that uses it, keeping the annotation working via a `TYPE_CHECKING` import. Same pattern as #779.

## Verification

- `import rbx.box.cli` now loads **1,285** modules instead of 1,289, and `iso639` is no longer among them.
- Added `iso639` to `CLI_LAZY_MODULES` in `tests/rbx/box/lazy_importing_test.py` so a regression fails the guard (test renamed to `test_cli_does_not_import_heavy_modules`).
- `tests/rbx/box/packaging` (417 passed, 4 skipped) and `tests/rbx/box/statements` (377 passed, 1 skipped) green -- those are the real consumers of `lang.py`.
- Spot-checked every public function in `lang.py` still returns the same values.
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxKKLBfNCWMC13VucjoAq1
