### PR TITLE
feat(run): add --benchmark to rbx run and rbx irun

### DIFF
--- a/docs/plans/2026-08-28-run-benchmark-design.md
+++ b/docs/plans/2026-08-28-run-benchmark-design.md
@@ -1,0 +1,184 @@
+# `rbx run --benchmark` design
+
+**Date:** 2026-08-28
+**Status:** approved, not yet implemented
+
+## Problem
+
+`rbx run` reports how long each solution took, but says nothing about how long
+*judging* took. The checker runs once per testcase per solution, and on problems
+with a heavy checker it can dominate the wall clock of a full run -- yet its cost
+is invisible. A setter who wants to know whether the checker is the bottleneck,
+or which testcase is expensive to judge, has no way to find out.
+
+The checker's `RunLog` is already produced on every check, in
+`rbx/box/checkers.py:_check`, and thrown away. Everything below is a matter of
+keeping it and reporting it.
+
+## Scope
+
+`--benchmark` / `-b` takes a level, mirroring `-v`:
+
+- `-b0` -- no benchmarking. The default; output is byte-identical to today's.
+- `-b1` -- benchmark the solution-running phase: checker (and interactor) time
+  per testcase, summarised per solution and per problem.
+- `-b2` -- benchmark test generation and validation too. **Out of scope here**;
+  tracked in [#801](https://github.com/rsalesc/rbx/issues/801). `-b2` is
+  rejected by validation for now.
+
+## Data model
+
+The checker's timing rides back on `CheckerResult`, in `rbx/grading/steps.py`:
+
+```python
+class RunTiming(BaseModel):
+    time: Optional[float] = None       # CPU seconds
+    wall_time: Optional[float] = None
+
+    @staticmethod
+    def of(log: Optional[RunLog]) -> Optional['RunTiming']: ...
+
+
+class CheckerResult(BaseModel):
+    ...
+    checker_timing: Optional[RunTiming] = None
+    interactor_timing: Optional[RunTiming] = None
+```
+
+`CheckerResult` is the right carrier: `checkers.py` is the only place that holds
+the checker's run log, and `Evaluation.result` is already persisted into the
+`.eval` artifact, so `rbx/box/tasks.py` needs no change at all. The two
+alternatives were rejected -- putting the fields on `TestcaseLog` mixes two
+programs' measurements into one `RunLog` subclass whose `time`/`memory` mean
+*the solution's*, and a new `Evaluation.judging` sub-model still needs a
+transport out of `checkers.py`, so it is the same change plus a hop.
+
+Both clocks are stored; only CPU time is reported. Storing the wall clock costs
+nothing and lets `-b2` report it later without a format migration.
+
+### Capture is unconditional
+
+Every run writes the timings, regardless of `-b`. They are two floats per
+evaluation, and `utils.model_to_yaml` dumps with `exclude_none=True`, so a
+testcase whose checker never ran writes exactly the bytes it writes today. The
+payoff is that `rbx ui` can show checker time for *any* past run rather than
+only for runs that happened to be benchmarked. `-b` gates reporting alone.
+
+### Where the timings are set
+
+- `checkers._check` sets `checker_timing` from the `checker_run_log` it already
+  computes, after `checker_mode.convert_run_log`.
+- `checkers.check_communication` sets `interactor_timing` from the
+  `interactor_run_log` it receives. Every one of its return paths funnels
+  through `_extra_check_and_sanitize`, which is the single hook to stamp it on.
+
+A testcase where the checker never ran -- `_check_pre_output` short-circuits on
+TLE, RTE, MLE and friends before `code.run_item` is reached -- leaves both fields
+`None`. That is deliberately distinct from a measured zero, and renders as `-`.
+
+### Cached checker runs
+
+Checker execution goes through `steps_with_caching.run`, so a warm cache replays
+a stored `RunLog`. That stored log carries the time the checker *actually* took
+when it ran, which is the number worth reporting: the value of the benchmark is
+the uncached, worst-case judging cost. So cached times are reported as-is, with
+no warning, and `-b1` never forces a re-run.
+
+## Reporting
+
+### Per-solution block (`rbx run` only)
+
+Appended under each solution's existing `Time:` / `Memory:` lines:
+
+```
+Benchmark: slowest test tests/3 - 1.2 s judging (1.15 s solution + 48 ms checker)
+Total judging: 14.3 s  (checker: 1.9 s)
+```
+
+"Judging time" for a testcase is solution time + checker time + interactor time.
+Interactive problems get the interactor as a third term in both the breakdown and
+the totals.
+
+### Problem-level block
+
+Printed after the timing summary:
+
+- the slowest solution to judge, by total judging time;
+- the solution that consumed the most checker time;
+- the single slowest testcase to judge across the whole run.
+
+### Under `--fail-fast`
+
+A solution that stops at its first bad verdict is not judged on the remaining
+testcases, so every total is a lower bound. Unlike the timing summary -- which is
+dropped entirely under `--ff`, because time limit inference reads it -- both
+benchmark blocks still print, computed over the testcases that actually ran and
+marked with the count:
+
+```
+Total judging: 3.1 s  (checker: 0.4 s)  (over 7/40 tests judged)
+```
+
+Benchmark output is diagnostic and feeds no inference, so a marked lower bound is
+more useful than nothing.
+
+### `--share`
+
+Both blocks are rendered into the recording console too, so a shared report is
+not missing them.
+
+### `rbx irun`
+
+Per-testcase checker and interactor times are printed on each testcase's block,
+and the problem-level summary is printed. The per-solution block is skipped: with
+a single testcase, "slowest test" says nothing.
+
+### Not printed
+
+Per-testcase times never appear in `rbx run`'s terminal output, in any mode,
+including `--detailed`. The plain report is one character per testcase and the
+detailed table is already wide; `rbx ui` is where per-test detail is read.
+
+## Flag
+
+Mirroring `VerificationLevel` in `rbx/box/environment.py`:
+
+```python
+class BenchmarkLevel(Enum):
+    NONE = 0
+    SOLUTIONS = 1
+```
+
+`-b` / `--benchmark`, an int option with `default_factory` returning `0`, bare
+`-b` meaning `1`, and an autocompletion adapter alongside `verification_level`.
+A level outside `{0, 1}` is an error naming #801, so `-b2` never
+silently under-delivers. Both `rbx run` and `rbx irun` take it; `-b` is free in
+both (`irun` already spends `-p` on `--print`, but not `-b`).
+
+## `rbx ui`
+
+`rbx/box/ui/utils/run_ui.py:get_run_testcase_metadata_markup` gains a line under
+the existing time/memory line:
+
+```
+Time: 1.15 s / Memory: 12 MB
+Checker: 48 ms
+```
+
+with an `Interactor:` line for communication problems. Unmeasured reads `-`.
+Because capture is unconditional, this works for any run recorded after this
+change ships, benchmarked or not; runs recorded before it show `-`.
+
+## Testing
+
+- Aggregation helpers in `rbx/box/solutions.py`: all-unmeasured input, partial
+  (`--ff`-shaped) input, interactive input with an interactor term.
+- Round trip: `checker_timing` survives `.eval` write and read, and a `None`
+  timing adds no keys to the dumped YAML.
+- CLI: `-b1` prints both blocks; `-b2` is rejected.
+- UI: the checker line renders, and reads `-` when nothing was measured.
+
+## Follow-up
+
+`-b2` -- benchmarking test generation and validation -- is tracked in
+[#801](https://github.com/rsalesc/rbx/issues/801) and is not implemented here.

--- a/docs/plans/2026-08-28-run-benchmark-design.md
+++ b/docs/plans/2026-08-28-run-benchmark-design.md
@@ -162,10 +162,14 @@ the existing time/memory line:
 
 ```
 Time: 1.15 s / Memory: 12 MB
-Checker: 48 ms
+Checker time: 48 ms
 ```
 
-with an `Interactor:` line for communication problems. Unmeasured reads `-`.
+with an `Interactor time:` line for communication problems. Unmeasured reads `-`.
+
+The label is `Checker time:`, not `Checker:`, because the pane already carries a
+`Checker:` line holding the checker's *message*. That line predates this feature
+and setters read it that way, so the new line is the one that moves.
 Because capture is unconditional, this works for any run recorded after this
 change ships, benchmarked or not; runs recorded before it show `-`.
 

--- a/docs/plans/2026-08-28-run-benchmark-design.md
+++ b/docs/plans/2026-08-28-run-benchmark-design.md
@@ -149,8 +149,9 @@ class BenchmarkLevel(Enum):
     SOLUTIONS = 1
 ```
 
-`-b` / `--benchmark`, an int option with `default_factory` returning `0`, bare
-`-b` meaning `1`, and an autocompletion adapter alongside `verification_level`.
+`-b` / `--benchmark`, an int option with `default_factory` returning `0`, and an
+autocompletion adapter alongside `verification_level`. A value is required, as
+for `-v`: Typer does not support `flag_value`, and `rbx run -v` alone errors too.
 A level outside `{0, 1}` is an error naming #801, so `-b2` never
 silently under-delivers. Both `rbx run` and `rbx irun` take it; `-b` is free in
 both (`irun` already spends `-p` on `--print`, but not `-b`).

--- a/docs/plans/2026-08-28-run-benchmark-design.md
+++ b/docs/plans/2026-08-28-run-benchmark-design.md
@@ -116,7 +116,7 @@ benchmark blocks still print, computed over the testcases that actually ran and
 marked with the count:
 
 ```
-Total judging: 3.1 s  (checker: 0.4 s)  (over 7/40 tests judged)
+Total judging: 3.1 s (checker: 400 ms) (over 7/40 tests judged)
 ```
 
 Benchmark output is diagnostic and feeds no inference, so a marked lower bound is

--- a/docs/plans/2026-08-28-run-benchmark.md
+++ b/docs/plans/2026-08-28-run-benchmark.md
@@ -381,7 +381,8 @@ def test_problem_benchmark_ranks_solutions(mock_skeleton, tmp_path):
     assert problem is not None
     assert problem.slowest_to_judge.solution.path == slow_judge.path
     assert problem.most_checker_time.solution.path == heavy_checker.path
-    assert problem.slowest_testcase.judging_time == pytest.approx(0.51)
+    # 500 ms solution + 1 ms checker, the larger of the two slowest tests.
+    assert problem.slowest_testcase.judging_time == pytest.approx(0.501)
 
 
 def test_problem_benchmark_is_none_without_any_solution_benchmarks():

--- a/docs/plans/2026-08-28-run-benchmark.md
+++ b/docs/plans/2026-08-28-run-benchmark.md
@@ -775,7 +775,12 @@ BenchmarkParam = Annotated[
 ]
 ```
 
-Verify that a bare `-b` (no value) yields `1`. Typer's int option normally *requires* a value; if `-b` alone errors, give the option `flag_value=BenchmarkLevel.SOLUTIONS.value` (Click supports `flag_value` on a non-boolean option) and add a test asserting `rbx run -b` behaves as `-b1`. Do not skip this check — the design promises bare `-b` means `-b1`.
+**A bare `-b` (no value) is an error, and that is correct.** Typer does not
+support `flag_value` -- it emits `DeprecationWarning: The 'is_flag' and
+'flag_value' parameters are not supported by Typer` -- so the trick that would
+make `-b` alone mean `-b1` is not available. It is also not wanted: the flag
+mirrors `-v`, which requires a value too (`rbx run -v` alone errors, `-v4`
+works). Spell the level: `-b1`, `-b 1` or `--benchmark 1`.
 
 In `rbx/box/completion/completers.py`, next to `_VERIFICATION_TABLE`:
 

--- a/docs/plans/2026-08-28-run-benchmark.md
+++ b/docs/plans/2026-08-28-run-benchmark.md
@@ -562,6 +562,46 @@ Commit: `feat(benchmark): aggregate checker and interactor timings per solution`
 
 ## Task 5: Rendering the two blocks
 
+> **The Task 4 API changed during review. These are the real names — the older
+> spellings elsewhere in this document are superseded by this block.**
+>
+> ```python
+> def checker_time_seconds(eval)    -> Optional[float]
+> def interactor_time_seconds(eval) -> Optional[float]
+> def judging_time_seconds(eval)    -> Optional[float]
+> def was_judged(eval)              -> bool
+>
+> @dataclass TestcaseJudging:
+>     entry: TestcaseEntry
+>     judging_time_seconds: float            # non-optional
+>     solution_time_seconds: float           # non-optional
+>     checker_time_seconds: Optional[float]      # None = unmeasured
+>     interactor_time_seconds: Optional[float]   # None = unmeasured
+>
+> @dataclass SolutionBenchmark:
+>     solution, slowest_testcase, judged, total_testcases
+>     total_judging_time_seconds: float
+>     total_checker_time_seconds: Optional[float]     # None iff never measured
+>     total_interactor_time_seconds: Optional[float]
+>     partial: bool                          # property: judged < total_testcases
+>
+> @dataclass ProblemBenchmark:
+>     slowest_to_judge, most_checker_time, slowest_testcase, partial
+> ```
+>
+> **Every duration is in SECONDS.** Use `formatting.get_formatted_time_in_seconds`,
+> NOT `get_formatted_time` (which takes milliseconds and would silently render
+> `0.29 ms` for 0.29 seconds -- there is no type checker in this repo to catch it).
+>
+> **Render every `Optional[float]` as `solutions._UNMEASURED` (`-`) when `None`.**
+> `None` means unmeasured; `0.0` is a real measurement and must print as one. This
+> is the `_get_evals_time_in_ms` precedent.
+>
+> **`most_checker_time` can point at a solution whose `total_checker_time_seconds`
+> is `None`**, when no solution had a checker at all. Suppress that line rather
+> than printing an unmeasured winner.
+
+
 **Files:**
 - Modify: `rbx/box/benchmark.py`
 - Test: `tests/rbx/box/benchmark_test.py`

--- a/docs/plans/2026-08-28-run-benchmark.md
+++ b/docs/plans/2026-08-28-run-benchmark.md
@@ -214,7 +214,7 @@ Expected: FAIL — `interactor_timing is None`.
 
 **Step 3: Implement**
 
-`check_communication` already funnels **every** return through `_extra_check_and_sanitize`. That is the single hook:
+`check_communication` funnels **almost** every return through `_extra_check_and_sanitize`, which is the hook to use:
 
 ```python
     def _extra_check_and_sanitize(result: CheckerResult) -> CheckerResult:
@@ -226,7 +226,34 @@ Expected: FAIL — `interactor_timing is None`.
         return result
 ```
 
-Check the tail of the function for any `return` that does **not** go through the helper and route it through one if you find it. Note the final `result = await check(...)` (step 6) returns a result that already carries `checker_timing`, and is then passed through `_extra_check_and_sanitize`, so it ends up with both.
+**But there is one return that bypasses the helper**, and it is not an oversight to
+"fix" blindly. Step 0 is:
+
+```python
+    if _any_failed([run_log, interactor_run_log]):
+        return CheckerResult(outcome=Outcome.INTERNAL_ERROR)
+```
+
+It already skips `sanitizer_warnings` today — that is pre-existing behaviour, not
+something this task introduced. Leave it unstamped, and say so in a comment: when
+the sandbox itself failed, there is no honest measurement to report, and an
+`INTERNAL_ERROR` result carrying a timing would invite the report to print one.
+Make that a decision on the record rather than an accident.
+
+Note the final `result = await check(...)` (step 6) returns a result that already
+carries `checker_timing`, and is then passed through `_extra_check_and_sanitize`,
+so it ends up with both.
+
+**A contract difference from Task 2 that you must not paper over.** In `_check`,
+"the checker never ran" and "`checker_run_log is None`" coincide, because the log
+is produced by the very call that runs the checker — so `RunTiming.of`'s `None`
+guard enforces the unmeasured contract for free. That does **not** carry over
+here. In a communication problem the interactor is spawned alongside the
+solution, so `interactor_run_log` is generally non-`None` even on paths where the
+verdict came from `check_with_no_output(run_log)`. Stamping it there is still
+honest — the interactor really did run and really did take that long — but you
+cannot copy Task 2's shape and assume `of()` is protecting you. Decide
+deliberately, and write the reason down.
 
 **Step 4: Run to verify it passes**
 

--- a/docs/plans/2026-08-28-run-benchmark.md
+++ b/docs/plans/2026-08-28-run-benchmark.md
@@ -892,7 +892,7 @@ Expected: FAIL.
 `run_and_print_interactive_solutions` gains `benchmark: BenchmarkLevel = BenchmarkLevel.NONE`. Inside the `async for item in items:` loop, right after `_print_solution_outcome`, print a one-line per-testcase timing when the level is on:
 
 ```
-Checker: 48 ms
+Checker time: 48 ms
 ```
 
 (plus `Interactor:` when there is an interactor timing). Accumulate `build_solution_benchmark(sol, skeleton, [eval])` into a list as you go, and after the loop call `build_problem_benchmark` / `print_problem_benchmark`.

--- a/docs/plans/2026-08-28-run-benchmark.md
+++ b/docs/plans/2026-08-28-run-benchmark.md
@@ -871,6 +871,23 @@ Commit: `feat(run): print the per-solution benchmark block under -b1`
 
 ## Task 8: The problem-level block
 
+> **Two facts Task 7 established that this task must not re-derive wrongly.**
+>
+> 1. `_print_detailed_run_report` does **not** construct a reporter.
+>    `print_run_report` builds the reporter and passes it only
+>    `reporter.structured_evaluations`; the detailed path builds each
+>    `SolutionOutcomeReport` itself. So it collects nothing into
+>    `reporter.solution_benchmarks`, and a problem-level block built off the
+>    reporter will simply not appear under `--detailed` unless this task builds
+>    the list separately on that path. Handle it explicitly and test it -- do not
+>    let `--detailed` silently lose the summary.
+> 2. `BenchmarkParam` carries its default via `default_factory` inside
+>    `typer.Option`, so it has no Python-level default and must be declared
+>    BEFORE the defaulted parameters in a command signature (it sits right after
+>    `verification`, which uses the identical pattern). Appending it last is a
+>    `SyntaxError`.
+
+
 **Files:**
 - Modify: `rbx/box/solutions.py` (`print_run_report`, `_print_detailed_run_report`)
 - Test: `tests/rbx/box/solutions_test.py`

--- a/docs/plans/2026-08-28-run-benchmark.md
+++ b/docs/plans/2026-08-28-run-benchmark.md
@@ -1,0 +1,1037 @@
+# `rbx run --benchmark` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `--benchmark` / `-b` to `rbx run` and `rbx irun`, so `-b1` reports how much time the checker (and interactor) spent judging each solution, and `rbx ui` can show per-testcase checker time.
+
+**Architecture:** The checker's `RunLog` is already produced in `rbx/box/checkers.py:_check` and thrown away. Keep its timing on `CheckerResult`, which is already persisted into each testcase's `.eval` artifact — so capture is unconditional and free, `rbx ui` reads it for any run, and `-b` gates *reporting* only. A new `rbx/box/benchmark.py` owns the level enum, the aggregation over evaluations, and the two report blocks.
+
+**Tech Stack:** Python 3.12+, Pydantic v2, Typer, Rich, pytest. Package manager is `uv`; run everything through `uv run`.
+
+**Design doc:** [`docs/plans/2026-08-28-run-benchmark-design.md`](2026-08-28-run-benchmark-design.md). Read it before Task 1 — it records *why* each decision was taken, and the answers to the questions you would otherwise be tempted to re-litigate.
+
+**Out of scope:** `-b2` (benchmarking test generation and validation) — tracked in [#801](https://github.com/rsalesc/rbx/issues/801). Also out of scope: the machine-readable `rbx/box/run_report.py` projection; benchmark data does not go into `report.yml` in this pass.
+
+---
+
+## Orientation (read once, before Task 1)
+
+Things about this codebase that will bite you if you do not know them:
+
+- **Run everything with `uv run`.** `uv run pytest ...`, `uv run ruff check .`, `uv run rbx ...`.
+- **Do not run the full test suite.** It is slow and produces spurious sandbox wall-clock timeouts. Run only the test files each task touches.
+- **Single quotes** for strings, **absolute imports only** (relative imports are banned by ruff's `TID` rule). Run `uv run ruff format .` and `uv run ruff check --fix .` before every commit.
+- **Commits must be Conventional Commits** — commitizen's pre-commit hook rejects anything else. The allowed types and the exact workflow are in `.claude/skills/commit.md`; use that skill for every commit in this plan. If the hook rejects a commit, fix and make a **new** commit, never amend.
+- **`utils.model_to_yaml` dumps with `exclude_unset=True, exclude_none=True`.** That is the whole reason optional timing fields cost existing `.eval` files zero bytes. Do not "helpfully" give them non-`None` defaults.
+- **A skipped testcase is `Outcome.SKIPPED`** with `log.time is None` (see `solutions._record_skipped_evaluation`). Every aggregation in this plan filters on `eval.result.outcome != Outcome.SKIPPED`. Never coalesce an unmeasured value to `0` — the codebase is deliberate about this and reports `-` instead.
+- **Test helpers already exist**: `tests/rbx/box/conftest.py` gives you `make_evaluation(outcome, time_ms=..., memory_bytes=..., testcase_index=...)` and the `mock_skeleton(solutions, entries_per_group=...)` fixture. Use them; do not hand-roll `Evaluation` objects.
+- **The completion spec is committed and drift-tested.** Adding a CLI flag makes `tests/rbx/box/completion/drift_test.py` fail until you regenerate `rbx/box/completion/_spec.py`. Task 10 does that. `mise run gen-completion-spec` is a no-op inside a worktree — run the underlying command directly (Task 10 spells it out).
+
+---
+
+## Task 1: `RunTiming` on `CheckerResult`
+
+**Files:**
+- Modify: `rbx/grading/steps.py` (near `class CheckerResult`, ~line 328)
+- Test: `tests/rbx/grading/steps_timing_test.py` (create)
+
+**Step 1: Write the failing tests**
+
+```python
+import pathlib
+
+from rbx import utils
+from rbx.grading.steps import CheckerResult, Outcome, RunLog, RunTiming
+
+
+def test_of_returns_none_for_a_missing_run_log():
+    assert RunTiming.of(None) is None
+
+
+def test_of_carries_both_clocks_off_the_run_log():
+    timing = RunTiming.of(RunLog(time=0.048, wall_time=0.051))
+    assert timing == RunTiming(time=0.048, wall_time=0.051)
+
+
+def test_a_result_without_timing_adds_no_keys_to_the_dumped_yaml():
+    # The `.eval` artifact is written with `model_to_yaml`, which drops None.
+    # A run whose checker never executed must write exactly the bytes it always
+    # did, so this file format stays backward compatible.
+    dumped = utils.model_to_yaml(CheckerResult(outcome=Outcome.ACCEPTED))
+    assert 'checker_timing' not in dumped
+    assert 'interactor_timing' not in dumped
+
+
+def test_timing_round_trips_through_yaml(tmp_path: pathlib.Path):
+    result = CheckerResult(
+        outcome=Outcome.ACCEPTED,
+        checker_timing=RunTiming(time=0.048, wall_time=0.051),
+    )
+    path = tmp_path / 'result.yml'
+    path.write_text(utils.model_to_yaml(result))
+
+    reloaded = utils.model_from_yaml(CheckerResult, path.read_text())
+    assert reloaded.checker_timing == RunTiming(time=0.048, wall_time=0.051)
+    assert reloaded.interactor_timing is None
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/grading/steps_timing_test.py -v`
+Expected: FAIL — `ImportError: cannot import name 'RunTiming'`.
+
+**Step 3: Implement**
+
+In `rbx/grading/steps.py`, immediately **above** `class CheckerResult`:
+
+```python
+class RunTiming(BaseModel):
+    """How long one judging program took on one testcase.
+
+    Both clocks are kept even though only CPU time is reported today: storing
+    the wall clock costs nothing, and lets a later benchmarking level report it
+    without migrating the `.eval` format.
+
+    `None` means *unmeasured*, never zero. A checker that never ran -- the
+    solution TLE'd or crashed, so `_check_pre_output` short-circuited -- has no
+    timing at all, and reporting `0 ms` for it would claim a measurement that
+    was never taken.
+    """
+
+    time: Optional[float] = None
+    wall_time: Optional[float] = None
+
+    @staticmethod
+    def of(log: Optional['RunLog']) -> Optional['RunTiming']:
+        if log is None:
+            return None
+        return RunTiming(time=log.time, wall_time=log.wall_time)
+```
+
+And add to `CheckerResult`:
+
+```python
+    # How long the checker took on this testcase, and -- for communication
+    # problems -- the interactor. Captured on every run regardless of
+    # `--benchmark`, because `exclude_none` makes it free and `rbx ui` can then
+    # show it for any past run. See docs/plans/2026-08-28-run-benchmark-design.md.
+    checker_timing: Optional[RunTiming] = None
+    interactor_timing: Optional[RunTiming] = None
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/grading/steps_timing_test.py -v`
+Expected: 4 passed.
+
+**Step 5: Format, lint, commit**
+
+```bash
+uv run ruff format . && uv run ruff check --fix .
+git add rbx/grading/steps.py tests/rbx/grading/steps_timing_test.py
+```
+Commit (via the `/commit` skill): `feat(grading): carry checker and interactor timing on CheckerResult`
+
+---
+
+## Task 2: Populate `checker_timing` in `checkers._check`
+
+**Files:**
+- Modify: `rbx/box/checkers.py` (`_check`, ~line 264)
+- Test: `tests/rbx/box/checkers_test.py`
+
+**Step 1: Write the failing test**
+
+Read the existing tests in `tests/rbx/box/checkers_test.py` first and copy the fixture style of whichever test already compiles and runs a real checker — do not invent a new harness. Add:
+
+```python
+async def test_check_records_the_checker_timing(...):
+    """A real checker run leaves its measured time on the result."""
+    result = await checkers.check(...)  # mirror the neighbouring test's setup
+
+    assert result.checker_timing is not None
+    assert result.checker_timing.time is not None
+    assert result.checker_timing.wall_time is not None
+
+
+async def test_check_records_no_timing_when_the_checker_never_ran(...):
+    """A solution that TLE'd short-circuits before the checker is invoked."""
+    result = checkers.check_with_no_output(
+        RunLog(exitstatus=SandboxBase.EXIT_TIMEOUT)
+    )
+
+    assert result.outcome == Outcome.TIME_LIMIT_EXCEEDED
+    assert result.checker_timing is None
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/checkers_test.py -k timing -v`
+Expected: FAIL — `checker_timing is None` on the first test.
+
+**Step 3: Implement**
+
+In `_check`, after `checker_run_log` is computed and `processed_checker_result` is built, stamp the timing on every result `_check` can return **from the point the checker actually ran**. The function has two return statements after that point (`if skip_run_log: return result` and `return _convert_tle(result, run_log)`), so set it once before them:
+
+```python
+    result = processed_checker_result
+    result.checker_timing = RunTiming.of(checker_run_log)
+
+    if skip_run_log:
+        return result
+    return _convert_tle(result, run_log)
+```
+
+`_convert_tle` mutates and returns the same object, so the timing survives it. Add `RunTiming` to the `rbx.grading.steps` import block at the top of the file.
+
+Note the early `OUTPUT_LIMIT_EXCEEDED` return above still leaves the timing `None`, which is correct: that path also never runs the checker.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/checkers_test.py -v`
+Expected: all pass, including the two new ones.
+
+**Step 5: Format, lint, commit**
+
+Commit: `feat(checkers): record the checker's execution time on its result`
+
+---
+
+## Task 3: Populate `interactor_timing` in `check_communication`
+
+**Files:**
+- Modify: `rbx/box/checkers.py` (`check_communication`, ~line 392)
+- Test: `tests/rbx/box/checkers_communication_test.py`
+
+**Step 1: Write the failing test**
+
+Mirror the setup of the existing communication tests. Assert that a result coming back from `check_communication` carries `interactor_timing` with a non-`None` `time`, **on more than one code path** — pick one test where the interactor decides the verdict and one where the checker does, because `check_communication` has many returns.
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/checkers_communication_test.py -k timing -v`
+Expected: FAIL — `interactor_timing is None`.
+
+**Step 3: Implement**
+
+`check_communication` already funnels **every** return through `_extra_check_and_sanitize`. That is the single hook:
+
+```python
+    def _extra_check_and_sanitize(result: CheckerResult) -> CheckerResult:
+        result.sanitizer_warnings = _check_sanitizer_warnings(run_log)
+        # Every return path of `check_communication` passes through here, which
+        # is why the interactor's timing is stamped on at this one point rather
+        # than at each of the eight returns.
+        result.interactor_timing = RunTiming.of(interactor_run_log)
+        return result
+```
+
+Check the tail of the function for any `return` that does **not** go through the helper and route it through one if you find it. Note the final `result = await check(...)` (step 6) returns a result that already carries `checker_timing`, and is then passed through `_extra_check_and_sanitize`, so it ends up with both.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/checkers_communication_test.py -v`
+Expected: all pass.
+
+**Step 5: Format, lint, commit**
+
+Commit: `feat(checkers): record the interactor's execution time on its result`
+
+---
+
+## Task 4: The benchmark module — level and aggregation
+
+**Files:**
+- Create: `rbx/box/benchmark.py`
+- Test: `tests/rbx/box/benchmark_test.py` (create)
+
+This task is pure computation; printing is Task 5. Keep it that way — the aggregation is what the tests can pin cheaply.
+
+**Step 1: Write the failing tests**
+
+```python
+import pytest
+
+from rbx.box import benchmark
+from rbx.box.schema import ExpectedOutcome, Solution
+from rbx.grading.steps import Outcome, RunTiming
+from tests.rbx.box.conftest import make_evaluation
+
+
+def timed(outcome, *, time_ms, checker_ms=None, interactor_ms=None, index=0):
+    """`make_evaluation`, plus the judging timings this module reads."""
+    eval = make_evaluation(outcome, time_ms=time_ms, testcase_index=index)
+    if checker_ms is not None:
+        eval.result.checker_timing = RunTiming(time=checker_ms / 1000.0)
+    if interactor_ms is not None:
+        eval.result.interactor_timing = RunTiming(time=interactor_ms / 1000.0)
+    return eval
+
+
+def test_judging_time_sums_solution_checker_and_interactor():
+    eval = timed(Outcome.ACCEPTED, time_ms=100, checker_ms=20, interactor_ms=5)
+    assert benchmark.judging_time(eval) == pytest.approx(0.125)
+
+
+def test_judging_time_is_none_when_the_solution_was_never_timed():
+    # A skipped testcase must not report an instantaneous judging time.
+    assert benchmark.judging_time(timed(Outcome.SKIPPED, time_ms=None)) is None
+
+
+def test_judging_time_counts_an_unmeasured_checker_as_absent_not_zero():
+    eval = timed(Outcome.TIME_LIMIT_EXCEEDED, time_ms=1000)
+    assert benchmark.judging_time(eval) == pytest.approx(1.0)
+
+
+def test_solution_benchmark_picks_the_slowest_testcase_to_judge(mock_skeleton, tmp_path):
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 3})
+    evals = [
+        timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0),
+        # Slowest *judging*, though not the slowest solution run: the point of
+        # the whole feature is that these two can disagree.
+        timed(Outcome.ACCEPTED, time_ms=90, checker_ms=200, index=1),
+        timed(Outcome.ACCEPTED, time_ms=150, checker_ms=5, index=2),
+    ]
+
+    bench = benchmark.build_solution_benchmark(solution, skeleton, evals)
+
+    assert bench is not None
+    assert bench.slowest.entry == skeleton.entries[1].group_entry
+    assert bench.slowest.judging_time == pytest.approx(0.29)
+    assert bench.slowest.checker_time == pytest.approx(0.2)
+    assert bench.total_judging_time == pytest.approx(0.555)
+    assert bench.total_checker_time == pytest.approx(0.215)
+    assert bench.judged == 3
+    assert bench.total == 3
+    assert not bench.partial
+
+
+def test_solution_benchmark_is_partial_when_testcases_were_skipped(mock_skeleton, tmp_path):
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 3})
+    evals = [
+        timed(Outcome.WRONG_ANSWER, time_ms=100, checker_ms=10, index=0),
+        timed(Outcome.SKIPPED, time_ms=None, index=1),
+        timed(Outcome.SKIPPED, time_ms=None, index=2),
+    ]
+
+    bench = benchmark.build_solution_benchmark(solution, skeleton, evals)
+
+    assert bench is not None
+    assert bench.judged == 1
+    assert bench.total == 3
+    assert bench.partial
+
+
+def test_solution_benchmark_is_none_when_nothing_was_judged(mock_skeleton, tmp_path):
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 2})
+    evals = [timed(Outcome.SKIPPED, time_ms=None, index=i) for i in range(2)]
+
+    assert benchmark.build_solution_benchmark(solution, skeleton, evals) is None
+
+
+def test_problem_benchmark_ranks_solutions(mock_skeleton, tmp_path):
+    slow_judge = Solution(path=tmp_path / 'a.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    heavy_checker = Solution(path=tmp_path / 'b.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([slow_judge, heavy_checker], entries_per_group={'test': 2})
+    per_solution = [
+        benchmark.build_solution_benchmark(
+            slow_judge,
+            skeleton,
+            [timed(Outcome.ACCEPTED, time_ms=500, checker_ms=1, index=i) for i in range(2)],
+        ),
+        benchmark.build_solution_benchmark(
+            heavy_checker,
+            skeleton,
+            [timed(Outcome.ACCEPTED, time_ms=10, checker_ms=300, index=i) for i in range(2)],
+        ),
+    ]
+
+    problem = benchmark.build_problem_benchmark([b for b in per_solution if b])
+
+    assert problem is not None
+    assert problem.slowest_to_judge.solution.path == slow_judge.path
+    assert problem.most_checker_time.solution.path == heavy_checker.path
+    assert problem.slowest_testcase.judging_time == pytest.approx(0.51)
+
+
+def test_problem_benchmark_is_none_without_any_solution_benchmarks():
+    assert benchmark.build_problem_benchmark([]) is None
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/benchmark_test.py -v`
+Expected: FAIL — `ModuleNotFoundError: rbx.box.benchmark`.
+
+**Step 3: Implement**
+
+Create `rbx/box/benchmark.py`. Keep the top-level imports light — this module is imported by the CLI command modules.
+
+```python
+"""Benchmarking of the judging phase, behind `rbx run --benchmark`.
+
+`rbx run` already reports how long each *solution* took. It says nothing about
+how long *judging* took, and on a problem with a heavy checker the checker can
+dominate the wall clock of a full run. This module turns the checker and
+interactor timings that every evaluation now carries (see
+`rbx.grading.steps.RunTiming`) into the two blocks `-b1` prints.
+
+The timings themselves are captured unconditionally; the level only decides
+whether anything is printed. See docs/plans/2026-08-28-run-benchmark-design.md.
+"""
+
+import dataclasses
+from enum import Enum
+from typing import List, Optional
+
+from rbx.box.schema import Solution
+from rbx.box.testcase_schema import TestcaseEntry
+from rbx.grading.steps import Evaluation, Outcome
+
+
+class BenchmarkLevel(Enum):
+    """How much of a run to benchmark. Mirrors `VerificationLevel`."""
+
+    NONE = 0
+    SOLUTIONS = 1
+
+
+def _timing_seconds(timing) -> float:
+    """An unmeasured program contributes nothing, rather than a zero."""
+    if timing is None or timing.time is None:
+        return 0.0
+    return timing.time
+
+
+def checker_time(eval: Evaluation) -> float:
+    return _timing_seconds(eval.result.checker_timing)
+
+
+def interactor_time(eval: Evaluation) -> float:
+    return _timing_seconds(eval.result.interactor_timing)
+
+
+def was_judged(eval: Evaluation) -> bool:
+    """Whether this testcase actually ran.
+
+    A `--fail-fast` run persists a `SKIPPED` evaluation for every testcase after
+    the one that decided the verdict, with no time on it at all.
+    """
+    return eval.result.outcome != Outcome.SKIPPED and eval.log.time is not None
+
+
+def judging_time(eval: Evaluation) -> Optional[float]:
+    """Solution time + checker time + interactor time, in seconds.
+
+    `None` when the solution itself was never timed: there is no judging time
+    for a testcase that never ran.
+    """
+    if not was_judged(eval):
+        return None
+    return (eval.log.time or 0.0) + checker_time(eval) + interactor_time(eval)
+
+
+@dataclasses.dataclass
+class TestcaseJudging:
+    entry: TestcaseEntry
+    judging_time: float
+    solution_time: float
+    checker_time: float
+    interactor_time: float
+
+
+@dataclasses.dataclass
+class SolutionBenchmark:
+    solution: Solution
+    slowest: TestcaseJudging
+    total_judging_time: float
+    total_checker_time: float
+    total_interactor_time: float
+    judged: int
+    total: int
+
+    @property
+    def partial(self) -> bool:
+        """Whether some testcases never ran, making every total a lower bound."""
+        return self.judged < self.total
+
+
+@dataclasses.dataclass
+class ProblemBenchmark:
+    slowest_to_judge: SolutionBenchmark
+    most_checker_time: SolutionBenchmark
+    slowest_testcase: TestcaseJudging
+    partial: bool
+
+
+def build_solution_benchmark(
+    solution: Solution,
+    skeleton,  # SolutionReportSkeleton; untyped to keep this module's imports light
+    evals: List[Evaluation],
+) -> Optional[SolutionBenchmark]:
+    """Aggregate one solution's evaluations, or None if none of them ran."""
+    judgings: List[TestcaseJudging] = []
+    for eval, entry in zip(evals, skeleton.entries):
+        total = judging_time(eval)
+        if total is None:
+            continue
+        judgings.append(
+            TestcaseJudging(
+                entry=entry.group_entry,
+                judging_time=total,
+                solution_time=eval.log.time or 0.0,
+                checker_time=checker_time(eval),
+                interactor_time=interactor_time(eval),
+            )
+        )
+
+    if not judgings:
+        return None
+
+    return SolutionBenchmark(
+        solution=solution,
+        slowest=max(judgings, key=lambda j: j.judging_time),
+        total_judging_time=sum(j.judging_time for j in judgings),
+        total_checker_time=sum(j.checker_time for j in judgings),
+        total_interactor_time=sum(j.interactor_time for j in judgings),
+        judged=len(judgings),
+        # `evals` can be shorter than the skeleton mid-run, so the denominator
+        # is the testset, not the list handed in.
+        total=len(skeleton.entries),
+    )
+
+
+def build_problem_benchmark(
+    benchmarks: List[SolutionBenchmark],
+) -> Optional[ProblemBenchmark]:
+    if not benchmarks:
+        return None
+    return ProblemBenchmark(
+        slowest_to_judge=max(benchmarks, key=lambda b: b.total_judging_time),
+        most_checker_time=max(benchmarks, key=lambda b: b.total_checker_time),
+        slowest_testcase=max(
+            (b.slowest for b in benchmarks), key=lambda j: j.judging_time
+        ),
+        partial=any(b.partial for b in benchmarks),
+    )
+```
+
+Check the real name of the `group_entry` attribute on `GenerationTestcaseEntry` (see `rbx/box/generation_schema.py`) and of `TestcaseEntry` before writing this — the plan uses `entry.group_entry`, matching `solutions.get_solution_eval`'s usage.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/benchmark_test.py -v`
+Expected: all pass.
+
+**Step 5: Format, lint, commit**
+
+Commit: `feat(benchmark): aggregate checker and interactor timings per solution`
+
+---
+
+## Task 5: Rendering the two blocks
+
+**Files:**
+- Modify: `rbx/box/benchmark.py`
+- Test: `tests/rbx/box/benchmark_test.py`
+
+**Step 1: Write the failing tests**
+
+Render into a `rich.console.Console(record=True, width=120)` and assert over `console.export_text()`. Assert on *substance*, not exact spacing:
+
+```python
+def test_solution_block_names_the_slowest_test_and_the_totals(...):
+    ...
+    out = render(benchmark.print_solution_benchmark, bench)
+    assert 'test/1' in out
+    assert 'checker' in out
+    assert 'over' not in out  # complete run says nothing about partiality
+
+
+def test_solution_block_marks_a_partial_run(...):
+    out = render(benchmark.print_solution_benchmark, partial_bench)
+    assert 'over 1/3 tests judged' in out
+
+
+def test_solution_block_omits_the_interactor_when_there_was_none(...):
+    out = render(benchmark.print_solution_benchmark, non_interactive_bench)
+    assert 'interactor' not in out.lower()
+
+
+def test_problem_block_names_both_extremes(...):
+    out = render(benchmark.print_problem_benchmark, problem)
+    assert 'a.cpp' in out
+    assert 'b.cpp' in out
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/benchmark_test.py -k block -v`
+Expected: FAIL — `AttributeError: module has no attribute 'print_solution_benchmark'`.
+
+**Step 3: Implement**
+
+Add to `rbx/box/benchmark.py`. Import `rich.console` and the formatters lazily inside the functions if you want to keep the module's import cost down; `get_formatted_time` and `get_formatted_time_in_seconds` live in `rbx/box/formatting.py` — grep for where `solutions.py` imports them and use the same source. Times are in **seconds** here and those helpers take **milliseconds**, so convert at the boundary and nowhere else.
+
+Shape of the output (match the surrounding report's Rich style — `[status]`, `[hilite]`, `href()` for solution paths, as `TimingSummary.print` does):
+
+```
+Benchmark: slowest test test/1 - 290 ms judging (90 ms solution + 200 ms checker)
+Total judging: 555 ms (checker: 215 ms)
+```
+
+with `, N ms interactor` / `(checker: X, interactor: Y)` added only when `total_interactor_time > 0`, and ` (over 1/3 tests judged)` appended to the totals line when `bench.partial`.
+
+The problem block:
+
+```
+Benchmark summary
+Slowest solution to judge: 1.02 s, sols/a.cpp
+Most checker time: 600 ms, sols/b.cpp
+Slowest testcase to judge: 510 ms, test/0 of sols/a.cpp
+```
+
+Both functions take `(console: rich.console.Console, bench)` so the `--share` recording console can be passed instead of the real one.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/benchmark_test.py -v`
+Expected: all pass.
+
+**Step 5: Format, lint, commit**
+
+Commit: `feat(benchmark): render the per-solution and problem-level blocks`
+
+---
+
+## Task 6: The `-b` flag and its completer
+
+**Files:**
+- Modify: `rbx/box/benchmark.py` (add `BenchmarkParam`, `parse_level`)
+- Modify: `rbx/box/completion/completers.py` (~line 155, next to `_VERIFICATION_TABLE`)
+- Test: `tests/rbx/box/benchmark_test.py`, `tests/rbx/box/completion/enum_consistency_test.py`
+
+**Step 1: Write the failing tests**
+
+```python
+# benchmark_test.py
+def test_parse_level_accepts_the_implemented_levels():
+    assert benchmark.parse_level(0) == benchmark.BenchmarkLevel.NONE
+    assert benchmark.parse_level(1) == benchmark.BenchmarkLevel.SOLUTIONS
+
+
+def test_parse_level_rejects_b2_and_points_at_the_tracking_issue():
+    with pytest.raises(typer.BadParameter) as exc:
+        benchmark.parse_level(2)
+    assert '801' in str(exc.value)
+
+
+def test_parse_level_rejects_nonsense():
+    with pytest.raises(typer.BadParameter):
+        benchmark.parse_level(7)
+```
+
+```python
+# enum_consistency_test.py -- alongside the verification one
+def test_benchmark_table_matches_benchmark_level_enum():
+    from rbx.box.benchmark import BenchmarkLevel
+
+    table = dict(completers._BENCHMARK_TABLE)  # noqa: SLF001
+    expected = {str(level.value): level.name for level in BenchmarkLevel}
+    assert table == expected
+```
+
+**Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/rbx/box/benchmark_test.py tests/rbx/box/completion/enum_consistency_test.py -v`
+Expected: FAIL on the three new tests.
+
+**Step 3: Implement**
+
+In `rbx/box/benchmark.py`:
+
+```python
+BENCHMARK_ISSUE_URL = 'https://github.com/rsalesc/rbx/issues/801'
+
+
+def parse_level(value: int) -> BenchmarkLevel:
+    """Turn the `-b` flag's int into a level, rejecting the unimplemented ones.
+
+    `-b2` -- benchmarking test generation and validation -- is specified but not
+    built. Rejecting it outright is deliberate: silently treating it as `-b1`
+    would hand back a report that quietly omits half of what was asked for.
+    """
+    try:
+        return BenchmarkLevel(value)
+    except ValueError:
+        pass
+    if value == 2:
+        raise typer.BadParameter(
+            'Benchmark level 2 (test generation and validation) is not '
+            f'implemented yet. Follow {BENCHMARK_ISSUE_URL}.'
+        )
+    raise typer.BadParameter(
+        f'Invalid benchmark level {value}. Valid levels are '
+        f'{", ".join(str(level.value) for level in BenchmarkLevel)}.'
+    )
+
+
+def _benchmark_autocompletion():
+    # Indirected through a function for the same reason
+    # `environment._verification_autocompletion` is: keeps this module's import
+    # surface off `rbx.annotations`.
+    from rbx import annotations
+
+    return annotations._adapt('benchmark_level')  # noqa: SLF001
+
+
+BenchmarkParam = Annotated[
+    int,
+    typer.Option(
+        '--benchmark',
+        '-b',
+        help='Benchmark level: 0 (off), 1 (benchmark the solution run).',
+        default_factory=lambda: BenchmarkLevel.NONE.value,
+        autocompletion=_benchmark_autocompletion(),
+    ),
+]
+```
+
+Verify that a bare `-b` (no value) yields `1`. Typer's int option normally *requires* a value; if `-b` alone errors, give the option `flag_value=BenchmarkLevel.SOLUTIONS.value` (Click supports `flag_value` on a non-boolean option) and add a test asserting `rbx run -b` behaves as `-b1`. Do not skip this check — the design promises bare `-b` means `-b1`.
+
+In `rbx/box/completion/completers.py`, next to `_VERIFICATION_TABLE`:
+
+```python
+_BENCHMARK_TABLE = (
+    ('0', 'NONE'),
+    ('1', 'SOLUTIONS'),
+)
+
+
+@register_completer('benchmark_level')
+def complete_benchmark_level(
+    ctx: CompletionContext, incomplete: str
+) -> List[CompletionItem]:
+    return [CompletionItem(v, help=h) for v, h in _BENCHMARK_TABLE]
+```
+
+**Step 4: Run to verify they pass**
+
+Run: `uv run pytest tests/rbx/box/benchmark_test.py tests/rbx/box/completion/enum_consistency_test.py tests/rbx/box/completion/registry_test.py -v`
+Expected: all pass.
+
+**Step 5: Format, lint, commit**
+
+Commit: `feat(cli): add the --benchmark level flag and its completer`
+
+---
+
+## Task 7: Wire `-b1` into `rbx run`
+
+**Files:**
+- Modify: `rbx/box/cli/commands/run.py` (`run`, ~line 76)
+- Modify: `rbx/box/solutions.py` (`TraditionalRunReporter`, `print_run_report`)
+- Test: `tests/rbx/box/solutions_test.py`
+
+**Step 1: Write the failing test**
+
+Drive `print_run_report` (or `TraditionalRunReporter.finish_solution` directly, whichever the neighbouring tests already exercise) with a recording console at `BenchmarkLevel.SOLUTIONS` and assert the block appears; then at `BenchmarkLevel.NONE` and assert it does **not**.
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/solutions_test.py -k benchmark -v`
+Expected: FAIL — `print_run_report() got an unexpected keyword argument 'benchmark'`.
+
+**Step 3: Implement**
+
+1. `TraditionalRunReporter.__init__` takes `benchmark: BenchmarkLevel = BenchmarkLevel.NONE` and stores it. Both subclasses pass `*args, **kwargs` through, so they need no change.
+
+2. In `TraditionalRunReporter.finish_solution`, **after** `render_solution_end` returns the report — this is the one place both reporters converge, so the block is written once:
+
+```python
+        report = self.render_solution_end(self.current_solution)
+        if report is not None and self.benchmark == BenchmarkLevel.SOLUTIONS:
+            bench = benchmark.build_solution_benchmark(
+                self.current_solution, self.result.skeleton, report.evals
+            )
+            if bench is not None:
+                benchmark.print_solution_benchmark(self.console, bench)
+                self.solution_benchmarks.append(bench)
+```
+
+Collect the per-solution benchmarks on the reporter (`self.solution_benchmarks: List[SolutionBenchmark] = []` in `__init__`) so Task 8 can build the problem block from them without recomputing.
+
+3. `print_run_report` grows `benchmark: BenchmarkLevel = BenchmarkLevel.NONE`, forwards it to `report_cls(...)`, and — because `_print_detailed_run_report` is a separate path — forwards it there too. Under `--detailed` the per-testcase table is unchanged; only the blocks are added.
+
+4. `rbx/box/cli/commands/run.py`'s `run` gains `benchmark_level: benchmark_module.BenchmarkParam`, calls `benchmark_module.parse_level(benchmark_level)` early (next to `_set_timing_profile`, so a bad level costs a build), and passes the level to **both** `print_run_report` calls — the terminal one and the `--share` recording one.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/solutions_test.py -v`
+Expected: all pass — including the existing tests, which must be untouched at `BenchmarkLevel.NONE`.
+
+**Step 5: Verify by hand on a real package**
+
+```bash
+cd tests/e2e   # pick any fixture package with solutions and a checker
+uv run rbx run -b1
+uv run rbx run -b1 --ff
+uv run rbx run          # must be byte-identical to before this branch
+```
+Expected: the per-solution block appears under `-b1`; under `--ff` it carries `(over N/M tests judged)`; plain `rbx run` is unchanged.
+
+**Step 6: Format, lint, commit**
+
+Commit: `feat(run): print the per-solution benchmark block under -b1`
+
+---
+
+## Task 8: The problem-level block
+
+**Files:**
+- Modify: `rbx/box/solutions.py` (`print_run_report`, `_print_detailed_run_report`)
+- Test: `tests/rbx/box/solutions_test.py`
+
+**Step 1: Write the failing test**
+
+Two solutions, one slow to run with a cheap checker and one fast to run with an expensive one; assert both are named in the output, and that the block appears even under a `--ff`-shaped (partial) input, marked partial.
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/solutions_test.py -k problem_benchmark -v`
+Expected: FAIL.
+
+**Step 3: Implement**
+
+In `print_run_report`, after the existing `_print_timing` call — and **outside** the `if not single_solution and timing:` guard, because the benchmark block is printed regardless of `--ff` and regardless of solution count:
+
+```python
+    if benchmark == BenchmarkLevel.SOLUTIONS:
+        problem_bench = benchmark_module.build_problem_benchmark(
+            reporter.solution_benchmarks
+        )
+        if problem_bench is not None:
+            benchmark_module.print_problem_benchmark(console, problem_bench)
+```
+
+Mirror it in `_print_detailed_run_report`.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/solutions_test.py -v`
+Expected: all pass.
+
+**Step 5: Verify by hand**
+
+`uv run rbx run -b1` on a package with several solutions — the summary must name real solution paths and a real testcase.
+
+**Step 6: Format, lint, commit**
+
+Commit: `feat(run): print the problem-level benchmark summary under -b1`
+
+---
+
+## Task 9: Wire `-b1` into `rbx irun`
+
+**Files:**
+- Modify: `rbx/box/cli/commands/run.py` (`irun`, ~line 354)
+- Modify: `rbx/box/solutions.py` (`run_and_print_interactive_solutions`, ~line 1403)
+- Test: `tests/rbx/box/solutions_test.py`
+
+Per the design: `irun -b1` prints per-testcase checker/interactor time on each testcase's block, and the problem-level summary. **No** per-solution block — with one testcase, "slowest test" says nothing.
+
+**Step 1: Write the failing test**
+
+Assert that at `BenchmarkLevel.SOLUTIONS` the per-testcase output carries a checker time, and that the problem summary is printed after the loop; at `NONE`, neither.
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/solutions_test.py -k irun_benchmark -v`
+Expected: FAIL.
+
+**Step 3: Implement**
+
+`run_and_print_interactive_solutions` gains `benchmark: BenchmarkLevel = BenchmarkLevel.NONE`. Inside the `async for item in items:` loop, right after `_print_solution_outcome`, print a one-line per-testcase timing when the level is on:
+
+```
+Checker: 48 ms
+```
+
+(plus `Interactor:` when there is an interactor timing). Accumulate `build_solution_benchmark(sol, skeleton, [eval])` into a list as you go, and after the loop call `build_problem_benchmark` / `print_problem_benchmark`.
+
+`irun` in `run.py` gains `benchmark_level: benchmark_module.BenchmarkParam`, parses it early, and forwards the level. `-b` is free in `irun` (`-p` is `--print` there, but `-b` is unused) — confirm no collision before wiring.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/solutions_test.py -v`
+Expected: all pass.
+
+**Step 5: Verify by hand**
+
+`uv run rbx irun -b1 -t test/0` on a fixture package.
+
+**Step 6: Format, lint, commit**
+
+Commit: `feat(irun): report checker timing per testcase under -b1`
+
+---
+
+## Task 10: `rbx ui` shows the checker time
+
+**Files:**
+- Modify: `rbx/box/ui/utils/run_ui.py` (`get_run_testcase_metadata_markup`, ~line 225)
+- Test: `tests/rbx/box/ui/` — find the existing test module for `run_ui`; create `tests/rbx/box/ui/test_run_ui.py` if there is none. Note this directory uses the `test_*.py` prefix, unlike the `*_test.py` suffix everywhere else under `tests/rbx/box/`.
+
+Note there is **no** `-b` gate here: capture is unconditional, so the UI reads whatever the `.eval` holds.
+
+**Step 1: Write the failing test**
+
+```python
+def test_metadata_markup_shows_the_checker_time(...):
+    markup = run_ui.get_run_testcase_metadata_markup(skeleton, solution, entry)
+    assert 'Checker:' in markup
+    assert '48 ms' in markup
+
+
+def test_metadata_markup_shows_a_dash_when_the_checker_never_ran(...):
+    # A TLE'd testcase short-circuits before the checker; '-' says
+    # 'unmeasured', which is not the same claim as '0 ms'.
+    assert 'Checker:[/b] -' in markup
+
+
+def test_metadata_markup_shows_the_interactor_line_only_when_there_is_one(...):
+    assert 'Interactor:' not in non_interactive_markup
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/rbx/box/ui/test_run_ui.py -v`
+Expected: FAIL.
+
+**Step 3: Implement**
+
+In `get_run_testcase_metadata_markup`, after the existing `Time: ... / Memory: ...` line:
+
+```python
+    checker_timing = eval.result.checker_timing
+    lines.append(
+        f'[b]Checker:[/b] '
+        f'{_format_judging_time(checker_timing)}'
+    )
+    if eval.result.interactor_timing is not None:
+        lines.append(
+            f'[b]Interactor:[/b] '
+            f'{_format_judging_time(eval.result.interactor_timing)}'
+        )
+```
+
+where `_format_judging_time` returns `solutions._UNMEASURED` (`'-'`) for a `None` timing or a `None` `time`, and `get_formatted_time(int(timing.time * 1000))` otherwise. Reuse the existing `_UNMEASURED` constant rather than spelling `'-'` again.
+
+**Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/rbx/box/ui/ -v`
+Expected: all pass.
+
+**Step 5: Verify by hand**
+
+`uv run rbx run` then `uv run rbx ui`, navigate to a testcase, confirm the checker line is there.
+
+**Step 6: Format, lint, commit**
+
+Commit: `feat(ui): show the checker execution time for each testcase`
+
+---
+
+## Task 11: Regenerate the completion spec and the CLI reference
+
+**Files:**
+- Modify: `rbx/box/completion/_spec.py` (generated)
+- Modify: `docs/setters/reference/cli.md` (generated)
+
+**Step 1: Confirm the drift**
+
+Run: `uv run pytest tests/rbx/box/completion/drift_test.py -v`
+Expected: FAIL — the committed spec has no `--benchmark` on `run`/`irun`.
+
+**Step 2: Regenerate**
+
+`mise run gen-completion-spec` is a **no-op inside a worktree**, so run its body directly:
+
+```bash
+uv run python -m rbx.box.completion.serialize
+uv run ruff format rbx/box/completion/_spec.py
+```
+
+**Step 3: Verify**
+
+Run: `uv run pytest tests/rbx/box/completion/ -v`
+Expected: all pass.
+
+**Step 4: Regenerate the CLI reference**
+
+`docs/setters/reference/cli.md` is generated by `rbx/box/dump_cli_docs.py` and is rewritten by a docs build. Regenerate it the way the repo does (grep `dump_cli_docs` in `mise.toml` / `mkdocs.yml` for the entry point) and commit **only** the `--benchmark` additions — revert any unrelated churn the generator introduces.
+
+**Step 5: Commit**
+
+Commit: `chore(completion): regenerate the spec and CLI reference for --benchmark`
+
+---
+
+## Task 12: Documentation
+
+**Files:**
+- Modify: whichever page under `docs/setters/` covers `rbx run`'s flags (grep for `--fail-fast` to find it)
+
+Follow [`docs/plans/docs-writing-style-guide.md`](docs-writing-style-guide.md) — notably: introduce a concept before using it, and never forward-reference a mechanism the reader has not met.
+
+Cover: what `-b1` measures (checker and interactor time, per testcase, per solution, per problem); that timings are captured on every run so `rbx ui` shows them without `-b`; that a cached checker reports its original measured time, which is the uncached cost and the number worth having; and that under `--ff` the totals are lower bounds and say so. Do **not** document `-b2`.
+
+**Verify:** build the docs non-strict (`uv run mkdocs build`) — there are ~9 pre-existing unrelated `--strict` warnings, so do not use `--strict` and do not try to fix them. Check that the docs build did not rewrite `docs/setters/reference/cli.md` beyond Task 11's changes.
+
+**Commit:** `docs(run): document the --benchmark flag`
+
+---
+
+## Task 13: Final verification
+
+**Step 1: Run every test file this branch touched**
+
+```bash
+uv run pytest \
+  tests/rbx/grading/steps_timing_test.py \
+  tests/rbx/box/benchmark_test.py \
+  tests/rbx/box/checkers_test.py \
+  tests/rbx/box/checkers_communication_test.py \
+  tests/rbx/box/solutions_test.py \
+  tests/rbx/box/run_report_test.py \
+  tests/rbx/box/completion/ \
+  tests/rbx/box/ui/ \
+  -v
+```
+
+Do **not** run the whole suite: it is slow and produces spurious sandbox timeouts. Known-unrelated pre-existing failures in this repo: C++/sandbox/docker tests, and `test_compute_walltime_uses_active_environment`. If one of those fails, it is not yours.
+
+**Step 2: Lint**
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+```
+
+**Step 3: Confirm `-b0` changed nothing**
+
+Run a package with and without the branch and diff the output of a plain `uv run rbx run`. It must be identical. Then confirm an `.eval` written by a plain run gained the `checker_timing` key and nothing else.
+
+**Step 4: Push and open a PR**
+
+Reference the design doc and #801 in the PR body.
+
+---
+
+## Notes for the executor
+
+- **Do not** re-open decisions the design doc settled — cached times reported as-is with no warning, unconditional capture, CPU time reported, `-b2` rejected. They were asked and answered.
+- **Do not** add per-testcase benchmark output to `rbx run`'s terminal report in any mode, including `--detailed`. That was explicitly ruled out.
+- If a task turns out to be bigger than one commit, split it — but keep each commit green.

--- a/docs/plans/2026-08-28-run-benchmark.md
+++ b/docs/plans/2026-08-28-run-benchmark.md
@@ -612,6 +612,13 @@ Total judging: 555 ms (checker: 215 ms)
 
 with `, N ms interactor` / `(checker: X, interactor: Y)` added only when `total_interactor_time > 0`, and ` (over 1/3 tests judged)` appended to the totals line when `bench.partial`.
 
+**A case Task 3 surfaced that this rendering must handle.** A communication
+problem with no checker (`checker_digest is None`) produces evaluations carrying
+an `interactor_timing` and **no** `checker_timing` at all. Render a missing
+checker timing as blank or `-`, never as `0 ms` -- the whole point of the
+`None`-means-unmeasured contract is that those are different claims. Cover it
+with a test.
+
 The problem block:
 
 ```

--- a/docs/setters/cheatsheet.md
+++ b/docs/setters/cheatsheet.md
@@ -35,6 +35,7 @@ Where a command has a page of its own, the :material-open-in-new: next to it tak
 | Run only the solutions carrying a [tag](#tag-a-solution) | `rbx run --tag brute-force` |
 | Stop a solution at its first non-accepted verdict [:material-open-in-new:](/setters/running#failing-fast) | `rbx run --ff` |
 | Run against a timing profile [:material-open-in-new:](/setters/profiling#using-profiles-when-running-solutions) | `rbx run -p icpc` |
+| Report how long the checker spent judging [:material-open-in-new:](/setters/running#benchmarking-the-judging-time) | `rbx run -b1` |
 | Copy the run report to the clipboard [:material-open-in-new:](/setters/running#sharing-a-report) | `rbx run --share png` |
 | Run a submission downloaded from {{boca}} | `rbx run @boca/123` |
 | Run a submission downloaded from {{moj}} [:material-open-in-new:](/setters/packaging/moj#downloading-a-submission) | `rbx run @moj/<contest>/<id>` |

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -121,6 +121,7 @@ rbx run <SOLUTIONS> [OPTIONS]
 | Name | Type | Description | Default |
 | :--- | :--- | :--- | :--- |
 | `--verification-level`, `--verification`, `-v` | INTEGER of [VerificationLevel][rbx.box.environment.VerificationLevel] | Verification level to use when building package. | `4` |
+| `--benchmark`, `-b` | INTEGER | Benchmark level: 0 (off), 1 (benchmark the solution run). | `0` |
 | `--outcome`, `-o` | TEXT | Include only solutions whose expected outcomes intersect with this. | - |
 | `--tag` | TEXT | Include only solutions whose tags intersect with this. | - |
 | `--check` | BOOLEAN | Whether to not build outputs for tests and run checker. | `True` |
@@ -196,6 +197,7 @@ rbx irun <SOLUTIONS> [OPTIONS]
 | Name | Type | Description | Default |
 | :--- | :--- | :--- | :--- |
 | `--verification-level`, `--verification`, `-v` | INTEGER of [VerificationLevel][rbx.box.environment.VerificationLevel] | Verification level to use when building package. | `4` |
+| `--benchmark`, `-b` | INTEGER | Benchmark level: 0 (off), 1 (benchmark the solution run). | `0` |
 | `--outcome`, `-o` | TEXT | Include only solutions whose expected outcomes intersect with this. | - |
 | `--tag` | TEXT | Include only solutions whose tags intersect with this. | - |
 | `--check` | BOOLEAN | Whether to not build outputs for tests and run checker. | `True` |

--- a/docs/setters/running/index.md
+++ b/docs/setters/running/index.md
@@ -198,3 +198,71 @@ rbx irun -g "gen 100 123" -p
 ```
 
 {{ asciinema("irun-generator") }}
+
+## Benchmarking the judging time
+
+`rbx run` tells you how long each **solution** took, and nothing about how long **judging**
+took. The checker, though, runs once per testcase per solution, and on a problem with a
+heavy checker it can dominate the wall clock of a whole run.
+
+`--benchmark` (`-b`) reports that cost. It takes a level, just like `-v`, and the level is
+required — a bare `-b` is an error:
+
+```bash
+# 0 is the default: nothing is benchmarked, and the report is the one above
+rbx run -b0
+
+# 1 benchmarks the solution run: how long the checker — and, on an interactive
+# problem, the interactor — spent judging
+rbx run -b1
+```
+
+Each solution then gets an extra block under its `Time:` and `Memory:` lines, naming the
+testcase that was slowest to judge, with its breakdown, and the totals over the whole
+testset:
+
+```{.bash .no-copy}
+Benchmark: slowest test secret/12 - 290 ms judging (90 ms solution + 200 ms checker)
+Total judging: 555 ms (checker: 215 ms)
+```
+
+Judging time is the solution's time plus the checker's, plus the interactor's on an
+[interactive problem](/setters/grading/interactors/), where it appears as a third term in
+both the breakdown and the totals.
+
+When several solutions ran, the report closes with the problem-wide extremes:
+
+```{.bash .no-copy}
+Benchmark summary
+Slowest solution to judge: 1.0 s, sols/slow.cpp
+Most checker time: 600 ms, sols/main.cpp
+Slowest testcase to judge: 501 ms, secret/12
+```
+
+Notice the durations follow the value: milliseconds below a second, seconds above it. A
+`-` means the value was never measured — no checker ran on that testcase, or the sandbox
+reported no clock — which is a different fact from a measured zero, and never rendered as
+one.
+
+`rbx irun` takes `-b1` too. There, the checker (and interactor) time is printed on each
+testcase's block, along with the summary. There is no per-solution block: with a single
+testcase, "slowest test" would say nothing.
+
+!!! tip
+    These timings are captured on **every** run, benchmarked or not — `-b` only decides
+    what gets printed. So `rbx ui` shows you the checker time of a run you've already
+    done, without re-running anything.
+
+Checker runs are cached, and a cached checker reports the time it took when it actually
+ran. {{rbx}} never re-runs a checker to benchmark it: the stored measurement is the
+uncached cost, which is the number worth having.
+
+Under `--fail-fast` every total is a **lower bound**, since a solution that stopped early
+was only judged on the testcases that ran. The report says so:
+
+```{.bash .no-copy}
+Total judging: 3.1 s (checker: 400 ms) (over 7/40 tests judged)
+```
+
+Unlike the timing summary, which `--ff` drops entirely because time limit inference reads
+it, the benchmark feeds no inference. A marked lower bound is more useful than nothing.

--- a/rbx/box/benchmark.py
+++ b/rbx/box/benchmark.py
@@ -12,7 +12,10 @@ milliseconds, the others seconds -- so a name that omits the unit invites a
 caller to mislabel it, which nothing here would raise on.
 
 The timings themselves are captured unconditionally; the level only decides
-whether anything is printed. See docs/plans/2026-08-28-run-benchmark-design.md.
+whether anything is printed. The `-b` flag itself lives here too -- its
+parameter definition, its completer hook and the parsing of its int into a
+level -- so that the levels and the flag that selects them stay in one file.
+See docs/plans/2026-08-28-run-benchmark-design.md.
 """
 
 import dataclasses
@@ -40,30 +43,54 @@ class BenchmarkLevel(Enum):
     SOLUTIONS = 1
 
 
-BENCHMARK_ISSUE_URL = 'https://github.com/rsalesc/rbx/issues/801'
+BENCHMARK_LEVEL_2_ISSUE_URL = 'https://github.com/rsalesc/rbx/issues/801'
+
+# Levels the design specifies but that are not built yet, each with what it
+# would benchmark and where its progress is tracked. Delete an entry when the
+# level lands: `parse_level` consults `BenchmarkLevel` first, so a value present
+# in both is accepted and this row becomes dead weight --
+# `test_unimplemented_levels_are_not_in_the_enum` is what catches that.
+_UNIMPLEMENTED_LEVELS = {
+    2: ('test generation and validation', BENCHMARK_LEVEL_2_ISSUE_URL),
+}
+
+# Click renders `Invalid value for <hint>: <message>`. Passing the hint by hand
+# is what names the flag at all: `parse_level` is called from a command body
+# rather than from a Click callback, so Click has no parameter to name itself.
+_BENCHMARK_PARAM_HINT = "'--benchmark' / '-b'"
 
 
 def parse_level(value: int) -> BenchmarkLevel:
     """Turn the `-b` flag's int into a level, rejecting the unimplemented ones.
 
-    `-b2` -- benchmarking test generation and validation -- is specified but not
-    built. Rejecting it outright is deliberate: silently treating it as `-b1`
-    would hand back a report that quietly omits half of what was asked for.
+    The enum is consulted first, so implementing a level is enough to make it
+    accepted. Rejecting an unimplemented level outright is deliberate: silently
+    treating `-b2` as `-b1` would hand back a report that quietly omits half of
+    what was asked for.
     """
-    if value == 2:
-        raise typer.BadParameter(
-            'Benchmarking test generation and validation (-b2) is not implemented '
-            f'yet. Follow {BENCHMARK_ISSUE_URL} for progress.'
-        )
     try:
         return BenchmarkLevel(value)
     except ValueError:
-        # The valid levels are read off the enum rather than spelled out -- a
-        # second copy of the list is exactly what goes stale when a level lands.
-        valid = ', '.join(str(level.value) for level in BenchmarkLevel)
+        pass
+
+    if value in _UNIMPLEMENTED_LEVELS:
+        description, issue_url = _UNIMPLEMENTED_LEVELS[value]
+        # The setter wants a benchmark now, so the usable level comes before the
+        # issue link -- the link is what to read later, not what to do next.
         raise typer.BadParameter(
-            f'Invalid benchmark level {value}. Valid levels are: {valid}.'
+            f'`-b{value}` ({description}) is not implemented yet'
+            ' -- use `-b1` to benchmark the solution run.'
+            f' Progress: {issue_url}',
+            param_hint=_BENCHMARK_PARAM_HINT,
         ) from None
+
+    # The valid levels are read off the enum rather than spelled out -- a
+    # second copy of the list is exactly what goes stale when a level lands.
+    valid = ', '.join(str(level.value) for level in BenchmarkLevel)
+    raise typer.BadParameter(
+        f'Benchmark level {value} is not a valid level. Valid levels are: {valid}.',
+        param_hint=_BENCHMARK_PARAM_HINT,
+    ) from None
 
 
 def _benchmark_autocompletion():

--- a/rbx/box/benchmark.py
+++ b/rbx/box/benchmark.py
@@ -1,0 +1,155 @@
+"""Benchmarking of the judging phase, behind `rbx run --benchmark`.
+
+`rbx run` already reports how long each *solution* took. It says nothing about
+how long *judging* took, and on a problem with a heavy checker the checker can
+dominate the wall clock of a full run. This module turns the checker and
+interactor timings that every evaluation now carries (see
+`rbx.grading.steps.RunTiming`) into the two blocks `-b1` prints.
+
+The timings themselves are captured unconditionally; the level only decides
+whether anything is printed. See docs/plans/2026-08-28-run-benchmark-design.md.
+"""
+
+import dataclasses
+from enum import Enum
+from typing import TYPE_CHECKING, List, Optional
+
+from rbx.box.schema import Solution
+from rbx.box.testcase_schema import TestcaseEntry
+from rbx.grading.steps import Evaluation, Outcome, RunTiming
+
+if TYPE_CHECKING:
+    # Imported only for typing -- `rbx.box.solutions` imports this module at
+    # runtime, and importing it back here would close the cycle.
+    from rbx.box.solutions import SolutionReportSkeleton
+
+
+class BenchmarkLevel(Enum):
+    """How much of a run to benchmark. Mirrors `VerificationLevel`."""
+
+    NONE = 0
+    SOLUTIONS = 1
+
+
+def _timing_seconds(timing: Optional[RunTiming]) -> float:
+    """An unmeasured program contributes nothing, rather than a zero.
+
+    A `RunTiming` can exist with its clocks unset, so the inner `None` needs
+    the same guard as the outer one.
+    """
+    if timing is None or timing.time is None:
+        return 0.0
+    return timing.time
+
+
+def checker_time(eval: Evaluation) -> float:
+    return _timing_seconds(eval.result.checker_timing)
+
+
+def interactor_time(eval: Evaluation) -> float:
+    return _timing_seconds(eval.result.interactor_timing)
+
+
+def was_judged(eval: Evaluation) -> bool:
+    """Whether this testcase actually ran.
+
+    A `--fail-fast` run persists a `SKIPPED` evaluation for every testcase after
+    the one that decided the verdict, with no time on it at all.
+    """
+    return eval.result.outcome != Outcome.SKIPPED and eval.log.time is not None
+
+
+def judging_time(eval: Evaluation) -> Optional[float]:
+    """Solution time + checker time + interactor time, in seconds.
+
+    `None` when the solution itself was never timed: there is no judging time
+    for a testcase that never ran.
+    """
+    if not was_judged(eval):
+        return None
+    return (eval.log.time or 0.0) + checker_time(eval) + interactor_time(eval)
+
+
+@dataclasses.dataclass
+class TestcaseJudging:
+    entry: TestcaseEntry
+    judging_time: float
+    solution_time: float
+    checker_time: float
+    interactor_time: float
+
+
+@dataclasses.dataclass
+class SolutionBenchmark:
+    solution: Solution
+    slowest: TestcaseJudging
+    total_judging_time: float
+    total_checker_time: float
+    total_interactor_time: float
+    judged: int
+    total: int
+
+    @property
+    def partial(self) -> bool:
+        """Whether some testcases never ran, making every total a lower bound."""
+        return self.judged < self.total
+
+
+@dataclasses.dataclass
+class ProblemBenchmark:
+    slowest_to_judge: SolutionBenchmark
+    most_checker_time: SolutionBenchmark
+    slowest_testcase: TestcaseJudging
+    partial: bool
+
+
+def build_solution_benchmark(
+    solution: Solution,
+    skeleton: 'SolutionReportSkeleton',
+    evals: List[Evaluation],
+) -> Optional[SolutionBenchmark]:
+    """Aggregate one solution's evaluations, or None if none of them ran."""
+    judgings: List[TestcaseJudging] = []
+    for eval, entry in zip(evals, skeleton.entries):
+        total = judging_time(eval)
+        if total is None:
+            continue
+        judgings.append(
+            TestcaseJudging(
+                entry=entry.group_entry,
+                judging_time=total,
+                solution_time=eval.log.time or 0.0,
+                checker_time=checker_time(eval),
+                interactor_time=interactor_time(eval),
+            )
+        )
+
+    if not judgings:
+        return None
+
+    return SolutionBenchmark(
+        solution=solution,
+        slowest=max(judgings, key=lambda j: j.judging_time),
+        total_judging_time=sum(j.judging_time for j in judgings),
+        total_checker_time=sum(j.checker_time for j in judgings),
+        total_interactor_time=sum(j.interactor_time for j in judgings),
+        judged=len(judgings),
+        # `evals` can be shorter than the skeleton mid-run, so the denominator
+        # is the testset, not the list handed in.
+        total=len(skeleton.entries),
+    )
+
+
+def build_problem_benchmark(
+    benchmarks: List[SolutionBenchmark],
+) -> Optional[ProblemBenchmark]:
+    if not benchmarks:
+        return None
+    return ProblemBenchmark(
+        slowest_to_judge=max(benchmarks, key=lambda b: b.total_judging_time),
+        most_checker_time=max(benchmarks, key=lambda b: b.total_checker_time),
+        slowest_testcase=max(
+            (b.slowest for b in benchmarks), key=lambda j: j.judging_time
+        ),
+        partial=any(b.partial for b in benchmarks),
+    )

--- a/rbx/box/benchmark.py
+++ b/rbx/box/benchmark.py
@@ -395,3 +395,33 @@ def print_problem_benchmark(
     """Print the problem-wide extremes, at the end of the run report."""
     for line in problem_benchmark_lines(problem):
         console.print(line)
+
+
+def report_solution_benchmark(
+    console: rich.console.Console,
+    level: BenchmarkLevel,
+    solution: Solution,
+    skeleton: 'SolutionReportSkeleton',
+    evals: List[Evaluation],
+) -> Optional[SolutionBenchmark]:
+    """Print one solution's block if the level asks for it, and hand it back to
+    be collected.
+
+    Both report paths -- the reporters and `--detailed`, which bypasses them --
+    build and print the same block from the same three values, so the level
+    check lives here, next to the level enum, rather than being spelled out at
+    each call site. `None` comes back when nothing was measured (a `--fail-fast`
+    run that skipped every one of this solution's testcases) or when the level
+    asks for no benchmark at all: in both cases there is nothing to collect for
+    the problem-wide summary.
+
+    ``evals`` must be a gapless prefix of ``skeleton.entries``; see
+    `build_solution_benchmark`.
+    """
+    if level != BenchmarkLevel.SOLUTIONS:
+        return None
+    bench = build_solution_benchmark(solution, skeleton, evals)
+    if bench is None:
+        return None
+    print_solution_benchmark(console, bench)
+    return bench

--- a/rbx/box/benchmark.py
+++ b/rbx/box/benchmark.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 import rich.console
 
-from rbx.box.formatting import UNMEASURED, get_formatted_time_in_seconds
+from rbx.box.formatting import UNMEASURED, get_formatted_duration_in_seconds
 from rbx.box.schema import Solution
 from rbx.box.testcase_schema import TestcaseEntry
 from rbx.grading.steps import Evaluation, Outcome, RunTiming
@@ -217,13 +217,17 @@ def build_problem_benchmark(
 def _measurement(seconds: Optional[float]) -> str:
     """A duration in seconds, or the unmeasured marker when there is none.
 
-    `None` never becomes `0.0 s` here: a checker that never ran and a checker
+    `None` never becomes `0 ms` here: a checker that never ran and a checker
     that ran instantaneously read differently, and only the second is a claim
     about how long judging took.
+
+    The adaptive formatter is the one that matters here: a checker routinely
+    costs a few milliseconds, and a fixed decimal place would report the whole
+    block as zeros.
     """
     if seconds is None:
         return UNMEASURED
-    return get_formatted_time_in_seconds(seconds)
+    return get_formatted_duration_in_seconds(seconds)
 
 
 def _hilite(seconds: Optional[float]) -> str:
@@ -239,6 +243,10 @@ def print_solution_benchmark(
     `--share` recording console gets these lines too.
     """
     slowest = bench.slowest_testcase
+    # The checker term is always printed, as `-` when unmeasured: a batch
+    # problem always has a checker, so its absence is a missing measurement and
+    # worth showing. The interactor below is different -- printing a term for it
+    # on a non-interactive problem would report a component that does not exist.
     breakdown = (
         f'{_hilite(slowest.solution_time_seconds)} solution'
         f' + {_hilite(slowest.checker_time_seconds)} checker'

--- a/rbx/box/benchmark.py
+++ b/rbx/box/benchmark.py
@@ -182,6 +182,12 @@ class TestcaseJudging:
     # `None` means unmeasured. See `checker_time_seconds`.
     checker_time_seconds: Optional[float]
     interactor_time_seconds: Optional[float]
+    # Whether an interactor ran at all, which the seconds cannot say: an
+    # interactor that ran without a clock reports `None` seconds, exactly like a
+    # batch problem that has no interactor. `rbx ui` tells the two apart by the
+    # timing object, and this report has to agree with it -- hiding an
+    # interactor that ran makes a communication problem read as a batch one.
+    has_interactor: bool = False
 
 
 @dataclasses.dataclass
@@ -195,6 +201,9 @@ class SolutionBenchmark:
     total_interactor_time_seconds: Optional[float]
     judged: int
     total_testcases: int
+    # Whether any judged testcase ran an interactor. See
+    # `TestcaseJudging.has_interactor`.
+    has_interactor: bool = False
 
     @property
     def partial(self) -> bool:
@@ -247,6 +256,7 @@ def build_solution_benchmark(
                 solution_time_seconds=eval.log.time or 0.0,
                 checker_time_seconds=checker_time_seconds(eval),
                 interactor_time_seconds=interactor_time_seconds(eval),
+                has_interactor=eval.result.interactor_timing is not None,
             )
         )
 
@@ -263,6 +273,7 @@ def build_solution_benchmark(
         total_interactor_time_seconds=_total_seconds(
             [j.interactor_time_seconds for j in judgings]
         ),
+        has_interactor=any(j.has_interactor for j in judgings),
         judged=len(judgings),
         # `evals` can be shorter than the skeleton mid-run, so the denominator
         # is the testset, not the list handed in.
@@ -327,8 +338,13 @@ def solution_benchmark_lines(bench: SolutionBenchmark) -> List[str]:
 
     # The totals, in contrast, always name the checker: on the problems where a
     # checker is expected, `checker: -` is the report that it went unmeasured.
+    # The interactor is named there whenever one *ran*, measured or not, which
+    # is how `rbx ui` gates its own interactor line. Gating on the seconds
+    # instead would drop an interactor the sandbox failed to clock, and a
+    # communication problem whose report never mentions an interactor reads as a
+    # batch problem -- a wrong claim, where `interactor: -` is a true one.
     totals = [f'checker: {_measurement(bench.total_checker_time_seconds)}']
-    if bench.total_interactor_time_seconds is not None:
+    if bench.has_interactor:
         totals.append(
             f'interactor: {_measurement(bench.total_interactor_time_seconds)}'
         )
@@ -399,29 +415,34 @@ def print_problem_benchmark(
 
 def report_solution_benchmark(
     console: rich.console.Console,
-    level: BenchmarkLevel,
     solution: Solution,
     skeleton: 'SolutionReportSkeleton',
     evals: List[Evaluation],
-) -> Optional[SolutionBenchmark]:
-    """Print one solution's block if the level asks for it, and hand it back to
-    be collected.
+    into: List[SolutionBenchmark],
+    *,
+    level: BenchmarkLevel,
+) -> None:
+    """Print one solution's block if the level asks for it, collecting it into
+    ``into`` for the problem-wide summary.
 
     Both report paths -- the reporters and `--detailed`, which bypasses them --
     build and print the same block from the same three values, so the level
     check lives here, next to the level enum, rather than being spelled out at
-    each call site. `None` comes back when nothing was measured (a `--fail-fast`
-    run that skipped every one of this solution's testcases) or when the level
-    asks for no benchmark at all: in both cases there is nothing to collect for
-    the problem-wide summary.
+    each call site. The destination list is taken rather than the benchmark
+    handed back, so that "print it, and keep it for the summary" is one call at
+    both sites instead of a convention each of them has to remember.
+
+    Nothing is appended when nothing was measured (a `--fail-fast` run that
+    skipped every one of this solution's testcases) or when the level asks for
+    no benchmark at all: in both cases there is nothing to summarize.
 
     ``evals`` must be a gapless prefix of ``skeleton.entries``; see
     `build_solution_benchmark`.
     """
     if level != BenchmarkLevel.SOLUTIONS:
-        return None
+        return
     bench = build_solution_benchmark(solution, skeleton, evals)
     if bench is None:
-        return None
+        return
     print_solution_benchmark(console, bench)
-    return bench
+    into.append(bench)

--- a/rbx/box/benchmark.py
+++ b/rbx/box/benchmark.py
@@ -6,10 +6,10 @@ dominate the wall clock of a full run. This module turns the checker and
 interactor timings that every evaluation now carries (see
 `rbx.grading.steps.RunTiming`) into the two blocks `-b1` prints.
 
-Every duration here is in seconds, and every name says so -- the renderer picks
-between `formatting.get_formatted_time` (milliseconds) and
-`formatting.get_formatted_time_in_seconds` on nothing but the name, and picking
-the wrong one mislabels the unit instead of raising.
+Every duration here is in seconds, and every name says so. The formatters in
+`rbx.box.formatting` are told apart by nothing but their names -- one takes
+milliseconds, the others seconds -- so a name that omits the unit invites a
+caller to mislabel it, which nothing here would raise on.
 
 The timings themselves are captured unconditionally; the level only decides
 whether anything is printed. See docs/plans/2026-08-28-run-benchmark-design.md.
@@ -230,8 +230,76 @@ def _measurement(seconds: Optional[float]) -> str:
     return get_formatted_duration_in_seconds(seconds)
 
 
-def _hilite(seconds: Optional[float]) -> str:
-    return f'[hilite]{_measurement(seconds)}[/hilite]'
+def solution_benchmark_lines(bench: SolutionBenchmark) -> List[str]:
+    """The markup lines of one solution's judging benchmark.
+
+    Kept apart from the printing so that tests can assert over the markup --
+    rich resolves an unknown style to nothing and prints no error, so a
+    misspelled tag is invisible in rendered text.
+    """
+    slowest = bench.slowest_testcase
+    # The breakdown names only the programs that were measured. An absent
+    # checker is normal on a communication problem, and an absent interactor on
+    # every other one, so a `- checker` term there is broken prose rather than a
+    # finding. The totals line below still reports the missing measurement.
+    terms = [f'{_measurement(slowest.solution_time_seconds)} solution']
+    if slowest.checker_time_seconds is not None:
+        terms.append(f'{_measurement(slowest.checker_time_seconds)} checker')
+    if slowest.interactor_time_seconds is not None:
+        terms.append(f'{_measurement(slowest.interactor_time_seconds)} interactor')
+    # The headline is the sum of these terms, so they are joined as a sum.
+    breakdown = ' + '.join(terms)
+
+    # The totals, in contrast, always name the checker: on the problems where a
+    # checker is expected, `checker: -` is the report that it went unmeasured.
+    totals = [f'checker: {_measurement(bench.total_checker_time_seconds)}']
+    if bench.total_interactor_time_seconds is not None:
+        totals.append(
+            f'interactor: {_measurement(bench.total_interactor_time_seconds)}'
+        )
+
+    total_line = (
+        f'Total judging: {_measurement(bench.total_judging_time_seconds)}'
+        f' ({", ".join(totals)})'
+    )
+    if bench.partial:
+        # A `--fail-fast` run stopped early, so every total above is a lower
+        # bound rather than the cost of judging the whole testset.
+        total_line += f' (over {bench.judged}/{bench.total_testcases} tests judged)'
+
+    return [
+        f'Benchmark: slowest test [item]{slowest.entry}[/item]'
+        f' - {_measurement(slowest.judging_time_seconds)} judging ({breakdown})',
+        total_line,
+    ]
+
+
+def problem_benchmark_lines(problem: ProblemBenchmark) -> List[str]:
+    """The markup lines of the problem-wide extremes."""
+    header = '[status]Benchmark summary[/status]'
+    if problem.partial:
+        header += ' (partial -- some tests were not judged)'
+
+    lines = [
+        header,
+        f'Slowest solution to judge: '
+        f'{_measurement(problem.slowest_to_judge.total_judging_time_seconds)}'
+        f', {problem.slowest_to_judge.solution.href()}',
+    ]
+    # `most_checker_time` always names a winner, even when no solution measured
+    # a checker at all -- an unmeasured winner is not a finding, so say nothing.
+    if problem.most_checker_time.total_checker_time_seconds is not None:
+        lines.append(
+            f'Most checker time: '
+            f'{_measurement(problem.most_checker_time.total_checker_time_seconds)}'
+            f', {problem.most_checker_time.solution.href()}'
+        )
+    lines.append(
+        f'Slowest testcase to judge: '
+        f'{_measurement(problem.slowest_testcase.judging_time_seconds)}'
+        f', [item]{problem.slowest_testcase.entry}[/item]'
+    )
+    return lines
 
 
 def print_solution_benchmark(
@@ -242,59 +310,13 @@ def print_solution_benchmark(
     The console is passed in rather than taken from `rbx.console` so that the
     `--share` recording console gets these lines too.
     """
-    slowest = bench.slowest_testcase
-    # The checker term is always printed, as `-` when unmeasured: a batch
-    # problem always has a checker, so its absence is a missing measurement and
-    # worth showing. The interactor below is different -- printing a term for it
-    # on a non-interactive problem would report a component that does not exist.
-    breakdown = (
-        f'{_hilite(slowest.solution_time_seconds)} solution'
-        f' + {_hilite(slowest.checker_time_seconds)} checker'
-    )
-    totals = f'(checker: {_hilite(bench.total_checker_time_seconds)}'
-    # The interactor is named only when there is one to name -- a batch problem
-    # must not grow a term reading `- interactor` on every solution.
-    if slowest.interactor_time_seconds is not None:
-        breakdown += f', {_hilite(slowest.interactor_time_seconds)} interactor'
-    if bench.total_interactor_time_seconds is not None:
-        totals += f', interactor: {_hilite(bench.total_interactor_time_seconds)}'
-    totals += ')'
-
-    console.print(
-        f'Benchmark: slowest test [item]{slowest.entry}[/item]'
-        f' - {_hilite(slowest.judging_time_seconds)} judging ({breakdown})'
-    )
-    console.print(
-        f'Total judging: {_hilite(bench.total_judging_time_seconds)} {totals}', end=''
-    )
-    if bench.partial:
-        # A `--fail-fast` run stopped early, so every total above is a lower
-        # bound rather than the cost of judging the whole testset.
-        console.print(f' (over {bench.judged}/{bench.total_testcases} tests judged)')
-    else:
-        console.print()
+    for line in solution_benchmark_lines(bench):
+        console.print(line)
 
 
 def print_problem_benchmark(
     console: rich.console.Console, problem: ProblemBenchmark
 ) -> None:
     """Print the problem-wide extremes, at the end of the run report."""
-    console.print('[status]Benchmark summary[/status]', end='')
-    if problem.partial:
-        console.print(' (partial -- some tests were not judged)', end='')
-    console.print()
-    console.print(
-        f'Slowest solution to judge: {_hilite(problem.slowest_to_judge.total_judging_time_seconds)}'
-        f', {problem.slowest_to_judge.solution.href()}'
-    )
-    # `most_checker_time` always names a winner, even when no solution measured
-    # a checker at all -- an unmeasured winner is not a finding, so say nothing.
-    if problem.most_checker_time.total_checker_time_seconds is not None:
-        console.print(
-            f'Most checker time: {_hilite(problem.most_checker_time.total_checker_time_seconds)}'
-            f', {problem.most_checker_time.solution.href()}'
-        )
-    console.print(
-        f'Slowest testcase to judge: {_hilite(problem.slowest_testcase.judging_time_seconds)}'
-        f', [item]{problem.slowest_testcase.entry}[/item]'
-    )
+    for line in problem_benchmark_lines(problem):
+        console.print(line)

--- a/rbx/box/benchmark.py
+++ b/rbx/box/benchmark.py
@@ -6,6 +6,11 @@ dominate the wall clock of a full run. This module turns the checker and
 interactor timings that every evaluation now carries (see
 `rbx.grading.steps.RunTiming`) into the two blocks `-b1` prints.
 
+Every duration here is in seconds, and every name says so -- the renderer picks
+between `formatting.get_formatted_time` (milliseconds) and
+`formatting.get_formatted_time_in_seconds` on nothing but the name, and picking
+the wrong one mislabels the unit instead of raising.
+
 The timings themselves are captured unconditionally; the level only decides
 whether anything is printed. See docs/plans/2026-08-28-run-benchmark-design.md.
 """
@@ -31,22 +36,35 @@ class BenchmarkLevel(Enum):
     SOLUTIONS = 1
 
 
-def _timing_seconds(timing: Optional[RunTiming]) -> float:
-    """An unmeasured program contributes nothing, rather than a zero.
+def _timing_seconds(timing: Optional[RunTiming]) -> Optional[float]:
+    """The measured CPU seconds, or `None` when the program was not measured.
 
-    A `RunTiming` can exist with its clocks unset, so the inner `None` needs
-    the same guard as the outer one.
+    A `RunTiming` can exist with its clocks unset, so the inner `None` needs the
+    same guard as the outer one. `None` is preserved rather than flattened to
+    `0.0`: a checker that never ran and a checker that ran instantaneously are
+    different facts, and only one of them may be printed as a measurement.
     """
-    if timing is None or timing.time is None:
-        return 0.0
+    if timing is None:
+        return None
     return timing.time
 
 
-def checker_time(eval: Evaluation) -> float:
+def checker_time_seconds(eval: Evaluation) -> Optional[float]:
+    """The checker's CPU seconds on this testcase, `None` if unmeasured.
+
+    Unmeasured means no checker ran (a communication problem may have none) or
+    the sandbox reported no clock. It contributes nothing to a sum, but a caller
+    that renders it on its own must keep the `None` rather than print `0.0 s`.
+    """
     return _timing_seconds(eval.result.checker_timing)
 
 
-def interactor_time(eval: Evaluation) -> float:
+def interactor_time_seconds(eval: Evaluation) -> Optional[float]:
+    """The interactor's CPU seconds on this testcase, `None` if unmeasured.
+
+    Unmeasured means the problem is not interactive, or the sandbox reported no
+    clock. As with the checker, `None` must survive to the renderer.
+    """
     return _timing_seconds(eval.result.interactor_timing)
 
 
@@ -59,40 +77,51 @@ def was_judged(eval: Evaluation) -> bool:
     return eval.result.outcome != Outcome.SKIPPED and eval.log.time is not None
 
 
-def judging_time(eval: Evaluation) -> Optional[float]:
+def judging_time_seconds(eval: Evaluation) -> Optional[float]:
     """Solution time + checker time + interactor time, in seconds.
 
     `None` when the solution itself was never timed: there is no judging time
-    for a testcase that never ran.
+    for a testcase that never ran. An unmeasured checker or interactor only
+    contributes nothing to the sum -- it does not make the whole `None`.
     """
     if not was_judged(eval):
         return None
-    return (eval.log.time or 0.0) + checker_time(eval) + interactor_time(eval)
+    # `was_judged` has already established that `log.time` is set, so the
+    # fallback is unreachable -- it is kept only so that this arithmetic reads
+    # uniformly with the two genuinely optional terms beside it.
+    return (
+        (eval.log.time or 0.0)
+        + (checker_time_seconds(eval) or 0.0)
+        + (interactor_time_seconds(eval) or 0.0)
+    )
 
 
 @dataclasses.dataclass
 class TestcaseJudging:
     entry: TestcaseEntry
-    judging_time: float
-    solution_time: float
-    checker_time: float
-    interactor_time: float
+    judging_time_seconds: float
+    solution_time_seconds: float
+    # `None` means unmeasured. See `checker_time_seconds`.
+    checker_time_seconds: Optional[float]
+    interactor_time_seconds: Optional[float]
 
 
 @dataclasses.dataclass
 class SolutionBenchmark:
     solution: Solution
-    slowest: TestcaseJudging
-    total_judging_time: float
-    total_checker_time: float
-    total_interactor_time: float
+    slowest_testcase: TestcaseJudging
+    total_judging_time_seconds: float
+    # `None` when no judged testcase measured that program at all. A genuine
+    # total of `0.0` is a measurement and stays `0.0`.
+    total_checker_time_seconds: Optional[float]
+    total_interactor_time_seconds: Optional[float]
     judged: int
-    total: int
+    total_testcases: int
 
     @property
     def partial(self) -> bool:
         """Whether some testcases never ran, making every total a lower bound."""
-        return self.judged < self.total
+        return self.judged < self.total_testcases
 
 
 @dataclasses.dataclass
@@ -103,24 +132,43 @@ class ProblemBenchmark:
     partial: bool
 
 
+def _total_seconds(values: List[Optional[float]]) -> Optional[float]:
+    """Sum the measured values, or `None` if none of them was measured."""
+    measured = [value for value in values if value is not None]
+    if not measured:
+        return None
+    return sum(measured)
+
+
 def build_solution_benchmark(
     solution: Solution,
     skeleton: 'SolutionReportSkeleton',
     evals: List[Evaluation],
 ) -> Optional[SolutionBenchmark]:
-    """Aggregate one solution's evaluations, or None if none of them ran."""
+    """Aggregate one solution's evaluations, or None if none of them ran.
+
+    Assumes ``evals`` is a prefix of ``skeleton.entries`` with no gaps -- the
+    same assumption `_get_evals_per_group` documents, and true for the same
+    reason: the reporters append in entry order, so a partial run is a prefix.
+    A gap would pair every later evaluation with the wrong entry, and here that
+    misnames the slowest testcase -- which is the one thing this report exists
+    to name. A caller that can skip an entry must pass entries alongside their
+    evaluations instead of relying on position.
+    """
     judgings: List[TestcaseJudging] = []
     for eval, entry in zip(evals, skeleton.entries):
-        total = judging_time(eval)
+        total = judging_time_seconds(eval)
         if total is None:
             continue
         judgings.append(
             TestcaseJudging(
                 entry=entry.group_entry,
-                judging_time=total,
-                solution_time=eval.log.time or 0.0,
-                checker_time=checker_time(eval),
-                interactor_time=interactor_time(eval),
+                judging_time_seconds=total,
+                # Unreachable fallback, as above: `judging_time_seconds`
+                # returning non-None already implies `log.time` is set.
+                solution_time_seconds=eval.log.time or 0.0,
+                checker_time_seconds=checker_time_seconds(eval),
+                interactor_time_seconds=interactor_time_seconds(eval),
             )
         )
 
@@ -129,27 +177,35 @@ def build_solution_benchmark(
 
     return SolutionBenchmark(
         solution=solution,
-        slowest=max(judgings, key=lambda j: j.judging_time),
-        total_judging_time=sum(j.judging_time for j in judgings),
-        total_checker_time=sum(j.checker_time for j in judgings),
-        total_interactor_time=sum(j.interactor_time for j in judgings),
+        slowest_testcase=max(judgings, key=lambda j: j.judging_time_seconds),
+        total_judging_time_seconds=sum(j.judging_time_seconds for j in judgings),
+        total_checker_time_seconds=_total_seconds(
+            [j.checker_time_seconds for j in judgings]
+        ),
+        total_interactor_time_seconds=_total_seconds(
+            [j.interactor_time_seconds for j in judgings]
+        ),
         judged=len(judgings),
         # `evals` can be shorter than the skeleton mid-run, so the denominator
         # is the testset, not the list handed in.
-        total=len(skeleton.entries),
+        total_testcases=len(skeleton.entries),
     )
 
 
 def build_problem_benchmark(
     benchmarks: List[SolutionBenchmark],
 ) -> Optional[ProblemBenchmark]:
+    """Rank the per-solution benchmarks, or None if there are none to rank."""
     if not benchmarks:
         return None
     return ProblemBenchmark(
-        slowest_to_judge=max(benchmarks, key=lambda b: b.total_judging_time),
-        most_checker_time=max(benchmarks, key=lambda b: b.total_checker_time),
+        slowest_to_judge=max(benchmarks, key=lambda b: b.total_judging_time_seconds),
+        most_checker_time=max(
+            benchmarks, key=lambda b: b.total_checker_time_seconds or 0.0
+        ),
         slowest_testcase=max(
-            (b.slowest for b in benchmarks), key=lambda j: j.judging_time
+            (b.slowest_testcase for b in benchmarks),
+            key=lambda j: j.judging_time_seconds,
         ),
         partial=any(b.partial for b in benchmarks),
     )

--- a/rbx/box/benchmark.py
+++ b/rbx/box/benchmark.py
@@ -17,9 +17,10 @@ whether anything is printed. See docs/plans/2026-08-28-run-benchmark-design.md.
 
 import dataclasses
 from enum import Enum
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Annotated, List, Optional
 
 import rich.console
+import typer
 
 from rbx.box.formatting import UNMEASURED, get_formatted_duration_in_seconds
 from rbx.box.schema import Solution
@@ -37,6 +38,53 @@ class BenchmarkLevel(Enum):
 
     NONE = 0
     SOLUTIONS = 1
+
+
+BENCHMARK_ISSUE_URL = 'https://github.com/rsalesc/rbx/issues/801'
+
+
+def parse_level(value: int) -> BenchmarkLevel:
+    """Turn the `-b` flag's int into a level, rejecting the unimplemented ones.
+
+    `-b2` -- benchmarking test generation and validation -- is specified but not
+    built. Rejecting it outright is deliberate: silently treating it as `-b1`
+    would hand back a report that quietly omits half of what was asked for.
+    """
+    if value == 2:
+        raise typer.BadParameter(
+            'Benchmarking test generation and validation (-b2) is not implemented '
+            f'yet. Follow {BENCHMARK_ISSUE_URL} for progress.'
+        )
+    try:
+        return BenchmarkLevel(value)
+    except ValueError:
+        # The valid levels are read off the enum rather than spelled out -- a
+        # second copy of the list is exactly what goes stale when a level lands.
+        valid = ', '.join(str(level.value) for level in BenchmarkLevel)
+        raise typer.BadParameter(
+            f'Invalid benchmark level {value}. Valid levels are: {valid}.'
+        ) from None
+
+
+def _benchmark_autocompletion():
+    # Indirect through a function so module load doesn't eagerly depend on
+    # rbx.annotations (keeps this module's import surface decoupled; the import
+    # is light either way).
+    from rbx import annotations
+
+    return annotations._adapt('benchmark_level')  # noqa: SLF001
+
+
+BenchmarkParam = Annotated[
+    int,
+    typer.Option(
+        '--benchmark',
+        '-b',
+        help='Benchmark level: 0 (off), 1 (benchmark the solution run).',
+        default_factory=lambda: BenchmarkLevel.NONE.value,
+        autocompletion=_benchmark_autocompletion(),
+    ),
+]
 
 
 def timing_seconds(timing: Optional[RunTiming]) -> Optional[float]:

--- a/rbx/box/benchmark.py
+++ b/rbx/box/benchmark.py
@@ -19,6 +19,9 @@ import dataclasses
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional
 
+import rich.console
+
+from rbx.box.formatting import UNMEASURED, get_formatted_time_in_seconds
 from rbx.box.schema import Solution
 from rbx.box.testcase_schema import TestcaseEntry
 from rbx.grading.steps import Evaluation, Outcome, RunTiming
@@ -36,7 +39,7 @@ class BenchmarkLevel(Enum):
     SOLUTIONS = 1
 
 
-def _timing_seconds(timing: Optional[RunTiming]) -> Optional[float]:
+def timing_seconds(timing: Optional[RunTiming]) -> Optional[float]:
     """The measured CPU seconds, or `None` when the program was not measured.
 
     A `RunTiming` can exist with its clocks unset, so the inner `None` needs the
@@ -56,7 +59,7 @@ def checker_time_seconds(eval: Evaluation) -> Optional[float]:
     the sandbox reported no clock. It contributes nothing to a sum, but a caller
     that renders it on its own must keep the `None` rather than print `0.0 s`.
     """
-    return _timing_seconds(eval.result.checker_timing)
+    return timing_seconds(eval.result.checker_timing)
 
 
 def interactor_time_seconds(eval: Evaluation) -> Optional[float]:
@@ -65,7 +68,7 @@ def interactor_time_seconds(eval: Evaluation) -> Optional[float]:
     Unmeasured means the problem is not interactive, or the sandbox reported no
     clock. As with the checker, `None` must survive to the renderer.
     """
-    return _timing_seconds(eval.result.interactor_timing)
+    return timing_seconds(eval.result.interactor_timing)
 
 
 def was_judged(eval: Evaluation) -> bool:
@@ -208,4 +211,82 @@ def build_problem_benchmark(
             key=lambda j: j.judging_time_seconds,
         ),
         partial=any(b.partial for b in benchmarks),
+    )
+
+
+def _measurement(seconds: Optional[float]) -> str:
+    """A duration in seconds, or the unmeasured marker when there is none.
+
+    `None` never becomes `0.0 s` here: a checker that never ran and a checker
+    that ran instantaneously read differently, and only the second is a claim
+    about how long judging took.
+    """
+    if seconds is None:
+        return UNMEASURED
+    return get_formatted_time_in_seconds(seconds)
+
+
+def _hilite(seconds: Optional[float]) -> str:
+    return f'[hilite]{_measurement(seconds)}[/hilite]'
+
+
+def print_solution_benchmark(
+    console: rich.console.Console, bench: SolutionBenchmark
+) -> None:
+    """Print one solution's judging benchmark, under its report block.
+
+    The console is passed in rather than taken from `rbx.console` so that the
+    `--share` recording console gets these lines too.
+    """
+    slowest = bench.slowest_testcase
+    breakdown = (
+        f'{_hilite(slowest.solution_time_seconds)} solution'
+        f' + {_hilite(slowest.checker_time_seconds)} checker'
+    )
+    totals = f'(checker: {_hilite(bench.total_checker_time_seconds)}'
+    # The interactor is named only when there is one to name -- a batch problem
+    # must not grow a term reading `- interactor` on every solution.
+    if slowest.interactor_time_seconds is not None:
+        breakdown += f', {_hilite(slowest.interactor_time_seconds)} interactor'
+    if bench.total_interactor_time_seconds is not None:
+        totals += f', interactor: {_hilite(bench.total_interactor_time_seconds)}'
+    totals += ')'
+
+    console.print(
+        f'Benchmark: slowest test [item]{slowest.entry}[/item]'
+        f' - {_hilite(slowest.judging_time_seconds)} judging ({breakdown})'
+    )
+    console.print(
+        f'Total judging: {_hilite(bench.total_judging_time_seconds)} {totals}', end=''
+    )
+    if bench.partial:
+        # A `--fail-fast` run stopped early, so every total above is a lower
+        # bound rather than the cost of judging the whole testset.
+        console.print(f' (over {bench.judged}/{bench.total_testcases} tests judged)')
+    else:
+        console.print()
+
+
+def print_problem_benchmark(
+    console: rich.console.Console, problem: ProblemBenchmark
+) -> None:
+    """Print the problem-wide extremes, at the end of the run report."""
+    console.print('[status]Benchmark summary[/status]', end='')
+    if problem.partial:
+        console.print(' (partial -- some tests were not judged)', end='')
+    console.print()
+    console.print(
+        f'Slowest solution to judge: {_hilite(problem.slowest_to_judge.total_judging_time_seconds)}'
+        f', {problem.slowest_to_judge.solution.href()}'
+    )
+    # `most_checker_time` always names a winner, even when no solution measured
+    # a checker at all -- an unmeasured winner is not a finding, so say nothing.
+    if problem.most_checker_time.total_checker_time_seconds is not None:
+        console.print(
+            f'Most checker time: {_hilite(problem.most_checker_time.total_checker_time_seconds)}'
+            f', {problem.most_checker_time.solution.href()}'
+        )
+    console.print(
+        f'Slowest testcase to judge: {_hilite(problem.slowest_testcase.judging_time_seconds)}'
+        f', [item]{problem.slowest_testcase.entry}[/item]'
     )

--- a/rbx/box/checkers.py
+++ b/rbx/box/checkers.py
@@ -407,6 +407,14 @@ async def check_communication(
 ) -> CheckerResult:
     def _extra_check_and_sanitize(result: CheckerResult) -> CheckerResult:
         result.sanitizer_warnings = _check_sanitizer_warnings(run_log)
+        # Every return path that reports a real judgement passes through here,
+        # which is why the interactor's timing is stamped at this one point
+        # rather than at each of the returns. Unlike the checker, the interactor
+        # is spawned alongside the solution, so `interactor_run_log` is normally
+        # present even on the paths where the verdict came from the solution's
+        # own log -- the interactor did run and did take that long, so stamping
+        # it is honest, but `of()`'s `None` guard is not what makes it so here.
+        result.interactor_timing = RunTiming.of(interactor_run_log)
         return result
 
     def _check_interactor(reinterpret_rte: bool = True) -> Optional[CheckerResult]:
@@ -437,6 +445,10 @@ async def check_communication(
 
     # 0. If any of the sandboxes failed, we should return an error.
     if _any_failed([run_log, interactor_run_log]):
+        # Deliberately left untimed, bypassing `_extra_check_and_sanitize` as it
+        # already did for the sanitizer warnings: when the sandbox itself failed
+        # there is no honest measurement to report, and an INTERNAL_ERROR
+        # carrying a timing would invite the benchmark report to print one.
         return CheckerResult(outcome=Outcome.INTERNAL_ERROR)
 
     interactor_first = (

--- a/rbx/box/checkers.py
+++ b/rbx/box/checkers.py
@@ -407,13 +407,11 @@ async def check_communication(
 ) -> CheckerResult:
     def _extra_check_and_sanitize(result: CheckerResult) -> CheckerResult:
         result.sanitizer_warnings = _check_sanitizer_warnings(run_log)
-        # Every return path that reports a real judgement passes through here,
-        # which is why the interactor's timing is stamped at this one point
-        # rather than at each of the returns. Unlike the checker, the interactor
-        # is spawned alongside the solution, so `interactor_run_log` is normally
-        # present even on the paths where the verdict came from the solution's
-        # own log -- the interactor did run and did take that long, so stamping
-        # it is honest, but `of()`'s `None` guard is not what makes it so here.
+        # Stamped at this one point because every judgement-bearing return
+        # passes through here. Step 0 has already rejected a `None` interactor
+        # log, so `of()`'s guard is unreachable below it -- what makes the stamp
+        # honest is that the interactor ran alongside the solution, even when
+        # the verdict came from the solution's own log.
         result.interactor_timing = RunTiming.of(interactor_run_log)
         return result
 
@@ -445,8 +443,8 @@ async def check_communication(
 
     # 0. If any of the sandboxes failed, we should return an error.
     if _any_failed([run_log, interactor_run_log]):
-        # Deliberately left untimed, bypassing `_extra_check_and_sanitize` as it
-        # already did for the sanitizer warnings: when the sandbox itself failed
+        # Deliberately left untimed, bypassing `_extra_check_and_sanitize` as this
+        # return already did for the sanitizer warnings: when the sandbox itself failed
         # there is no honest measurement to report, and an INTERNAL_ERROR
         # carrying a timing would invite the benchmark report to print one.
         return CheckerResult(outcome=Outcome.INTERNAL_ERROR)

--- a/rbx/box/checkers.py
+++ b/rbx/box/checkers.py
@@ -350,6 +350,8 @@ async def _check(
     result = processed_checker_result
     # Stamped here, past every early return that never reached the checker --
     # those keep a `None` timing, which reads as unmeasured rather than zero.
+    # Not inside `process_checker_run_log`, which the interactor shares and
+    # which would therefore mislabel the interactor's time as the checker's.
     result.checker_timing = RunTiming.of(checker_run_log)
 
     if skip_run_log:

--- a/rbx/box/checkers.py
+++ b/rbx/box/checkers.py
@@ -17,6 +17,7 @@ from rbx.grading.steps import (
     GradingFileInput,
     Outcome,
     RunLog,
+    RunTiming,
 )
 from rbx.utils import StatusProgress
 
@@ -347,6 +348,9 @@ async def _check(
         raise typer.Exit(1)
 
     result = processed_checker_result
+    # Stamped here, past every early return that never reached the checker --
+    # those keep a `None` timing, which reads as unmeasured rather than zero.
+    result.checker_timing = RunTiming.of(checker_run_log)
 
     if skip_run_log:
         return result

--- a/rbx/box/cli/commands/run.py
+++ b/rbx/box/cli/commands/run.py
@@ -15,6 +15,9 @@ from ordered_set import OrderedSet
 from rbx import annotations, console, utils
 from rbx.annotations import PackagePath
 from rbx.box import (
+    benchmark as benchmark_module,
+)
+from rbx.box import (
     environment,
     generators,
     limits_info,
@@ -75,6 +78,11 @@ def _set_timing_profile(profile: Optional[str]) -> None:
 @syncer.sync
 async def run(
     verification: environment.VerificationParam,
+    # Ahead of every optional parameter because it carries no default of its
+    # own -- `BenchmarkParam` supplies one through `default_factory`, exactly as
+    # `VerificationParam` above does. It is an option, so where it sits in the
+    # signature says nothing about the command line.
+    benchmark_level: benchmark_module.BenchmarkParam,
     solutions: Annotated[
         Optional[List[str]],
         PackagePath,
@@ -168,6 +176,10 @@ async def run(
     ] = None,
 ):
     _set_timing_profile(profile)
+    # Parsed here, beside the profile and for the same reason: a level rbx
+    # cannot report on is a mistake in the command line, and a mistake should
+    # cost the setter an error rather than a whole build.
+    benchmark = benchmark_module.parse_level(benchmark_level)
 
     if share is not None and share not in ('png', 'text'):
         console.console.print(
@@ -278,6 +290,7 @@ async def run(
             # testcases that never ran, so every extreme in the timing summary --
             # and the time limit picked off it -- would rest on a lower bound.
             timing=not fail_fast,
+            benchmark_level=benchmark,
         )
 
         def _print_fail_fast_warning(to: rich.console.Console) -> None:
@@ -300,6 +313,9 @@ async def run(
                 detailed=detailed,
                 skip_printing_limits=sanitized,
                 timing=not fail_fast,
+                # Benchmarked too: a shared copy silently missing a block the
+                # setter asked for reads as a run that had nothing to report.
+                benchmark_level=benchmark,
             )
             # The shared report is the copy that leaves this machine, and whoever
             # reads it never sees the warning printed below.

--- a/rbx/box/cli/commands/run.py
+++ b/rbx/box/cli/commands/run.py
@@ -15,9 +15,7 @@ from ordered_set import OrderedSet
 from rbx import annotations, console, utils
 from rbx.annotations import PackagePath
 from rbx.box import (
-    benchmark as benchmark_module,
-)
-from rbx.box import (
+    benchmark,
     environment,
     generators,
     limits_info,
@@ -78,11 +76,14 @@ def _set_timing_profile(profile: Optional[str]) -> None:
 @syncer.sync
 async def run(
     verification: environment.VerificationParam,
-    # Ahead of every optional parameter because it carries no default of its
-    # own -- `BenchmarkParam` supplies one through `default_factory`, exactly as
-    # `VerificationParam` above does. It is an option, so where it sits in the
-    # signature says nothing about the command line.
-    benchmark_level: benchmark_module.BenchmarkParam,
+    # Ahead of every parameter that carries a Python-level default, because this
+    # one carries none of its own -- `BenchmarkParam` supplies its default
+    # through `default_factory`, exactly as `VerificationParam` above does.
+    # Tidying it further down the list is a `SyntaxError` raised when this module
+    # is imported, and command modules are imported lazily: `rbx --help` would go
+    # on working while `rbx run` alone blew up. It is an option either way, so
+    # where it sits in the signature says nothing about the command line.
+    benchmark_level: benchmark.BenchmarkParam,
     solutions: Annotated[
         Optional[List[str]],
         PackagePath,
@@ -179,7 +180,7 @@ async def run(
     # Parsed here, beside the profile and for the same reason: a level rbx
     # cannot report on is a mistake in the command line, and a mistake should
     # cost the setter an error rather than a whole build.
-    benchmark = benchmark_module.parse_level(benchmark_level)
+    level = benchmark.parse_level(benchmark_level)
 
     if share is not None and share not in ('png', 'text'):
         console.console.print(
@@ -290,7 +291,7 @@ async def run(
             # testcases that never ran, so every extreme in the timing summary --
             # and the time limit picked off it -- would rest on a lower bound.
             timing=not fail_fast,
-            benchmark_level=benchmark,
+            benchmark_level=level,
         )
 
         def _print_fail_fast_warning(to: rich.console.Console) -> None:
@@ -315,7 +316,7 @@ async def run(
                 timing=not fail_fast,
                 # Benchmarked too: a shared copy silently missing a block the
                 # setter asked for reads as a run that had nothing to report.
-                benchmark_level=benchmark,
+                benchmark_level=level,
             )
             # The shared report is the copy that leaves this machine, and whoever
             # reads it never sees the warning printed below.

--- a/rbx/box/cli/commands/run.py
+++ b/rbx/box/cli/commands/run.py
@@ -370,6 +370,9 @@ async def summary_cmd(
 @syncer.sync
 async def irun(
     verification: environment.VerificationParam,
+    # Ahead of every parameter that carries a Python-level default, for the
+    # reason `run` above spells out: `BenchmarkParam` has no default of its own.
+    benchmark_level: benchmark.BenchmarkParam,
     solutions: Annotated[
         Optional[List[str]],
         PackagePath,
@@ -468,6 +471,10 @@ async def irun(
         ),
     ] = None,
 ):
+    # Parsed before anything runs, so an unimplemented level is refused rather
+    # than reported after a whole run.
+    level = benchmark.parse_level(benchmark_level)
+
     _set_timing_profile(profile)
 
     if not print:
@@ -535,4 +542,5 @@ async def irun(
             only_accepted=only_accepted,
             validate=validate,
             visualize=visualize,
+            benchmark_level=level,
         )

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -150,6 +150,14 @@ SPEC = {
                     'value': {'completer': 'verification_level', 'kind': 'completer'},
                 },
                 {
+                    'help': 'Benchmark level: 0 (off), 1 (benchmark the solution run).',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--benchmark', '-b'],
+                    'takes_value': True,
+                    'value': {'completer': 'benchmark_level', 'kind': 'completer'},
+                },
+                {
                     'help': None,
                     'kind': 'argument',
                     'multiple': False,
@@ -432,6 +440,14 @@ SPEC = {
                     'names': ['--verification-level', '--verification', '-v'],
                     'takes_value': True,
                     'value': {'completer': 'verification_level', 'kind': 'completer'},
+                },
+                {
+                    'help': 'Benchmark level: 0 (off), 1 (benchmark the solution run).',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--benchmark', '-b'],
+                    'takes_value': True,
+                    'value': {'completer': 'benchmark_level', 'kind': 'completer'},
                 },
                 {
                     'help': None,
@@ -3379,6 +3395,7 @@ SPEC = {
 }
 
 COMPLETERS = {
+    'benchmark_level': 'rbx.box.completion.completers:complete_benchmark_level',
     'contest_variant': 'rbx.box.completion.completers:complete_contest_variant',
     'language': 'rbx.box.completion.completers:complete_language',
     'outcome': 'rbx.box.completion.completers:complete_outcome',

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -165,6 +165,22 @@ def complete_verification_level(
     return [CompletionItem(v, help=h) for v, h in _VERIFICATION_TABLE]
 
 
+# (value, level name). Kept in sync with benchmark.BenchmarkLevel by
+# enum_consistency_test.py. A literal rather than an import: this module is on
+# the shell-completion path, and `rbx.box.benchmark` pulls the schema in.
+_BENCHMARK_TABLE = (
+    ('0', 'NONE'),
+    ('1', 'SOLUTIONS'),
+)
+
+
+@register_completer('benchmark_level')
+def complete_benchmark_level(
+    ctx: CompletionContext, incomplete: str
+) -> List[CompletionItem]:
+    return [CompletionItem(v, help=h) for v, h in _BENCHMARK_TABLE]
+
+
 @register_completer('runner')
 def complete_runner(ctx: CompletionContext, incomplete: str) -> List[CompletionItem]:
     # `runners.names` is a leaf module with no imports of its own, which is why

--- a/rbx/box/formatting.py
+++ b/rbx/box/formatting.py
@@ -61,7 +61,7 @@ def get_formatted_time_in_seconds(time_in_seconds: float) -> str:
 
 
 def get_formatted_duration_in_seconds(time_in_seconds: float) -> str:
-    """A duration that may span milliseconds to minutes, read at a useful scale.
+    """A duration that may span milliseconds to seconds, read at a useful scale.
 
     `get_formatted_time_in_seconds` fixes one decimal place, which is right for
     a whole run's judging time but renders every realistic checker time as
@@ -71,8 +71,17 @@ def get_formatted_duration_in_seconds(time_in_seconds: float) -> str:
     Rounds rather than truncates: at the millisecond scale truncation is a
     visible lie (`0.0499 s` reading as `49 ms`). `solutions._get_evals_time_in_ms`
     truncates instead because it compares against a time *limit*, where rounding
-    up could turn a pass into a fail.
+    up could turn a pass into a fail. The branch reads the rounded milliseconds
+    rather than the raw value, so `0.9999 s` reads `1.0 s` and never `1000 ms`.
+
+    A duration that rounds to nothing is reported as `<1 ms`, so that it is not
+    read as a measured zero. A negative duration would render with a leading
+    `-`, colliding with `UNMEASURED` -- no sandbox clock produces one today, so
+    it is not guarded against.
     """
-    if time_in_seconds < 1.0:
-        return get_formatted_time(round(time_in_seconds * 1000))
+    time_in_ms = round(time_in_seconds * 1000)
+    if time_in_seconds > 0 and time_in_ms == 0:
+        return '<1 ms'
+    if time_in_ms < 1000:
+        return get_formatted_time(time_in_ms)
     return get_formatted_time_in_seconds(time_in_seconds)

--- a/rbx/box/formatting.py
+++ b/rbx/box/formatting.py
@@ -40,6 +40,10 @@ def href(
     return f'[{style}][link={url_str}]{text}[/link][/{style}]'
 
 
+# What a formatted time or memory reads as when nothing was measured at all.
+UNMEASURED = '-'
+
+
 def get_formatted_memory(memory_in_bytes: int, mib_decimal_places: int = 0) -> str:
     if memory_in_bytes < 1024 * 1024:
         if memory_in_bytes < 1024:

--- a/rbx/box/formatting.py
+++ b/rbx/box/formatting.py
@@ -58,3 +58,21 @@ def get_formatted_time(time_in_ms: int) -> str:
 
 def get_formatted_time_in_seconds(time_in_seconds: float) -> str:
     return f'{time_in_seconds:.1f} s'
+
+
+def get_formatted_duration_in_seconds(time_in_seconds: float) -> str:
+    """A duration that may span milliseconds to minutes, read at a useful scale.
+
+    `get_formatted_time_in_seconds` fixes one decimal place, which is right for
+    a whole run's judging time but renders every realistic checker time as
+    `0.0 s`. Benchmarks compare durations several orders of magnitude apart, so
+    the unit follows the value.
+
+    Rounds rather than truncates: at the millisecond scale truncation is a
+    visible lie (`0.0499 s` reading as `49 ms`). `solutions._get_evals_time_in_ms`
+    truncates instead because it compares against a time *limit*, where rounding
+    up could turn a pass into a fail.
+    """
+    if time_in_seconds < 1.0:
+        return get_formatted_time(round(time_in_seconds * 1000))
+    return get_formatted_time_in_seconds(time_in_seconds)

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -57,7 +57,6 @@ from rbx.box.formatting import (
     UNMEASURED,
     get_formatted_memory,
     get_formatted_time,
-    get_formatted_time_in_seconds,
     href,
 )
 from rbx.box.generation_schema import GenerationTestcaseEntry, TestcaseOrScriptEntry
@@ -1737,12 +1736,6 @@ def _get_evals_time_in_ms(evals: List[Evaluation]) -> Optional[int]:
     return max(int(time * 1000) for time in times)
 
 
-def _get_evals_judging_time_in_seconds(evals: List[Evaluation]) -> float:
-    if not evals:
-        return 0
-    return sum((eval.log.wall_time or 0.0) for eval in evals)
-
-
 def _get_evals_memory_in_bytes(evals: List[Evaluation]) -> Optional[int]:
     memories = [eval.log.memory for eval in evals if eval.log.memory is not None]
     if not memories:
@@ -1755,11 +1748,6 @@ def get_evals_formatted_time(evals: List[Evaluation]) -> str:
     if max_time is None:
         return UNMEASURED
     return get_formatted_time(max_time)
-
-
-def get_evals_formatted_judging_time(evals: List[Evaluation]) -> str:
-    total_time = _get_evals_judging_time_in_seconds(evals)
-    return get_formatted_time_in_seconds(total_time)
 
 
 def get_capped_evals_formatted_time(
@@ -2085,7 +2073,6 @@ class SolutionOutcomeReport(BaseModel):
             res = scoring_res + res
         res += f'\nTime: {get_capped_evals_formatted_time(self.limits, self.evals, self.verification)}'
         res += f'\nMemory: {get_evals_formatted_memory(self.evals)}'
-        # res += f'\nJudging time: {get_evals_formatted_judging_time(self.evals)}'
         if print_message and self.message is not None:
             entry, msg = self.message
             if msg:

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -3074,6 +3074,13 @@ class TraditionalRunReporter:
                 if solution_benchmark is not None:
                     benchmark.print_solution_benchmark(self.console, solution_benchmark)
                     self.solution_benchmarks.append(solution_benchmark)
+            # The blank line that separates one solution from the next. It used
+            # to close `render_solution_end`, where it reads more naturally --
+            # but the benchmark block is printed here, after that returns, so a
+            # separator emitted there would land *above* the block and make it
+            # read as a header for the next solution rather than a footer for
+            # the one it measures. Keep it last, and keep it here.
+            self.console.print()
         self.current_solution = None
         self.current_solution_evals = []
         return report is None or report.status.ok()
@@ -3416,7 +3423,6 @@ class LiveRunReporter(TraditionalRunReporter):
             verification=self.verification,
             print_message=True,
         )
-        self.console.print()
         return report
 
     def _stop_live(self) -> None:
@@ -3511,7 +3517,6 @@ class SingleSolutionRunReporter(TraditionalRunReporter):
         if self._elapsed is not None and self.console.is_terminal:
             self.console.print(f'[status]Ran in[/status] {self._elapsed}.')
         self._elapsed = None
-        self.console.print()
         return report
 
     def render_group_end(self, group: GroupSkeleton):

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -1597,9 +1597,12 @@ def _print_interactive_judging_time(
     checker_seconds = benchmark.checker_time_seconds(eval)
     line = f'[status]Checker time:[/status] {_measurement(checker_seconds)}'
     # Only a communication problem has an interactor, so a batch testcase must
-    # not spend half a line on a program that does not exist.
-    interactor_seconds = benchmark.interactor_time_seconds(eval)
-    if interactor_seconds is not None:
+    # not spend half a line on a program that does not exist. The half is gated
+    # on the timing object, exactly as `rbx ui` gates it; what it reads comes
+    # from the clock inside it, which may be unset -- an interactor that ran
+    # unmeasured is still an interactor, and reads as `-`.
+    if eval.result.interactor_timing is not None:
+        interactor_seconds = benchmark.interactor_time_seconds(eval)
         line += (
             f' / [status]Interactor time:[/status] {_measurement(interactor_seconds)}'
         )

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -2573,7 +2573,13 @@ async def _print_timing(
     console: rich.console.Console,
     skeleton: SolutionReportSkeleton,
     evaluations: StructuredEvaluation,
-):
+) -> bool:
+    """Print the timing summary, reporting whether there was one to print.
+
+    Nothing is printed when no solution measured anything -- a fully skipped
+    run, say. The caller needs to know which happened: the summary ends without
+    a trailing blank line, so whatever follows it has to supply its own.
+    """
     summary = TimingSummary()
     summary_per_language = collections.defaultdict(TimingSummary)
     tls_per_language = {}
@@ -2662,7 +2668,7 @@ async def _print_timing(
             summary_per_language[language].add_slow(solution_time, solution)
 
     if not summary.has_timings():
-        return
+        return False
 
     all_languages = set(summary_per_language)
     all_tl = min(all_tls) if all_tls else None
@@ -2671,7 +2677,7 @@ async def _print_timing(
 
     if len(all_languages) <= 1 or (len(all_tls) <= 1 and len(all_expanded_tls) <= 1):
         summary.print(console, tl=all_tl, expanded_tl=all_expanded_tl)
-        return
+        return True
 
     # Otherwise, print per language.
     # TODO: reconsider having the concept of a global language time limit.
@@ -2686,6 +2692,7 @@ async def _print_timing(
             tl=cur_tl,
             expanded_tl=cur_expanded_tl,
         )
+    return True
 
 
 def _length_markup(markup: str) -> int:
@@ -2855,6 +2862,37 @@ async def _render_detailed_group_table(
                 throttled_update()
 
 
+def _print_problem_benchmark(
+    console: rich.console.Console,
+    benchmark_level: benchmark.BenchmarkLevel,
+    solution_benchmarks: List[benchmark.SolutionBenchmark],
+    separate: bool = False,
+) -> None:
+    """Close the report with the problem-wide extremes, under `-b1`.
+
+    Both report paths end here, and neither guards this on the timing summary
+    having been printed. The timing summary is suppressed on a run that may stop
+    early -- time limit inference reads it, and a solution that stopped early
+    only measures a lower bound -- but the benchmark feeds no inference, carries
+    its own `(partial ...)` marker and is purely diagnostic, so it still prints.
+    A single solution gets it too: one solution is every extreme at once, but
+    the block is where the run's totals are read off, not just its ranking.
+
+    ``separate`` opens with a blank line. Pass it when the timing summary was
+    printed just above -- that summary ends on its last line, so without one the
+    two blocks read as one. The last solution's report already ends in a blank
+    line, so nothing is needed when the benchmark follows that instead.
+    """
+    if benchmark_level != benchmark.BenchmarkLevel.SOLUTIONS:
+        return
+    problem_bench = benchmark.build_problem_benchmark(solution_benchmarks)
+    if problem_bench is None:
+        return
+    if separate:
+        console.print()
+    benchmark.print_problem_benchmark(console, problem_bench)
+
+
 async def _print_detailed_run_report(
     result: RunSolutionResult,
     console: rich.console.Console,
@@ -2879,6 +2917,10 @@ async def _print_detailed_run_report(
     # `--detailed` bypasses the reporters entirely, so it has to publish the
     # report itself or `rbx run -d` would leave none behind.
     report_writer = run_report.RunReportWriter(package.get_problem_runs_dir())
+    # And for the same reason it has to collect the per-solution benchmarks as
+    # it goes: there is no reporter here holding a `solution_benchmarks` list,
+    # so without this the summary would silently vanish under `-d`.
+    solution_benchmarks: List[benchmark.SolutionBenchmark] = []
     for index, solution in enumerate(result.skeleton.solutions):
         all_evals = []
         for evals in structured_evaluations[str(solution.path)].values():
@@ -2906,18 +2948,24 @@ async def _print_detailed_run_report(
             )
             if solution_benchmark is not None:
                 benchmark.print_solution_benchmark(console, solution_benchmark)
+                solution_benchmarks.append(solution_benchmark)
         if _gates_report(solution, gating_solutions):
             ok = ok and report.status.ok()
         console.print()
 
     console.print()
 
+    printed_timing = False
     if timing:
-        await _print_timing(
+        printed_timing = await _print_timing(
             console,
             result.skeleton,
             structured_evaluations,
         )
+
+    _print_problem_benchmark(
+        console, benchmark_level, solution_benchmarks, separate=printed_timing
+    )
     return ok
 
 
@@ -3630,11 +3678,19 @@ async def print_run_report(
         # torn down before anything else reaches the terminal.
         reporter.close()
 
+    printed_timing = False
     if not single_solution and timing:
-        await _print_timing(
+        printed_timing = await _print_timing(
             console,
             result.skeleton,
             reporter.structured_evaluations,
         )
+
+    _print_problem_benchmark(
+        console,
+        benchmark_level,
+        reporter.solution_benchmarks,
+        separate=printed_timing,
+    )
 
     return ok

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -54,6 +54,7 @@ from rbx.box.environment import (
     VerificationLevel,
 )
 from rbx.box.formatting import (
+    UNMEASURED,
     get_formatted_memory,
     get_formatted_time,
     get_formatted_time_in_seconds,
@@ -1749,14 +1750,10 @@ def _get_evals_memory_in_bytes(evals: List[Evaluation]) -> Optional[int]:
     return max(int(memory) for memory in memories)
 
 
-# What a formatted time or memory reads as when nothing was measured at all.
-_UNMEASURED = '-'
-
-
 def get_evals_formatted_time(evals: List[Evaluation]) -> str:
     max_time = _get_evals_time_in_ms(evals)
     if max_time is None:
-        return _UNMEASURED
+        return UNMEASURED
     return get_formatted_time(max_time)
 
 
@@ -1772,7 +1769,7 @@ def get_capped_evals_formatted_time(
 ) -> str:
     max_time = _get_evals_time_in_ms(evals)
     if max_time is None:
-        return _UNMEASURED
+        return UNMEASURED
     has_tle = any(eval.result.outcome.is_slow() for eval in evals)
     has_ile = any(
         eval.result.outcome == Outcome.IDLENESS_LIMIT_EXCEEDED for eval in evals
@@ -1802,7 +1799,7 @@ def get_capped_evals_formatted_time(
 def get_evals_formatted_memory(evals: List[Evaluation]) -> str:
     max_memory = _get_evals_memory_in_bytes(evals)
     if max_memory is None:
-        return _UNMEASURED
+        return UNMEASURED
     return get_formatted_memory(max_memory)
 
 

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -2926,7 +2926,12 @@ async def _print_detailed_run_report(
         for evals in structured_evaluations[str(solution.path)].values():
             all_evals.extend(evals)
 
-        # Resolve futures.
+        # Resolve futures. The `None` filter only ever drops a trailing run:
+        # every entry starts out `None` and is filled in entry order as the
+        # items arrive, and a testcase that was skipped is persisted as a
+        # `SKIPPED` evaluation rather than left unset -- so the survivors stay
+        # the gapless prefix `_get_evals_per_group` and the benchmark both
+        # assume.
         all_evals = [await eval() for eval in all_evals if eval is not None]
         _print_solution_header(solution, console)
         report = _print_solution_outcome(
@@ -2942,13 +2947,15 @@ async def _print_detailed_run_report(
         )
         # `--detailed` bypasses the reporters, so it prints the benchmark block
         # itself for the same reason it publishes the report itself.
-        if benchmark_level == benchmark.BenchmarkLevel.SOLUTIONS:
-            solution_benchmark = benchmark.build_solution_benchmark(
-                solution, result.skeleton, report.evals
-            )
-            if solution_benchmark is not None:
-                benchmark.print_solution_benchmark(console, solution_benchmark)
-                solution_benchmarks.append(solution_benchmark)
+        solution_benchmark = benchmark.report_solution_benchmark(
+            console,
+            benchmark_level,
+            solution,
+            result.skeleton,
+            report.evals,
+        )
+        if solution_benchmark is not None:
+            solution_benchmarks.append(solution_benchmark)
         if _gates_report(solution, gating_solutions):
             ok = ok and report.status.ok()
         console.print()
@@ -3005,6 +3012,8 @@ class TraditionalRunReporter:
     verification: VerificationLevel
     structured_evaluations: StructuredEvaluation
     limits_per_solution: Dict[str, Limits]
+    benchmark_level: benchmark.BenchmarkLevel
+    solution_benchmarks: List[benchmark.SolutionBenchmark]
 
     current_solution: Optional[Solution]
     current_group: Optional[GroupSkeleton]
@@ -3113,21 +3122,23 @@ class TraditionalRunReporter:
             # written once and both get it. `LiveRunReporter` has already
             # stopped its live region by the time that returns, so printing
             # plainly to the console cannot land inside a live frame.
-            if self.benchmark_level == benchmark.BenchmarkLevel.SOLUTIONS:
-                solution_benchmark = benchmark.build_solution_benchmark(
-                    self.current_solution, self.result.skeleton, report.evals
-                )
-                # `None` when nothing about this solution was measured -- a
-                # `--fail-fast` run that skipped every one of its testcases.
-                if solution_benchmark is not None:
-                    benchmark.print_solution_benchmark(self.console, solution_benchmark)
-                    self.solution_benchmarks.append(solution_benchmark)
+            solution_benchmark = benchmark.report_solution_benchmark(
+                self.console,
+                self.benchmark_level,
+                self.current_solution,
+                self.result.skeleton,
+                report.evals,
+            )
+            if solution_benchmark is not None:
+                self.solution_benchmarks.append(solution_benchmark)
             # The blank line that separates one solution from the next. It used
             # to close `render_solution_end`, where it reads more naturally --
             # but the benchmark block is printed here, after that returns, so a
             # separator emitted there would land *above* the block and make it
             # read as a header for the next solution rather than a footer for
-            # the one it measures. Keep it last, and keep it here.
+            # the one it measures. Keep it last, and keep it here. Both concrete
+            # reporters always return a report, so this is the same
+            # unconditional separator the overrides used to print.
             self.console.print()
         self.current_solution = None
         self.current_solution_evals = []
@@ -3142,6 +3153,10 @@ class TraditionalRunReporter:
         ``finish_solution`` publishes it (see ``run_report``). Recomputing it
         there instead would push every issue onto the stack a second time --
         ``get_solution_outcome_report`` reports issues unless told not to.
+
+        Render the verdict only. The blank line separating one solution from the
+        next belongs to ``finish_solution``, which prints it below the benchmark
+        block -- see the comment there.
         """
         return None
 
@@ -3640,7 +3655,9 @@ async def print_run_report(
 
     single_solution = len(result.skeleton.solutions) == 1
     report_cls = SingleSolutionRunReporter if single_solution else LiveRunReporter
-    reporter = report_cls(result, verification, console, benchmark_level)
+    reporter = report_cls(
+        result, verification, console, benchmark_level=benchmark_level
+    )
 
     if detailed:
         return await _print_detailed_run_report(

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -56,6 +56,7 @@ from rbx.box.environment import (
 )
 from rbx.box.formatting import (
     UNMEASURED,
+    get_formatted_duration_in_seconds,
     get_formatted_memory,
     get_formatted_time,
     href,
@@ -1416,6 +1417,7 @@ async def run_and_print_interactive_solutions(
     only_accepted: bool = False,
     validate: bool = True,
     visualize: bool = False,
+    benchmark_level: benchmark.BenchmarkLevel = benchmark.BenchmarkLevel.NONE,
 ):
     pkg = package.find_problem_package_or_die()
 
@@ -1468,6 +1470,10 @@ async def run_and_print_interactive_solutions(
             visualize=visualize,
         )
 
+    # Collected as the loop streams, since there is no reporter here holding a
+    # list of them -- same shape as the `--detailed` path in `print_run_report`.
+    solution_benchmarks: List[benchmark.SolutionBenchmark] = []
+
     async for item in items:
         sol = skeleton.find_solution_skeleton(item.solution)
         assert sol is not None
@@ -1482,6 +1488,20 @@ async def run_and_print_interactive_solutions(
             _print_solution_outcome(
                 sol, skeleton, [eval], console.console, verification, subset=True
             )
+            _print_interactive_judging_time(console.console, benchmark_level, eval)
+
+        # Deliberately not `benchmark.report_solution_benchmark`: that prints
+        # the per-solution block, whose headline is the run's slowest testcase.
+        # This command runs exactly one, so that block would only restate the
+        # line just printed. The benchmark is still built, because the summary
+        # below ranks solutions against each other and one testcase each is
+        # enough for that.
+        if benchmark_level == benchmark.BenchmarkLevel.SOLUTIONS:
+            solution_bench = benchmark.build_solution_benchmark(
+                item.solution, skeleton, [eval]
+            )
+            if solution_bench is not None:
+                solution_benchmarks.append(solution_bench)
 
         stdout_path = eval.log.stdout_absolute_path
         merged_path = (
@@ -1543,6 +1563,60 @@ async def run_and_print_interactive_solutions(
                 )
             _print_checker_stderr_hint(eval)
             console.console.print()
+
+    # Under `no_progress` like every other block this command prints: the whole
+    # command runs inside the caller's `StatusProgress`, so a line printed with
+    # the spinner still running is interleaved with its frames.
+    #
+    # `separate=True` unconditionally: what a solution's block ends with here
+    # depends on `-p` and on which artifacts the run produced, so there is no
+    # trailing blank line to rely on the way the full report has one.
+    with utils.no_progress(progress):
+        _print_problem_benchmark(
+            console.console, benchmark_level, solution_benchmarks, separate=True
+        )
+
+
+def _print_interactive_judging_time(
+    out: rich.console.Console,
+    benchmark_level: benchmark.BenchmarkLevel,
+    eval: Evaluation,
+) -> None:
+    """Report what judging this one testcase cost, under `-b1`.
+
+    `rbx run` reports the slowest testcase of a whole testset; this command runs
+    a single one, so the testcase's own times are what there is to say. The
+    wording and the shape are `rbx ui`'s -- see
+    `ui.utils.run_ui._get_formatted_judging_time` and its call site -- because a
+    setter reading the same fact in two places should not meet two spellings of
+    it. Only the markup differs: the surrounding lines of this block are
+    `[status]`-labelled, and the panel's are bold.
+    """
+    if benchmark_level != benchmark.BenchmarkLevel.SOLUTIONS:
+        return
+    checker_seconds = benchmark.checker_time_seconds(eval)
+    line = f'[status]Checker time:[/status] {_measurement(checker_seconds)}'
+    # Only a communication problem has an interactor, so a batch testcase must
+    # not spend half a line on a program that does not exist.
+    interactor_seconds = benchmark.interactor_time_seconds(eval)
+    if interactor_seconds is not None:
+        line += (
+            f' / [status]Interactor time:[/status] {_measurement(interactor_seconds)}'
+        )
+    out.print(line)
+
+
+def _measurement(seconds: Optional[float]) -> str:
+    """A duration in seconds, or the unmeasured marker when there is none.
+
+    `None` never becomes `0 ms`: a checker that never ran and a checker that ran
+    instantaneously read differently, and only the second is a claim about how
+    long judging took. Same rule, and the same adaptive formatter, as
+    `benchmark._measurement`.
+    """
+    if seconds is None:
+        return UNMEASURED
+    return get_formatted_duration_in_seconds(seconds)
 
 
 def _print_checker_stderr_hint(eval: Evaluation) -> None:

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel
 
 from rbx import console, utils
 from rbx.box import (
+    benchmark,
     checkers,
     code,
     compilation_findings,
@@ -2861,6 +2862,7 @@ async def _print_detailed_run_report(
     timing: bool = True,
     verification: VerificationLevel = VerificationLevel.NONE,
     gating_solutions: Optional[Set[str]] = None,
+    benchmark_level: benchmark.BenchmarkLevel = benchmark.BenchmarkLevel.NONE,
 ) -> bool:
     for group in result.skeleton.groups:
         console.print(f'[bold][status]{group.name}[/status][/bold]')
@@ -2896,6 +2898,14 @@ async def _print_detailed_run_report(
         report_writer.add(
             run_report.build_solution_report(index, result.skeleton, report)
         )
+        # `--detailed` bypasses the reporters, so it prints the benchmark block
+        # itself for the same reason it publishes the report itself.
+        if benchmark_level == benchmark.BenchmarkLevel.SOLUTIONS:
+            solution_benchmark = benchmark.build_solution_benchmark(
+                solution, result.skeleton, report.evals
+            )
+            if solution_benchmark is not None:
+                benchmark.print_solution_benchmark(console, solution_benchmark)
         if _gates_report(solution, gating_solutions):
             ok = ok and report.status.ok()
         console.print()
@@ -2960,10 +2970,18 @@ class TraditionalRunReporter:
         result: RunSolutionResult,
         verification: VerificationLevel,
         console: rich.console.Console,
+        benchmark_level: benchmark.BenchmarkLevel = benchmark.BenchmarkLevel.NONE,
     ):
         self.result = result
         self.console = console
         self.verification = verification
+        # Named for the level rather than for the module it comes from, since
+        # this file refers to `benchmark` the module throughout.
+        self.benchmark_level = benchmark_level
+        # Every solution's benchmark, in the order the solutions finished. Read
+        # by nothing yet: the problem-wide summary that ranks them is built on
+        # top of this list, and collecting them here is what will let it.
+        self.solution_benchmarks: List[benchmark.SolutionBenchmark] = []
         self.structured_evaluations = consume_and_key_evaluation_items(
             result.items, result.skeleton
         )
@@ -3042,6 +3060,20 @@ class TraditionalRunReporter:
                     report,
                 )
             )
+            # Printed from here rather than from either `render_solution_end`
+            # because this is where the two reporters converge, so the block is
+            # written once and both get it. `LiveRunReporter` has already
+            # stopped its live region by the time that returns, so printing
+            # plainly to the console cannot land inside a live frame.
+            if self.benchmark_level == benchmark.BenchmarkLevel.SOLUTIONS:
+                solution_benchmark = benchmark.build_solution_benchmark(
+                    self.current_solution, self.result.skeleton, report.evals
+                )
+                # `None` when nothing about this solution was measured -- a
+                # `--fail-fast` run that skipped every one of its testcases.
+                if solution_benchmark is not None:
+                    benchmark.print_solution_benchmark(self.console, solution_benchmark)
+                    self.solution_benchmarks.append(solution_benchmark)
         self.current_solution = None
         self.current_solution_evals = []
         return report is None or report.status.ok()
@@ -3531,6 +3563,7 @@ async def print_run_report(
     timing: bool = True,
     skip_printing_limits: bool = False,
     gating_solutions: Optional[Set[str]] = None,
+    benchmark_level: benchmark.BenchmarkLevel = benchmark.BenchmarkLevel.NONE,
 ) -> bool:
     """Run every tracked solution and report it.
 
@@ -3544,13 +3577,17 @@ async def print_run_report(
     report. Pass ``False`` when the run may stop early: every line of that
     summary is an extreme over the solutions, and a solution that did not run to
     the end only measures a lower bound.
+
+    ``benchmark_level`` decides whether the judging benchmark is reported. The
+    timings it reads are captured on every run regardless, so the level only
+    ever decides what is printed.
     """
     if not skip_printing_limits:
         _print_limits(result.skeleton.limits)
 
     single_solution = len(result.skeleton.solutions) == 1
     report_cls = SingleSolutionRunReporter if single_solution else LiveRunReporter
-    reporter = report_cls(result, verification, console)
+    reporter = report_cls(result, verification, console, benchmark_level)
 
     if detailed:
         return await _print_detailed_run_report(
@@ -3560,6 +3597,7 @@ async def print_run_report(
             verification=verification,
             timing=timing,
             gating_solutions=gating_solutions,
+            benchmark_level=benchmark_level,
         )
 
     ok = True

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -1562,19 +1562,19 @@ async def run_and_print_interactive_solutions(
                     f'[status]Stderr:[/status] {href(package.relpath(eval.log.stderr_absolute_path))}'
                 )
             _print_checker_stderr_hint(eval)
-            console.console.print()
+
+        # The blank line that ends this solution's section. What that section
+        # ends *with* depends on `-p` and on which artifacts the run produced,
+        # so it is closed here, once, rather than by each branch above -- every
+        # section of a report owns its own trailing blank line, and the summary
+        # below relies on that instead of printing a separator of its own.
+        console.console.print()
 
     # Under `no_progress` like every other block this command prints: the whole
     # command runs inside the caller's `StatusProgress`, so a line printed with
     # the spinner still running is interleaved with its frames.
-    #
-    # `separate=True` unconditionally: what a solution's block ends with here
-    # depends on `-p` and on which artifacts the run produced, so there is no
-    # trailing blank line to rely on the way the full report has one.
     with utils.no_progress(progress):
-        _print_problem_benchmark(
-            console.console, benchmark_level, solution_benchmarks, separate=True
-        )
+        _print_problem_benchmark(console.console, benchmark_level, solution_benchmarks)
 
 
 def _print_interactive_judging_time(
@@ -2650,12 +2650,13 @@ async def _print_timing(
     console: rich.console.Console,
     skeleton: SolutionReportSkeleton,
     evaluations: StructuredEvaluation,
-) -> bool:
-    """Print the timing summary, reporting whether there was one to print.
+) -> None:
+    """Print the timing summary, closing it with its own blank line.
 
-    Nothing is printed when no solution measured anything -- a fully skipped
-    run, say. The caller needs to know which happened: the summary ends without
-    a trailing blank line, so whatever follows it has to supply its own.
+    Nothing at all is printed when no solution measured anything -- a fully
+    skipped run, say -- and the blank line goes with it. Every section of the
+    report owns the blank line that ends it, so whatever follows this one need
+    not know whether it printed, nor how it terminates.
     """
     summary = TimingSummary()
     summary_per_language = collections.defaultdict(TimingSummary)
@@ -2745,7 +2746,7 @@ async def _print_timing(
             summary_per_language[language].add_slow(solution_time, solution)
 
     if not summary.has_timings():
-        return False
+        return
 
     all_languages = set(summary_per_language)
     all_tl = min(all_tls) if all_tls else None
@@ -2754,7 +2755,8 @@ async def _print_timing(
 
     if len(all_languages) <= 1 or (len(all_tls) <= 1 and len(all_expanded_tls) <= 1):
         summary.print(console, tl=all_tl, expanded_tl=all_expanded_tl)
-        return True
+        console.print()
+        return
 
     # Otherwise, print per language.
     # TODO: reconsider having the concept of a global language time limit.
@@ -2769,7 +2771,7 @@ async def _print_timing(
             tl=cur_tl,
             expanded_tl=cur_expanded_tl,
         )
-    return True
+    console.print()
 
 
 def _length_markup(markup: str) -> int:
@@ -2943,30 +2945,34 @@ def _print_problem_benchmark(
     console: rich.console.Console,
     benchmark_level: benchmark.BenchmarkLevel,
     solution_benchmarks: List[benchmark.SolutionBenchmark],
-    separate: bool = False,
 ) -> None:
     """Close the report with the problem-wide extremes, under `-b1`.
+
+    Every line here is an extreme *across* solutions, so it takes at least two
+    of them to say anything. On a single solution -- `rbx run <one-solution>
+    -b1`, the commonest way the flag is used -- every extreme names the only
+    candidate and every number restates the per-solution block printed
+    immediately above, so the whole section is a second copy of what the reader
+    just read. It is suppressed there rather than kept for its totals: the
+    per-solution block is where those totals already are.
 
     Both report paths end here, and neither guards this on the timing summary
     having been printed. The timing summary is suppressed on a run that may stop
     early -- time limit inference reads it, and a solution that stopped early
     only measures a lower bound -- but the benchmark feeds no inference, carries
     its own `(partial ...)` marker and is purely diagnostic, so it still prints.
-    A single solution gets it too: one solution is every extreme at once, but
-    the block is where the run's totals are read off, not just its ranking.
 
-    ``separate`` opens with a blank line. Pass it when the timing summary was
-    printed just above -- that summary ends on its last line, so without one the
-    two blocks read as one. The last solution's report already ends in a blank
-    line, so nothing is needed when the benchmark follows that instead.
+    No blank line is opened here. Whatever precedes this ends with its own, so
+    the separator is never printed twice and never forgotten -- see
+    `_print_timing`.
     """
     if benchmark_level != benchmark.BenchmarkLevel.SOLUTIONS:
+        return
+    if len(solution_benchmarks) < 2:
         return
     problem_bench = benchmark.build_problem_benchmark(solution_benchmarks)
     if problem_bench is None:
         return
-    if separate:
-        console.print()
     benchmark.print_problem_benchmark(console, problem_bench)
 
 
@@ -3024,32 +3030,28 @@ async def _print_detailed_run_report(
         )
         # `--detailed` bypasses the reporters, so it prints the benchmark block
         # itself for the same reason it publishes the report itself.
-        solution_benchmark = benchmark.report_solution_benchmark(
+        benchmark.report_solution_benchmark(
             console,
-            benchmark_level,
             solution,
             result.skeleton,
             report.evals,
+            solution_benchmarks,
+            level=benchmark_level,
         )
-        if solution_benchmark is not None:
-            solution_benchmarks.append(solution_benchmark)
         if _gates_report(solution, gating_solutions):
             ok = ok and report.status.ok()
+        # The blank line that ends this solution's section -- including the last
+        # one's, which is why nothing more is printed after the loop.
         console.print()
 
-    console.print()
-
-    printed_timing = False
     if timing:
-        printed_timing = await _print_timing(
+        await _print_timing(
             console,
             result.skeleton,
             structured_evaluations,
         )
 
-    _print_problem_benchmark(
-        console, benchmark_level, solution_benchmarks, separate=printed_timing
-    )
+    _print_problem_benchmark(console, benchmark_level, solution_benchmarks)
     return ok
 
 
@@ -3199,15 +3201,14 @@ class TraditionalRunReporter:
             # written once and both get it. `LiveRunReporter` has already
             # stopped its live region by the time that returns, so printing
             # plainly to the console cannot land inside a live frame.
-            solution_benchmark = benchmark.report_solution_benchmark(
+            benchmark.report_solution_benchmark(
                 self.console,
-                self.benchmark_level,
                 self.current_solution,
                 self.result.skeleton,
                 report.evals,
+                self.solution_benchmarks,
+                level=self.benchmark_level,
             )
-            if solution_benchmark is not None:
-                self.solution_benchmarks.append(solution_benchmark)
             # The blank line that separates one solution from the next. It used
             # to close `render_solution_end`, where it reads more naturally --
             # but the benchmark block is printed here, after that returns, so a
@@ -3772,19 +3773,13 @@ async def print_run_report(
         # torn down before anything else reaches the terminal.
         reporter.close()
 
-    printed_timing = False
     if not single_solution and timing:
-        printed_timing = await _print_timing(
+        await _print_timing(
             console,
             result.skeleton,
             reporter.structured_evaluations,
         )
 
-    _print_problem_benchmark(
-        console,
-        benchmark_level,
-        reporter.solution_benchmarks,
-        separate=printed_timing,
-    )
+    _print_problem_benchmark(console, benchmark_level, reporter.solution_benchmarks)
 
     return ok

--- a/rbx/box/ui/utils/run_ui.py
+++ b/rbx/box/ui/utils/run_ui.py
@@ -7,7 +7,7 @@ from textual.widgets.option_list import Option
 
 from rbx import console, utils
 from rbx.box import package, solutions
-from rbx.box.formatting import get_formatted_time
+from rbx.box.formatting import UNMEASURED, get_formatted_time
 from rbx.box.generation_schema import GenerationTestcaseEntry
 from rbx.box.schema import Solution
 from rbx.box.solutions import (
@@ -224,14 +224,11 @@ def _get_checker_msg_last_line(eval: Evaluation) -> Optional[str]:
 
 
 def _get_formatted_judging_time(timing: Optional[RunTiming]) -> str:
-    """A judging program's CPU time, as milliseconds, or the unmeasured marker.
-
-    Both guards are needed: a run that never happened has no `RunTiming` at all,
-    and a `RunTiming` that exists may still carry a `None` clock. Either way
-    nothing was measured, and rendering `0 ms` would claim otherwise.
-    """
+    """A judging program's CPU time in milliseconds, or the unmeasured marker."""
+    # The same unmeasured rule -- a `RunTiming` can exist with a `None` clock --
+    # lives in `benchmark._timing_seconds`; keep the two in agreement.
     if timing is None or timing.time is None:
-        return solutions._UNMEASURED  # noqa: SLF001
+        return UNMEASURED
     # `RunTiming` keeps seconds; `get_formatted_time` wants milliseconds.
     return get_formatted_time(int(timing.time * 1000))
 
@@ -259,17 +256,19 @@ def get_run_testcase_metadata_markup(
     # already spells `Checker:` for the checker's *message* -- a line setters
     # have read that way since long before judging times existed. Do not
     # shorten it back into a collision.
-    lines.append(
+    judging_str = (
         f'[b]Checker time:[/b] '
         f'{_get_formatted_judging_time(eval.result.checker_timing)}'
     )
     # Only a communication problem has an interactor, so a batch testcase must
-    # not grow a line reading `-` for a program that does not exist.
+    # not spend half a row on a program that does not exist. The half is gated
+    # on the timing object; what it reads comes from the clock inside it.
     if eval.result.interactor_timing is not None:
-        lines.append(
-            f'[b]Interactor time:[/b] '
+        judging_str += (
+            f' / [b]Interactor time:[/b] '
             f'{_get_formatted_judging_time(eval.result.interactor_timing)}'
         )
+    lines.append(judging_str)
     if checker_msg is not None:
         lines.append(f'[b]Checker:[/b] {utils.escape_markup(checker_msg)}')
     # Only `--keep-checker-stderr` runs have one, and only its presence is worth

--- a/rbx/box/ui/utils/run_ui.py
+++ b/rbx/box/ui/utils/run_ui.py
@@ -7,6 +7,7 @@ from textual.widgets.option_list import Option
 
 from rbx import console, utils
 from rbx.box import package, solutions
+from rbx.box.formatting import get_formatted_time
 from rbx.box.generation_schema import GenerationTestcaseEntry
 from rbx.box.schema import Solution
 from rbx.box.solutions import (
@@ -16,7 +17,7 @@ from rbx.box.solutions import (
     get_solution_score_markup,
 )
 from rbx.box.testcase_schema import TestcaseEntry
-from rbx.grading.steps import Evaluation
+from rbx.grading.steps import Evaluation, RunTiming
 
 
 def is_main_solution(solution: Solution) -> bool:
@@ -222,6 +223,19 @@ def _get_checker_msg_last_line(eval: Evaluation) -> Optional[str]:
     return eval.result.message.rstrip().split('\n')[-1]
 
 
+def _get_formatted_judging_time(timing: Optional[RunTiming]) -> str:
+    """A judging program's CPU time, as milliseconds, or the unmeasured marker.
+
+    Both guards are needed: a run that never happened has no `RunTiming` at all,
+    and a `RunTiming` that exists may still carry a `None` clock. Either way
+    nothing was measured, and rendering `0 ms` would claim otherwise.
+    """
+    if timing is None or timing.time is None:
+        return solutions._UNMEASURED  # noqa: SLF001
+    # `RunTiming` keeps seconds; `get_formatted_time` wants milliseconds.
+    return get_formatted_time(int(timing.time * 1000))
+
+
 def get_run_testcase_metadata_markup(
     skeleton: SolutionReportSkeleton, solution: SolutionSkeleton, entry: TestcaseEntry
 ) -> Optional[str]:
@@ -241,6 +255,16 @@ def get_run_testcase_metadata_markup(
         f'[b]{solutions.get_full_outcome_markup_verdict(eval.result.outcome)}[/b]'
     )
     lines.append(f'[b]Time:[/b] {time_str} / [b]Memory:[/b] {memory_str}')
+    lines.append(
+        f'[b]Checker:[/b] {_get_formatted_judging_time(eval.result.checker_timing)}'
+    )
+    # Only a communication problem has an interactor, so a batch testcase must
+    # not grow a line reading `-` for a program that does not exist.
+    if eval.result.interactor_timing is not None:
+        lines.append(
+            f'[b]Interactor:[/b] '
+            f'{_get_formatted_judging_time(eval.result.interactor_timing)}'
+        )
     if checker_msg is not None:
         lines.append(f'[b]Checker:[/b] {utils.escape_markup(checker_msg)}')
     # Only `--keep-checker-stderr` runs have one, and only its presence is worth

--- a/rbx/box/ui/utils/run_ui.py
+++ b/rbx/box/ui/utils/run_ui.py
@@ -255,14 +255,19 @@ def get_run_testcase_metadata_markup(
         f'[b]{solutions.get_full_outcome_markup_verdict(eval.result.outcome)}[/b]'
     )
     lines.append(f'[b]Time:[/b] {time_str} / [b]Memory:[/b] {memory_str}')
+    # The label is `Checker time:`, not `Checker:`, because the line below
+    # already spells `Checker:` for the checker's *message* -- a line setters
+    # have read that way since long before judging times existed. Do not
+    # shorten it back into a collision.
     lines.append(
-        f'[b]Checker:[/b] {_get_formatted_judging_time(eval.result.checker_timing)}'
+        f'[b]Checker time:[/b] '
+        f'{_get_formatted_judging_time(eval.result.checker_timing)}'
     )
     # Only a communication problem has an interactor, so a batch testcase must
     # not grow a line reading `-` for a program that does not exist.
     if eval.result.interactor_timing is not None:
         lines.append(
-            f'[b]Interactor:[/b] '
+            f'[b]Interactor time:[/b] '
             f'{_get_formatted_judging_time(eval.result.interactor_timing)}'
         )
     if checker_msg is not None:

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -334,7 +334,8 @@ class RunTiming(BaseModel):
 
     `None` means *unmeasured*, never zero -- a checker that never ran has no
     timing at all, and reporting `0 ms` would claim a measurement that was
-    never taken.
+    never taken. The two clocks are independently optional, so a `RunTiming`
+    that exists can still carry a `None` on either of them.
     """
 
     time: Optional[float] = None

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -325,11 +325,40 @@ class TestcaseLog(RunLog):
     checker_stderr_absolute_path: Optional[pathlib.Path] = None
 
 
+class RunTiming(BaseModel):
+    """How long one judging program took on one testcase.
+
+    Both clocks are kept even though only CPU time is reported today: storing
+    the wall clock costs nothing, and lets a later benchmarking level report it
+    without migrating the `.eval` format.
+
+    `None` means *unmeasured*, never zero. A checker that never ran -- the
+    solution TLE'd or crashed, so `_check_pre_output` short-circuited -- has no
+    timing at all, and reporting `0 ms` for it would claim a measurement that
+    was never taken.
+    """
+
+    time: Optional[float] = None
+    wall_time: Optional[float] = None
+
+    @staticmethod
+    def of(log: Optional['RunLog']) -> Optional['RunTiming']:
+        if log is None:
+            return None
+        return RunTiming(time=log.time, wall_time=log.wall_time)
+
+
 class CheckerResult(BaseModel):
     outcome: Outcome
     message: str = ''
     no_tle_outcome: Optional[Outcome] = None
     sanitizer_warnings: bool = False
+    # How long the checker took on this testcase, and -- for communication
+    # problems -- the interactor. Captured on every run regardless of
+    # `--benchmark`, because `exclude_none` makes it free and `rbx ui` can then
+    # show it for any past run. See docs/plans/2026-08-28-run-benchmark-design.md.
+    checker_timing: Optional[RunTiming] = None
+    interactor_timing: Optional[RunTiming] = None
 
 
 class Evaluation(BaseModel):

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -332,10 +332,9 @@ class RunTiming(BaseModel):
     the wall clock costs nothing, and lets a later benchmarking level report it
     without migrating the `.eval` format.
 
-    `None` means *unmeasured*, never zero. A checker that never ran -- the
-    solution TLE'd or crashed, so `_check_pre_output` short-circuited -- has no
-    timing at all, and reporting `0 ms` for it would claim a measurement that
-    was never taken.
+    `None` means *unmeasured*, never zero -- a checker that never ran has no
+    timing at all, and reporting `0 ms` would claim a measurement that was
+    never taken.
     """
 
     time: Optional[float] = None
@@ -343,6 +342,10 @@ class RunTiming(BaseModel):
 
     @staticmethod
     def of(log: Optional['RunLog']) -> Optional['RunTiming']:
+        # Clocks are copied as-is: a `TestcaseLog` carries `None` when the run
+        # never happened, and that unmeasured-ness must survive the copy. The
+        # caller owes us a log from a run that actually took place -- a default
+        # `RunLog` would hand back a fabricated zero.
         if log is None:
             return None
         return RunTiming(time=log.time, wall_time=log.wall_time)

--- a/tests/rbx/box/benchmark_test.py
+++ b/tests/rbx/box/benchmark_test.py
@@ -503,9 +503,18 @@ def test_parse_level_accepts_the_implemented_levels():
 def test_parse_level_rejects_b2_and_points_at_the_tracking_issue():
     with pytest.raises(typer.BadParameter) as exc:
         benchmark.parse_level(2)
-    assert '801' in str(exc.value)
+    assert benchmark.BENCHMARK_LEVEL_2_ISSUE_URL in str(exc.value)
+    assert '-b2' in str(exc.value)
 
 
 def test_parse_level_rejects_nonsense():
     with pytest.raises(typer.BadParameter):
         benchmark.parse_level(7)
+
+
+def test_unimplemented_levels_are_not_in_the_enum():
+    # The rejection table and the enum must stay disjoint: `parse_level` looks
+    # the enum up first, so a level that lands while its row is still here is
+    # accepted with a stale row left behind. This is the test that fails then.
+    unimplemented = set(benchmark._UNIMPLEMENTED_LEVELS)  # noqa: SLF001
+    assert unimplemented & {level.value for level in benchmark.BenchmarkLevel} == set()

--- a/tests/rbx/box/benchmark_test.py
+++ b/tests/rbx/box/benchmark_test.py
@@ -1,0 +1,153 @@
+import pytest
+
+from rbx.box import benchmark
+from rbx.box.schema import ExpectedOutcome, Solution
+from rbx.grading.steps import Outcome, RunTiming
+from tests.rbx.box.conftest import make_evaluation
+
+
+def timed(outcome, *, time_ms, checker_ms=None, interactor_ms=None, index=0):
+    """`make_evaluation`, plus the judging timings this module reads."""
+    eval = make_evaluation(outcome, time_ms=time_ms, testcase_index=index)
+    if checker_ms is not None:
+        eval.result.checker_timing = RunTiming(time=checker_ms / 1000.0)
+    if interactor_ms is not None:
+        eval.result.interactor_timing = RunTiming(time=interactor_ms / 1000.0)
+    return eval
+
+
+def test_judging_time_sums_solution_checker_and_interactor():
+    eval = timed(Outcome.ACCEPTED, time_ms=100, checker_ms=20, interactor_ms=5)
+    assert benchmark.judging_time(eval) == pytest.approx(0.125)
+
+
+def test_judging_time_is_none_when_the_solution_was_never_timed():
+    # A skipped testcase must not report an instantaneous judging time.
+    assert benchmark.judging_time(timed(Outcome.SKIPPED, time_ms=None)) is None
+
+
+def test_judging_time_counts_an_unmeasured_checker_as_absent_not_zero():
+    eval = timed(Outcome.TIME_LIMIT_EXCEEDED, time_ms=1000)
+    assert benchmark.judging_time(eval) == pytest.approx(1.0)
+
+
+def test_judging_time_tolerates_a_timing_with_no_clock_on_it():
+    # `RunTiming` can exist with both clocks unset -- guard the inner `None`,
+    # not just the outer one.
+    eval = timed(Outcome.ACCEPTED, time_ms=100)
+    eval.result.checker_timing = RunTiming()
+    assert benchmark.judging_time(eval) == pytest.approx(0.1)
+
+
+def test_judging_time_handles_a_communication_problem_without_a_checker():
+    eval = timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=30)
+    assert eval.result.checker_timing is None
+    assert benchmark.judging_time(eval) == pytest.approx(0.13)
+
+
+def test_solution_benchmark_picks_the_slowest_testcase_to_judge(
+    mock_skeleton, tmp_path
+):
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 3})
+    evals = [
+        timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0),
+        # Slowest *judging*, though not the slowest solution run: the point of
+        # the whole feature is that these two can disagree.
+        timed(Outcome.ACCEPTED, time_ms=90, checker_ms=200, index=1),
+        timed(Outcome.ACCEPTED, time_ms=150, checker_ms=5, index=2),
+    ]
+
+    bench = benchmark.build_solution_benchmark(solution, skeleton, evals)
+
+    assert bench is not None
+    assert bench.slowest.entry == skeleton.entries[1].group_entry
+    assert bench.slowest.judging_time == pytest.approx(0.29)
+    assert bench.slowest.checker_time == pytest.approx(0.2)
+    assert bench.total_judging_time == pytest.approx(0.555)
+    assert bench.total_checker_time == pytest.approx(0.215)
+    assert bench.judged == 3
+    assert bench.total == 3
+    assert not bench.partial
+
+
+def test_solution_benchmark_is_partial_when_testcases_were_skipped(
+    mock_skeleton, tmp_path
+):
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 3})
+    evals = [
+        timed(Outcome.WRONG_ANSWER, time_ms=100, checker_ms=10, index=0),
+        timed(Outcome.SKIPPED, time_ms=None, index=1),
+        timed(Outcome.SKIPPED, time_ms=None, index=2),
+    ]
+
+    bench = benchmark.build_solution_benchmark(solution, skeleton, evals)
+
+    assert bench is not None
+    assert bench.judged == 1
+    assert bench.total == 3
+    assert bench.partial
+
+
+def test_solution_benchmark_counts_the_testset_not_the_evals_handed_in(
+    mock_skeleton, tmp_path
+):
+    # Mid-run, only the finished evaluations are known, but the run is still
+    # partial against the full testset.
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 3})
+
+    bench = benchmark.build_solution_benchmark(
+        solution, skeleton, [timed(Outcome.ACCEPTED, time_ms=100, index=0)]
+    )
+
+    assert bench is not None
+    assert bench.judged == 1
+    assert bench.total == 3
+    assert bench.partial
+
+
+def test_solution_benchmark_is_none_when_nothing_was_judged(mock_skeleton, tmp_path):
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 2})
+    evals = [timed(Outcome.SKIPPED, time_ms=None, index=i) for i in range(2)]
+
+    assert benchmark.build_solution_benchmark(solution, skeleton, evals) is None
+
+
+def test_problem_benchmark_ranks_solutions(mock_skeleton, tmp_path):
+    slow_judge = Solution(path=tmp_path / 'a.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    heavy_checker = Solution(path=tmp_path / 'b.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([slow_judge, heavy_checker], entries_per_group={'test': 2})
+    per_solution = [
+        benchmark.build_solution_benchmark(
+            slow_judge,
+            skeleton,
+            [
+                timed(Outcome.ACCEPTED, time_ms=500, checker_ms=1, index=i)
+                for i in range(2)
+            ],
+        ),
+        benchmark.build_solution_benchmark(
+            heavy_checker,
+            skeleton,
+            [
+                timed(Outcome.ACCEPTED, time_ms=10, checker_ms=300, index=i)
+                for i in range(2)
+            ],
+        ),
+    ]
+
+    problem = benchmark.build_problem_benchmark([b for b in per_solution if b])
+
+    assert problem is not None
+    assert problem.slowest_to_judge.solution.path == slow_judge.path
+    assert problem.most_checker_time.solution.path == heavy_checker.path
+    # 500 ms of solution plus 1 ms of checker beats the heavy checker's
+    # 10 ms + 300 ms.
+    assert problem.slowest_testcase.judging_time == pytest.approx(0.501)
+
+
+def test_problem_benchmark_is_none_without_any_solution_benchmarks():
+    assert benchmark.build_problem_benchmark([]) is None

--- a/tests/rbx/box/benchmark_test.py
+++ b/tests/rbx/box/benchmark_test.py
@@ -1,4 +1,5 @@
 import pytest
+import rich.console
 
 from rbx.box import benchmark
 from rbx.box.schema import ExpectedOutcome, Solution
@@ -231,3 +232,191 @@ def test_problem_benchmark_ranks_a_solution_with_no_checker_last(
 
 def test_problem_benchmark_is_none_without_any_solution_benchmarks():
     assert benchmark.build_problem_benchmark([]) is None
+
+
+def render(printer, *args):
+    """Render one of the report blocks into a throwaway recording console."""
+    console = rich.console.Console(record=True, width=120)
+    printer(console, *args)
+    return console.export_text()
+
+
+def solution_benchmark(mock_skeleton, tmp_path, evals, *, path='sol.cpp', total=None):
+    """Build a `SolutionBenchmark` out of the evaluations a run would produce."""
+    solution = Solution(path=tmp_path / path, outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton(
+        [solution], entries_per_group={'test': total or len(evals)}
+    )
+    bench = benchmark.build_solution_benchmark(solution, skeleton, evals)
+    assert bench is not None
+    return bench
+
+
+def test_solution_block_names_the_slowest_testcase_and_both_totals(
+    mock_skeleton, tmp_path
+):
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [
+            timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0),
+            timed(Outcome.ACCEPTED, time_ms=90, checker_ms=200, index=1),
+            timed(Outcome.ACCEPTED, time_ms=150, checker_ms=5, index=2),
+        ],
+    )
+
+    text = render(benchmark.print_solution_benchmark, bench)
+
+    assert 'test/1' in text
+    # 0.29 s of judging, split into 0.09 s of solution and 0.2 s of checker.
+    assert '0.3 s' in text
+    assert '0.1 s' in text
+    assert '0.2 s' in text
+    # Totals: 0.555 s of judging, 0.215 s of it in the checker.
+    assert '0.6 s' in text
+    assert 'checker' in text
+
+
+def test_solution_block_marks_a_partial_run_as_a_lower_bound(mock_skeleton, tmp_path):
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.WRONG_ANSWER, time_ms=100, checker_ms=10, index=0)],
+        total=3,
+    )
+
+    text = render(benchmark.print_solution_benchmark, bench)
+
+    assert '1/3' in text
+
+
+def test_solution_block_does_not_mark_a_complete_run(mock_skeleton, tmp_path):
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0)],
+    )
+
+    text = render(benchmark.print_solution_benchmark, bench)
+
+    assert 'judged' not in text
+
+
+def test_solution_block_omits_the_interactor_on_a_non_interactive_problem(
+    mock_skeleton, tmp_path
+):
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0)],
+    )
+
+    text = render(benchmark.print_solution_benchmark, bench)
+
+    assert 'interactor' not in text
+
+
+def test_solution_block_reports_the_interactor_when_there_is_one(
+    mock_skeleton, tmp_path
+):
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [
+            timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=300, index=0),
+            timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=300, index=1),
+        ],
+    )
+
+    text = render(benchmark.print_solution_benchmark, bench)
+
+    # Once in the slowest testcase's breakdown, once in the totals.
+    assert text.count('interactor') == 2
+    assert '0.4 s' in text
+    assert '0.8 s' in text
+
+
+def test_solution_block_renders_an_unmeasured_checker_total_as_a_dash(
+    mock_skeleton, tmp_path
+):
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=10, index=0)],
+    )
+
+    text = render(benchmark.print_solution_benchmark, bench)
+
+    assert 'checker: -' in text
+    assert 'checker: 0.0 s' not in text
+
+
+def test_solution_block_renders_a_genuine_zero_checker_total_as_a_measurement(
+    mock_skeleton, tmp_path
+):
+    # A checker that measurably took no time is a measurement, and must not be
+    # rendered like a checker that never ran.
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.ACCEPTED, time_ms=100, checker_ms=0, index=0)],
+    )
+
+    text = render(benchmark.print_solution_benchmark, bench)
+
+    assert 'checker: 0.0 s' in text
+    assert 'checker: -' not in text
+
+
+def problem_benchmark(mock_skeleton, tmp_path):
+    slow_judge = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.ACCEPTED, time_ms=500, checker_ms=1, index=i) for i in range(2)],
+        path='a.cpp',
+    )
+    heavy_checker = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [
+            timed(Outcome.ACCEPTED, time_ms=10, checker_ms=300, index=i)
+            for i in range(2)
+        ],
+        path='b.cpp',
+    )
+    problem = benchmark.build_problem_benchmark([slow_judge, heavy_checker])
+    assert problem is not None
+    return problem
+
+
+def test_problem_block_names_both_extremes(mock_skeleton, tmp_path):
+    text = render(
+        benchmark.print_problem_benchmark, problem_benchmark(mock_skeleton, tmp_path)
+    )
+
+    # The solution paths are absolute, so a narrow console wraps them mid-name.
+    unwrapped = text.replace('\n', '')
+    assert 'a.cpp' in unwrapped
+    assert 'b.cpp' in unwrapped
+    assert 'test/0' in text
+    assert '1.0 s' in text  # slowest to judge
+    assert '0.6 s' in text  # most checker time
+    assert '0.5 s' in text  # slowest testcase
+
+
+def test_problem_block_omits_the_checker_line_when_no_solution_had_a_checker(
+    mock_skeleton, tmp_path
+):
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.ACCEPTED, time_ms=100, index=0)],
+        path='a.cpp',
+    )
+    problem = benchmark.build_problem_benchmark([bench])
+    assert problem is not None
+    assert problem.most_checker_time.total_checker_time_seconds is None
+
+    text = render(benchmark.print_problem_benchmark, problem)
+
+    assert 'checker' not in text

--- a/tests/rbx/box/benchmark_test.py
+++ b/tests/rbx/box/benchmark_test.py
@@ -18,31 +18,34 @@ def timed(outcome, *, time_ms, checker_ms=None, interactor_ms=None, index=0):
 
 def test_judging_time_sums_solution_checker_and_interactor():
     eval = timed(Outcome.ACCEPTED, time_ms=100, checker_ms=20, interactor_ms=5)
-    assert benchmark.judging_time(eval) == pytest.approx(0.125)
+    assert benchmark.judging_time_seconds(eval) == pytest.approx(0.125)
 
 
 def test_judging_time_is_none_when_the_solution_was_never_timed():
     # A skipped testcase must not report an instantaneous judging time.
-    assert benchmark.judging_time(timed(Outcome.SKIPPED, time_ms=None)) is None
+    assert benchmark.judging_time_seconds(timed(Outcome.SKIPPED, time_ms=None)) is None
 
 
 def test_judging_time_counts_an_unmeasured_checker_as_absent_not_zero():
     eval = timed(Outcome.TIME_LIMIT_EXCEEDED, time_ms=1000)
-    assert benchmark.judging_time(eval) == pytest.approx(1.0)
+    assert benchmark.checker_time_seconds(eval) is None
+    assert benchmark.judging_time_seconds(eval) == pytest.approx(1.0)
 
 
-def test_judging_time_tolerates_a_timing_with_no_clock_on_it():
+def test_checker_time_is_none_when_the_timing_carries_no_clock():
     # `RunTiming` can exist with both clocks unset -- guard the inner `None`,
     # not just the outer one.
     eval = timed(Outcome.ACCEPTED, time_ms=100)
     eval.result.checker_timing = RunTiming()
-    assert benchmark.judging_time(eval) == pytest.approx(0.1)
+    assert benchmark.checker_time_seconds(eval) is None
+    assert benchmark.judging_time_seconds(eval) == pytest.approx(0.1)
 
 
 def test_judging_time_handles_a_communication_problem_without_a_checker():
     eval = timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=30)
-    assert eval.result.checker_timing is None
-    assert benchmark.judging_time(eval) == pytest.approx(0.13)
+    assert benchmark.checker_time_seconds(eval) is None
+    assert benchmark.interactor_time_seconds(eval) == pytest.approx(0.03)
+    assert benchmark.judging_time_seconds(eval) == pytest.approx(0.13)
 
 
 def test_solution_benchmark_picks_the_slowest_testcase_to_judge(
@@ -61,14 +64,67 @@ def test_solution_benchmark_picks_the_slowest_testcase_to_judge(
     bench = benchmark.build_solution_benchmark(solution, skeleton, evals)
 
     assert bench is not None
-    assert bench.slowest.entry == skeleton.entries[1].group_entry
-    assert bench.slowest.judging_time == pytest.approx(0.29)
-    assert bench.slowest.checker_time == pytest.approx(0.2)
-    assert bench.total_judging_time == pytest.approx(0.555)
-    assert bench.total_checker_time == pytest.approx(0.215)
+    assert bench.slowest_testcase.entry == skeleton.entries[1].group_entry
+    assert bench.slowest_testcase.judging_time_seconds == pytest.approx(0.29)
+    assert bench.slowest_testcase.solution_time_seconds == pytest.approx(0.09)
+    assert bench.slowest_testcase.checker_time_seconds == pytest.approx(0.2)
+    assert bench.total_judging_time_seconds == pytest.approx(0.555)
+    assert bench.total_checker_time_seconds == pytest.approx(0.215)
     assert bench.judged == 3
-    assert bench.total == 3
+    assert bench.total_testcases == 3
     assert not bench.partial
+
+
+def test_solution_benchmark_reports_no_checker_total_when_none_was_measured(
+    mock_skeleton, tmp_path
+):
+    # A communication problem may have no checker at all. Reporting a total of
+    # `0.0 s` would claim a measurement that was never taken.
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 2})
+    evals = [
+        timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=10, index=i)
+        for i in range(2)
+    ]
+
+    bench = benchmark.build_solution_benchmark(solution, skeleton, evals)
+
+    assert bench is not None
+    assert bench.total_checker_time_seconds is None
+    assert bench.total_interactor_time_seconds == pytest.approx(0.02)
+
+
+def test_solution_benchmark_keeps_a_genuine_zero_checker_total(mock_skeleton, tmp_path):
+    # A checker that measurably took no time is a measurement, and must not be
+    # confused with a checker that never ran.
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 2})
+    evals = [
+        timed(Outcome.ACCEPTED, time_ms=100, checker_ms=0, index=i) for i in range(2)
+    ]
+
+    bench = benchmark.build_solution_benchmark(solution, skeleton, evals)
+
+    assert bench is not None
+    assert bench.total_checker_time_seconds == pytest.approx(0.0)
+    assert bench.total_checker_time_seconds is not None
+    assert bench.total_interactor_time_seconds is None
+
+
+def test_solution_benchmark_totals_only_the_measured_testcases(mock_skeleton, tmp_path):
+    # A checker measured on some testcases and not others still has a total --
+    # the unmeasured ones simply contribute nothing.
+    solution = Solution(path=tmp_path / 'sol.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'test': 2})
+    evals = [
+        timed(Outcome.ACCEPTED, time_ms=100, checker_ms=40, index=0),
+        timed(Outcome.ACCEPTED, time_ms=100, index=1),
+    ]
+
+    bench = benchmark.build_solution_benchmark(solution, skeleton, evals)
+
+    assert bench is not None
+    assert bench.total_checker_time_seconds == pytest.approx(0.04)
 
 
 def test_solution_benchmark_is_partial_when_testcases_were_skipped(
@@ -86,7 +142,7 @@ def test_solution_benchmark_is_partial_when_testcases_were_skipped(
 
     assert bench is not None
     assert bench.judged == 1
-    assert bench.total == 3
+    assert bench.total_testcases == 3
     assert bench.partial
 
 
@@ -104,7 +160,7 @@ def test_solution_benchmark_counts_the_testset_not_the_evals_handed_in(
 
     assert bench is not None
     assert bench.judged == 1
-    assert bench.total == 3
+    assert bench.total_testcases == 3
     assert bench.partial
 
 
@@ -146,7 +202,31 @@ def test_problem_benchmark_ranks_solutions(mock_skeleton, tmp_path):
     assert problem.most_checker_time.solution.path == heavy_checker.path
     # 500 ms of solution plus 1 ms of checker beats the heavy checker's
     # 10 ms + 300 ms.
-    assert problem.slowest_testcase.judging_time == pytest.approx(0.501)
+    assert problem.slowest_testcase.judging_time_seconds == pytest.approx(0.501)
+
+
+def test_problem_benchmark_ranks_a_solution_with_no_checker_last(
+    mock_skeleton, tmp_path
+):
+    # An unmeasured checker must not win `most_checker_time` by being `None`.
+    with_checker = Solution(path=tmp_path / 'a.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    without = Solution(path=tmp_path / 'b.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([with_checker, without], entries_per_group={'test': 1})
+    benchmarks = [
+        benchmark.build_solution_benchmark(
+            without, skeleton, [timed(Outcome.ACCEPTED, time_ms=10, index=0)]
+        ),
+        benchmark.build_solution_benchmark(
+            with_checker,
+            skeleton,
+            [timed(Outcome.ACCEPTED, time_ms=10, checker_ms=50, index=0)],
+        ),
+    ]
+
+    problem = benchmark.build_problem_benchmark([b for b in benchmarks if b])
+
+    assert problem is not None
+    assert problem.most_checker_time.solution.path == with_checker.path
 
 
 def test_problem_benchmark_is_none_without_any_solution_benchmarks():

--- a/tests/rbx/box/benchmark_test.py
+++ b/tests/rbx/box/benchmark_test.py
@@ -1,7 +1,7 @@
 import pytest
 import rich.console
 
-from rbx.box import benchmark
+from rbx.box import benchmark, formatting
 from rbx.box.schema import ExpectedOutcome, Solution
 from rbx.grading.steps import Outcome, RunTiming
 from tests.rbx.box.conftest import make_evaluation
@@ -234,6 +234,25 @@ def test_problem_benchmark_is_none_without_any_solution_benchmarks():
     assert benchmark.build_problem_benchmark([]) is None
 
 
+def test_duration_under_a_second_is_rendered_in_milliseconds():
+    # A checker routinely costs tens of milliseconds; one decimal place of
+    # seconds would report every one of them as `0.0 s`.
+    assert formatting.get_formatted_duration_in_seconds(0.048) == '48 ms'
+
+
+def test_duration_under_a_second_rounds_to_the_nearest_millisecond():
+    # Truncating would read `49 ms`, which is a visible lie at this scale.
+    assert formatting.get_formatted_duration_in_seconds(0.0499) == '50 ms'
+
+
+def test_duration_of_at_least_a_second_is_rendered_in_seconds():
+    assert formatting.get_formatted_duration_in_seconds(1.02) == '1.0 s'
+
+
+def test_duration_of_exactly_one_second_is_rendered_in_seconds():
+    assert formatting.get_formatted_duration_in_seconds(1.0) == '1.0 s'
+
+
 def render(printer, *args):
     """Render one of the report blocks into a throwaway recording console."""
     console = rich.console.Console(record=True, width=120)
@@ -268,13 +287,13 @@ def test_solution_block_names_the_slowest_testcase_and_both_totals(
     text = render(benchmark.print_solution_benchmark, bench)
 
     assert 'test/1' in text
-    # 0.29 s of judging, split into 0.09 s of solution and 0.2 s of checker.
-    assert '0.3 s' in text
-    assert '0.1 s' in text
-    assert '0.2 s' in text
-    # Totals: 0.555 s of judging, 0.215 s of it in the checker.
-    assert '0.6 s' in text
-    assert 'checker' in text
+    # 290 ms of judging, split into 90 ms of solution and 200 ms of checker.
+    assert '290 ms' in text
+    assert '90 ms' in text
+    assert '200 ms' in text
+    # Totals: 555 ms of judging, 215 ms of it in the checker.
+    assert '555 ms' in text
+    assert 'checker: 215 ms' in text
 
 
 def test_solution_block_marks_a_partial_run_as_a_lower_bound(mock_skeleton, tmp_path):
@@ -332,8 +351,8 @@ def test_solution_block_reports_the_interactor_when_there_is_one(
 
     # Once in the slowest testcase's breakdown, once in the totals.
     assert text.count('interactor') == 2
-    assert '0.4 s' in text
-    assert '0.8 s' in text
+    assert '300 ms interactor' in text
+    assert 'interactor: 600 ms' in text
 
 
 def test_solution_block_renders_an_unmeasured_checker_total_as_a_dash(
@@ -348,7 +367,7 @@ def test_solution_block_renders_an_unmeasured_checker_total_as_a_dash(
     text = render(benchmark.print_solution_benchmark, bench)
 
     assert 'checker: -' in text
-    assert 'checker: 0.0 s' not in text
+    assert 'checker: 0 ms' not in text
 
 
 def test_solution_block_renders_a_genuine_zero_checker_total_as_a_measurement(
@@ -364,7 +383,7 @@ def test_solution_block_renders_a_genuine_zero_checker_total_as_a_measurement(
 
     text = render(benchmark.print_solution_benchmark, bench)
 
-    assert 'checker: 0.0 s' in text
+    assert 'checker: 0 ms' in text
     assert 'checker: -' not in text
 
 
@@ -399,9 +418,9 @@ def test_problem_block_names_both_extremes(mock_skeleton, tmp_path):
     assert 'a.cpp' in unwrapped
     assert 'b.cpp' in unwrapped
     assert 'test/0' in text
-    assert '1.0 s' in text  # slowest to judge
-    assert '0.6 s' in text  # most checker time
-    assert '0.5 s' in text  # slowest testcase
+    assert '1.0 s' in text  # slowest to judge, 1002 ms
+    assert '600 ms' in text  # most checker time
+    assert '501 ms' in text  # slowest testcase
 
 
 def test_problem_block_omits_the_checker_line_when_no_solution_had_a_checker(

--- a/tests/rbx/box/benchmark_test.py
+++ b/tests/rbx/box/benchmark_test.py
@@ -1,7 +1,6 @@
 import pytest
-import rich.console
 
-from rbx.box import benchmark, formatting
+from rbx.box import benchmark, formatting, sharing
 from rbx.box.schema import ExpectedOutcome, Solution
 from rbx.grading.steps import Outcome, RunTiming
 from tests.rbx.box.conftest import make_evaluation
@@ -253,11 +252,18 @@ def test_duration_of_exactly_one_second_is_rendered_in_seconds():
     assert formatting.get_formatted_duration_in_seconds(1.0) == '1.0 s'
 
 
-def render(printer, *args):
-    """Render one of the report blocks into a throwaway recording console."""
-    console = rich.console.Console(record=True, width=120)
-    printer(console, *args)
-    return console.export_text()
+def test_duration_that_rounds_up_to_a_second_is_rendered_in_seconds():
+    # Branching on the raw value would render `1000 ms` beside a sibling's
+    # `1.0 s`, which reads as two scales for the same duration.
+    assert formatting.get_formatted_duration_in_seconds(0.9999) == '1.0 s'
+
+
+def test_duration_below_a_millisecond_is_not_rendered_as_a_measured_zero():
+    assert formatting.get_formatted_duration_in_seconds(0.0004) == '<1 ms'
+
+
+def test_duration_of_zero_is_rendered_as_a_measured_zero():
+    assert formatting.get_formatted_duration_in_seconds(0.0) == '0 ms'
 
 
 def solution_benchmark(mock_skeleton, tmp_path, evals, *, path='sol.cpp', total=None):
@@ -284,16 +290,13 @@ def test_solution_block_names_the_slowest_testcase_and_both_totals(
         ],
     )
 
-    text = render(benchmark.print_solution_benchmark, bench)
+    breakdown, totals = benchmark.solution_benchmark_lines(bench)
 
-    assert 'test/1' in text
     # 290 ms of judging, split into 90 ms of solution and 200 ms of checker.
-    assert '290 ms' in text
-    assert '90 ms' in text
-    assert '200 ms' in text
+    assert 'test/1' in breakdown
+    assert '290 ms judging (90 ms solution + 200 ms checker)' in breakdown
     # Totals: 555 ms of judging, 215 ms of it in the checker.
-    assert '555 ms' in text
-    assert 'checker: 215 ms' in text
+    assert totals == 'Total judging: 555 ms (checker: 215 ms)'
 
 
 def test_solution_block_marks_a_partial_run_as_a_lower_bound(mock_skeleton, tmp_path):
@@ -304,9 +307,9 @@ def test_solution_block_marks_a_partial_run_as_a_lower_bound(mock_skeleton, tmp_
         total=3,
     )
 
-    text = render(benchmark.print_solution_benchmark, bench)
+    _, totals = benchmark.solution_benchmark_lines(bench)
 
-    assert '1/3' in text
+    assert totals.endswith('(over 1/3 tests judged)')
 
 
 def test_solution_block_does_not_mark_a_complete_run(mock_skeleton, tmp_path):
@@ -316,9 +319,9 @@ def test_solution_block_does_not_mark_a_complete_run(mock_skeleton, tmp_path):
         [timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0)],
     )
 
-    text = render(benchmark.print_solution_benchmark, bench)
+    _, totals = benchmark.solution_benchmark_lines(bench)
 
-    assert 'judged' not in text
+    assert 'judged' not in totals
 
 
 def test_solution_block_omits_the_interactor_on_a_non_interactive_problem(
@@ -330,9 +333,28 @@ def test_solution_block_omits_the_interactor_on_a_non_interactive_problem(
         [timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0)],
     )
 
-    text = render(benchmark.print_solution_benchmark, bench)
+    lines = benchmark.solution_benchmark_lines(bench)
 
-    assert 'interactor' not in text
+    assert not any('interactor' in line for line in lines)
+
+
+def test_solution_block_omits_the_checker_term_when_there_was_no_checker(
+    mock_skeleton, tmp_path
+):
+    # A communication problem may have no checker at all. Naming it in the sum
+    # would read `+ - checker`, which is broken prose rather than a finding --
+    # the totals line reports the missing measurement instead.
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=30, index=0)],
+    )
+
+    breakdown, totals = benchmark.solution_benchmark_lines(bench)
+
+    assert '130 ms judging (100 ms solution + 30 ms interactor)' in breakdown
+    assert 'checker' not in breakdown
+    assert 'checker: -' in totals
 
 
 def test_solution_block_reports_the_interactor_when_there_is_one(
@@ -342,17 +364,24 @@ def test_solution_block_reports_the_interactor_when_there_is_one(
         mock_skeleton,
         tmp_path,
         [
-            timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=300, index=0),
-            timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=300, index=1),
+            timed(
+                Outcome.ACCEPTED, time_ms=100, checker_ms=5, interactor_ms=300, index=0
+            ),
+            timed(
+                Outcome.ACCEPTED, time_ms=100, checker_ms=5, interactor_ms=300, index=1
+            ),
         ],
     )
 
-    text = render(benchmark.print_solution_benchmark, bench)
+    breakdown, totals = benchmark.solution_benchmark_lines(bench)
 
-    # Once in the slowest testcase's breakdown, once in the totals.
-    assert text.count('interactor') == 2
-    assert '300 ms interactor' in text
-    assert 'interactor: 600 ms' in text
+    # Every term of the headline is summed into it, so all of them are joined
+    # with `+` rather than the interactor reading as an aside.
+    assert (
+        '405 ms judging (100 ms solution + 5 ms checker + 300 ms interactor)'
+        in breakdown
+    )
+    assert totals == 'Total judging: 810 ms (checker: 10 ms, interactor: 600 ms)'
 
 
 def test_solution_block_renders_an_unmeasured_checker_total_as_a_dash(
@@ -364,10 +393,10 @@ def test_solution_block_renders_an_unmeasured_checker_total_as_a_dash(
         [timed(Outcome.ACCEPTED, time_ms=100, interactor_ms=10, index=0)],
     )
 
-    text = render(benchmark.print_solution_benchmark, bench)
+    _, totals = benchmark.solution_benchmark_lines(bench)
 
-    assert 'checker: -' in text
-    assert 'checker: 0 ms' not in text
+    assert 'checker: -' in totals
+    assert 'checker: 0 ms' not in totals
 
 
 def test_solution_block_renders_a_genuine_zero_checker_total_as_a_measurement(
@@ -381,10 +410,10 @@ def test_solution_block_renders_a_genuine_zero_checker_total_as_a_measurement(
         [timed(Outcome.ACCEPTED, time_ms=100, checker_ms=0, index=0)],
     )
 
-    text = render(benchmark.print_solution_benchmark, bench)
+    _, totals = benchmark.solution_benchmark_lines(bench)
 
-    assert 'checker: 0 ms' in text
-    assert 'checker: -' not in text
+    assert 'checker: 0 ms' in totals
+    assert 'checker: -' not in totals
 
 
 def problem_benchmark(mock_skeleton, tmp_path):
@@ -409,18 +438,16 @@ def problem_benchmark(mock_skeleton, tmp_path):
 
 
 def test_problem_block_names_both_extremes(mock_skeleton, tmp_path):
-    text = render(
-        benchmark.print_problem_benchmark, problem_benchmark(mock_skeleton, tmp_path)
+    lines = benchmark.problem_benchmark_lines(
+        problem_benchmark(mock_skeleton, tmp_path)
     )
 
-    # The solution paths are absolute, so a narrow console wraps them mid-name.
-    unwrapped = text.replace('\n', '')
-    assert 'a.cpp' in unwrapped
-    assert 'b.cpp' in unwrapped
-    assert 'test/0' in text
-    assert '1.0 s' in text  # slowest to judge, 1002 ms
-    assert '600 ms' in text  # most checker time
-    assert '501 ms' in text  # slowest testcase
+    slowest, most_checker, slowest_testcase = lines[1:]
+    assert slowest.startswith('Slowest solution to judge: 1.0 s,')
+    assert 'a.cpp' in slowest
+    assert most_checker.startswith('Most checker time: 600 ms,')
+    assert 'b.cpp' in most_checker
+    assert slowest_testcase == 'Slowest testcase to judge: 501 ms, [item]test/0[/item]'
 
 
 def test_problem_block_omits_the_checker_line_when_no_solution_had_a_checker(
@@ -436,6 +463,32 @@ def test_problem_block_omits_the_checker_line_when_no_solution_had_a_checker(
     assert problem is not None
     assert problem.most_checker_time.total_checker_time_seconds is None
 
-    text = render(benchmark.print_problem_benchmark, problem)
+    lines = benchmark.problem_benchmark_lines(problem)
 
-    assert 'checker' not in text
+    assert not any('checker' in line for line in lines)
+
+
+def test_the_blocks_styles_resolve_against_the_report_theme(mock_skeleton, tmp_path):
+    # Rich resolves an unknown style to nothing and prints no error, so a
+    # misspelled tag passes every assertion over plain text. Render through the
+    # themed console the `--share` path uses and read the styles back, so that
+    # a `[hilte]` or an unbalanced tag fails here.
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0)],
+        path='a.cpp',
+    )
+    problem = benchmark.build_problem_benchmark([bench])
+    assert problem is not None
+    console = sharing.recording_console(width=400)
+
+    benchmark.print_solution_benchmark(console, bench)
+    benchmark.print_problem_benchmark(console, problem)
+    styled = console.export_text(styles=True)
+
+    # `Style.render` reproduces exactly the escapes the export carries, so this
+    # pins the styled text to the *theme's* style rather than to whatever the
+    # console falls back to when a tag does not resolve.
+    assert console.get_style('item').render('test/0') in styled
+    assert console.get_style('status').render('Benchmark summary') in styled

--- a/tests/rbx/box/benchmark_test.py
+++ b/tests/rbx/box/benchmark_test.py
@@ -1,4 +1,5 @@
 import pytest
+import typer
 
 from rbx.box import benchmark, formatting, sharing
 from rbx.box.schema import ExpectedOutcome, Solution
@@ -492,3 +493,19 @@ def test_the_blocks_styles_resolve_against_the_report_theme(mock_skeleton, tmp_p
     # console falls back to when a tag does not resolve.
     assert console.get_style('item').render('test/0') in styled
     assert console.get_style('status').render('Benchmark summary') in styled
+
+
+def test_parse_level_accepts_the_implemented_levels():
+    assert benchmark.parse_level(0) == benchmark.BenchmarkLevel.NONE
+    assert benchmark.parse_level(1) == benchmark.BenchmarkLevel.SOLUTIONS
+
+
+def test_parse_level_rejects_b2_and_points_at_the_tracking_issue():
+    with pytest.raises(typer.BadParameter) as exc:
+        benchmark.parse_level(2)
+    assert '801' in str(exc.value)
+
+
+def test_parse_level_rejects_nonsense():
+    with pytest.raises(typer.BadParameter):
+        benchmark.parse_level(7)

--- a/tests/rbx/box/benchmark_test.py
+++ b/tests/rbx/box/benchmark_test.py
@@ -385,6 +385,60 @@ def test_solution_block_reports_the_interactor_when_there_is_one(
     assert totals == 'Total judging: 810 ms (checker: 10 ms, interactor: 600 ms)'
 
 
+# The three states an interactor can be in, and what the totals line says about
+# each. The gate is whether one *ran*, not whether it was clocked -- which is
+# how `rbx ui` gates its own `Interactor time:` line. Gating on the seconds
+# would collapse the last two states into the first, and a communication
+# problem whose report never names an interactor reads as a batch problem.
+
+
+def test_solution_block_says_nothing_about_an_interactor_when_there_is_none(
+    mock_skeleton, tmp_path
+):
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0)],
+    )
+
+    assert not any(
+        'interactor' in line for line in benchmark.solution_benchmark_lines(bench)
+    )
+
+
+def test_solution_block_reports_a_measured_interactor_total(mock_skeleton, tmp_path):
+    bench = solution_benchmark(
+        mock_skeleton,
+        tmp_path,
+        [
+            timed(
+                Outcome.ACCEPTED, time_ms=100, checker_ms=10, interactor_ms=30, index=0
+            )
+        ],
+    )
+
+    _, totals = benchmark.solution_benchmark_lines(bench)
+
+    assert 'interactor: 30 ms' in totals
+
+
+def test_solution_block_names_an_interactor_that_ran_unmeasured(
+    mock_skeleton, tmp_path
+):
+    # A `RunTiming` with no clock: the interactor ran, the sandbox reported no
+    # time. `interactor: -` is the true report; saying nothing is not.
+    eval = timed(Outcome.ACCEPTED, time_ms=100, checker_ms=10, index=0)
+    eval.result.interactor_timing = RunTiming()
+    bench = solution_benchmark(mock_skeleton, tmp_path, [eval])
+
+    breakdown, totals = benchmark.solution_benchmark_lines(bench)
+
+    assert 'interactor: -' in totals
+    # The breakdown is a sum, though, so an unmeasured term is left out of it --
+    # `+ - interactor` is broken prose, exactly as it is for the checker.
+    assert 'interactor' not in breakdown
+
+
 def test_solution_block_renders_an_unmeasured_checker_total_as_a_dash(
     mock_skeleton, tmp_path
 ):

--- a/tests/rbx/box/checkers_communication_test.py
+++ b/tests/rbx/box/checkers_communication_test.py
@@ -869,3 +869,91 @@ class TestCheckCommunicationInteractorComplexScenarios:
         )
 
         assert result.outcome == Outcome.IDLENESS_LIMIT_EXCEEDED
+
+
+# Benchmarking: how long the interactor itself took (`rbx run --benchmark`).
+class TestCheckCommunicationInteractorTiming:
+    async def test_check_communication_records_the_interactor_timing_on_a_wa(
+        self,
+        checker_digest: str,
+        testcase: Testcase,
+        program_output: pathlib.Path,
+        interactor_stderr: pathlib.Path,
+        run_log: RunLog,
+        interactor_run_log: RunLog,
+    ) -> None:
+        """The interactor decides the verdict here, and reports its own time."""
+        interactor_run_log.exitcode = 1
+        interactor_run_log.exitstatus = SandboxBase.EXIT_NONZERO_RETURN
+        interactor_run_log.time = 0.25
+        interactor_run_log.wall_time = 0.5
+
+        result = await checkers.check_communication(
+            checker_digest,
+            run_log,
+            interactor_run_log,
+            interactor_stderr,
+            testcase,
+            program_output,
+        )
+
+        assert result.outcome == Outcome.WRONG_ANSWER
+        assert result.interactor_timing is not None
+        assert result.interactor_timing.time == 0.25
+        assert result.interactor_timing.wall_time == 0.5
+
+    async def test_check_communication_records_both_timings_when_the_checker_decides(
+        self,
+        checker_digest: str,
+        testcase: Testcase,
+        program_output: pathlib.Path,
+        interactor_stderr: pathlib.Path,
+        run_log: RunLog,
+        interactor_run_log: RunLog,
+    ) -> None:
+        """The checker's own time is kept alongside the interactor's."""
+        assert testcase.outputPath is not None
+        testcase.outputPath.write_text('123\n')
+        program_output.write_text('123\n')
+        interactor_run_log.time = 0.25
+
+        result = await checkers.check_communication(
+            checker_digest,
+            run_log,
+            interactor_run_log,
+            interactor_stderr,
+            testcase,
+            program_output,
+        )
+
+        assert result.outcome == Outcome.ACCEPTED
+        assert result.interactor_timing is not None
+        assert result.interactor_timing.time == 0.25
+        assert result.checker_timing is not None
+        assert result.checker_timing.time is not None
+
+    async def test_check_communication_records_no_interactor_timing_on_sandbox_failure(
+        self,
+        checker_digest: str,
+        testcase: Testcase,
+        program_output: pathlib.Path,
+        interactor_stderr: pathlib.Path,
+        run_log: RunLog,
+        interactor_run_log: RunLog,
+    ) -> None:
+        """A failed sandbox has no honest measurement to report."""
+        interactor_run_log.exitstatus = SandboxBase.EXIT_SANDBOX_ERROR
+        interactor_run_log.time = 0.25
+
+        result = await checkers.check_communication(
+            checker_digest,
+            run_log,
+            interactor_run_log,
+            interactor_stderr,
+            testcase,
+            program_output,
+        )
+
+        assert result.outcome == Outcome.INTERNAL_ERROR
+        # Unmeasured, not zero -- the sandbox itself broke.
+        assert result.interactor_timing is None

--- a/tests/rbx/box/checkers_communication_test.py
+++ b/tests/rbx/box/checkers_communication_test.py
@@ -957,3 +957,31 @@ class TestCheckCommunicationInteractorTiming:
         assert result.outcome == Outcome.INTERNAL_ERROR
         # Unmeasured, not zero -- the sandbox itself broke.
         assert result.interactor_timing is None
+
+    async def test_check_communication_keeps_the_interactor_timing_when_the_solution_tles(
+        self,
+        checker_digest: str,
+        testcase: Testcase,
+        program_output: pathlib.Path,
+        interactor_stderr: pathlib.Path,
+        run_log: RunLog,
+        interactor_run_log: RunLog,
+    ) -> None:
+        """The verdict comes from the solution's log, the timing still doesn't."""
+        run_log.exitstatus = SandboxBase.EXIT_TIMEOUT
+        interactor_run_log.time = 0.25
+
+        result = await checkers.check_communication(
+            checker_digest,
+            run_log,
+            interactor_run_log,
+            interactor_stderr,
+            testcase,
+            program_output,
+        )
+
+        assert result.outcome == Outcome.TIME_LIMIT_EXCEEDED
+        # The interactor ran alongside the solution, so its time is real even
+        # though it had no say in the verdict.
+        assert result.interactor_timing is not None
+        assert result.interactor_timing.time == 0.25

--- a/tests/rbx/box/checkers_test.py
+++ b/tests/rbx/box/checkers_test.py
@@ -988,11 +988,13 @@ async def test_check_skips_checker_stderr_file_when_checker_said_nothing(
 
 
 # Benchmarking: how long the checker itself took (`rbx run --benchmark`).
+@pytest.mark.parametrize('skip_run_log', [False, True])
 async def test_check_records_the_checker_timing(
     checker_digest: str,
     testcase: Testcase,
     program_output: pathlib.Path,
     run_log: RunLog,
+    skip_run_log: bool,
 ) -> None:
     """A real checker run leaves its measured time on the result."""
     assert testcase.outputPath
@@ -1004,6 +1006,7 @@ async def test_check_records_the_checker_timing(
         run_log,
         testcase,
         program_output,
+        skip_run_log=skip_run_log,
     )
 
     assert result.outcome == Outcome.ACCEPTED
@@ -1012,7 +1015,26 @@ async def test_check_records_the_checker_timing(
     assert result.checker_timing.wall_time is not None
 
 
-async def test_check_records_no_timing_when_the_checker_never_ran(
+async def test_check_keeps_the_checker_timing_across_a_soft_tle(
+    checker_digest: str,
+    testcase: Testcase,
+    program_output: pathlib.Path,
+    run_log: RunLog,
+) -> None:
+    """The checker ran; the later TLE conversion must not discard its time."""
+    assert testcase.outputPath
+    testcase.outputPath.write_text('123\n')
+    program_output.write_text('123\n')
+    run_log.time = 1.5  # Over the TL but under 2*TL -- soft TLE.
+
+    result = await checkers.check(checker_digest, run_log, testcase, program_output)
+
+    assert result.outcome == Outcome.TIME_LIMIT_EXCEEDED
+    assert result.no_tle_outcome == Outcome.ACCEPTED
+    assert result.checker_timing is not None
+
+
+async def test_check_records_no_timing_when_the_solution_timed_out(
     checker_digest: str,
     testcase: Testcase,
     program_output: pathlib.Path,

--- a/tests/rbx/box/checkers_test.py
+++ b/tests/rbx/box/checkers_test.py
@@ -985,3 +985,52 @@ async def test_check_skips_checker_stderr_file_when_checker_said_nothing(
     # An empty file would read as "the checker was run and said nothing", which
     # is exactly what its absence already says -- without the clutter.
     assert not sink.exists()
+
+
+# Benchmarking: how long the checker itself took (`rbx run --benchmark`).
+async def test_check_records_the_checker_timing(
+    checker_digest: str,
+    testcase: Testcase,
+    program_output: pathlib.Path,
+    run_log: RunLog,
+) -> None:
+    """A real checker run leaves its measured time on the result."""
+    assert testcase.outputPath
+    testcase.outputPath.write_text('123\n')
+    program_output.write_text('123\n')
+
+    result = await checkers.check(
+        checker_digest,
+        run_log,
+        testcase,
+        program_output,
+    )
+
+    assert result.outcome == Outcome.ACCEPTED
+    assert result.checker_timing is not None
+    assert result.checker_timing.time is not None
+    assert result.checker_timing.wall_time is not None
+
+
+async def test_check_records_no_timing_when_the_checker_never_ran(
+    checker_digest: str,
+    testcase: Testcase,
+    program_output: pathlib.Path,
+    run_log: RunLog,
+) -> None:
+    """A solution that TLE'd short-circuits before the checker is invoked."""
+    assert testcase.outputPath
+    testcase.outputPath.write_text('123\n')
+    program_output.write_text('123\n')
+
+    run_log.exitstatus = SandboxBase.EXIT_TIMEOUT
+    result = await checkers.check(
+        checker_digest,
+        run_log,
+        testcase,
+        program_output,
+    )
+
+    assert result.outcome == Outcome.TIME_LIMIT_EXCEEDED
+    # Unmeasured, not zero -- the checker was never given the chance to run.
+    assert result.checker_timing is None

--- a/tests/rbx/box/completion/enum_consistency_test.py
+++ b/tests/rbx/box/completion/enum_consistency_test.py
@@ -30,3 +30,11 @@ def test_solution_prefixes_cover_registered_expanders():
 
     prefixes = {p for p, _ in completers._SOLUTION_PREFIXES}  # noqa: SLF001
     assert prefixes == {'@main', '@boca/', '@moj/'}
+
+
+def test_benchmark_table_matches_benchmark_level_enum():
+    from rbx.box.benchmark import BenchmarkLevel
+
+    table = dict(completers._BENCHMARK_TABLE)  # noqa: SLF001
+    expected = {str(level.value): level.name for level in BenchmarkLevel}
+    assert table == expected

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -2083,16 +2083,23 @@ async def test_benchmark_block_is_absent_by_default(
     assert benchmark_lines(default_console) == []
     # Drop the block from the benchmarked report and the two are identical, so
     # the flag cannot have changed anything else.
-    # The summary closes the report and opens with a blank line of its own, so
-    # cut the tail from that separator down; the per-solution blocks then come
-    # out line by line.
+    # The summary closes the report, and the blank line above it belongs to the
+    # section before it -- which the `-b0` report prints too -- so the cut is at
+    # the header itself. The per-solution blocks then come out line by line.
     lines = rendered_lines(benchmarked_console)
     summary = next(
-        index
-        for index, line in enumerate(lines)
-        if line.strip().startswith('Benchmark summary')
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.strip().startswith('Benchmark summary')
+        ),
+        None,
     )
-    lines = lines[: summary - 1]
+    # Two solutions here, so the problem-level block is expected: without a
+    # default this would surface as a `StopIteration` from a test about the
+    # per-solution block.
+    assert summary is not None
+    lines = lines[:summary]
     block = set(benchmark_lines(benchmarked_console))
     without_block = [line for line in lines if line.strip() not in block]
     assert without_block == rendered_lines(default_console)
@@ -2333,6 +2340,7 @@ async def run_detailed_report(
     console: rich.console.Console,
     runs_dir: pathlib.Path,
     benchmark_level: BenchmarkLevel = BenchmarkLevel.NONE,
+    timing: bool = True,
 ) -> bool:
     """Drive `print_run_report` down its `--detailed` path.
 
@@ -2352,6 +2360,7 @@ async def run_detailed_report(
             console,
             VerificationLevel.FULL,
             detailed=True,
+            timing=timing,
             benchmark_level=benchmark_level,
         )
 
@@ -2453,6 +2462,110 @@ async def test_problem_benchmark_prints_when_the_timing_summary_is_suppressed(
     # No timing summary above it here, so the separator has to come from the
     # last solution's own trailing blank line rather than be printed twice.
     assert_summary_stands_apart(console)
+
+
+# `rbx run` reaches four different tails under `-b1`: `--detailed` swaps the
+# whole report path, and `--fail-fast` drops the timing summary from either of
+# them (`cli.commands.run` passes `timing=not fail_fast`). Each section owns the
+# blank line that ends it, so all four have to come out spaced the same -- the
+# `-d --ff` one used to print two, because the detailed path closed every
+# solution *and* the loop.
+@pytest.mark.parametrize('detailed', [False, True], ids=['plain', 'detailed'])
+@pytest.mark.parametrize('fail_fast', [False, True], ids=['full', 'fail_fast'])
+@pytest.mark.parametrize(
+    'benchmark_level',
+    [BenchmarkLevel.NONE, BenchmarkLevel.SOLUTIONS],
+    ids=['b0', 'b1'],
+)
+async def test_every_report_path_is_spaced_the_same(
+    mock_problem_root,
+    mock_skeleton,
+    mock_binary_scoring,
+    detailed,
+    fail_fast,
+    benchmark_level,
+):
+    skeleton = mock_skeleton(
+        two_solutions_with_disagreeing_extremes(), entries_per_group={'group1': 2}
+    )
+    verdicts = (
+        {('group1', 0): Outcome.ACCEPTED, ('group1', 1): Outcome.SKIPPED}
+        if fail_fast
+        else _ALL_ACCEPTED
+    )
+    result = make_run_result_with_per_solution_times(
+        skeleton, verdicts, _DISAGREEING_TIMES_MS
+    )
+
+    console = recording_console()
+    with fresh_issue_stack():
+        if detailed:
+            await run_detailed_report(
+                result,
+                console,
+                mock_problem_root / 'runs',
+                benchmark_level=benchmark_level,
+                timing=not fail_fast,
+            )
+        else:
+            await print_run_report(
+                result,
+                console,
+                VerificationLevel.FULL,
+                timing=not fail_fast,
+                benchmark_level=benchmark_level,
+            )
+
+    lines = rendered_lines(console)
+    # No section is separated from the next by more than one blank line, on any
+    # of the paths.
+    assert not any(
+        first == '' and second == '' for first, second in zip(lines, lines[1:])
+    )
+    if benchmark_level == BenchmarkLevel.SOLUTIONS:
+        assert problem_benchmark_lines(console)
+        assert_summary_stands_apart(console)
+
+
+async def test_problem_benchmark_is_omitted_for_a_single_solution(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """`rbx run <one-solution> -b1` is the commonest way the flag is used, and
+    every line of the summary is an extreme *across* solutions. With one
+    solution each extreme names the only candidate and each number restates the
+    per-solution block printed right above, so the whole section is a second
+    copy of what the reader just read."""
+    solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED)
+    skeleton = mock_skeleton([solution], entries_per_group={'group1': 2})
+    result = make_run_result(
+        skeleton,
+        {('group1', 0): Outcome.ACCEPTED, ('group1', 1): Outcome.ACCEPTED},
+        checker_time_ms=20,
+    )
+
+    console = recording_console()
+    await print_run_report(
+        result,
+        console,
+        VerificationLevel.FULL,
+        benchmark_level=BenchmarkLevel.SOLUTIONS,
+    )
+
+    # The per-solution block is still there -- it is where the totals are read
+    # off, and it is what makes the summary redundant here.
+    assert benchmark_lines(console) == expected_benchmark_lines(
+        uniform_solution_bench(
+            solution,
+            solution_time_ms=100,
+            checker_time_ms=20,
+            judged=2,
+            total_testcases=2,
+        )
+    )
+    # Asserted through `problem_benchmark_lines` rather than `benchmark_lines`:
+    # the latter filters on the per-solution labels, which the summary's own
+    # header does not carry, so it would come back empty either way.
+    assert problem_benchmark_lines(console) == []
 
 
 @pytest.mark.test_pkg('problems/abort-groups')
@@ -3376,6 +3489,27 @@ async def test_interactive_run_closes_with_the_problem_benchmark(
         'Most checker time: 48 ms, sol1.cpp',
         'Slowest testcase to judge: 148 ms, group1/0',
     ]
+    assert_summary_stands_apart(console)
+
+
+async def test_interactive_run_omits_the_summary_for_a_single_solution(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """`rbx irun -b1` on one solution is as common as `rbx run -b1` on one, and
+    the summary is as redundant: every extreme names the only solution, over the
+    only testcase, whose times the `Checker time:` line above already gave."""
+    solutions = interactive_solutions(count=1)
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 1})
+    console = recording_console()
+
+    with stubbed_interactive_run(skeleton, [interactive_eval()], console):
+        await solutions_module.run_and_print_interactive_solutions(
+            verification=VerificationLevel.ALL_SOLUTIONS,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert judging_time_lines(console) == ['Checker time: 20 ms']
+    assert problem_benchmark_lines(console) == []
 
 
 async def test_interactive_run_benchmark_is_absent_by_default(
@@ -3411,15 +3545,20 @@ async def test_interactive_run_benchmark_is_absent_by_default(
     assert problem_benchmark_lines(default_console) == []
 
     # Drop what `-b1` added and the two reports are identical, so the flag
-    # cannot have changed anything else. The summary closes the report behind a
-    # blank line of its own, so cut from that separator down.
+    # cannot have changed anything else. The blank line above the summary is the
+    # last solution's own, which the `-b0` report prints too, so cut at the
+    # header itself.
     lines = rendered_lines(benchmarked_console)
     summary = next(
-        index
-        for index, line in enumerate(lines)
-        if line.strip().startswith('Benchmark summary')
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.strip().startswith('Benchmark summary')
+        ),
+        None,
     )
-    lines = lines[: summary - 1]
+    assert summary is not None
+    lines = lines[:summary]
     added = set(judging_time_lines(benchmarked_console))
     assert [line for line in lines if line.strip() not in added] == rendered_lines(
         default_console

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -3424,3 +3424,26 @@ async def test_interactive_run_benchmark_is_absent_by_default(
     assert [line for line in lines if line.strip() not in added] == rendered_lines(
         default_console
     )
+
+
+async def test_interactive_run_reports_an_unmeasured_interactor_as_unmeasured(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """The interactor half is gated on the interactor having run at all, not on
+    its clock -- an interactor whose time the sandbox did not report is still an
+    interactor, and hiding the half would read as a batch problem."""
+    solutions = interactive_solutions(count=1)
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 1})
+    eval = interactive_eval()
+    eval.result.interactor_timing = RunTiming(time=None)
+    console = recording_console()
+
+    with stubbed_interactive_run(
+        skeleton, [eval], console, task_type=schema.TaskType.COMMUNICATION
+    ):
+        await solutions_module.run_and_print_interactive_solutions(
+            verification=VerificationLevel.ALL_SOLUTIONS,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert judging_time_lines(console) == ['Checker time: 20 ms / Interactor time: -']

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -13,6 +13,7 @@ from rich.text import Text
 from rbx import utils
 from rbx.box import package
 from rbx.box import solutions as solutions_module
+from rbx.box.benchmark import BenchmarkLevel
 from rbx.box.deferred import Deferred
 from rbx.box.environment import VerificationLevel
 from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
@@ -64,6 +65,7 @@ from rbx.grading.steps import (
     CompilationError,
     Evaluation,
     Outcome,
+    RunTiming,
 )
 
 # The synthetic skeleton/evaluation builders live in conftest so that other run
@@ -282,8 +284,14 @@ def make_reporter_skeleton(
 def make_run_result(
     skeleton: SolutionReportSkeleton,
     verdicts: Dict[Tuple[str, int], Outcome],
+    checker_time_ms: Optional[int] = None,
 ) -> RunSolutionResult:
-    """Present fixed verdicts as an already-computed run."""
+    """Present fixed verdicts as an already-computed run.
+
+    ``checker_time_ms`` gives every judged testcase a checker measurement. Left
+    ``None``, the checkers are unmeasured -- which is what an `.eval` written
+    before checker timings existed looks like, so both shapes are worth driving.
+    """
 
     def resolved(evaluation: Evaluation) -> Deferred[Evaluation]:
         async def fn() -> Evaluation:
@@ -295,12 +303,15 @@ def make_run_result(
         # A skipped testcase never entered the sandbox, so it carries no time
         # and no memory -- exactly what the runner records for one.
         unmeasured = outcome == Outcome.SKIPPED
-        return make_evaluation(
+        evaluation = make_evaluation(
             outcome,
             time_ms=None if unmeasured else 100,
             memory_bytes=None if unmeasured else 1024,
             testcase_index=index,
         )
+        if checker_time_ms is not None and not unmeasured:
+            evaluation.result.checker_timing = RunTiming(time=checker_time_ms / 1000.0)
+        return evaluation
 
     return RunSolutionResult(
         skeleton=skeleton,
@@ -1937,6 +1948,121 @@ async def test_plain_report_drops_the_timing_summary_when_timing_is_off(
     console = recording_console()
     await print_run_report(result, console, VerificationLevel.FULL, timing=False)
     assert 'Timing summary' not in console.export_text(clear=False)
+
+
+# `--benchmark` / `-b1`. The block is printed once per solution, from
+# `finish_solution` -- the one place both reporters converge -- so the tests
+# below drive whole reports rather than either reporter's renderer.
+
+
+def benchmark_lines(console: rich.console.Console) -> List[str]:
+    """The per-solution benchmark block's lines, in the order they were printed."""
+    return [
+        line.strip()
+        for line in rendered_lines(console)
+        if line.strip().startswith('Benchmark:')
+        or line.strip().startswith('Total judging:')
+    ]
+
+
+async def test_benchmark_block_reports_judging_time_per_solution(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """`-b1` adds one block per solution, naming its slowest testcase and what
+    judging the whole solution cost."""
+    solutions = [
+        Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED),
+        Solution(path=pathlib.Path('other.cpp'), outcome=ExpectedOutcome.ACCEPTED),
+    ]
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 2})
+    result = make_run_result(
+        skeleton,
+        {('group1', 0): Outcome.ACCEPTED, ('group1', 1): Outcome.ACCEPTED},
+        checker_time_ms=20,
+    )
+
+    console = recording_console()
+    await print_run_report(
+        result,
+        console,
+        VerificationLevel.FULL,
+        benchmark_level=BenchmarkLevel.SOLUTIONS,
+    )
+
+    # Two solutions, two blocks of two lines each. Every testcase took 100 ms of
+    # solution time plus 20 ms of checker time, so the slowest is 120 ms and the
+    # two of them total 240 ms, of which 40 ms is checker.
+    assert (
+        benchmark_lines(console)
+        == [
+            'Benchmark: slowest test group1/0 - 120 ms judging (100 ms solution + 20 ms checker)',
+            'Total judging: 240 ms (checker: 40 ms)',
+        ]
+        * 2
+    )
+
+
+async def test_benchmark_block_is_absent_by_default(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """Without `-b1` nothing is benchmarked, and the report is otherwise the
+    very same report -- the block is added, never a line moved."""
+    solutions = [
+        Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED),
+        Solution(path=pathlib.Path('other.cpp'), outcome=ExpectedOutcome.ACCEPTED),
+    ]
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 2})
+    verdicts = {('group1', 0): Outcome.ACCEPTED, ('group1', 1): Outcome.ACCEPTED}
+
+    default_console = recording_console()
+    await print_run_report(
+        make_run_result(skeleton, verdicts, checker_time_ms=20),
+        default_console,
+        VerificationLevel.FULL,
+    )
+    benchmarked_console = recording_console()
+    await print_run_report(
+        make_run_result(skeleton, verdicts, checker_time_ms=20),
+        benchmarked_console,
+        VerificationLevel.FULL,
+        benchmark_level=BenchmarkLevel.SOLUTIONS,
+    )
+
+    assert benchmark_lines(default_console) == []
+    # Drop the block from the benchmarked report and the two are identical, so
+    # the flag cannot have changed anything else.
+    block = set(benchmark_lines(benchmarked_console))
+    without_block = [
+        line
+        for line in rendered_lines(benchmarked_console)
+        if line.strip() not in block
+    ]
+    assert without_block == rendered_lines(default_console)
+
+
+async def test_benchmark_block_is_skipped_when_nothing_was_judged(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """A `--fail-fast` run can skip every testcase of a solution, and a skipped
+    testcase carries no time at all. There is nothing to benchmark then, and
+    reporting `0 ms` would claim a measurement nobody took."""
+    solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.INCORRECT)
+    skeleton = mock_skeleton([solution], entries_per_group={'group1': 2})
+    result = make_run_result(
+        skeleton,
+        {('group1', 0): Outcome.SKIPPED, ('group1', 1): Outcome.SKIPPED},
+    )
+
+    console = recording_console()
+    with fresh_issue_stack():
+        await print_run_report(
+            result,
+            console,
+            VerificationLevel.FULL,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert benchmark_lines(console) == []
 
 
 @pytest.mark.test_pkg('problems/abort-groups')

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -3162,3 +3162,265 @@ async def test_a_slow_testcase_repaints_the_header_while_it_waits(
     # drawn by frames nothing in this reporter asked for.
     assert 'testrun 4821' in during
     assert 'running' in during
+
+
+# `rbx irun -b1`. The interactive path is a different one: it streams a block
+# per solution as each finishes, over a single testcase. So it reports the
+# *testcase's* judging times inline and closes with the same problem-level
+# summary -- but no per-solution "slowest test" block, which over one testcase
+# would only restate the line above it.
+
+
+@contextlib.contextmanager
+def stubbed_interactive_run(
+    skeleton: SolutionReportSkeleton,
+    evals: List[Evaluation],
+    console: rich.console.Console,
+    task_type: schema.TaskType = schema.TaskType.BATCH,
+) -> Iterator[None]:
+    """Drive `run_and_print_interactive_solutions` over canned evaluations.
+
+    Only the run's *inputs* are stubbed -- generating the testcase, compiling
+    the solutions and running them -- because each of the three shells out to a
+    compiler or a sandbox. Everything the benchmark wiring lives in (the
+    streaming loop, the per-solution printing and the closing summary) is the
+    real thing.
+    """
+    pkg = schema.Package(name='problem', timeLimit=1000, memoryLimit=256)
+    pkg.type = task_type
+    entry = skeleton.entries[0]
+
+    async def fake_generate(*args, **kwargs) -> GenerationTestcaseEntry:
+        return entry
+
+    async def fake_skeleton(*args, **kwargs) -> SolutionReportSkeleton:
+        return skeleton
+
+    def fake_run(*args, **kwargs):
+        async def gen():
+            for solution, eval in zip(skeleton.solutions, evals):
+
+                async def resolved(eval=eval) -> Evaluation:
+                    return eval
+
+                yield EvaluationItem(
+                    solution=solution,
+                    testcase_entry=entry.group_entry,
+                    eval=Deferred(resolved),
+                )
+
+        return gen()
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'rbx.box.solutions.package.find_problem_package_or_die',
+                return_value=pkg,
+            )
+        )
+        stack.enter_context(
+            patch(
+                'rbx.box.solutions.package.get_problem_iruns_dir',
+                return_value=skeleton.solutions[0].runs_dir / 'iruns',
+            )
+        )
+        stack.enter_context(
+            patch('rbx.box.solutions._generate_testcase_interactively', fake_generate)
+        )
+        stack.enter_context(
+            patch('rbx.box.solutions._get_interactive_skeleton', fake_skeleton)
+        )
+        stack.enter_context(
+            patch('rbx.box.solutions._run_interactive_solutions', fake_run)
+        )
+        stack.enter_context(patch('rbx.box.solutions.console.console', console))
+        yield
+
+
+def interactive_solutions(count: int = 2) -> List[Solution]:
+    return [
+        Solution(path=pathlib.Path(f'sol{i}.cpp'), outcome=ExpectedOutcome.ACCEPTED)
+        for i in range(count)
+    ]
+
+
+def interactive_eval(
+    checker_time_ms: Optional[int] = 20,
+    interactor_time_ms: Optional[int] = None,
+) -> Evaluation:
+    eval = make_evaluation(Outcome.ACCEPTED, time_ms=100, memory_bytes=1024)
+    if checker_time_ms is not None:
+        eval.result.checker_timing = RunTiming(time=checker_time_ms / 1000.0)
+    if interactor_time_ms is not None:
+        eval.result.interactor_timing = RunTiming(time=interactor_time_ms / 1000.0)
+    return eval
+
+
+def judging_time_lines(console: rich.console.Console) -> List[str]:
+    """The per-testcase judging lines, in the order they were printed."""
+    return [
+        line.strip()
+        for line in rendered_lines(console)
+        if line.strip().startswith('Checker time:')
+    ]
+
+
+async def test_interactive_run_reports_judging_time_per_testcase(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """`irun -b1` times the one testcase it ran, once per solution."""
+    solutions = interactive_solutions()
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 1})
+    console = recording_console()
+
+    with stubbed_interactive_run(
+        skeleton, [interactive_eval(), interactive_eval(checker_time_ms=48)], console
+    ):
+        await solutions_module.run_and_print_interactive_solutions(
+            verification=VerificationLevel.ALL_SOLUTIONS,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert judging_time_lines(console) == [
+        'Checker time: 20 ms',
+        'Checker time: 48 ms',
+    ]
+
+
+async def test_interactive_run_reports_the_interactor_when_there_is_one(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """A communication problem spends time in the interactor too, and the pair
+    is spelled as `rbx ui` spells it -- one line, checker first."""
+    solutions = interactive_solutions(count=1)
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 1})
+    console = recording_console()
+
+    with stubbed_interactive_run(
+        skeleton,
+        [interactive_eval(interactor_time_ms=1200)],
+        console,
+        task_type=schema.TaskType.COMMUNICATION,
+    ):
+        await solutions_module.run_and_print_interactive_solutions(
+            verification=VerificationLevel.ALL_SOLUTIONS,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert judging_time_lines(console) == [
+        'Checker time: 20 ms / Interactor time: 1.2 s'
+    ]
+
+
+async def test_interactive_run_reports_an_unmeasured_checker_as_unmeasured(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """No checker ran, or the sandbox reported no clock. `0 ms` would claim a
+    measurement nobody took."""
+    solutions = interactive_solutions(count=1)
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 1})
+    console = recording_console()
+
+    with stubbed_interactive_run(
+        skeleton, [interactive_eval(checker_time_ms=None)], console
+    ):
+        await solutions_module.run_and_print_interactive_solutions(
+            verification=VerificationLevel.ALL_SOLUTIONS,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert judging_time_lines(console) == ['Checker time: -']
+
+
+async def test_interactive_run_prints_no_slowest_test_block(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """`rbx run` names each solution's slowest testcase; `irun` runs exactly one,
+    so that block would only restate the line above it. Deliberately absent --
+    do not "fix" this into printing what `rbx run` prints."""
+    solutions = interactive_solutions()
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 1})
+    console = recording_console()
+
+    with stubbed_interactive_run(
+        skeleton, [interactive_eval(), interactive_eval()], console
+    ):
+        await solutions_module.run_and_print_interactive_solutions(
+            verification=VerificationLevel.ALL_SOLUTIONS,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert benchmark_lines(console) == []
+
+
+async def test_interactive_run_closes_with_the_problem_benchmark(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """The summary still ranks solutions against each other, which one testcase
+    each is enough for."""
+    solutions = interactive_solutions()
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 1})
+    console = recording_console()
+
+    with stubbed_interactive_run(
+        skeleton, [interactive_eval(), interactive_eval(checker_time_ms=48)], console
+    ):
+        await solutions_module.run_and_print_interactive_solutions(
+            verification=VerificationLevel.ALL_SOLUTIONS,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert problem_benchmark_lines(console) == [
+        'Benchmark summary',
+        'Slowest solution to judge: 148 ms, sol1.cpp',
+        'Most checker time: 48 ms, sol1.cpp',
+        'Slowest testcase to judge: 148 ms, group1/0',
+    ]
+
+
+async def test_interactive_run_benchmark_is_absent_by_default(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """Without `-b1` nothing is timed, and the report is otherwise the very same
+    report -- lines are added, never moved."""
+    solutions = interactive_solutions()
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 1})
+
+    default_console = recording_console()
+    with stubbed_interactive_run(
+        skeleton,
+        [interactive_eval(), interactive_eval(checker_time_ms=48)],
+        default_console,
+    ):
+        await solutions_module.run_and_print_interactive_solutions(
+            verification=VerificationLevel.ALL_SOLUTIONS,
+        )
+
+    benchmarked_console = recording_console()
+    with stubbed_interactive_run(
+        skeleton,
+        [interactive_eval(), interactive_eval(checker_time_ms=48)],
+        benchmarked_console,
+    ):
+        await solutions_module.run_and_print_interactive_solutions(
+            verification=VerificationLevel.ALL_SOLUTIONS,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert judging_time_lines(default_console) == []
+    assert problem_benchmark_lines(default_console) == []
+
+    # Drop what `-b1` added and the two reports are identical, so the flag
+    # cannot have changed anything else. The summary closes the report behind a
+    # blank line of its own, so cut from that separator down.
+    lines = rendered_lines(benchmarked_console)
+    summary = next(
+        index
+        for index, line in enumerate(lines)
+        if line.strip().startswith('Benchmark summary')
+    )
+    lines = lines[: summary - 1]
+    added = set(judging_time_lines(benchmarked_console))
+    assert [line for line in lines if line.strip() not in added] == rendered_lines(
+        default_console
+    )

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -2032,12 +2032,19 @@ async def test_benchmark_block_is_absent_by_default(
     # Drop the block from the benchmarked report and the two are identical, so
     # the flag cannot have changed anything else.
     block = set(benchmark_lines(benchmarked_console))
-    without_block = [
-        line
-        for line in rendered_lines(benchmarked_console)
-        if line.strip() not in block
-    ]
+    lines = rendered_lines(benchmarked_console)
+    without_block = [line for line in lines if line.strip() not in block]
     assert without_block == rendered_lines(default_console)
+    # And the block hugs the solution it measures. Removing it above says
+    # nothing about where it sat, so pin the placement: the solution's verdict
+    # runs straight into the block, and the blank line that separates one
+    # solution from the next falls below it rather than above.
+    for index, line in enumerate(lines):
+        if not line.strip().startswith('Benchmark:'):
+            continue
+        assert lines[index - 1].strip() != ''
+        assert lines[index + 1].strip().startswith('Total judging:')
+        assert lines[index + 2] == ''
 
 
 async def test_benchmark_block_is_skipped_when_nothing_was_judged(
@@ -2063,6 +2070,40 @@ async def test_benchmark_block_is_skipped_when_nothing_was_judged(
         )
 
     assert benchmark_lines(console) == []
+
+
+async def test_benchmark_block_marks_a_partial_run_as_a_lower_bound(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """The shape `--fail-fast` actually produces: the solution is judged on its
+    first testcase and the rest are skipped. The block still prints, and says
+    how many tests it covers -- without that, a total measured over one third of
+    the testset reads as the cost of judging the whole thing."""
+    solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.INCORRECT)
+    skeleton = mock_skeleton([solution], entries_per_group={'group1': 3})
+    result = make_run_result(
+        skeleton,
+        {
+            ('group1', 0): Outcome.WRONG_ANSWER,
+            ('group1', 1): Outcome.SKIPPED,
+            ('group1', 2): Outcome.SKIPPED,
+        },
+        checker_time_ms=20,
+    )
+
+    console = recording_console()
+    with fresh_issue_stack():
+        await print_run_report(
+            result,
+            console,
+            VerificationLevel.FULL,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert benchmark_lines(console) == [
+        'Benchmark: slowest test group1/0 - 120 ms judging (100 ms solution + 20 ms checker)',
+        'Total judging: 120 ms (checker: 20 ms) (over 1/3 tests judged)',
+    ]
 
 
 @pytest.mark.test_pkg('problems/abort-groups')

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -11,6 +11,7 @@ import rich.style
 from rich.text import Text
 
 from rbx import utils
+from rbx.box import benchmark as benchmark_module
 from rbx.box import package, schema
 from rbx.box import solutions as solutions_module
 from rbx.box.benchmark import BenchmarkLevel
@@ -1965,6 +1966,53 @@ def benchmark_lines(console: rich.console.Console) -> List[str]:
     ]
 
 
+def uniform_solution_bench(
+    solution: Solution,
+    solution_time_ms: int,
+    checker_time_ms: int,
+    judged: int,
+    total_testcases: int,
+) -> benchmark_module.SolutionBenchmark:
+    """The benchmark of a solution whose testcases all cost the same.
+
+    The wiring tests below drive uniform times, so what the report should print
+    can be built from the run's own inputs instead of transcribed. The wording of
+    the block is `benchmark.solution_benchmark_lines`' contract and
+    `benchmark_test.py` is what pins it -- transcribing it here would break two
+    files on one wording tweak.
+    """
+    solution_seconds = solution_time_ms / 1000
+    checker_seconds = checker_time_ms / 1000
+    per_test_seconds = solution_seconds + checker_seconds
+    return benchmark_module.SolutionBenchmark(
+        solution=solution,
+        slowest_testcase=benchmark_module.TestcaseJudging(
+            entry=TestcaseEntry(group='group1', index=0),
+            judging_time_seconds=per_test_seconds,
+            solution_time_seconds=solution_seconds,
+            checker_time_seconds=checker_seconds,
+            interactor_time_seconds=None,
+        ),
+        total_judging_time_seconds=sum([per_test_seconds] * judged),
+        total_checker_time_seconds=sum([checker_seconds] * judged),
+        total_interactor_time_seconds=None,
+        judged=judged,
+        total_testcases=total_testcases,
+    )
+
+
+def expected_benchmark_lines(
+    *benches: benchmark_module.SolutionBenchmark,
+) -> List[str]:
+    """The per-solution blocks these benchmarks print, through the same console
+    the report uses -- so a comparison against `benchmark_lines` asserts on the
+    wiring rather than on the wording."""
+    console = recording_console()
+    for bench in benches:
+        benchmark_module.print_solution_benchmark(console, bench)
+    return [line.strip() for line in rendered_lines(console) if line.strip()]
+
+
 async def test_benchmark_block_reports_judging_time_per_solution(
     mock_problem_root, mock_skeleton, mock_binary_scoring
 ):
@@ -1989,16 +2037,20 @@ async def test_benchmark_block_reports_judging_time_per_solution(
         benchmark_level=BenchmarkLevel.SOLUTIONS,
     )
 
-    # Two solutions, two blocks of two lines each. Every testcase took 100 ms of
-    # solution time plus 20 ms of checker time, so the slowest is 120 ms and the
-    # two of them total 240 ms, of which 40 ms is checker.
-    assert (
-        benchmark_lines(console)
-        == [
-            'Benchmark: slowest test group1/0 - 120 ms judging (100 ms solution + 20 ms checker)',
-            'Total judging: 240 ms (checker: 40 ms)',
-        ]
-        * 2
+    # Two solutions, one block each, and each block is the one the solution's
+    # own measurements render to: every testcase took 100 ms of solution time
+    # plus 20 ms of checker time.
+    assert benchmark_lines(console) == expected_benchmark_lines(
+        *(
+            uniform_solution_bench(
+                solution,
+                solution_time_ms=100,
+                checker_time_ms=20,
+                judged=2,
+                total_testcases=2,
+            )
+            for solution in solutions
+        )
     )
 
 
@@ -2064,21 +2116,28 @@ async def test_benchmark_block_is_skipped_when_nothing_was_judged(
     reporting `0 ms` would claim a measurement nobody took."""
     solution = Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.INCORRECT)
     skeleton = mock_skeleton([solution], entries_per_group={'group1': 2})
-    result = make_run_result(
-        skeleton,
-        {('group1', 0): Outcome.SKIPPED, ('group1', 1): Outcome.SKIPPED},
-    )
+    verdicts = {('group1', 0): Outcome.SKIPPED, ('group1', 1): Outcome.SKIPPED}
 
     console = recording_console()
     with fresh_issue_stack():
         await print_run_report(
-            result,
+            make_run_result(skeleton, verdicts),
             console,
             VerificationLevel.FULL,
             benchmark_level=BenchmarkLevel.SOLUTIONS,
         )
+    default_console = recording_console()
+    with fresh_issue_stack():
+        await print_run_report(
+            make_run_result(skeleton, verdicts),
+            default_console,
+            VerificationLevel.FULL,
+        )
 
-    assert benchmark_lines(console) == []
+    # Compared against the whole `-b0` report rather than filtered by the block's
+    # labels: a filter keyed on the wording would come back empty, and the test
+    # would pass for the wrong reason, the day that wording changes.
+    assert rendered_lines(console) == rendered_lines(default_console)
 
 
 async def test_benchmark_block_marks_a_partial_run_as_a_lower_bound(
@@ -2303,9 +2362,8 @@ async def test_detailed_report_prints_both_benchmark_blocks(
     """`--detailed` builds its reports without the reporter, so it prints the
     per-solution blocks itself and has to collect them itself for the summary.
     It would otherwise print every block and silently drop the summary."""
-    skeleton = mock_skeleton(
-        two_solutions_with_disagreeing_extremes(), entries_per_group={'group1': 2}
-    )
+    solutions = two_solutions_with_disagreeing_extremes()
+    skeleton = mock_skeleton(solutions, entries_per_group={'group1': 2})
     result = make_run_result_with_per_solution_times(
         skeleton, _ALL_ACCEPTED, _DISAGREEING_TIMES_MS
     )
@@ -2320,12 +2378,18 @@ async def test_detailed_report_prints_both_benchmark_blocks(
 
     # One per-solution block per solution, in the order the solutions are
     # reported, and then the one summary.
-    assert benchmark_lines(console) == [
-        'Benchmark: slowest test group1/0 - 501 ms judging (500 ms solution + 1 ms checker)',
-        'Total judging: 1.0 s (checker: 2 ms)',
-        'Benchmark: slowest test group1/0 - 210 ms judging (10 ms solution + 200 ms checker)',
-        'Total judging: 420 ms (checker: 400 ms)',
-    ]
+    assert benchmark_lines(console) == expected_benchmark_lines(
+        *(
+            uniform_solution_bench(
+                solution,
+                solution_time_ms=_DISAGREEING_TIMES_MS[str(solution.path)][0],
+                checker_time_ms=_DISAGREEING_TIMES_MS[str(solution.path)][1],
+                judged=2,
+                total_testcases=2,
+            )
+            for solution in solutions
+        )
+    )
     assert problem_benchmark_lines(console) == [
         'Benchmark summary',
         'Slowest solution to judge: 1.0 s, sol.cpp',

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -11,7 +11,7 @@ import rich.style
 from rich.text import Text
 
 from rbx import utils
-from rbx.box import package
+from rbx.box import package, schema
 from rbx.box import solutions as solutions_module
 from rbx.box.benchmark import BenchmarkLevel
 from rbx.box.deferred import Deferred
@@ -2031,8 +2031,17 @@ async def test_benchmark_block_is_absent_by_default(
     assert benchmark_lines(default_console) == []
     # Drop the block from the benchmarked report and the two are identical, so
     # the flag cannot have changed anything else.
-    block = set(benchmark_lines(benchmarked_console))
+    # The summary closes the report and opens with a blank line of its own, so
+    # cut the tail from that separator down; the per-solution blocks then come
+    # out line by line.
     lines = rendered_lines(benchmarked_console)
+    summary = next(
+        index
+        for index, line in enumerate(lines)
+        if line.strip().startswith('Benchmark summary')
+    )
+    lines = lines[: summary - 1]
+    block = set(benchmark_lines(benchmarked_console))
     without_block = [line for line in lines if line.strip() not in block]
     assert without_block == rendered_lines(default_console)
     # And the block hugs the solution it measures. Removing it above says
@@ -2104,6 +2113,282 @@ async def test_benchmark_block_marks_a_partial_run_as_a_lower_bound(
         'Benchmark: slowest test group1/0 - 120 ms judging (100 ms solution + 20 ms checker)',
         'Total judging: 120 ms (checker: 20 ms) (over 1/3 tests judged)',
     ]
+
+
+# The problem-level block, printed once at the end of the report. It ranks the
+# per-solution benchmarks, so every test below needs at least two solutions that
+# actually differ -- one solution can only ever be every extreme at once.
+
+PROBLEM_BENCHMARK_PREFIXES = (
+    'Benchmark summary',
+    'Slowest solution to judge:',
+    'Most checker time:',
+    'Slowest testcase to judge:',
+)
+
+
+def problem_benchmark_lines(console: rich.console.Console) -> List[str]:
+    """The problem-level benchmark block's lines, in the order they were printed."""
+    return [
+        line.strip()
+        for line in rendered_lines(console)
+        if line.strip().startswith(PROBLEM_BENCHMARK_PREFIXES)
+    ]
+
+
+def make_run_result_with_per_solution_times(
+    skeleton: SolutionReportSkeleton,
+    verdicts: Dict[Tuple[str, int], Outcome],
+    times_ms_per_solution: Dict[str, Tuple[int, int]],
+) -> RunSolutionResult:
+    """Like `make_run_result`, but times each solution differently.
+
+    ``times_ms_per_solution`` maps a solution's path to its ``(solution,
+    checker)`` milliseconds per judged testcase. `make_run_result` times every
+    solution identically, which makes every extreme the same solution -- and a
+    ranking that cannot disagree with itself proves nothing about the ranking.
+    """
+
+    def resolved(evaluation: Evaluation) -> Deferred[Evaluation]:
+        async def fn() -> Evaluation:
+            return evaluation
+
+        return Deferred(fn)
+
+    def make(solution_path: str, outcome: Outcome, index: int) -> Evaluation:
+        unmeasured = outcome == Outcome.SKIPPED
+        solution_time_ms, checker_time_ms = times_ms_per_solution[solution_path]
+        evaluation = make_evaluation(
+            outcome,
+            time_ms=None if unmeasured else solution_time_ms,
+            memory_bytes=None if unmeasured else 1024,
+            testcase_index=index,
+        )
+        if not unmeasured:
+            evaluation.result.checker_timing = RunTiming(time=checker_time_ms / 1000.0)
+        return evaluation
+
+    return RunSolutionResult(
+        skeleton=skeleton,
+        items=[
+            EvaluationItem(
+                solution=solution,
+                testcase_entry=entry.group_entry,
+                eval=resolved(
+                    make(
+                        str(solution.path),
+                        verdicts[entry.group_entry.key()],
+                        entry.group_entry.index,
+                    )
+                ),
+            )
+            for solution in skeleton.solutions
+            for entry in skeleton.entries
+        ],
+    )
+
+
+def two_solutions_with_disagreeing_extremes() -> List[Solution]:
+    """`sol.cpp` is the slowest to judge, `other.cpp` spends the most on the
+    checker -- see `_DISAGREEING_TIMES_MS`."""
+    return [
+        Solution(path=pathlib.Path('sol.cpp'), outcome=ExpectedOutcome.ACCEPTED),
+        Solution(path=pathlib.Path('other.cpp'), outcome=ExpectedOutcome.ACCEPTED),
+    ]
+
+
+# A slow solution with a cheap checker against a fast one with an expensive
+# checker. Over two testcases `sol.cpp` totals 1002 ms of judging to
+# `other.cpp`'s 420 ms, while `other.cpp` spends 400 ms in the checker to
+# `sol.cpp`'s 2 ms -- so the two rankings name different solutions.
+_DISAGREEING_TIMES_MS = {'sol.cpp': (500, 1), 'other.cpp': (10, 200)}
+
+_ALL_ACCEPTED = {('group1', 0): Outcome.ACCEPTED, ('group1', 1): Outcome.ACCEPTED}
+
+
+async def test_problem_benchmark_names_the_extremes_across_solutions(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """`-b1` closes the report with the problem-wide extremes, each naming the
+    solution it belongs to -- which is not necessarily the same solution."""
+    skeleton = mock_skeleton(
+        two_solutions_with_disagreeing_extremes(), entries_per_group={'group1': 2}
+    )
+    result = make_run_result_with_per_solution_times(
+        skeleton, _ALL_ACCEPTED, _DISAGREEING_TIMES_MS
+    )
+
+    console = recording_console()
+    await print_run_report(
+        result,
+        console,
+        VerificationLevel.FULL,
+        benchmark_level=BenchmarkLevel.SOLUTIONS,
+    )
+
+    assert problem_benchmark_lines(console) == [
+        'Benchmark summary',
+        'Slowest solution to judge: 1.0 s, sol.cpp',
+        'Most checker time: 400 ms, other.cpp',
+        'Slowest testcase to judge: 501 ms, group1/0',
+    ]
+    assert_summary_stands_apart(console)
+
+
+def assert_summary_stands_apart(console: rich.console.Console) -> None:
+    """The summary opens its own block.
+
+    Whatever precedes it -- the timing summary, or the last solution's report --
+    it has to be one blank line above, or the two read as a single block.
+    """
+    lines = rendered_lines(console)
+    header = next(
+        index
+        for index, line in enumerate(lines)
+        if line.strip().startswith('Benchmark summary')
+    )
+    assert lines[header - 1] == ''
+    assert lines[header - 2] != ''
+
+
+async def test_problem_benchmark_is_absent_by_default(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """Without `-b1` there is no summary either -- the per-solution blocks and
+    this one are the same flag."""
+    skeleton = mock_skeleton(
+        two_solutions_with_disagreeing_extremes(), entries_per_group={'group1': 2}
+    )
+    result = make_run_result_with_per_solution_times(
+        skeleton, _ALL_ACCEPTED, _DISAGREEING_TIMES_MS
+    )
+
+    console = recording_console()
+    await print_run_report(result, console, VerificationLevel.FULL)
+
+    assert problem_benchmark_lines(console) == []
+
+
+async def run_detailed_report(
+    result: RunSolutionResult,
+    console: rich.console.Console,
+    runs_dir: pathlib.Path,
+    benchmark_level: BenchmarkLevel = BenchmarkLevel.NONE,
+) -> bool:
+    """Drive `print_run_report` down its `--detailed` path.
+
+    That path draws its tables off the package on disk and publishes its report
+    into the runs dir, neither of which a synthetic run has -- so both lookups
+    are stubbed here rather than in every test that walks the path.
+    """
+    with (
+        patch(
+            'rbx.box.solutions.package.get_testgroup',
+            side_effect=lambda name: schema.TestcaseGroup(name=name),
+        ),
+        patch('rbx.box.solutions.package.get_problem_runs_dir', return_value=runs_dir),
+    ):
+        return await print_run_report(
+            result,
+            console,
+            VerificationLevel.FULL,
+            detailed=True,
+            benchmark_level=benchmark_level,
+        )
+
+
+async def test_detailed_report_prints_both_benchmark_blocks(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """`--detailed` builds its reports without the reporter, so it prints the
+    per-solution blocks itself and has to collect them itself for the summary.
+    It would otherwise print every block and silently drop the summary."""
+    skeleton = mock_skeleton(
+        two_solutions_with_disagreeing_extremes(), entries_per_group={'group1': 2}
+    )
+    result = make_run_result_with_per_solution_times(
+        skeleton, _ALL_ACCEPTED, _DISAGREEING_TIMES_MS
+    )
+
+    console = recording_console()
+    await run_detailed_report(
+        result,
+        console,
+        mock_problem_root / 'runs',
+        benchmark_level=BenchmarkLevel.SOLUTIONS,
+    )
+
+    # One per-solution block per solution, in the order the solutions are
+    # reported, and then the one summary.
+    assert benchmark_lines(console) == [
+        'Benchmark: slowest test group1/0 - 501 ms judging (500 ms solution + 1 ms checker)',
+        'Total judging: 1.0 s (checker: 2 ms)',
+        'Benchmark: slowest test group1/0 - 210 ms judging (10 ms solution + 200 ms checker)',
+        'Total judging: 420 ms (checker: 400 ms)',
+    ]
+    assert problem_benchmark_lines(console) == [
+        'Benchmark summary',
+        'Slowest solution to judge: 1.0 s, sol.cpp',
+        'Most checker time: 400 ms, other.cpp',
+        'Slowest testcase to judge: 501 ms, group1/0',
+    ]
+
+
+async def test_detailed_report_has_no_benchmark_blocks_by_default(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """`--detailed` on its own benchmarks nothing, per-solution or summary."""
+    skeleton = mock_skeleton(
+        two_solutions_with_disagreeing_extremes(), entries_per_group={'group1': 2}
+    )
+    result = make_run_result_with_per_solution_times(
+        skeleton, _ALL_ACCEPTED, _DISAGREEING_TIMES_MS
+    )
+
+    console = recording_console()
+    await run_detailed_report(result, console, mock_problem_root / 'runs')
+
+    assert benchmark_lines(console) == []
+    assert problem_benchmark_lines(console) == []
+
+
+async def test_problem_benchmark_prints_when_the_timing_summary_is_suppressed(
+    mock_problem_root, mock_skeleton, mock_binary_scoring
+):
+    """A `--fail-fast` run drops the timing summary, because time limit
+    inference reads it and a run that stopped early only measures a lower bound.
+    The benchmark summary feeds no inference and says so itself, so it stays."""
+    skeleton = mock_skeleton(
+        two_solutions_with_disagreeing_extremes(), entries_per_group={'group1': 2}
+    )
+    result = make_run_result_with_per_solution_times(
+        skeleton,
+        {('group1', 0): Outcome.ACCEPTED, ('group1', 1): Outcome.SKIPPED},
+        _DISAGREEING_TIMES_MS,
+    )
+
+    console = recording_console()
+    with fresh_issue_stack():
+        await print_run_report(
+            result,
+            console,
+            VerificationLevel.FULL,
+            timing=False,
+            benchmark_level=BenchmarkLevel.SOLUTIONS,
+        )
+
+    assert 'Timing summary' not in console.export_text(clear=False)
+    # Half the testset went unjudged, so every total is a lower bound and the
+    # header says so.
+    assert problem_benchmark_lines(console) == [
+        'Benchmark summary (partial -- some tests were not judged)',
+        'Slowest solution to judge: 501 ms, sol.cpp',
+        'Most checker time: 200 ms, other.cpp',
+        'Slowest testcase to judge: 501 ms, group1/0',
+    ]
+    # No timing summary above it here, so the separator has to come from the
+    # last solution's own trailing blank line rather than be printed twice.
+    assert_summary_stands_apart(console)
 
 
 @pytest.mark.test_pkg('problems/abort-groups')

--- a/tests/rbx/box/ui/test_run_ui.py
+++ b/tests/rbx/box/ui/test_run_ui.py
@@ -493,26 +493,26 @@ def _metadata_markup_for(tmp_path, **kwargs) -> str:
 
 def test_metadata_shows_the_measured_checker_time(tmp_path):
     markup = _metadata_markup_for(tmp_path, checker_timing=RunTiming(time=0.048))
-    assert '[b]Checker:[/b] 48 ms' in markup
+    assert '[b]Checker time:[/b] 48 ms' in markup
 
 
 def test_metadata_shows_no_checker_time_when_the_checker_never_ran(tmp_path):
     """A checker that never ran has no measurement -- never `0 ms`."""
     markup = _metadata_markup_for(tmp_path, checker_timing=None)
-    assert '[b]Checker:[/b] -' in markup
+    assert '[b]Checker time:[/b] -' in markup
     assert '0 ms' not in markup
 
 
 def test_metadata_shows_no_checker_time_when_the_clock_is_unset(tmp_path):
     """A `RunTiming` can exist while its clocks are `None` -- still unmeasured."""
     markup = _metadata_markup_for(tmp_path, checker_timing=RunTiming(wall_time=0.048))
-    assert '[b]Checker:[/b] -' in markup
+    assert '[b]Checker time:[/b] -' in markup
     assert '0 ms' not in markup
 
 
 def test_metadata_has_no_interactor_line_for_a_batch_problem(tmp_path):
     markup = _metadata_markup_for(tmp_path, checker_timing=RunTiming(time=0.048))
-    assert 'Interactor:' not in markup
+    assert 'Interactor time:' not in markup
 
 
 def test_metadata_shows_the_interactor_time_when_there_is_one(tmp_path):
@@ -520,5 +520,5 @@ def test_metadata_shows_the_interactor_time_when_there_is_one(tmp_path):
     markup = _metadata_markup_for(
         tmp_path, checker_timing=None, interactor_timing=RunTiming(time=1.2)
     )
-    assert '[b]Interactor:[/b] 1200 ms' in markup
-    assert '[b]Checker:[/b] -' in markup
+    assert '[b]Interactor time:[/b] 1200 ms' in markup
+    assert '[b]Checker time:[/b] -' in markup

--- a/tests/rbx/box/ui/test_run_ui.py
+++ b/tests/rbx/box/ui/test_run_ui.py
@@ -7,6 +7,7 @@ through subgroups.
 """
 
 import pathlib
+from typing import Optional
 from unittest import mock
 
 from rbx import utils
@@ -37,6 +38,7 @@ from rbx.grading.steps import (
     CheckerResult,
     Evaluation,
     Outcome,
+    RunTiming,
     TestcaseIO,
     TestcaseLog,
 )
@@ -453,3 +455,70 @@ def test_run_testcase_metadata_does_not_time_a_skipped_testcase(tmp_path):
     assert 'SKIPPED' in markup
     assert '0 ms' not in markup
     assert '0 B' not in markup
+
+
+def _write_timed_eval(
+    prefix: pathlib.Path,
+    checker_timing: Optional[RunTiming],
+    interactor_timing: Optional[RunTiming] = None,
+) -> None:
+    """An `.eval` carrying whatever judging timings a run captured."""
+    prefix.parent.mkdir(parents=True, exist_ok=True)
+    eval = Evaluation(
+        result=CheckerResult(
+            outcome=Outcome.ACCEPTED,
+            checker_timing=checker_timing,
+            interactor_timing=interactor_timing,
+        ),
+        # An odd solution time, so `0 ms` cannot appear on the Time line and
+        # mask a checker line wrongly claiming a zero measurement.
+        log=TestcaseLog(time=0.123, wall_time=0.123, memory=1024),
+        testcase=TestcaseIO(index=0),
+    )
+    prefix.with_suffix('.eval').write_text(utils.model_to_yaml(eval))
+
+
+def _metadata_markup_for(tmp_path, **kwargs) -> str:
+    skeleton = _make_skeleton(
+        tmp_path / 'runs', tmp_path / 'tests', stems=['1-gen-000']
+    )
+    sol = skeleton.solutions[0]
+    _write_timed_eval(sol.runs_dir / 'main' / '1-gen-000', **kwargs)
+    markup = get_run_testcase_metadata_markup(
+        skeleton, sol, skeleton.entries[0].group_entry
+    )
+    assert markup is not None
+    return markup
+
+
+def test_metadata_shows_the_measured_checker_time(tmp_path):
+    markup = _metadata_markup_for(tmp_path, checker_timing=RunTiming(time=0.048))
+    assert '[b]Checker:[/b] 48 ms' in markup
+
+
+def test_metadata_shows_no_checker_time_when_the_checker_never_ran(tmp_path):
+    """A checker that never ran has no measurement -- never `0 ms`."""
+    markup = _metadata_markup_for(tmp_path, checker_timing=None)
+    assert '[b]Checker:[/b] -' in markup
+    assert '0 ms' not in markup
+
+
+def test_metadata_shows_no_checker_time_when_the_clock_is_unset(tmp_path):
+    """A `RunTiming` can exist while its clocks are `None` -- still unmeasured."""
+    markup = _metadata_markup_for(tmp_path, checker_timing=RunTiming(wall_time=0.048))
+    assert '[b]Checker:[/b] -' in markup
+    assert '0 ms' not in markup
+
+
+def test_metadata_has_no_interactor_line_for_a_batch_problem(tmp_path):
+    markup = _metadata_markup_for(tmp_path, checker_timing=RunTiming(time=0.048))
+    assert 'Interactor:' not in markup
+
+
+def test_metadata_shows_the_interactor_time_when_there_is_one(tmp_path):
+    """A communication problem with no checker still times its interactor."""
+    markup = _metadata_markup_for(
+        tmp_path, checker_timing=None, interactor_timing=RunTiming(time=1.2)
+    )
+    assert '[b]Interactor:[/b] 1200 ms' in markup
+    assert '[b]Checker:[/b] -' in markup

--- a/tests/rbx/box/ui/test_run_ui.py
+++ b/tests/rbx/box/ui/test_run_ui.py
@@ -478,12 +478,20 @@ def _write_timed_eval(
     prefix.with_suffix('.eval').write_text(utils.model_to_yaml(eval))
 
 
-def _metadata_markup_for(tmp_path, **kwargs) -> str:
+def _metadata_markup_for(
+    tmp_path,
+    checker_timing: Optional[RunTiming],
+    interactor_timing: Optional[RunTiming] = None,
+) -> str:
     skeleton = _make_skeleton(
         tmp_path / 'runs', tmp_path / 'tests', stems=['1-gen-000']
     )
     sol = skeleton.solutions[0]
-    _write_timed_eval(sol.runs_dir / 'main' / '1-gen-000', **kwargs)
+    _write_timed_eval(
+        sol.runs_dir / 'main' / '1-gen-000',
+        checker_timing=checker_timing,
+        interactor_timing=interactor_timing,
+    )
     markup = get_run_testcase_metadata_markup(
         skeleton, sol, skeleton.entries[0].group_entry
     )
@@ -496,14 +504,14 @@ def test_metadata_shows_the_measured_checker_time(tmp_path):
     assert '[b]Checker time:[/b] 48 ms' in markup
 
 
-def test_metadata_shows_no_checker_time_when_the_checker_never_ran(tmp_path):
+def test_metadata_shows_a_dash_when_the_checker_never_ran(tmp_path):
     """A checker that never ran has no measurement -- never `0 ms`."""
     markup = _metadata_markup_for(tmp_path, checker_timing=None)
     assert '[b]Checker time:[/b] -' in markup
     assert '0 ms' not in markup
 
 
-def test_metadata_shows_no_checker_time_when_the_clock_is_unset(tmp_path):
+def test_metadata_shows_a_dash_when_the_checker_clock_is_unset(tmp_path):
     """A `RunTiming` can exist while its clocks are `None` -- still unmeasured."""
     markup = _metadata_markup_for(tmp_path, checker_timing=RunTiming(wall_time=0.048))
     assert '[b]Checker time:[/b] -' in markup
@@ -520,5 +528,15 @@ def test_metadata_shows_the_interactor_time_when_there_is_one(tmp_path):
     markup = _metadata_markup_for(
         tmp_path, checker_timing=None, interactor_timing=RunTiming(time=1.2)
     )
-    assert '[b]Interactor time:[/b] 1200 ms' in markup
-    assert '[b]Checker time:[/b] -' in markup
+    assert '[b]Checker time:[/b] - / [b]Interactor time:[/b] 1200 ms' in markup
+
+
+def test_metadata_shows_a_dash_when_the_interactor_clock_is_unset(tmp_path):
+    """The half is gated on the timing object, but reads from the clock in it."""
+    markup = _metadata_markup_for(
+        tmp_path,
+        checker_timing=RunTiming(time=0.048),
+        interactor_timing=RunTiming(wall_time=1.2),
+    )
+    assert '[b]Checker time:[/b] 48 ms / [b]Interactor time:[/b] -' in markup
+    assert '0 ms' not in markup

--- a/tests/rbx/grading/steps_timing_test.py
+++ b/tests/rbx/grading/steps_timing_test.py
@@ -1,0 +1,35 @@
+import pathlib
+
+from rbx import utils
+from rbx.grading.steps import CheckerResult, Outcome, RunLog, RunTiming
+
+
+def test_of_returns_none_for_a_missing_run_log():
+    assert RunTiming.of(None) is None
+
+
+def test_of_carries_both_clocks_off_the_run_log():
+    timing = RunTiming.of(RunLog(time=0.048, wall_time=0.051))
+    assert timing == RunTiming(time=0.048, wall_time=0.051)
+
+
+def test_a_result_without_timing_adds_no_keys_to_the_dumped_yaml():
+    # The `.eval` artifact is written with `model_to_yaml`, which drops None.
+    # A run whose checker never executed must write exactly the bytes it always
+    # did, so this file format stays backward compatible.
+    dumped = utils.model_to_yaml(CheckerResult(outcome=Outcome.ACCEPTED))
+    assert 'checker_timing' not in dumped
+    assert 'interactor_timing' not in dumped
+
+
+def test_timing_round_trips_through_yaml(tmp_path: pathlib.Path):
+    result = CheckerResult(
+        outcome=Outcome.ACCEPTED,
+        checker_timing=RunTiming(time=0.048, wall_time=0.051),
+    )
+    path = tmp_path / 'result.yml'
+    path.write_text(utils.model_to_yaml(result))
+
+    reloaded = utils.model_from_yaml(CheckerResult, path.read_text())
+    assert reloaded.checker_timing == RunTiming(time=0.048, wall_time=0.051)
+    assert reloaded.interactor_timing is None

--- a/tests/rbx/grading/steps_timing_test.py
+++ b/tests/rbx/grading/steps_timing_test.py
@@ -33,3 +33,9 @@ def test_timing_round_trips_through_yaml(tmp_path: pathlib.Path):
     reloaded = utils.model_from_yaml(CheckerResult, path.read_text())
     assert reloaded.checker_timing == RunTiming(time=0.048, wall_time=0.051)
     assert reloaded.interactor_timing is None
+
+
+def test_a_result_without_timing_has_no_timing_at_all():
+    result = CheckerResult(outcome=Outcome.ACCEPTED)
+    assert result.checker_timing is None
+    assert result.interactor_timing is None


### PR DESCRIPTION
Adds `--benchmark` / `-b` to `rbx run` and `rbx irun`. `-b1` reports how long the **checker** — and, on interactive problems, the **interactor** — spent judging each solution.

The checker's `RunLog` was already produced on every check in `rbx/box/checkers.py:_check` and then discarded. This PR keeps it.

On the `ab-problem` fixture the checker costs **7.7 ms** against the solution's **7.0 ms** — more than half the judging time, and previously invisible.

## What it looks like

```
Time: 11 ms
Memory: 10 MiB
Benchmark: slowest test samples/0 - 21 ms judging (11 ms solution + 10 ms checker)
Total judging: 81 ms (checker: 42 ms)

Timing summary:
...

Benchmark summary
Slowest solution to judge: 82 ms, sols/main.cpp
Most checker time: 45 ms, sols/main.cpp
Slowest testcase to judge: 21 ms, samples/0
```

`rbx ui` gains a `Checker time:` / `Interactor time:` line per testcase.

## Design

Rationale in [`docs/plans/2026-08-28-run-benchmark-design.md`](docs/plans/2026-08-28-run-benchmark-design.md); task-by-task plan in [`docs/plans/2026-08-28-run-benchmark.md`](docs/plans/2026-08-28-run-benchmark.md).

- **Timings ride on `CheckerResult`**, already persisted into each testcase's `.eval`, so `rbx/box/tasks.py` needed no change at all.
- **Capture is unconditional; `-b` gates only reporting.** `model_to_yaml` uses `exclude_none`, so an ordinary run writes exactly the bytes it always did — verified against a real `.eval`. The payoff is that `rbx ui` shows checker time for *any* run.
- **A cached checker reports the time it took when it ran.** rbx never re-runs a checker to benchmark it; the stored measurement is the uncached cost.
- **`None` means unmeasured, never zero**, end to end. `0.0` is a real measurement and prints as one; an unmeasured value prints `-`. A checker that never ran (solution TLE'd) and one that ran instantly are different facts.
- **Durations render adaptively** — ms below a second, seconds above. The pre-existing `get_formatted_time_in_seconds` is `.1f`, which would have rendered every realistic checker time as `0.0 s`.
- **`--fail-fast` prints the blocks, marked `(over N/M tests judged)`.** Unlike the timing summary, which `--ff` suppresses because time-limit inference reads it, the benchmark feeds no inference — a marked lower bound beats nothing.
- **`-b2`** is rejected with an actionable message pointing at #801, rather than silently behaving as `-b1`. The rejection is derived from a table, so implementing level 2 makes it work with no code change and two tests go red if it is left stale.

## Coverage

`-b1` works under `--detailed`, `--share`, `--fail-fast` and every combination; an 8-case parametrized matrix asserts consistent spacing across `detailed × fail_fast × benchmark_level`. The problem-level summary is omitted for a single solution, where it merely restated the block above it.

## Not in scope

- `-b2` (test generation and validation) — tracked in #801.
- Benchmark fields in the machine-readable `report.yml`.
- Per-testcase timings in `rbx run`'s terminal output; per-test detail lives in `rbx ui`.

## Note for the reviewer

`docs/setters/reference/cli.md` has drifted ~888 insertions / 510 deletions from its generator (which now emits anchor ids and index tables the committed file predates). Rather than bury two rows in that flood, the two `--benchmark` rows were hand-inserted in the generator's own ordering — matching what the previous commit to that file did. A full regeneration is worth doing deliberately, on its own.
