### PR TITLE
test(cli): keep the nested coverage run out of the outer data file

### DIFF
--- a/tests/rbx/box/lazy_importing_test.py
+++ b/tests/rbx/box/lazy_importing_test.py
@@ -1,7 +1,8 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 LAZY_MODULES = {
     'gitpython',
@@ -28,11 +29,12 @@ CLI_LAZY_MODULES = {
 }
 
 
-def _imported_modules(*args: str) -> List[str]:
+def _imported_modules(*args: str, env: Optional[dict] = None) -> List[str]:
     result = subprocess.run(
         [sys.executable, *args],
         capture_output=True,
         encoding='utf-8',
+        env=env,
     )
     assert result.returncode == 0, result.stderr
     modules = result.stdout.splitlines()
@@ -42,9 +44,16 @@ def _imported_modules(*args: str) -> List[str]:
     return modules
 
 
-def test_rich_not_imported_unnecessary():
+def test_rich_not_imported_unnecessary(tmp_path: Path):
     file_path = Path(__file__).parent / 'lazy_importing_main.py'
-    modules = _imported_modules('-m', 'coverage', 'run', str(file_path))
+    # `coverage run` writes its data file to $COVERAGE_FILE (`.coverage` in the
+    # cwd by default), and this nested run measures statements only. Under
+    # `pytest --cov-branch` that clobbers the outer run's data file with
+    # statement data, and pytest-cov's final combine dies with
+    # "Can't combine branch coverage data with statement data" -- every test
+    # passing but the process exiting 3. Keep the nested data out of the way.
+    env = {**os.environ, 'COVERAGE_FILE': str(tmp_path / '.coverage')}
+    modules = _imported_modules('-m', 'coverage', 'run', str(file_path), env=env)
     assert not [module for module in modules if module in LAZY_MODULES]
 
 


### PR DESCRIPTION
## Problem

The `tests` workflow fails on every tag push (e.g. [run 32825704354](https://github.com/rsalesc/rbx/actions/runs/32825704354/job/97733080972)) with all tests green:

```
=== 5703 passed, 2 skipped, 57 deselected, 79 warnings in 447.44s ===
INTERNALERROR> coverage.exceptions.DataError: Can't combine branch coverage data with statement data
[test-cov] ERROR task failed  →  exit code 3
```

`test_rich_not_imported_unnecessary` shells out to `python -m coverage run lazy_importing_main.py`. That nested run writes **statement-only** data to `.coverage` in the cwd (the default `COVERAGE_FILE`), clobbering the outer run's data file. `mise run test-cov` passes `--cov-branch`, so pytest-cov's final `combine()` tries to merge its branch `.coverage.<host>.<pid>.*` worker files into a statement-only base and raises `DataError`.

Deterministic, not flaky — it reproduces with just two test files.

## Fix

Point the nested `coverage run` at a `COVERAGE_FILE` inside `tmp_path` so it can't touch the outer run's data.

## Verification

Before:

```
$ uv run pytest tests/rbx/box/lazy_importing_test.py tests/rbx/box/lazy_cli_test.py --cov=rbx --cov-branch --cov-report=xml
42 passed
INTERNALERROR> coverage.exceptions.DataError: Can't combine branch coverage data with statement data
```

After: `42 passed`, exit 0, `coverage.xml` written, no stray `.coverage.*` left behind. `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHFHEgeSjeWBnHbpZCgQTg