### PR TITLE
perf(cli): keep prompt_toolkit off the import path of every command

### DIFF
--- a/rbx/box/presets/__init__.py
+++ b/rbx/box/presets/__init__.py
@@ -21,7 +21,6 @@ from typing import (
 )
 
 import pydantic
-import questionary
 import ruyaml
 import typer
 import yaml
@@ -119,6 +118,8 @@ def _collect_expansions(
     expansions: List[VariableExpansion],
 ) -> List[Tuple[str, str, List[str]]]:
     """Prompt the user for expansion values and return (needle, value, globs) tuples."""
+    import questionary
+
     result: List[Tuple[str, str, List[str]]] = []
     for exp in expansions:
         if exp.replacement == ReplacementMode.PROMPT:
@@ -886,6 +887,8 @@ def pick_variant(
     Returns None for the canonical template. Never prompts when the preset
     declares no variants, or when stdin is not a TTY.
     """
+    import questionary
+
     if variant is not None:
         # An explicit flag always wins: never second-guess it with a prompt,
         # and let `resolve_template` be the one to reject a bad id.
@@ -1171,6 +1174,7 @@ def _install_preset_from_remote(
     update: bool = False,
 ):
     import git
+    import questionary
 
     assert fetch_info.fetch_uri is not None
     with tempfile.TemporaryDirectory() as d:
@@ -1249,6 +1253,8 @@ def _install_preset_from_resources(
     ensure_problem: bool = False,
     update: bool = False,
 ):
+    import questionary
+
     if not questionary.confirm(
         'Do you really want to install this preset from its local copy? This is usually unsafe for mature projects, and means that youre not online.'
     ).ask():
@@ -1601,6 +1607,8 @@ def maybe_offer_to_register(
     """After a user creates a package with an explicit ``--preset`` URI, offer
     to add it to the user registry. Interactive-only, and only when the preset
     is not already known to the registry."""
+    import questionary
+
     from rbx.box.presets.registry_schema import RegistryPreset
 
     if fetch_info is None or not getattr(fetch_info, 'uri', None):

--- a/rbx/box/presets/registry.py
+++ b/rbx/box/presets/registry.py
@@ -1,7 +1,6 @@
 import pathlib
 from typing import Optional
 
-import questionary
 import ruyaml
 import typer
 
@@ -90,6 +89,8 @@ def find_in_registry(uri_or_name: str) -> Optional[RegistryPreset]:
 
 
 def pick_preset() -> RegistryPreset:
+    import questionary
+
     reg = get_merged_registry()
     if not reg.presets:
         console.console.print('[error]No presets available in the registry.[/error]')

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import functools
 import math
@@ -8,7 +10,6 @@ import rich
 import rich.console
 import typer
 from ordered_set import OrderedSet
-from prompt_toolkit.formatted_text import ANSI
 from pydantic import BaseModel, Field
 
 from rbx import console, utils
@@ -41,6 +42,11 @@ from rbx.box.solutions import (
 from rbx.grading.steps import Outcome
 
 if TYPE_CHECKING:
+    # `ANSI` is annotation-only here; the render callbacks that build `ANSI`
+    # values import it locally, so an interactive-only dependency stays off the
+    # import path of every command.
+    from prompt_toolkit.formatted_text import ANSI
+
     # Only for the annotation -- the backend itself is resolved by the CLI and
     # handed down. `RunPurpose` above is a live import instead because it is a
     # *value* this module passes: `runners.base` only reaches back into
@@ -567,6 +573,8 @@ def build_preview_renderer(
     forced-relative specs) to an ``ANSI`` preview: the resolved limits table, or
     an inline error for invalid groupings. Pure -- reuses the already-collected
     timings, never re-runs solutions."""
+
+    from prompt_toolkit.formatted_text import ANSI
 
     @functools.lru_cache(maxsize=None)
     def _render(assignment_items: tuple, relative_items: tuple) -> ANSI:

--- a/rbx/box/timing_group_picker.py
+++ b/rbx/box/timing_group_picker.py
@@ -1,10 +1,14 @@
-from typing import Callable, Dict, List, Optional
+from __future__ import annotations
 
-from prompt_toolkit.formatted_text import AnyFormattedText
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional
+
 from pydantic import BaseModel
 
 from rbx.box import timing_groups
 from rbx.box.environment import LanguageGroupFallback
+
+if TYPE_CHECKING:
+    from prompt_toolkit.formatted_text import AnyFormattedText
 
 
 class GroupAssignment(BaseModel):

--- a/tests/rbx/box/lazy_importing_test.py
+++ b/tests/rbx/box/lazy_importing_test.py
@@ -17,6 +17,8 @@ LAZY_MODULES = {
 # Modules that must not be loaded by `rbx.box.cli`, which every command pulls in.
 CLI_LAZY_MODULES = {
     'textual',
+    'questionary',
+    'prompt_toolkit',
 }
 
 

--- a/tests/rbx/box/presets/test_expansion.py
+++ b/tests/rbx/box/presets/test_expansion.py
@@ -105,12 +105,12 @@ class TestCollectExpansions:
                 prompt='Enter the problem name:',
             ),
         ]
