### PR TITLE
feat(cli): accept extra compiler flags in rbx compile

### DIFF
--- a/docs/plans/2026-08-26-compile-extra-flags-design.md
+++ b/docs/plans/2026-08-26-compile-extra-flags-design.md
@@ -1,0 +1,85 @@
+# Extra compiler flags for `rbx compile`
+
+Design for [#767](https://github.com/rsalesc/rbx/issues/767).
+
+## Problem
+
+`rbx compile` builds an asset with exactly the command `env.rbx.yml` declares for its
+language, plus whatever `--sanitized` and `--warnings` inject. There is no way to add a
+one-off flag. Two things suffer:
+
+- **Debugging one-offs.** Reproducing a bug under `-DLOCAL -g -O0` or a sanitizer the
+  tool does not wire up means editing `env.rbx.yml`, compiling, then reverting it.
+- **Trying a flag before adopting it.** Deciding whether the package's C++ command
+  should carry a new flag requires the same edit-and-revert dance.
+
+Neither is a scripting or CI need, so the feature stays a convenience on the
+interactive path.
+
+## CLI surface
+
+```
+rbx compile [PATH] [-s] [-w] [-a] [-- EXTRA...]
+```
+
+`compile_command` takes a variadic `extra` argument and sets
+`ignore_unknown_options`, so everything after `--` reaches the compiler verbatim --
+including tokens that collide with rbx's own options. `rbx compile sol.cpp -- -s`
+passes `-s` to the compiler; `rbx compile -s sol.cpp -- -O0` sanitizes *and* adds
+`-O0`.
+
+Click fills positional arguments in order and does not tell us where `--` was, so
+`rbx compile -- -O0` would bind `-O0` to `PATH`. A leading-dash `PATH` is never a real
+path, so it is shifted to the front of `extra` and the command falls through to the
+usual interactive prompt.
+
+Under `--all` the flags apply to every asset compiled.
+
+## Where the flags land
+
+A language may compile in several steps. Java is the awkward one:
+
+```yaml
+compilation:
+  commands:
+    - "javac -Xlint -encoding UTF-8 {compilable}"
+    - "jar cvf {executable} @glob:*.class"
+```
+
+`-DFOO` belongs on `javac`, not on `jar`. The rule, mirroring how sanitizer and
+warning flags are already placed:
+
+> Append the flags to every command whose `command_kinds()` intersects the language's
+> kinds. If no command matches, append to the first command.
+
+`javac` reports `{JAVA, JVM}` and takes the flags; `jar` reports nothing and is left
+alone. C, C++ and Kotlin are single-command and match directly. A language whose
+compiler `command_kinds()` does not recognise -- `rustc`, `fpc`, `ghc` -- falls back
+to the first command, which is the only command such a language has.
+
+The flags are appended after the sanitizer and warning flags, so the user's flags come
+last on the command line and win.
+
+## Interpreted languages
+
+Python declares no `compilation.commands`, so `compile_item` returns the source
+unchanged and the flags can do nothing. Silently dropping them is the worst outcome
+for a debugging one-off, so rbx warns, names the language, and continues to the
+passthrough artifact. It stays a warning rather than an error because `--all` on a
+package that mixes Python and C++ solutions is legitimate.
+
+## Precompiled headers
+
+`compile_item` precompiles the headers in `__internal__/`. GCC rejects a PCH built
+under different `-D` flags than the translation unit that includes it, so extra flags
+would either fail the build or silently skip the PCH. When extra flags are present,
+precompilation is disabled. That costs time only on the debugging path.
+
+## Caching
+
+`steps_with_caching.compile` keys its cache on the command list, so a different set of
+extra flags is a different cache entry with no extra work.
+
+## Scope
+
+`rbx compile` only. `rbx run`, `rbx build` and the packaging commands are untouched.

--- a/docs/setters/cheatsheet.md
+++ b/docs/setters/cheatsheet.md
@@ -15,6 +15,7 @@ Where a command has a page of its own, the :material-open-in-new: next to it tak
 | Create a new package in folder `package` [:material-open-in-new:](/setters/first-steps) | `rbx create` |
 | Compile a file given its path | `rbx compile my/file.cpp` |
 | Compile every asset of the package | `rbx compile -a` |
+| Compile a file with extra compiler flags | `rbx compile my/file.cpp -- -DLOCAL -g` |
 | Open the problem configuration in a text editor [:material-open-in-new:](/setters/reference/package) | `rbx edit` |
 | Generate all testcases [:material-open-in-new:](/setters/testset#building-the-testset) | `rbx build` |
 | Generate all testcases and their visualizations [:material-open-in-new:](/setters/testset/visualizers) | `rbx build --visualize` |

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -279,7 +279,7 @@ Compile an asset given its path.
 
 **Usage:**
 ```bash
-rbx compile <PATH> [OPTIONS]
+rbx compile <PATH> <EXTRA_FLAGS> [OPTIONS]
 ```
 
 **Arguments:**
@@ -287,6 +287,7 @@ rbx compile <PATH> [OPTIONS]
 | Name | Description | Required |
 | :--- | :--- | :--- |
 | `PATH` | Path to the asset to compile. | No |
+| `EXTRA_FLAGS` | Extra flags to pass to the compiler, after a `--` separator. | No |
 
 | Name | Type | Description | Default |
 | :--- | :--- | :--- | :--- |

--- a/rbx/box/cli/commands/assets.py
+++ b/rbx/box/cli/commands/assets.py
@@ -9,7 +9,7 @@ there too.
 
 import pathlib
 import tempfile
-from typing import Annotated, Optional
+from typing import Annotated, List, Optional
 
 import syncer
 import typer
@@ -30,6 +30,7 @@ app = typer.Typer(cls=annotations.AliasGroup)
     'compile',
     rich_help_panel='Testing',
     help='Compile an asset given its path.',
+    context_settings={'ignore_unknown_options': True},
 )
 @package.within_problem
 @syncer.sync
@@ -57,7 +58,22 @@ async def compile_command(
         '-a',
         help='Whether to compile all assets.',
     ),
+    extra_flags: Annotated[
+        Optional[List[str]],
+        typer.Argument(
+            metavar='[-- EXTRA_FLAGS...]',
+            help='Extra flags to pass to the compiler, after a `--` separator.',
+        ),
+    ] = None,
 ):
