### PR TITLE
fix(validators): do not report hit bounds for partial builds

### DIFF
--- a/rbx/box/builder.py
+++ b/rbx/box/builder.py
@@ -34,6 +34,13 @@ async def build(
     is_run: bool = False,
     is_statement: bool = False,
 ) -> bool:
+    """Build the testset.
+
+    `groups` restricts the build to a subset of the testcase groups. `is_statement`
+    marks a build whose only purpose is feeding a statement its samples: coverage
+    of the constraint bounds is never the question there, so the hit-bounds
+    section of the validation report is dropped entirely.
+    """
     no_main_solution_report = False
     # None, not [], when the build did not validate: the manifest omits its
     # `validation` key entirely rather than publishing an empty coverage table
@@ -63,7 +70,9 @@ async def build(
                 groups=groups,
             )
             input_validation_infos = infos
-            print_validation_report(infos)
+            print_validation_report(
+                infos, groups=groups, report_hit_bounds=not is_statement
+            )
 
         if has_validation_errors(infos):
             console.console.print(

--- a/rbx/box/testcase_sample_utils.py
+++ b/rbx/box/testcase_sample_utils.py
@@ -366,6 +366,7 @@ async def build_samples(
             groups=set(['samples']),
             output=None,
             validate=validate,
+            is_statement=True,
         )
     if not ok:
         return False

--- a/rbx/box/validators.py
+++ b/rbx/box/validators.py
@@ -523,9 +523,34 @@ def has_validation_errors(infos: List[TestcaseValidationInfo]) -> bool:
     return any(not info.ok for info in infos)
 
 
+def _is_partial_build(groups: Optional[Set[str]]) -> bool:
+    """Whether the build that produced these infos covered only some groups.
+
+    A group is always built whole, so a per-group hit-bounds row is as complete
+    on a subset build as on a full one. The package-wide row is not: it asserts
+    that the testset *as a whole* hits every bound, which the groups that were
+    left out were free to be the ones to do.
+    """
+    if groups is None:
+        return False
+    pkg = package.find_problem_package_or_die()
+    return not set(group.name for group in pkg.testcases).issubset(groups)
+
+
 def print_validation_report(
-    infos: List[TestcaseValidationInfo], output_validation: bool = False
+    infos: List[TestcaseValidationInfo],
+    output_validation: bool = False,
+    groups: Optional[Set[str]] = None,
+    report_hit_bounds: bool = True,
 ):
+    """Print the validation report for `infos`.
+
+    `groups` is the group filter of the build that produced `infos`, if any: a
+    build restricted to a subset of the groups gets no package-wide hit-bounds
+    row, only the per-group ones. `report_hit_bounds=False` drops the whole
+    hit-bounds section -- for callers whose testset is a subset by construction
+    and for whom coverage is never the question, like statement building.
+    """
     any_failure = any(not info.ok for info in infos)
     validator_mode_str = 'output validator' if output_validation else 'validator'
 
@@ -557,7 +582,15 @@ def print_validation_report(
         console.console.print()
         return
 
-    if not _has_group_specific_bounds():
+    if not report_hit_bounds:
+        hit_bounds_per_group = {}
+    elif _is_partial_build(groups):
+        # Only the per-group rows survive a subset build. When the bounds are
+        # shared package-wide there are no per-group rows to keep: a single
+        # group is not expected to hit the whole package's bounds on its own.
+        if not _has_group_specific_bounds():
+            hit_bounds_per_group = {}
+    elif not _has_group_specific_bounds():
         hit_bounds_per_group = {None: _merge_hit_bounds(hit_bounds_per_group.values())}
 
     def _is_hit_bound_good(hit_bounds: HitBounds) -> bool:

--- a/tests/rbx/box/validators_test.py
+++ b/tests/rbx/box/validators_test.py
@@ -181,6 +181,98 @@ async def test_main_validator_no_hit_bound_issues(
     assert '- "x": max-value not hit' not in out
 
 
+async def test_subset_build_does_not_report_package_wide_hit_bounds(
+    testing_pkg: testing_package.TestingPackage,
+    capsys: pytest.CaptureFixture[str],
+):
+    """A subset build cannot assert the package-wide bounds are unhit.
+
+    The groups it left out were free to be the ones hitting them -- which is what
+    made every statement build (samples only) report every bound as unhit.
+    """
+    testing_pkg.add_testgroup_from_glob('samples', 'manual_tests/samples/*.in')
+    testing_pkg.add_testgroup_from_glob('main', 'manual_tests/main/*.in')
+    testing_pkg.add_file('manual_tests/samples/000.in').write_text('59\n')
+    testing_pkg.add_file('manual_tests/main/000.in').write_text('1\n')
+
+    testing_pkg.set_validator(
+        'validator.cpp', src='validators/int-validator-bounded.cpp'
+    )
+
+    assert _has_group_specific_bounds() is False
+
+    await generate_testcases()
+
+    validation_infos = await validate_testcases(groups={'samples'})
+    print_validation_report(validation_infos, groups={'samples'})
+
+    assert not has_validation_errors(validation_infos)
+
+    out = capsys.readouterr().out
+    assert 'Hit bounds:' not in out
+    assert 'not hit' not in out
+    assert 'No validation issues found.' in out
+
+
+async def test_subset_build_still_reports_group_specific_hit_bounds(
+    testing_pkg: testing_package.TestingPackage,
+    capsys: pytest.CaptureFixture[str],
+):
+    """A group is built whole, so its own row is as complete as on a full build."""
+    testing_pkg.add_testgroup_from_glob('samples', 'manual_tests/samples/*.in')
+    testing_pkg.add_testgroup_from_glob('main', 'manual_tests/main/*.in')
+    testing_pkg.add_file('manual_tests/samples/000.in').write_text('59\n')
+    testing_pkg.add_file('manual_tests/main/000.in').write_text('73\n')
+
+    testing_pkg.set_validator(
+        'validator.cpp', src='validators/int-validator-bounded.cpp'
+    )
+    testing_pkg.yml.testcases[1].vars = {'N': {'max': 100}}
+    testing_pkg.save()
+
+    assert _has_group_specific_bounds() is True
+
+    await generate_testcases()
+
+    validation_infos = await validate_testcases(groups={'main'})
+    print_validation_report(validation_infos, groups={'main'})
+
+    assert not has_validation_errors(validation_infos)
+
+    out = capsys.readouterr().out
+    assert 'Group main hit bounds:' in out
+    assert '- "x": min-value not hit' in out
+
+
+async def test_hit_bounds_can_be_suppressed_entirely(
+    testing_pkg: testing_package.TestingPackage,
+    capsys: pytest.CaptureFixture[str],
+):
+    """What statement building asks for: never report coverage, not even here.
+
+    A samples-only package is a full build of every group it has, so the subset
+    rule alone would still report its bounds.
+    """
+    testing_pkg.add_testgroup_from_glob('samples', 'manual_tests/*.in')
+    testing_pkg.add_file('manual_tests/000.in').write_text('59\n')
+
+    testing_pkg.set_validator(
+        'validator.cpp', src='validators/int-validator-bounded.cpp'
+    )
+
+    await generate_testcases()
+
+    validation_infos = await validate_testcases()
+    print_validation_report(validation_infos, report_hit_bounds=False)
+
+    assert not has_validation_errors(validation_infos)
+
+    out = capsys.readouterr().out
+    assert 'Hit bounds:' not in out
+    assert 'not hit' not in out
+    assert 'No validation issues found.' in out
+
+
 async def test_group_specific_validator_catches_invalid_cases(
     testing_pkg: testing_package.TestingPackage,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Problem

Since #686, samples feed the package-wide hit bounds. Statement building runs `builder.build(groups={'samples'})`, so every statement build reported every constraint bound as `min-value not hit` / `max-value not hit` — expected, since samples are tiny, and pure noise.

## The two rules

**A subset build gets no package-wide row.** That row asserts the testset *as a whole* hits every bound; a build restricted to some groups cannot claim otherwise, because the groups it left out were free to be the ones hitting it.

**Per-group rows survive a subset build.** A group is always built whole — `generate_testcases` filters by group, never within one — so a group's own row is exactly as complete as on a full build. That keeps the coverage report useful for points problems built one group at a time.

It follows that when bounds are *not* group-specific, a subset build reports nothing at all: every group shares the same bounds, so no single group is individually expected to hit them and a per-group row would be the same false positive wearing a group label.

**Statement builds drop the section outright**, through the until-now unused `is_statement` flag. The subset rule alone is not enough there: a samples-only package (exactly the case #686 fixed) has `groups == {'samples'} ==` all groups, so it is not a subset and would still report. `build_samples()` is the single entry point for statement samples, used by both `rbx st b` and the packagers, so the flag is set there.

## Changes

- `rbx/box/validators.py` — `print_validation_report` takes `groups` and `report_hit_bounds`; new `_is_partial_build` helper.
- `rbx/box/builder.py` — passes both through; `is_statement` is documented and now actually read.
- `rbx/box/testcase_sample_utils.py` — `build_samples` passes `is_statement=True`.
- Three regression tests.

The testset manifest is deliberately untouched: it stores bounds per group, and a per-group row is accurate whether or not the other groups were built.

## Notes

The pre-existing conservative over-reporting in per-group mode is left alone. `_has_group_specific_bounds()` is package-wide, so a package where a single group declares `vars` gets per-group rows for every group, including ones without their own bounds. That is a deliberate documented choice for full builds, and a subset build makes each printed row no less accurate — it only omits the absent groups' rows.

## Testing

All 7 hit-bounds tests pass, including #686's samples-only test, unchanged. The 6 other failures in `validators_test.py` are pre-existing — verified by stashing this change and reproducing them identically on a clean tree (the known local `failed verification on validator` environment issue). `ruff check`/`format` clean; the 49 sample-utils and manifest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ynmaVVXzevaoQJ2Z5R7wk