### PR TITLE
feat(grading): honor the configured stack limit on linux

### DIFF
--- a/docs/stack-limit.md
+++ b/docs/stack-limit.md
@@ -101,3 +101,8 @@ languages:
 !!! warning
     `stackLimit` is enforced on Linux only. On MacOS, the stack of a sandboxed program is
     whatever your shell hands down, which is exactly what the sections above are about.
+
+!!! note
+    JVM programs -- Java and Kotlin -- are exempt. The JVM manages its own thread stacks, so
+    the limit would only bound the launcher's main thread and never the code you wrote. This
+    mirrors what {{rbx}} already does with the memory limit for those languages.

--- a/docs/stack-limit.md
+++ b/docs/stack-limit.md
@@ -68,3 +68,36 @@ sudo launchctl limit stack <soft_limit_in_bytes> <hard_limit_in_bytes>
 This configuration will NOT persist after a reboot, but will persist across terminals.
 
 
+
+## Cap the stack of the programs {{rbx}} runs
+
+Everything above is about your machine's limits. Inside the sandbox, {{rbx}} makes the stack as
+large as the system allows, so a solution is never cut short by a limit the real judge would not
+have imposed.
+
+If you want the sandbox to enforce a stack limit instead -- to reproduce a judge that caps it, or
+to catch a solution that recurses deeper than it should -- set `stackLimit`, in MiB, on any
+sandbox configuration in your `env.rbx.yml`:
+
+```yaml
+defaultExecution:
+  sandbox:
+    stackLimit: 256 # 256mb
+```
+
+To apply it to solutions only, and leave checkers, validators and generators unbounded, use the
+`solutionOverrides` of the language that runs them:
+
+```yaml
+languages:
+  - name: "cpp"
+    execution:
+      command: "./{executable}"
+      solutionOverrides:
+        sandbox:
+          stackLimit: 256 # 256mb
+```
+
+!!! warning
+    `stackLimit` is enforced on Linux only. On MacOS, the stack of a sandboxed program is
+    whatever your shell hands down, which is exactly what the sections above are about.