+    extra_flags = list(extra_flags or [])
+
+    # Click fills positional arguments in order and does not report where `--` was,
+    # so `rbx compile -- -O0` binds `-O0` to `path`. A leading dash is never a path.
+    if path is not None and path.startswith('-'):
+        extra_flags.insert(0, path)
+        path = None
+
     if path is None and not all:
         import questionary
 
@@ -68,16 +84,33 @@ async def compile_command(
 
     if all:
         for solution in package.get_solutions():
-            await compile.any(str(solution.path), sanitized, warnings)
+            await compile.any(
+                str(solution.path), sanitized, warnings, extra_flags=extra_flags
+            )
         if package.get_checker() is not None:
-            await compile.any(str(package.get_checker().path), sanitized, warnings)
+            await compile.any(
+                str(package.get_checker().path),
+                sanitized,
+                warnings,
+                extra_flags=extra_flags,
+            )
         if package.get_validator() is not None:
-            await compile.any(str(package.get_validator().path), sanitized, warnings)
+            await compile.any(
+                str(package.get_validator().path),
+                sanitized,
+                warnings,
+                extra_flags=extra_flags,
+            )
         if package.get_interactor() is not None:
-            await compile.any(str(package.get_interactor().path), sanitized, warnings)
+            await compile.any(
+                str(package.get_interactor().path),
+                sanitized,
+                warnings,
+                extra_flags=extra_flags,
+            )
 
     if path is not None:
-        await compile.any(path, sanitized, warnings)
+        await compile.any(path, sanitized, warnings, extra_flags=extra_flags)
 
 
 @app.command(

--- a/rbx/box/code.py
+++ b/rbx/box/code.py
@@ -30,6 +30,7 @@ from rbx.box.environment import (
     get_mapped_commands,
     get_sandbox_params_from_config,
     is_interpreted,
+    language_kinds,
     merge_execution_configs,
 )
 from rbx.box.formatting import get_formatted_memory
@@ -152,6 +153,34 @@ def add_cpp_flags(commands: List[str], force_warnings: bool) -> List[str]:
     if cfg.warnings.enabled or force_warnings:
         return [add_warning_flags_to_command(command) for command in commands]
     return commands
+
+
+def add_extra_flags_to_commands(
+    commands: List[str], extra_flags: List[str], language: EnvironmentLanguage
+) -> List[str]:
+    """Append user-supplied compiler flags to a language's compilation commands.
+
+    A language may compile in several steps -- Java runs ``javac`` and then ``jar`` --
+    and the flags belong on the compiler, not on the packaging step. Commands are
+    matched by :func:`command_kinds` on their executable against the language's own
+    kinds, the same way sanitizer and warning flags are placed. When no command
+    matches (a compiler ``command_kinds`` does not recognise, such as ``rustc``), the
+    flags go to the first command, which is the only command such a language has.
+
+    The flags are appended last so they take precedence over the flags rbx injects.
+    """
+    if not extra_flags:
+        return commands
+
+    suffix = ' ' + shlex.join(extra_flags)
+    kinds = language_kinds(language)
+
+    def matches(command: str) -> bool:
+        return bool(command_kinds(steps.get_exe_from_command(command)) & kinds)
+
+    if not any(matches(command) for command in commands):
+        return [commands[0] + suffix] + commands[1:]
+    return [command + suffix if matches(command) else command for command in commands]
 
 
 def _add_warning_pragmas(code: str) -> str:
@@ -612,6 +641,7 @@ async def compile_item(
     verbose: bool = False,
     precompile: bool = True,
     kind: Optional['AssetKind'] = None,
+    extra_flags: Optional[List[str]] = None,
 ) -> str:
     with package.get_new_sandbox() as sandbox:
         _check_stack_limit()
@@ -641,6 +671,11 @@ async def compile_item(
 
         if not compilation_options.commands:
             # Language is not compiled.
+            if extra_flags:
+                console.console.print(
+                    f'[warning]Extra compiler flags ignored: [item]{language}[/item] '
+                    'is not a compiled language.[/warning]'
+                )
             return await sandbox.file_cacher.put_file_from_path(compilable_path)
 
         commands = get_mapped_commands(
@@ -720,8 +755,15 @@ async def compile_item(
         if bits_artifact is not None or added_always_include:
             commands = _add_internal_include(commands)
 
-        # Precompile C++ interesting header files.
-        if precompile and _should_precompile(commands):
+        # User-supplied flags go last so they win over everything rbx injects.
+        commands = add_extra_flags_to_commands(
+            commands, extra_flags or [], get_language(language)
+        )
+
+        # Precompile C++ interesting header files. Skipped when the user passed extra
+        # flags: GCC rejects a precompiled header built under different flags than the
+        # translation unit including it.
+        if precompile and not extra_flags and _should_precompile(commands):
             with profiling.Profiler('code.precompile'):
                 precompilation_inputs = []
                 for input in artifacts.inputs:

--- a/rbx/box/compile.py
+++ b/rbx/box/compile.py
@@ -1,4 +1,5 @@
 import pathlib
+from typing import List, Optional
 
 import typer
 
@@ -16,10 +17,19 @@ def _compile_out():
     return package.get_build_path() / 'exe'
 
 
-async def _compile(item: CodeItem, sanitized: SanitizationLevel, warnings: bool):
+async def _compile(
+    item: CodeItem,
+    sanitized: SanitizationLevel,
+    warnings: bool,
+    extra_flags: Optional[List[str]] = None,
+):
     console.console.print(f'Compiling {item.href()}...')
     digest = await code.compile_item(
-        item, sanitized, force_warnings=warnings, verbose=True
+        item,
+        sanitized,
+        force_warnings=warnings,
+        verbose=True,
+        extra_flags=extra_flags,
     )
     cacher = package.get_file_cacher()
     out_path = _compile_out()
@@ -35,7 +45,12 @@ async def _compile(item: CodeItem, sanitized: SanitizationLevel, warnings: bool)
     )
 
 
-async def any(path: str, sanitized: bool = False, warnings: bool = False):
+async def any(
+    path: str,
+    sanitized: bool = False,
+    warnings: bool = False,
+    extra_flags: Optional[List[str]] = None,
+):
     pkg = package.find_problem_package_or_die()
 
     path = str(remote.expand_file(path))
@@ -46,6 +61,7 @@ async def any(path: str, sanitized: bool = False, warnings: bool = False):
             solution,
             sanitized=SanitizationLevel.FORCE if sanitized else SanitizationLevel.NONE,
             warnings=warnings,
+            extra_flags=extra_flags,
         )
         return
 
@@ -57,6 +73,7 @@ async def any(path: str, sanitized: bool = False, warnings: bool = False):
                 if sanitized
                 else SanitizationLevel.PREFER,
                 warnings=warnings,
+                extra_flags=extra_flags,
             )
             return
 
@@ -68,6 +85,7 @@ async def any(path: str, sanitized: bool = False, warnings: bool = False):
             if sanitized
             else SanitizationLevel.PREFER,
             warnings=warnings,
+            extra_flags=extra_flags,
         )
         return
 
@@ -78,6 +96,7 @@ async def any(path: str, sanitized: bool = False, warnings: bool = False):
             if sanitized
             else SanitizationLevel.PREFER,
             warnings=warnings,
+            extra_flags=extra_flags,
         )
         return
 
