### PR TITLE
fix(contest): propagate the contest selection to spawned commands

### DIFF
--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import pathlib
 import shutil
 import subprocess
@@ -418,6 +419,24 @@ KEEP_GOING_OPTION = typer.Option(
 )
 
 
+def _export_contest_selection() -> None:
+    """Make the active contest selection visible to the `rbx` children we spawn.
+
+    `-C <id>` is materialized into a contextvar, which dies with this process,
+    so a child would fall back to the canonical contest and fail to find itself
+    in its `problems[]`. `RBX_CONTEST` is the only channel that survives the
+    fork, and the root callbacks already read it, so exporting it here is
+    enough -- for the inline `subprocess.call`, for the commands the TUI
+    spawns, and for whatever the user types into the TUI later.
+
+    No-op when there is no explicit selection (single-contest mode), and a
+    self-assignment when the selection came from the env var in the first place.
+    """
+    selection = contest_state.resolve_explicit_selection()
+    if selection is not None:
+        os.environ[contest_state.ENV_VAR] = selection
+
+
 def _build_command_argvs_or_die(
     args: List[str],
 ) -> Tuple[List[List[str]], Optional[str]]:
@@ -447,6 +466,7 @@ def each(ctx: typer.Context, keep_going: bool = KEEP_GOING_OPTION) -> None:
     from rbx.box.ui.command_app import CommandEntry, start_command_app
 
     contest = find_contest_package_or_die()
