### PR TITLE
fix(deps): silence compiler warnings from the python scanner

### DIFF
--- a/rbx/box/dependencies/python.py
+++ b/rbx/box/dependencies/python.py
@@ -1,5 +1,6 @@
 import ast
 import pathlib
+import warnings
 from typing import List, Optional
 
 from rbx import utils
@@ -47,7 +48,12 @@ class PythonScanner(scanner.DependencyScanner):
     def references(self, file: pathlib.Path) -> List[Reference]:
         file = pathlib.Path(file)
         try:
-            tree = ast.parse(file.read_text())
+            with warnings.catch_warnings():
+                # Scanning a user file must not surface the compiler's own
+                # diagnostics (e.g. SyntaxWarning for invalid escape sequences)
+                # in the middle of unrelated rbx output.
+                warnings.simplefilter('ignore')
+                tree = ast.parse(file.read_text(), filename=str(file))
         except SyntaxError:
             return []
         base_dir = file.parent

--- a/tests/rbx/box/dependencies_test.py
+++ b/tests/rbx/box/dependencies_test.py
@@ -132,6 +132,16 @@ class TestPythonReferences:
         assert pathlib.Path('a/__init__.py') in targets
         assert pathlib.Path('a/b/__init__.py') in targets
 
+    def test_scanning_does_not_leak_compiler_warnings(self, testing_pkg, recwarn):
+        from rbx.box.dependencies import python
+
+        # An invalid escape sequence makes CPython's compiler emit a
+        # SyntaxWarning; scanning a file must not surface it to the user.
+        main = testing_pkg.add_file('main.py')
+        main.write_text('S = "a\\.b"\nimport os\n')
+        python.PythonScanner().references(pathlib.Path('main.py'))
+        assert [w for w in recwarn.list if issubclass(w.category, SyntaxWarning)] == []
+
 
 class TestExpand:
     def test_cpp_transitive_excludes_root(self, testing_pkg):


### PR DESCRIPTION
## Problem

The Python dependency scanner parses every Python file in a package to discover imports:

```python
tree = ast.parse(file.read_text())
```

CPython's compiler emits its own diagnostics during that parse — a `SyntaxWarning` for an invalid escape sequence, for instance — straight to stderr. Nothing catches them, so they leak into the middle of unrelated rbx output. A real `rbx run` report:

```
solutions/wrong/ivan-no-solution.py (.rbx/runs/7) · 0.1s
  testplan (1) 0/✗ (18 ms, 28 MiB)
OK
...
<unknown>:21: SyntaxWarning: "\." is an invalid escape sequence.
```

The warning came from a *different* solution in the package (one with `\.` inside a non-raw string), and `<unknown>` gave the user nothing to go on, since the parse carried no filename.

## Fix

Suppress warnings around the parse, and pass the real filename so anything that does surface later is actionable.

The suppression is `simplefilter('ignore')` rather than `SyntaxWarning` alone — parsing arbitrary user source can raise `DeprecationWarning` and friends too, and none of them are rbx's business to report here. The `except SyntaxError` path is untouched, so unparseable files still degrade to no references.

## Test

`TestPythonReferences::test_scanning_does_not_leak_compiler_warnings` uses pytest's `recwarn`; it fails on `main` with exactly the warning above and passes with the fix. `tests/rbx/box/dependencies_test.py` + `tests/rbx/box/code_dependencies_integration_test.py`: 19 passed.

Also verified against the package that surfaced this — scanning the offending file is now silent and still returns correct references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hra73PeACCgHNxjJJYAtRF