### PR TITLE
perf(cli): keep the symlink check off the startup path

### DIFF
--- a/rbx/box/git_utils.py
+++ b/rbx/box/git_utils.py
@@ -1,30 +1,49 @@
+import json
 import pathlib
 import subprocess
-from typing import List, Optional
-
-import git
+import time
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from rbx import utils
+
+if TYPE_CHECKING:
+    import git
 
 
 def get_repo_or_nil(
     root: pathlib.Path = pathlib.Path(), search_parent_directories: bool = False
-) -> Optional[git.Repo]:
+) -> Optional['git.Repo']:
+    # GitPython is expensive to import (~80ms), so keep it off the module level:
+    # only the few commands that really need a `Repo` object should pay for it.
+    import git
+
     try:
         return git.Repo(root, search_parent_directories=search_parent_directories)
     except git.InvalidGitRepositoryError:
         return None
 
 
+def find_repo_root(
+    path: pathlib.Path, search_parent_directories: bool = True
+) -> Optional[pathlib.Path]:
+    """Find the working tree root containing `path`, without going through GitPython."""
+    path = utils.abspath(path)
+    candidates = [path, *path.parents] if search_parent_directories else [path]
+    for candidate in candidates:
+        if (candidate / '.git').exists():
+            return candidate
+    return None
+
+
 def is_repo(path: pathlib.Path) -> bool:
-    return get_repo_or_nil(path, search_parent_directories=False) is not None
+    return find_repo_root(path, search_parent_directories=False) is not None
 
 
 def is_within_repo(path: pathlib.Path) -> bool:
-    return get_repo_or_nil(path, search_parent_directories=True) is not None
+    return find_repo_root(path, search_parent_directories=True) is not None
 
 
-def get_any_remote(repo: git.Repo) -> Optional[git.Remote]:
+def get_any_remote(repo: 'git.Repo') -> Optional['git.Remote']:
     for remote in repo.remotes:
         if remote.exists():
             return remote
@@ -100,15 +119,15 @@ def resolve_remote_head(uri: str) -> str:
 
 
 def check_symlinks(root: pathlib.Path) -> bool:
-    if not utils.command_exists('git'):
+    working_dir = find_repo_root(root)
+    if working_dir is None:
         return True
-    repo = get_repo_or_nil(root, search_parent_directories=True)
-    if repo is None:
+    if not utils.command_exists('git'):
         return True
 
     completed_process = subprocess.run(
         ['git', 'ls-files', '-s'],
-        cwd=repo.working_dir,
+        cwd=working_dir,
         check=True,
         capture_output=True,
         text=True,
@@ -127,7 +146,7 @@ def check_symlinks(root: pathlib.Path) -> bool:
 
     bad = []
     for rel in symlink_paths:
-        fp = pathlib.Path(repo.working_dir) / rel
+        fp = working_dir / rel
         try:
             if fp.exists() and not fp.is_symlink():
                 bad.append(rel)
@@ -135,3 +154,64 @@ def check_symlinks(root: pathlib.Path) -> bool:
             bad.append(rel)
 
     return len(bad) == 0
+
+
+# The symlink check runs before every command dispatch, and costs a `git
+# ls-files` over the whole working tree. Remember a good verdict for a day so
+# only the first invocation of the day pays for it.
+SYMLINK_CHECK_TTL_SECONDS = 24 * 60 * 60
+
+
+def _symlink_check_cache_path() -> pathlib.Path:
+    return utils.get_app_path() / 'symlink-check.json'
+
+
+def _read_symlink_check_cache() -> Dict[str, float]:
+    try:
+        cache = json.loads(_symlink_check_cache_path().read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(cache, dict):
+        return {}
+    return {
+        key: value for key, value in cache.items() if isinstance(value, (int, float))
+    }
+
+
+def _write_symlink_check_cache(cache: Dict[str, float]) -> None:
+    path = _symlink_check_cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(cache))
+    except OSError:
+        # A cache we cannot persist is not worth failing a command over.
+        pass
+
+
+def check_symlinks_cached(root: pathlib.Path) -> bool:
+    """`check_symlinks`, remembering a good verdict per repository for a day.
+
+    Only successful checks are cached: a repository that does not preserve
+    symlinks keeps warning on every command until it is actually fixed.
+    """
+    working_dir = find_repo_root(root)
+    if working_dir is None:
+        return True
+
+    now = time.time()
+    cache = _read_symlink_check_cache()
+    checked_at = cache.get(str(working_dir))
+    if checked_at is not None and 0 <= now - checked_at < SYMLINK_CHECK_TTL_SECONDS:
+        return True
+
+    if not check_symlinks(working_dir):
+        return False
+
+    cache = {
+        key: value
+        for key, value in cache.items()
+        if 0 <= now - value < SYMLINK_CHECK_TTL_SECONDS
+    }
+    cache[str(working_dir)] = now
+    _write_symlink_check_cache(cache)
+    return True

--- a/rbx/box/main.py
+++ b/rbx/box/main.py
@@ -73,7 +73,7 @@ def app():
 
     from rbx.box import git_utils
 
-    if not git_utils.check_symlinks(pathlib.Path.cwd()):
+    if not git_utils.check_symlinks_cached(pathlib.Path.cwd()):
         from rbx import console
         from rbx.box.formatting import ref
 

--- a/tests/rbx/box/test_git_utils.py
+++ b/tests/rbx/box/test_git_utils.py
@@ -1,4 +1,7 @@
+import json
 import subprocess
+import sys
+import time
 
 import pytest
 
@@ -74,33 +77,33 @@ class TestHasRemoteTag:
         assert git_utils.has_remote_tag('x', '2.0.0') is False
 
 
+def _make_repo(monkeypatch, tmp_path, *tracked_symlinks: str):
+    """Turn `tmp_path` into a repo root whose listing yields `tracked_symlinks`."""
+    (tmp_path / '.git').mkdir()
+    monkeypatch.setattr(git_utils.utils, 'command_exists', lambda cmd: True)
+
+    stdout = ''.join(f'120000 {"0" * 40} 0\t{path}\n' for path in tracked_symlinks)
+
+    def fake_run(cmd, cwd, check, capture_output, text):
+        assert cmd == ['git', 'ls-files', '-s']
+        assert cwd == tmp_path
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr='')
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+
 class TestCheckSymlinks:
     def test_git_not_installed(self, monkeypatch, tmp_path):