+    _export_contest_selection()
     argvs, placeholder_prefix = _build_command_argvs_or_die(ctx.args)
     commands = [
         CommandEntry(
@@ -492,6 +512,7 @@ def on(
     ],
     keep_going: bool = KEEP_GOING_OPTION,
 ) -> None:
+    _export_contest_selection()
     try:
         problems_of_interest = contest_utils.get_problems_of_interest(problems)
     except problem_selector.ProblemSelectorError as e:

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -1,12 +1,13 @@
 """Tests for `rbx contest` Typer commands."""
 
+import os
 import pathlib
 from unittest import mock
 
 import pytest
 from typer.testing import CliRunner
 
-from rbx.box.contest import contest_utils
+from rbx.box.contest import contest_state, contest_utils
 from rbx.box.contest import main as contest_main
 
 
@@ -27,6 +28,14 @@ def clear_package_caches():
     contest_utils.clear_all_caches()
     yield
     contest_utils.clear_all_caches()
+
+
+@pytest.fixture
+def clean_contest_env(monkeypatch: pytest.MonkeyPatch):
+    # `rbx on`/`rbx each` export the selection into the real process env, so
+    # swap in a copy that the rest of the suite cannot see.
+    monkeypatch.setattr(os, 'environ', dict(os.environ))
+    os.environ.pop(contest_state.ENV_VAR, None)
 
 
 def _write_minimal_problem(dest: pathlib.Path, name: str) -> None:
@@ -384,6 +393,23 @@ class TestContestOn:
         _write_minimal_problem(tmp_path / 'probs' / 'a', 'prob-a')
         return tmp_path
 
+    @pytest.fixture
+    def variant_contest_dir(
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        clear_package_caches,
+    ) -> pathlib.Path:
+        # A real canonical contest that does NOT list the problem, plus a
+        # `warmup` variant that does -- the shape that made `-C` mandatory.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'contest.rbx.yml').write_text('name: ctt\nproblems: []\n')
+        (tmp_path / 'contest.warmup.rbx.yml').write_text(
+            'name: warmup\nproblems:\n  - short_name: A\n    path: probs/a\n'
+        )
+        _write_minimal_problem(tmp_path / 'probs' / 'a', 'prob-a')
+        return tmp_path
+
     def test_single_command_on_single_problem_runs_inline(
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
@@ -440,6 +466,61 @@ class TestContestOn:
         assert commands[0].argvs == [['rbx', 'build'], ['rbx', 'run', '-k']]
         assert kwargs['keep_going'] is False
 
+    def test_selection_is_exported_to_the_inline_child(
+        self,
+        runner: CliRunner,
+        variant_contest_dir: pathlib.Path,
+        clean_contest_env,
+    ):
+        # `-C` only lives in a contextvar, so the child would otherwise resolve
+        # the canonical contest and not find itself in its `problems[]`.
+        with (
+            mock.patch.object(contest_main.subprocess, 'call') as call,
+            mock.patch('rbx.box.ui.command_app.start_command_app'),
+        ):
+            result = runner.invoke(
+                contest_main.app, ['-C', 'warmup', 'on', 'A', 'build']
+            )
+
+        assert result.exit_code == 0, result.output
+        call.assert_called_once()
+        assert os.environ[contest_state.ENV_VAR] == 'warmup'
+
+    def test_selection_is_exported_before_the_app_starts(
+        self,
+        runner: CliRunner,
+        variant_contest_dir: pathlib.Path,
+        clean_contest_env,
+    ):
+        seen = {}
+        with mock.patch(
+            'rbx.box.ui.command_app.start_command_app',
+            side_effect=lambda *a, **k: seen.update(
+                env=os.environ.get(contest_state.ENV_VAR)
+            ),
+        ):
+            result = runner.invoke(
+                contest_main.app, ['-C', 'warmup', 'on', 'A', 'build', '::', 'run']
+            )
+
+        assert result.exit_code == 0, result.output
+        assert seen['env'] == 'warmup'
+
+    def test_no_selection_leaves_the_env_alone(
+        self,
+        runner: CliRunner,
+        contest_dir: pathlib.Path,
+        clean_contest_env,
+    ):
+        with (
+            mock.patch.object(contest_main.subprocess, 'call'),
+            mock.patch('rbx.box.ui.command_app.start_command_app'),
+        ):
+            result = runner.invoke(contest_main.app, ['on', 'A', 'build'])
+
+        assert result.exit_code == 0, result.output
+        assert contest_state.ENV_VAR not in os.environ
+
     def test_empty_command_in_chain_is_an_error(
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
@@ -482,6 +563,33 @@ class TestContestEach:
         assert len(commands) == 2
         for command in commands:
             assert command.argvs == [['rbx', 'build'], ['rbx', 'package', 'build']]
+
+    def test_each_exports_the_selection_before_the_app_starts(
+        self,
+        runner: CliRunner,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        clear_package_caches,
+        clean_contest_env,
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'contest.rbx.yml').write_text('name: ctt\nproblems: []\n')
+        (tmp_path / 'contest.warmup.rbx.yml').write_text(
+            'name: warmup\nproblems:\n  - short_name: A\n    path: probs/a\n'
+        )
+        _write_minimal_problem(tmp_path / 'probs' / 'a', 'prob-a')
+
+        seen = {}
+        with mock.patch(
+            'rbx.box.ui.command_app.start_command_app',
+            side_effect=lambda *a, **k: seen.update(
+                env=os.environ.get(contest_state.ENV_VAR)
+            ),
+        ):
+            result = runner.invoke(contest_main.app, ['-C', 'warmup', 'each', 'build'])
+
+        assert result.exit_code == 0, result.output
+        assert seen['env'] == 'warmup'
 
     def test_each_without_args_opens_an_empty_app(
         self, runner: CliRunner, contest_dir: pathlib.Path


### PR DESCRIPTION
`rbx -C warmup on A <cmd>` failed with:

```
This problem directory is not listed in the active contest's problems[] field.
```

`-C <id>` is materialized into a contextvar (`contest_state.selected_variant_id_var`), which dies with the process. Both `rbx on` and `rbx each` spawn fresh `rbx` children — the inline `subprocess.call` in the single-command fast path, and the `CommandEntry` argvs the TUI runs — and neither carried the selection across. The child therefore resolved the canonical `contest.rbx.yml`, did not find itself in its `problems[]`, and `require_problem_in_contest` bailed out. Anything downstream that needs the contest letter (`rbx package moj`, and so `rbx time --runner moj`) died there.

## Fix

Export the resolved selection into `RBX_CONTEST` — the only channel that survives the fork, and one both root callbacks already read — at the top of `on` and `each`:

```python
def _export_contest_selection() -> None:
    selection = contest_state.resolve_explicit_selection()
    if selection is not None:
        os.environ[contest_state.ENV_VAR] = selection
```

Chosen over re-injecting `-C` into each spawned argv: it is one place instead of three, and it also covers commands the user types into the TUI later, which the argv approach would miss. No-op in single-contest mode; a self-assignment when the selection came from `RBX_CONTEST` to begin with.

Deliberately scoped to `on`/`each` rather than the root callback — exporting `RBX_CONTEST` globally would leak it into compilation and sandbox subprocesses, which have no business seeing it.

## Tests

Four regression tests in `tests/rbx/box/contest/test_contest_main.py`: the inline fast path, the TUI chain path, `each`, and a no-selection case asserting the env is left untouched. They fail without the fix (`assert None == 'warmup'`, `KeyError: 'RBX_CONTEST'`).

Since `_export_contest_selection` writes to the real process env, the tests swap in a copy of `os.environ` — `monkeypatch.delenv` would not undo a set that happens inside the test. The contextvar is already isolated by the autouse `_isolate_global_state` fixture.

- `tests/rbx/box/contest/` + `tests/rbx/box/test_naming.py`: 221 passed.
- Verified end-to-end on a real contest with a canonical `contest.rbx.yml` plus a `contest.warmup.rbx.yml` sibling, `RBX_CONTEST` explicitly unset: `rbx -C warmup on A package moj` now resolves the letter and writes `build.rbx/A-reuniao.zip`, where it previously errored out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC8UkPGYF4QzpUyJ1jUKtN