@@ -85,4 +104,5 @@ async def any(path: str, sanitized: bool = False, warnings: bool = False):
         CodeItem(path=pathlib.Path(path)),
         sanitized=SanitizationLevel.FORCE if sanitized else SanitizationLevel.NONE,
         warnings=warnings,
+        extra_flags=extra_flags,
     )

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -823,6 +823,15 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': None,
+                    'kind': 'argument',
+                    'multiple': False,
+                    'names': [],
+                    'takes_value': True,
+                    'value': {'kind': 'none'},
+                    'variadic': True,
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,

--- a/tests/rbx/box/code_compile_test.py
+++ b/tests/rbx/box/code_compile_test.py
@@ -1,4 +1,5 @@
 import pathlib
+import shlex
 import sys
 from unittest import mock
 
@@ -6,6 +7,11 @@ import pytest
 import typer
 
 from rbx.box import code, package
+from rbx.box.environment import (
+    CompilationConfig,
+    EnvironmentLanguage,
+    ExecutionConfig,
+)
 from rbx.box.schema import CodeItem
 from rbx.box.testing import testing_package
 from rbx.grading import steps
@@ -786,6 +792,82 @@ int custom_function();
         )
         assert compilable is not None
 
+    async def test_extra_flags_come_last_on_the_command(
+        self, testing_pkg: testing_package.TestingPackage, mock_steps_with_caching
+    ):
+        """User flags win, so they are appended after everything rbx injects."""
+        cpp_file = testing_pkg.add_file('solution.cpp', src='compile_test/simple.cpp')
+        code_item = CodeItem(path=cpp_file, language='cpp')
+
+        await code.compile_item(
+            code_item, force_warnings=True, extra_flags=['-DLOCAL', '-O0']
+        )
+
+        commands = mock_steps_with_caching.call_args[0][0]
+
+        assert commands[0].endswith(' -DLOCAL -O0')
+        # And they really are last: after the warning flags rbx added itself.
+        parts = commands[0].split()
+        assert parts.index('-O0') > parts.index('-Wall')
+
+    async def test_extra_flags_reach_javac_and_not_jar(
+        self, testing_pkg: testing_package.TestingPackage, mock_steps_with_caching
+    ):
+        java_file = testing_pkg.add_file(
+            'Solution.java', src='compile_test/simple.java'
+        )
+        code_item = CodeItem(path=java_file, language='java')
+
+        await code.compile_item(code_item, extra_flags=['-nowarn'])
+
+        commands = mock_steps_with_caching.call_args[0][0]
+
+        assert commands[0] == 'javac -Xlint -encoding UTF-8 Simple.java -nowarn'
+        assert commands[1] == 'jar cvf Main.jar @glob:*.class'
+
+    async def test_extra_flags_disable_precompilation(
+        self,
+        testing_pkg: testing_package.TestingPackage,
+        mock_steps_with_caching,
+        mock_precompile_header,
+    ):
+        """GCC rejects a PCH built under different flags than its includer."""
+        cpp_file = testing_pkg.add_file('solution.cpp', src='compile_test/simple.cpp')
+        code_item = CodeItem(path=cpp_file, language='cpp')
+
+        await code.compile_item(code_item, extra_flags=['-DLOCAL'])
+
+        mock_precompile_header.assert_not_called()
+
+    async def test_a_plain_compile_still_precompiles(
+        self,
+        testing_pkg: testing_package.TestingPackage,
+        mock_steps_with_caching,
+        mock_precompile_header,
+    ):
+        cpp_file = testing_pkg.add_file('solution.cpp', src='compile_test/simple.cpp')
+        code_item = CodeItem(path=cpp_file, language='cpp')
+
+        await code.compile_item(code_item)
+
+        mock_precompile_header.assert_called()
+
+    async def test_extra_flags_on_an_interpreted_language_warn(
+        self,
+        testing_pkg: testing_package.TestingPackage,
+        mock_steps_with_caching,
+        capsys,
+    ):
+        """Silently dropping the flags is the worst outcome for a debugging one-off."""
+        py_file = testing_pkg.add_file('solution.py', src='compile_test/simple.py')
+        code_item = CodeItem(path=py_file, language='py')
+
+        result = await code.compile_item(code_item, extra_flags=['-O2'])
+
+        assert isinstance(result, str)
+        mock_steps_with_caching.assert_not_called()
+        assert 'py' in capsys.readouterr().out
+
 
 class TestRelativeSourcePath:
     def test_nested_source_is_package_relative(
@@ -895,3 +977,76 @@ class TestExecutionFiles:
         item = CodeItem(path=sol, language='py', executionFiles=['m.py'])
         wd = CodeItemWithDigest.create(item, 'deadbeef')
         assert wd.executionFiles == ['m.py']
+
+
+def _language(name: str, extension: str, commands) -> EnvironmentLanguage:
+    return EnvironmentLanguage(
+        name=name,
+        extension=extension,
+        compilation=CompilationConfig(commands=commands),
+        execution=ExecutionConfig(command='./{executable}'),
+    )
+
+
+class TestExtraFlagPlacement:
+    """Where user-supplied compiler flags land, per language.
+
+    A language may compile in several steps, and the flags belong on the compiler
+    rather than on a packaging step, so placement is a decision worth pinning.
+    """
+
+    def test_single_command_language_gets_the_flags(self):
+        language = _language(
+            'cpp', 'cpp', ['g++ -std=c++20 -o {executable} {compilable}']
+        )
+
+        assert code.add_extra_flags_to_commands(
+            ['g++ -std=c++20 -o executable sol.cpp'], ['-DLOCAL', '-O0'], language
+        ) == ['g++ -std=c++20 -o executable sol.cpp -DLOCAL -O0']
+
+    def test_java_puts_the_flags_on_javac_and_not_on_jar(self):
+        language = _language(
+            'java',
+            'java',
+            [
+                'javac -Xlint -encoding UTF-8 {compilable}',
+                'jar cvf {executable} @glob:*.class',
+            ],
+        )
+
+        assert code.add_extra_flags_to_commands(
+            [
+                'javac -Xlint -encoding UTF-8 Main.java',
+                'jar cvf Main.jar @glob:*.class',
+            ],
+            ['-nowarn'],
+            language,
+        ) == [
+            'javac -Xlint -encoding UTF-8 Main.java -nowarn',
+            'jar cvf Main.jar @glob:*.class',
+        ]
+
+    def test_an_unrecognized_compiler_falls_back_to_the_first_command(self):
+        # `command_kinds` knows nothing about rustc, so nothing matches and the
+        # flags go to the only command such a language has.
+        language = _language('rs', 'rs', ['rustc -O -o {executable} {compilable}'])
+
+        assert code.add_extra_flags_to_commands(
+            ['rustc -O -o executable sol.rs'], ['-C', 'debuginfo=2'], language
+        ) == ['rustc -O -o executable sol.rs -C debuginfo=2']
+
+    def test_no_flags_leaves_the_commands_untouched(self):
+        language = _language('cpp', 'cpp', ['g++ -o {executable} {compilable}'])
+        commands = ['g++ -o executable sol.cpp']
+
+        assert code.add_extra_flags_to_commands(commands, [], language) == commands
+
+    def test_flags_needing_quotes_survive_the_round_trip(self):
+        # Commands are shlex-split before execution, so a flag carrying a space
+        # has to be re-quoted on the way in.
+        language = _language('cpp', 'cpp', ['g++ -o {executable} {compilable}'])
+
+        (command,) = code.add_extra_flags_to_commands(
+            ['g++ -o executable sol.cpp'], ['-DMSG=hello world'], language
+        )
+        assert shlex.split(command)[-1] == '-DMSG=hello world'

--- a/tests/rbx/box/test_compile_cli.py
+++ b/tests/rbx/box/test_compile_cli.py
@@ -1,0 +1,108 @@
+"""What `rbx compile -- <flags>` hands to the compiler.
+
+Everything after `--` is meant to reach the compiler verbatim, including tokens
+that collide with rbx's own options. Click fills positional arguments in order
+and does not report where the separator was, so the parsing is a decision the
+command takes itself and is pinned here rather than through a real compilation.
+"""
+
+import asyncio
+from typing import Any, Dict, List
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box import cli
+from rbx.box.testing import testing_package
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _skip_preset_check():
+    # The root Typer callback checks the active preset's compatibility, which is
+    # unrelated to the wiring under test and fails for the bare testing package.
+    with mock.patch('rbx.box.presets.check_active_preset_compatibility'):
+        yield
+
+
+def _invoke_compile(runner: CliRunner, *args: str):
+    calls: List[Dict[str, Any]] = []
+
+    async def compile_any(path, sanitized=False, warnings=False, extra_flags=None):
+        calls.append(
+            {
+                'path': path,
+                'sanitized': sanitized,
+                'warnings': warnings,
+                'extra_flags': extra_flags,
+            }
+        )
+
+    with mock.patch('rbx.box.compile.any', compile_any):
+        result = runner.invoke(cli.app, ['compile', *args])
+    return result, calls
+
+
+def test_flags_after_the_separator_reach_the_compiler(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, calls = _invoke_compile(runner, 'sol.cpp', '--', '-DLOCAL', '-O0')
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    assert calls[0]['path'] == 'sol.cpp'
+    assert calls[0]['extra_flags'] == ['-DLOCAL', '-O0']
+
+
+def test_the_separator_shields_rbx_own_options(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    # `-s` is `--sanitized` to rbx, but after `--` it belongs to the compiler.
+    result, calls = _invoke_compile(runner, 'sol.cpp', '--', '-s', '-g')
+
+    assert result.exit_code == 0, result.output
+    assert calls[0]['sanitized'] is False
+    assert calls[0]['extra_flags'] == ['-s', '-g']
+
+
+def test_rbx_options_before_the_separator_are_still_rbx_options(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, calls = _invoke_compile(runner, '-s', '-w', 'sol.cpp', '--', '-DLOCAL')
+
+    assert result.exit_code == 0, result.output
+    assert calls[0]['sanitized'] is True
+    assert calls[0]['warnings'] is True
+    assert calls[0]['extra_flags'] == ['-DLOCAL']
+
+
+def test_a_leading_dash_is_a_flag_not_a_path(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    # `rbx compile -- -O0 -g` has no path: Click would otherwise bind `-O0` to it.
+    # With no path left, the command falls through to asking for one.
+    with mock.patch('questionary.path') as path_prompt:
+        path_prompt.return_value.ask_async = mock.AsyncMock(return_value='sol.cpp')
+        result, calls = _invoke_compile(runner, '--', '-O0', '-g')
+
+    assert result.exit_code == 0, result.output
+    assert calls[0]['path'] == 'sol.cpp'
+    assert calls[0]['extra_flags'] == ['-O0', '-g']
+
+
+def test_no_extra_flags_is_an_empty_list(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, calls = _invoke_compile(runner, 'sol.cpp')
+
+    assert result.exit_code == 0, result.output
+    assert calls[0]['extra_flags'] == []


### PR DESCRIPTION
Closes #767.

`rbx compile` now forwards everything after `--` to the compiler:

```bash
rbx compile sols/main.cpp -- -DLOCAL -g -O0
```

Reproducing a bug under a one-off flag, or trying a flag before adopting it
into `env.rbx.yml`, previously meant editing the environment and reverting it.

### Where the flags land

The issue flagged multi-step languages as ambiguous. Java compiles in two
commands and `-DFOO` belongs on `javac`, not on `jar`:

> Append the flags to every command whose `command_kinds()` matches the
> language's kinds. If no command matches, append to the first command.

`javac` reports `{JAVA, JVM}` and takes them; `jar` reports nothing and is left
alone. C/C++/Kotlin are single-command and match directly. A compiler
`command_kinds()` doesn't recognise (`rustc`, `fpc`, `ghc`) falls back to the
first command — the only command such a language has. This mirrors how sanitizer
and warning flags are already placed.

The flags go on last, so they win over everything rbx injects.

### Details worth a look

- **The separator shields rbx's own options.** `rbx compile sol.cpp -- -s` passes
  `-s` to the compiler, not `--sanitized` to rbx.
- **`rbx compile -- -O0` has no path.** Click fills positional arguments in order
  and doesn't report where `--` was, so it would bind `-O0` to `PATH`. A leading
  dash is never a path, so it's shifted into the flags and the command falls
  through to the usual prompt.
- **Precompiled headers are skipped when extra flags are present.** GCC rejects a
  PCH built under different flags than the translation unit including it. Costs
  time only on the debugging path.
- **Interpreted languages warn rather than fail.** Python has no compilation
  commands, so the flags can do nothing; silently dropping them is the worst
  outcome for a debugging one-off, but it stays a warning because `--all` on a
  mixed package is legitimate.
- **Caching needed no work** — the cache key is already the command list.

### Verification

- New `tests/rbx/box/test_compile_cli.py` (5 tests) pins the `--` parsing.
- New tests in `code_compile_test.py` cover placement per language, the rustc
  fallback, shlex round-tripping, the precompile skip, and the warning.
- 1118 tests pass across the affected suites; `ruff check`/`format` clean.
- Checked end-to-end against a real package: a solution guarded by
  `#ifndef LOCAL / #error` fails without the flag and builds with
  `-- -DLOCAL`, which appears last on the real `g++` command line.

Design doc: `docs/plans/2026-08-26-compile-extra-flags-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dzkGmyfExNnfX57Kt6jXp