+        (tmp_path / '.git').mkdir()
         monkeypatch.setattr(git_utils.utils, 'command_exists', lambda cmd: False)
         assert git_utils.check_symlinks(tmp_path) is True
 
     def test_not_a_repo(self, monkeypatch, tmp_path):
         monkeypatch.setattr(git_utils.utils, 'command_exists', lambda cmd: True)
-        monkeypatch.setattr(git_utils, 'get_repo_or_nil', lambda path, **kwargs: None)
         assert git_utils.check_symlinks(tmp_path) is True
 
     def test_valid_symlinks(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(git_utils.utils, 'command_exists', lambda cmd: True)
-
-        mock_repo = type('Repo', (), {'working_dir': str(tmp_path)})()
-        monkeypatch.setattr(
-            git_utils, 'get_repo_or_nil', lambda path, **kwargs: mock_repo
-        )
-
-        def fake_run(cmd, cwd, check, capture_output, text):
-            return subprocess.CompletedProcess(
-                cmd,
-                0,
-                stdout='120000 0000000000000000000000000000000000000000 0\tlink_to_file',
-                stderr='',
-            )
-
-        monkeypatch.setattr(subprocess, 'run', fake_run)
+        _make_repo(monkeypatch, tmp_path, 'link_to_file')
 
         # Create the file and the symlink
         (tmp_path / 'target').touch()
@@ -109,22 +112,7 @@ class TestCheckSymlinks:
         assert git_utils.check_symlinks(tmp_path) is True
 
     def test_broken_symlinks_regular_file(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(git_utils.utils, 'command_exists', lambda cmd: True)
-
-        mock_repo = type('Repo', (), {'working_dir': str(tmp_path)})()
-        monkeypatch.setattr(
-            git_utils, 'get_repo_or_nil', lambda path, **kwargs: mock_repo
-        )
-
-        def fake_run(cmd, cwd, check, capture_output, text):
-            return subprocess.CompletedProcess(
-                cmd,
-                0,
-                stdout='120000 0000000000000000000000000000000000000000 0\tshould_be_link',
-                stderr='',
-            )
-
-        monkeypatch.setattr(subprocess, 'run', fake_run)
+        _make_repo(monkeypatch, tmp_path, 'should_be_link')
 
         # Create a regular file instead of a symlink
         (tmp_path / 'should_be_link').touch()
@@ -132,23 +120,104 @@ class TestCheckSymlinks:
         assert git_utils.check_symlinks(tmp_path) is False
 
     def test_missing_symlink(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(git_utils.utils, 'command_exists', lambda cmd: True)
-
-        mock_repo = type('Repo', (), {'working_dir': str(tmp_path)})()
-        monkeypatch.setattr(
-            git_utils, 'get_repo_or_nil', lambda path, **kwargs: mock_repo
-        )
-
-        def fake_run(cmd, cwd, check, capture_output, text):
-            return subprocess.CompletedProcess(
-                cmd,
-                0,
-                stdout='120000 0000000000000000000000000000000000000000 0\tmissing_link',
-                stderr='',
-            )
-
-        monkeypatch.setattr(subprocess, 'run', fake_run)
+        _make_repo(monkeypatch, tmp_path, 'missing_link')
 
         # Do not create the file
 
         assert git_utils.check_symlinks(tmp_path) is True
+
+    def test_finds_repo_root_from_a_subdirectory(self, monkeypatch, tmp_path):
+        _make_repo(monkeypatch, tmp_path, 'should_be_link')
+        (tmp_path / 'should_be_link').touch()
+        nested = tmp_path / 'a' / 'b'
+        nested.mkdir(parents=True)
+
+        assert git_utils.check_symlinks(nested) is False
+
+    def test_does_not_import_gitpython(self):
+        # GitPython costs ~80ms to import and this check runs before every
+        # command dispatch, so it must not pull the library in.
+        output = subprocess.check_output(
+            [
+                sys.executable,
+                '-c',
+                'import pathlib, sys; from rbx.box import git_utils; '
+                'git_utils.check_symlinks(pathlib.Path()); '
+                "print('git' in sys.modules)",
+            ],
+            text=True,
+        )
+        assert output.strip() == 'False'
+
+
+class TestCheckSymlinksCached:
+    def test_caches_good_verdict(self, monkeypatch, tmp_path):
+        (tmp_path / '.git').mkdir()
+        monkeypatch.setattr(
+            git_utils, '_symlink_check_cache_path', lambda: tmp_path / 'cache.json'
+        )
+
+        calls = []
+        monkeypatch.setattr(
+            git_utils, 'check_symlinks', lambda root: calls.append(root) or True
+        )
+
+        assert git_utils.check_symlinks_cached(tmp_path) is True
+        assert git_utils.check_symlinks_cached(tmp_path) is True
+        assert calls == [tmp_path]
+
+    def test_expired_entry_is_rechecked(self, monkeypatch, tmp_path):
+        (tmp_path / '.git').mkdir()
+        cache_path = tmp_path / 'cache.json'
+        monkeypatch.setattr(git_utils, '_symlink_check_cache_path', lambda: cache_path)
+        cache_path.write_text(
+            json.dumps(
+                {str(tmp_path): time.time() - git_utils.SYMLINK_CHECK_TTL_SECONDS - 1}
+            )
+        )
+
+        calls = []
+        monkeypatch.setattr(
+            git_utils, 'check_symlinks', lambda root: calls.append(root) or True
+        )
+
+        assert git_utils.check_symlinks_cached(tmp_path) is True
+        assert calls == [tmp_path]
+
+    def test_bad_verdict_is_not_cached(self, monkeypatch, tmp_path):
+        (tmp_path / '.git').mkdir()
+        monkeypatch.setattr(
+            git_utils, '_symlink_check_cache_path', lambda: tmp_path / 'cache.json'
+        )
+
+        calls = []
+        monkeypatch.setattr(
+            git_utils, 'check_symlinks', lambda root: calls.append(root) or False
+        )
+
+        assert git_utils.check_symlinks_cached(tmp_path) is False
+        assert git_utils.check_symlinks_cached(tmp_path) is False
+        assert calls == [tmp_path, tmp_path]
+
+    def test_not_a_repo_skips_the_check_entirely(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            git_utils, '_symlink_check_cache_path', lambda: tmp_path / 'cache.json'
+        )
+
+        def _boom(root):
+            raise AssertionError('should not be called outside a repo')
+
+        monkeypatch.setattr(git_utils, 'check_symlinks', _boom)
+
+        assert git_utils.check_symlinks_cached(tmp_path) is True
+
+    def test_corrupt_cache_is_ignored(self, monkeypatch, tmp_path):
+        (tmp_path / '.git').mkdir()
+        cache_path = tmp_path / 'cache.json'
+        monkeypatch.setattr(git_utils, '_symlink_check_cache_path', lambda: cache_path)
+        cache_path.write_text('not json')
+
+        monkeypatch.setattr(git_utils, 'check_symlinks', lambda root: True)
+
+        assert git_utils.check_symlinks_cached(tmp_path) is True
+        assert str(tmp_path) in json.loads(cache_path.read_text())


### PR DESCRIPTION
Closes #748.

`rbx/box/main.py` ran `git_utils.check_symlinks()` before every command dispatch — `--help`, shell completion, everything — for ~105 ms.

**Drop GitPython from the path.** `check_symlinks` only needed the repo's working-tree root, so it now walks parent directories for `.git` instead of constructing a `git.Repo`. `import git` moved inside `get_repo_or_nil`, so only the preset commands that really need a `Repo` object pay the ~84 ms import. `is_repo` / `is_within_repo` go through the same parent walk.

**Cache the verdict.** New `check_symlinks_cached` remembers a good verdict per repository root for a day, in `~/.../rbx/symlink-check.json`. Only *good* verdicts are cached — a repo that doesn't preserve symlinks keeps warning on every command until it's actually fixed. Corrupt or unwritable cache files are ignored rather than raised.

### Verification

`rbx --help`, instrumented to record `Popen` calls and check `sys.modules`:

| | GitPython imported | subprocesses spawned |
|---|---|---|
| before | yes | `['git']`, `['git', 'ls-files', '-s']` |
| after (cold) | no | `['git']`, `['git', 'ls-files', '-s']` |
| after (warm) | **no** | **none** |

Wall clock for `rbx --help`, 7 runs: median 730 ms → 567 ms, min 654 ms → 560 ms.

Tests: `tests/rbx/box/test_git_utils.py` rewritten around the new repo-root discovery (a shared `_make_repo` helper replaces the `get_repo_or_nil` mocks), plus coverage for repo-root discovery from a subdirectory, a subprocess test asserting GitPython stays unimported, and the cache's hit / expiry / bad-verdict / corrupt-file behaviour. `tests/rbx/box/presets tests/rbx/box/test_git_utils.py` — 394 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaU1dfA154ZCuHDXfLYBjJ