-        with mock.patch('rbx.box.presets.questionary') as mock_q:
-            mock_q.text.return_value.ask.return_value = 'my-problem'
+        with mock.patch('questionary.text') as mock_text:
+            mock_text.return_value.ask.return_value = 'my-problem'
             result = _collect_expansions(expansions)
 
         assert result == [('__NAME__', 'my-problem', [])]
-        mock_q.text.assert_called_once_with('Enter the problem name:')
+        mock_text.assert_called_once_with('Enter the problem name:')
 
     def test_multiple_expansions(self):
         expansions = [
@@ -124,8 +124,8 @@ class TestCollectExpansions:
                 prompt='B?',
             ),
         ]
-        with mock.patch('rbx.box.presets.questionary') as mock_q:
-            mock_q.text.return_value.ask.side_effect = ['val_a', 'val_b']
+        with mock.patch('questionary.text') as mock_text:
+            mock_text.return_value.ask.side_effect = ['val_a', 'val_b']
             result = _collect_expansions(expansions)
 
         assert result == [

--- a/tests/rbx/box/presets/test_preset_registry.py
+++ b/tests/rbx/box/presets/test_preset_registry.py
@@ -1,4 +1,5 @@
 import pytest
+import questionary
 from pydantic import ValidationError
 
 from rbx.box.presets.registry_schema import PresetRegistry, RegistryPreset
@@ -145,9 +146,7 @@ class TestPicker:
             def ask(self_inner):
                 return 'default'
 
-        monkeypatch.setattr(
-            registry.questionary, 'select', lambda *a, **k: FakeSelect()
-        )
+        monkeypatch.setattr(questionary, 'select', lambda *a, **k: FakeSelect())
         chosen = registry.pick_preset()
         assert chosen is entry
 
@@ -169,8 +168,6 @@ class TestPicker:
             def ask(self_inner):
                 return None  # user hit Ctrl-C
 
-        monkeypatch.setattr(
-            registry.questionary, 'select', lambda *a, **k: FakeSelect()
-        )
+        monkeypatch.setattr(questionary, 'select', lambda *a, **k: FakeSelect())
         with pytest.raises(click.exceptions.Exit):
             registry.pick_preset()

--- a/tests/rbx/box/presets/test_preset_variants.py
+++ b/tests/rbx/box/presets/test_preset_variants.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from typing import Any, Iterable, Optional
 
 import pytest
+import questionary
 import typer
 from pydantic import ValidationError
 
@@ -1267,7 +1268,7 @@ def fake_no_tty(monkeypatch):
 
 def _patch_select(monkeypatch, answer: Any) -> _FakeSelect:
     fake = _FakeSelect(answer)
-    monkeypatch.setattr(presets.questionary, 'select', fake)
+    monkeypatch.setattr(questionary, 'select', fake)
     return fake
 
 

--- a/tests/rbx/box/presets/test_presets_additions_test.py
+++ b/tests/rbx/box/presets/test_presets_additions_test.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import click
 import pytest
+import questionary
 
 from rbx.box import presets
 
@@ -199,7 +200,7 @@ class TestCopyLocalPreset:
 
         # User accepts adding submodule
         monkeypatch.setattr(
-            presets.questionary,
+            questionary,
             'confirm',
             lambda *a, **k: SimpleNamespace(ask=lambda: True),
         )

--- a/tests/rbx/box/presets/test_registry_cli.py
+++ b/tests/rbx/box/presets/test_registry_cli.py
@@ -1,4 +1,5 @@
 import pytest
+import questionary
 from typer.testing import CliRunner
 
 from rbx.box import presets
@@ -88,7 +89,7 @@ class TestOfferToRegister:
         monkeypatch.setattr(presets.utils, 'is_interactive_tty', lambda: True)
         # Confirm "yes".
         monkeypatch.setattr(
-            presets.questionary,
+            questionary,
             'confirm',
             lambda *a, **k: SimpleNamespace(ask=lambda: True),
         )
@@ -125,7 +126,7 @@ class TestOfferToRegister:
             called['confirm'] = True
             return SimpleNamespace(ask=lambda: True)
 
-        monkeypatch.setattr(presets.questionary, 'confirm', _confirm)
+        monkeypatch.setattr(questionary, 'confirm', _confirm)
         presets.maybe_offer_to_register(SimpleNamespace(uri='o/r'), tmp_path)
         assert called['confirm'] is False  # already known -> no prompt
 


### PR DESCRIPTION
Closes #751. Part of #746.

`prompt_toolkit` was loaded on **every** `rbx` command through three module-scope imports:

- `rbx/box/timing_group_picker.py` — `AnyFormattedText`, used only in an annotation. The module already imported `prompt_toolkit` lazily inside the function that needs it; this leftover defeated it.
- `rbx/box/timing.py` — `ANSI`, used in annotations and at runtime inside the nested render callbacks.
- `rbx/box/presets` (`__init__.py`, `registry.py`) — `questionary` → `prompt_toolkit`, sitting on the *package-model* import chain (`cli → compile → code → download → header → package → environment → presets`). Loading the package model should not load an interactive prompt toolkit.

## Changes

- `timing_group_picker.py`: `from __future__ import annotations` + a `TYPE_CHECKING` guard.
- `timing.py`: same, plus a function-local `from prompt_toolkit.formatted_text import ANSI` in `build_preview_renderer`, which is where the `ANSI(...)` values are actually built.
- `presets/__init__.py`, `presets/registry.py`: `import questionary` moved into the five functions that actually prompt (`_collect_expansions`, `pick_variant`, `_install_preset_from_remote`, `_install_preset_from_resources`, `maybe_offer_to_register`, `pick_preset`).

## Tests

Tests that monkeypatched `presets.questionary` / `registry.questionary` now patch attributes on the `questionary` module itself, which is what a function-local `import questionary` resolves.

Added a regression guard: `questionary` and `prompt_toolkit` join `CLI_LAZY_MODULES` in `tests/rbx/box/lazy_importing_test.py`. Verified it bites — on `main`, `import rbx.box.cli` pulls both.

## Measurement

The issue's 43 ms was `prompt_toolkit` self time from `-X importtime`, not a delta. Measured properly:

| | before | after |
|---|---|---|
| `import rbx.box.cli` pulls `prompt_toolkit`/`questionary` | yes | no |
| `prompt_toolkit` cumulative import time on `rbx --help` | 202 ms (`questionary` 225 ms) | not imported |
| `uv run rbx --help`, avg of 7 warm runs | 822.5 ms | 722.7 ms |

~100 ms off every command.

Suite: `tests/rbx/box/presets`, `tests/rbx/box/test_timing*.py` — 660 passed. Plus `lazy_importing_test.py`, `completion/firewall_test.py`, `test_stress_promote.py`, `testcases/test_promote.py`, `test_time_runner_cli.py` — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ts41SFLF58tCfL9Rsz8wg