--- a/rbx/box/environment.py
+++ b/rbx/box/environment.py
@@ -132,7 +132,9 @@ class EnvironmentSandbox(BaseModel):
 
     stackLimit: Optional[int] = Field(
         default=None,
-        description="""Stack limit in MiB.""",
+        description="""Stack limit in MiB. Only enforced on Linux; ignored on macOS,
+where the stack is whatever the host shell provides. When unset, the stack is
+made as large as the system allows.""",
     )
 
     preserveEnv: Optional[bool] = Field(
@@ -847,6 +849,7 @@ def get_sandbox_params_from_config(
     params.timeout = config.timeLimit
     params.wallclock_timeout = config.wallTimeLimit
     params.address_space = config.memoryLimit
+    params.stack_space = config.stackLimit
     params.max_processes = config.maxProcesses
     params.fsize = config.fileSizeLimit
     if config.preserveEnv:

--- a/rbx/grading/judge/program.py
+++ b/rbx/grading/judge/program.py
@@ -89,6 +89,7 @@ class ProgramParams:
     time_limit: Optional[float] = None  # seconds
     wall_time_limit: Optional[float] = None  # seconds
     memory_limit: Optional[int] = None  # megabytes
+    stack_limit: Optional[int] = None  # megabytes
     fs_limit: Optional[int] = None  # kilobytes
     env: Dict[str, str] = dataclasses.field(default_factory=dict)
     pgid: Optional[int] = None
@@ -106,13 +107,20 @@ def get_preexec_fn(params: ProgramParams):
         if params.fs_limit is not None:
             fs_limit = params.fs_limit * 1024  # in bytes
             resource.setrlimit(resource.RLIMIT_FSIZE, (fs_limit + 1, fs_limit * 2))
+        # Darwin is left alone: it refuses most RLIMIT_STACK changes, so the
+        # stack there is whatever the host shell hands down (which is what
+        # `rbx`'s stack limit check nags about).
         if sys.platform != 'darwin':
+            stack_limit = (
+                params.stack_limit * 1024 * 1024
+                if params.stack_limit is not None
+                else resource.RLIM_INFINITY
+            )
             try:
-                resource.setrlimit(
-                    resource.RLIMIT_STACK,
-                    (resource.RLIM_INFINITY, resource.RLIM_INFINITY),
-                )
-            except ValueError:
+                resource.setrlimit(resource.RLIMIT_STACK, (stack_limit, stack_limit))
+            except (ValueError, OSError):
+                # Asking for more than the hard limit allows; fall back to
+                # whatever the process already inherited.
                 pass
 
     return preexec_fn

--- a/rbx/grading/judge/sandboxes/stupid_sandbox.py
+++ b/rbx/grading/judge/sandboxes/stupid_sandbox.py
@@ -125,6 +125,7 @@ class StupidSandbox(SandboxBase):
             if params.wallclock_timeout
             else None,
             memory_limit=params.address_space,
+            stack_limit=params.stack_space,
             fs_limit=params.fsize,
             env=params.set_env,
             io=self._get_io(params),

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -470,6 +470,21 @@ def _split_and_expand(
     return res
 
 
+def _relax_limits_for_jvm(command: str, params: SandboxParams) -> None:
+    """Drop the limits the JVM cannot live under, for JVM commands only.
+
+    The JVM manages its own memory and its own thread stacks, so neither rlimit
+    means for it what it means for a native program: an ``RLIMIT_AS`` makes it
+    refuse to start at all, and an ``RLIMIT_STACK`` bounds only the launcher's
+    main thread -- never the stack the user code actually runs on. Enforcing
+    either would just break Java and Kotlin without limiting anything.
+    """
+    if LanguageKind.JVM not in command_kinds(get_exe_from_command(command)):
+        return
+    params.address_space = None
+    params.stack_space = None
+
+
 def get_exe_from_command(command: str) -> str:
     cmds = shlex.split(command)
     if not cmds:
@@ -781,9 +796,7 @@ async def compile(
         stderr_file = pathlib.PosixPath(f'compile-{i}.stderr')
         params.set_stdall(stdout=stdout_file, stderr=stderr_file)
 
-        # Remove memory constraints for Java.
-        if LanguageKind.JVM in command_kinds(get_exe_from_command(command)):
-            params.address_space = None
+        _relax_limits_for_jvm(command, params)
 
         try:
             sandbox_log = await asyncio.to_thread(sandbox.run, cmd, params)
@@ -876,9 +889,7 @@ async def run(
     cmd = _split_and_expand(command, sandbox, params)
     params = params.model_copy(deep=True)  # Copy to allow further modification.
 
-    # Remove memory constraints for Java.
-    if LanguageKind.JVM in command_kinds(get_exe_from_command(command)):
-        params.address_space = None
+    _relax_limits_for_jvm(command, params)
 
     try:
         sandbox_log = await asyncio.to_thread(sandbox.run, cmd, params)
@@ -922,8 +933,7 @@ async def run_coordinated(
     interactor_params = interactor.params.model_copy(deep=True)
     solution_params = solution.params.model_copy(deep=True)
 
-    if LanguageKind.JVM in command_kinds(get_exe_from_command(solution.command)):
-        solution_params.address_space = None
+    _relax_limits_for_jvm(solution.command, solution_params)
 
     try:
         solution_sandbox_log, interactor_sandbox_log = await asyncio.to_thread(

--- a/tests/rbx/box/test_environment_sandbox.py
+++ b/tests/rbx/box/test_environment_sandbox.py
@@ -1,0 +1,44 @@
+from rbx.box.environment import (
+    EnvironmentSandbox,
+    ExecutionConfig,
+    SolutionExecutionOverrides,
+    get_sandbox_params_from_config,
+    merge_execution_configs,
+)
+
+
+def test_stack_limit_reaches_the_sandbox_params():
+    params = get_sandbox_params_from_config(EnvironmentSandbox(stackLimit=64))
+
+    assert params.stack_space == 64
+
+
+def test_stack_limit_is_unset_by_default():
+    params = get_sandbox_params_from_config(EnvironmentSandbox())
+
+    assert params.stack_space is None
+
+
+def test_stack_limit_can_be_overridden_for_solutions_only():
+    config = ExecutionConfig(
+        sandbox=EnvironmentSandbox(stackLimit=8),
+        solutionOverrides=SolutionExecutionOverrides(
+            sandbox=EnvironmentSandbox(stackLimit=256)
+        ),
+    )
+
+    for_solutions = merge_execution_configs([config], solution=True)
+    assert for_solutions.sandbox is not None
+    assert for_solutions.sandbox.stackLimit == 256
+
+    # `merge_execution_configs` mutates the config it is given, so re-build it
+    # before asking for the non-solution view.
+    config = ExecutionConfig(
+        sandbox=EnvironmentSandbox(stackLimit=8),
+        solutionOverrides=SolutionExecutionOverrides(
+            sandbox=EnvironmentSandbox(stackLimit=256)
+        ),
+    )
+    for_others = merge_execution_configs([config], solution=False)
+    assert for_others.sandbox is not None
+    assert for_others.sandbox.stackLimit == 8

--- a/tests/rbx/grading/judge/test_program.py
+++ b/tests/rbx/grading/judge/test_program.py
@@ -592,6 +592,63 @@ class TestProgramMocks:
 
         stack_call = calls[3]
         assert stack_call[0][0] == resource_module.RLIMIT_STACK
+        # No stack limit was asked for, so the stack is made unbounded.
+        assert stack_call[0][1] == (
+            resource_module.RLIM_INFINITY,
+            resource_module.RLIM_INFINITY,
+        )
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_preexec_fn_applies_stack_limit_on_linux(self, mock_setrlimit, _):
+        import resource as resource_module
+
+        params = ProgramParams(stack_limit=64)
+
+        get_preexec_fn(params)()
+
+        stack_calls = [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_STACK
+        ]
+        assert len(stack_calls) == 1
+        assert stack_calls[0][0][1] == (64 * 1024 * 1024, 64 * 1024 * 1024)
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_preexec_fn_survives_a_stack_limit_the_system_refuses(
+        self, mock_setrlimit, _
+    ):
+        import resource as resource_module
+
+        def refuse_stack(which, limits):
+            if which == resource_module.RLIMIT_STACK:
+                raise ValueError('current limit exceeds maximum limit')
+
+        mock_setrlimit.side_effect = refuse_stack
+
+        # Must not blow up: preexec_fn runs in the forked child, so raising
+        # there would take the whole run down.
+        get_preexec_fn(ProgramParams(stack_limit=1024))()
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'darwin')
+    def test_preexec_fn_ignores_stack_limit_on_darwin(self, mock_setrlimit, _):
+        import resource as resource_module
+
+        params = ProgramParams(stack_limit=64)
+
+        get_preexec_fn(params)()
+
+        assert not [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_STACK
+        ]
 
     @mock.patch('os.setpgid')
     @mock.patch('resource.setrlimit')

--- a/tests/rbx/grading/steps_compile_test.py
+++ b/tests/rbx/grading/steps_compile_test.py
@@ -133,7 +133,10 @@ class TestStepsCompile:
         )
         artifacts.logs = GradingLogsHolder()
 
-        params = SandboxParams(address_space=1024)  # Set memory constraint
+        params = SandboxParams(
+            address_space=1024,  # Set memory constraint
+            stack_space=64,  # Set stack constraint
+        )
         commands = ['javac Simple.java']
 
         # Use mock to capture the params passed to sandbox.run
@@ -143,11 +146,13 @@ class TestStepsCompile:
             assert output_file.exists()
             # Original params should not be modified
             assert params.address_space == 1024
-            # But the params passed to sandbox.run should have address_space removed
+            assert params.stack_space == 64
+            # But the params passed to sandbox.run should have both removed
             mock_run.assert_called_once()
             call_args = mock_run.call_args
             captured_params = call_args[0][1]  # Second argument (params)
             assert captured_params.address_space is None
+            assert captured_params.stack_space is None
 
     async def test_compile_compilation_error_returns_false(
         self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path

--- a/tests/rbx/grading/steps_run_coordinated_test.py
+++ b/tests/rbx/grading/steps_run_coordinated_test.py
@@ -327,6 +327,7 @@ class TestStepsRunCoordinated:
             params=SandboxParams(
                 timeout=5000,
                 address_space=512,  # 512MB limit
+                stack_space=64,  # 64MB stack
             ),
         )
 
@@ -336,6 +337,7 @@ class TestStepsRunCoordinated:
             params=SandboxParams(
                 timeout=5000,
                 address_space=256,  # This should be removed for Java
+                stack_space=32,  # This should be removed for Java too
             ),
         )
 
@@ -367,9 +369,16 @@ class TestStepsRunCoordinated:
                 'Java solution should have address_space removed'
             )
 
-            # Verify that the interactor still has its address_space constraint
+            assert solution_params_actual.stack_space is None, (
+                'Java solution should have stack_space removed'
+            )
+
+            # Verify that the interactor still has its constraints
             assert interactor_params_actual.address_space == 512, (
                 'Interactor should keep its address_space constraint'
+            )
+            assert interactor_params_actual.stack_space == 64, (
+                'Interactor should keep its stack_space constraint'
             )
 
         # The key test is that the function doesn't fail due to memory constraints

--- a/tests/rbx/grading/steps_run_test.py
+++ b/tests/rbx/grading/steps_run_test.py
@@ -356,10 +356,10 @@ class TestStepsRun:
         assert artifacts.logs.run.metadata is not None
         assert artifacts.logs.run.metadata.language == 'python'
 
-    async def test_run_java_removes_memory_constraints(
+    async def test_run_java_removes_memory_and_stack_constraints(
         self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path
     ):
-        """Test that Java commands have memory constraints removed."""
+        """Test that Java commands have memory and stack constraints removed."""
         # Setup input file
         source_file = testdata_path / 'steps_run_test' / 'simple.java'
         artifacts = GradingArtifacts(root=cleandir)
@@ -376,6 +376,7 @@ class TestStepsRun:
         params = SandboxParams(
             stdout_file=pathlib.Path('output.txt'),
             address_space=1024,  # Set memory constraint
+            stack_space=64,  # Set stack constraint
         )
         command = 'java Simple'
 
@@ -386,11 +387,45 @@ class TestStepsRun:
             assert result is not None
             # Original params should not be modified
             assert params.address_space == 1024
-            # But the params passed to sandbox.run should have address_space removed
+            assert params.stack_space == 64
+            # But the params passed to sandbox.run should have both removed
             mock_run.assert_called_once()
             call_args = mock_run.call_args
             captured_params = call_args[0][1]  # Second argument (params)
             assert captured_params.address_space is None
+            assert captured_params.stack_space is None
+
+    async def test_run_non_jvm_keeps_memory_and_stack_constraints(
+        self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path
+    ):
+        """The JVM carve-out is for the JVM only: everything else is limited."""
+        script_file = testdata_path / 'steps_run_test' / 'simple_output.py'
+        artifacts = GradingArtifacts(root=cleandir)
+        artifacts.inputs.append(
+            GradingFileInput(src=script_file, dest=pathlib.Path('script.py'))
+        )
+        artifacts.outputs.append(
+            GradingFileOutput(
+                src=pathlib.Path('output.txt'), dest=pathlib.Path('output.txt')
+            )
+        )
+        artifacts.logs = GradingLogsHolder()
+
+        params = SandboxParams(
+            stdout_file=pathlib.Path('output.txt'),
+            address_space=1024,
+            stack_space=64,
+        )
+        command = f'{sys.executable} script.py'
+
+        with patch.object(sandbox, 'run', wraps=sandbox.run) as mock_run:
+            result = await steps.run(command, params, sandbox, artifacts)
+
+            assert result is not None
+            mock_run.assert_called_once()
+            captured_params = mock_run.call_args[0][1]
+            assert captured_params.address_space == 1024
+            assert captured_params.stack_space == 64
 
     async def test_run_with_optional_output_file(
         self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path


### PR DESCRIPTION
## What

`EnvironmentSandbox.stackLimit` (in `env.rbx.yml`) and `SandboxParams.stack_space` were both declared but never read by anything: `get_sandbox_params_from_config` never mapped the former, and nothing ever read the latter. In practice the sandbox always raised `RLIMIT_STACK` to `RLIM_INFINITY` on Linux, and left it alone on macOS -- so a configured `stackLimit` parsed fine and did nothing.

This wires the field through to `get_preexec_fn`:

- `ProgramParams` gains `stack_limit` (MiB), passed by `StupidSandbox` from `SandboxParams.stack_space`.
- `get_sandbox_params_from_config` maps `config.stackLimit` -> `params.stack_space`.
- When no limit is configured, the stack is still made unbounded -- unchanged behavior.
- The whole thing stays behind the existing `sys.platform != 'darwin'` guard. macOS refuses most `RLIMIT_STACK` changes, so the stack there remains whatever the host shell provides (which is what `_check_stack_limit` already nags about).

Because the limit flows through the per-language `solutionOverrides`, it can now be capped **for solutions only**, leaving checkers, validators and generators unbounded:

```yaml
languages:
  - name: "cpp"
    execution:
      command: "./{executable}"
      solutionOverrides:
        sandbox:
          stackLimit: 256 # 256mb
```

## JVM programs are exempt

The second commit excludes Java and Kotlin from the stack limit, for the same reason the memory limit is already dropped for them: the JVM manages its own thread stacks, so an `RLIMIT_STACK` bounds only the launcher's main thread and never the code the user wrote. Enforcing it would break those languages without limiting anything.

`steps.py` had the JVM memory carve-out duplicated across `compile`, `run` and `run_coordinated`; those three sites now share a `_relax_limits_for_jvm` helper that drops both `address_space` and `stack_space`. Behavior for the memory limit is unchanged.

## Notes

- The `except ValueError` around `setrlimit` was widened to `OSError`: asking for more than the hard limit raises `PermissionError`, and an exception inside `preexec_fn` takes the whole run down. On failure we fall back to whatever the process inherited. That silent degradation is tracked in #800, which proposes a parent-side warning (the placement BAPCtools uses) rather than changing this `except`.
- Sandbox cache keys are unchanged when no stack limit is set (`get_cacheable_params` excludes `None`), so this does not invalidate existing caches.

## Testing

- `test_program.py` pins all three cases: unset -> infinity, set -> that value on Linux, ignored on darwin; plus a "system refuses the limit" case that must not raise.
- New `tests/rbx/box/test_environment_sandbox.py` covers the config -> params mapping and the solutions-only override.
- The three existing JVM tests (compile / run / run_coordinated) now assert `stack_space` is dropped alongside `address_space`, and a new non-JVM control asserts both survive for a Python command.
- 430 tests pass across `tests/rbx/grading/` and the environment test files; ruff and `mkdocs build` clean.
- Caveat: developed on macOS, so the Linux branch is covered by unit tests with `sys.platform` mocked, not by a real run under a lowered stack.

## Docs

`docs/stack-limit.md` gains a closing section documenting `stackLimit`, the solutions-only form, the Linux-only caveat, and the JVM exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCzCbnKDkG33mkjZCcFo4W
