### PR TITLE
feat(vscode): show expanded var values inline in statements

### DIFF
--- a/docs/plans/2026-08-28-vscode-statement-var-hints-design.md
+++ b/docs/plans/2026-08-28-vscode-statement-var-hints-design.md
@@ -108,8 +108,15 @@ Python, one new lazy command:
 
 The `ENTRIES` row is not optional bookkeeping -- `tests/rbx/box/lazy_cli_test.py`
 pins the table against the modules, and `--help` renders from the table without
-importing the module. Output is the flat dotted-key map,
-`{"N.max": 100000, "A.max": 1000000000}`, i.e. `Package.expanded_vars` verbatim.
+importing the module. Output is the flat dotted-key map of
+`Package.expanded_vars`, with every value rendered to its display *string*:
+`{"N.max": "100000", "A.max": "1000000000"}`. Strings, not JSON numbers,
+because `JSON.parse` yields IEEE doubles -- a bound of `` py`10**18 + 7` ``
+would reach the extension as `1000000000000000000` and badge a wrong value,
+and `` py`10**21` `` would badge as `1e+21`. The extension only ever displays
+these, so rendering them in Python (where the int is exact) keeps D5's
+"absent, never wrong" promise. The renderer is `str`, which is what Jinja
+itself calls on an unfiltered value, so a bool badges as `True`/`False`.
 
 Extension, following the pure/impure split every `src/rbx/*.ts` module already
 observes:

--- a/docs/plans/2026-08-28-vscode-statement-var-hints-design.md
+++ b/docs/plans/2026-08-28-vscode-statement-var-hints-design.md
@@ -88,8 +88,14 @@ level.
 This is a property to keep, not merely to observe, so it is a test: running
 `rbx vars` in a package with no `.box/` leaves it with no `.box/`.
 
-`rbx visualize` is the extension's existing precedent for spawning at all
-(`visualize.ts:19`), and brings the discovery path this feature reuses.
+`rbx visualize` is the extension's existing precedent for spawning at all, and
+brings the discovery path this feature reuses. Its header also records that the
+rule's stated rationale is out of date: rbx cache directories take a *shared*
+session lock and support any number of concurrent processes, and a cache is
+emptied only under an *exclusive* lock that waits for or refuses live holders.
+So even a command that did touch the cache could not corrupt a run in flight.
+`rbx vars` does not touch it at all, which makes it a narrower exception than
+the one already taken.
 
 ## D3. Components
 

--- a/docs/plans/2026-08-28-vscode-statement-var-hints-design.md
+++ b/docs/plans/2026-08-28-vscode-statement-var-hints-design.md
@@ -145,14 +145,16 @@ globbing `*.rbx.tex` is not.
 The vars cache memoizes per package root, resolves the binary through
 `rbx/executable.ts` (setting, then `PATH`, then a login-shell probe, validated
 by `--version`, cached per root), and is invalidated by the **existing**
-`**/problem.rbx.yml` watcher and its 200 ms debounce. The spawn is therefore
-paid on save, not on keystroke.
+`**/problem.rbx.yml` watcher. That watcher is un-debounced -- the 200 ms
+debounce belongs to the `.rbx` artifact and `testset.yml` watchers, which are
+not the ones that produce vars -- so invalidation is immediate. The spawn is
+paid on save, not on keystroke, because a save is what the watcher observes.
 
 ## D4. Data flow
 
 ```
 problem.rbx.yml saved
-  -> existing watcher, 200 ms debounce
+  -> existing (un-debounced) problem.rbx.yml watcher
   -> vars cache invalidated for that root
   -> onDidChangeInlayHints fires
   -> VS Code re-requests hints for visible statement editors

--- a/docs/plans/2026-08-28-vscode-statement-var-hints-design.md
+++ b/docs/plans/2026-08-28-vscode-statement-var-hints-design.md
@@ -1,0 +1,174 @@
+# VS Code: show expanded vars inline in statements (#797)
+
+A constraints block is the densest use of vars in the whole package:
+
+```latex
+\begin{itemize}
+  \item $1 \le N \le \VAR{N.max}$
+  \item $1 \le a_i \le \VAR{A.max}$
+\end{itemize}
+```
+
+Reading that file, a setter cannot see the one thing that matters -- the
+numbers. `N.max` may be a literal, may be `` py`10**5` ``, may be derived from
+another var. Answering "what does this actually say?" means leaving the editor
+for `problem.rbx.yml`, and then mentally re-running the expansion.
+
+This design puts the value beside the reference, as an inlay hint.
+
+## D1. The badge shows the value, and nothing else
+
+Scope of v1, in the order the alternatives were rejected:
+
+**Values, not constraint provenance.** A badge could also carry what validation
+learned about the var -- `min_hit`/`max_hit` coverage from `validation[].bounds`,
+or the range the validator truly enforces. The latter does not exist yet:
+`validators.py:75` reads testlib's overview log and *skips* the
+`constant-bounds` lines, which are the only place the real `readInt(lo, hi)`
+numbers appear. Both are worth surfacing one day; neither is what makes a
+statement file unreadable today.
+
+**Root scope only.** `\VAR{N.max}` and `\VAR{vars.N.max}` resolve against the
+package var set and have exactly one value. `\VAR{g.N.max}` does not: it almost
+always sits inside a `\BLOCK{for ...}` loop, so one source line renders a
+different value per group. Showing a list, a range, or a group-labelled value
+all trade the badge's terseness for a case the constraints block does not have.
+Group, `problem`/`p.`, and `contest.` scopes get no badge at all -- an absent
+badge is never wrong.
+
+**Raw value, even under a filter.** `\VAR{N.max | sci}` renders `10^{5}`, via
+`scientific_notation` (`latex_jinja.py:107`) and its several non-obvious
+retreats: it declines to abbreviate `100007`, declines `532`, and switches
+between `10^{5}` and `2 \times 10^{5}`. Porting that to TypeScript duplicates
+logic that can drift, to produce LaTeX source rather than a number. The filter
+decides typesetting; the badge answers "what number is this?", so it shows
+`100000` regardless of the pipeline.
+
+## D2. The value comes from rbx, not from an artifact
+
+Var values cannot be computed by the extension. A value may be
+`` py`<expr>` ``, evaluated by `rbx.box.safeeval` against the other vars in a
+fixpoint loop (`fields.py:180`). Nested blocks flatten to dotted keys. A reader
+that re-implements this is a second, diverging expander.
+
+`build/testset.yml` carries expanded vars already, but only per group, and says
+so itself:
+
+> The vars the group was actually validated against -- package vars with the
+> group's overrides already merged and expanded. A reader cannot redo this
+> merge, since expansion re-evaluates interpolated vars.
+
+There is no package-level var set in the manifest. Adding one is five lines,
+and was rejected on freshness rather than effort: the badge would then exist
+only after a build, and after an edit to `problem.rbx.yml` it would show the
+*previous* build's number until the next build. A silently stale value is worse
+than no value for a feature whose entire job is showing the right one --
+especially since the moment a setter most wants the badge is the moment they
+are changing the var. Gating badges on manifest mtime avoids the lie but
+removes the badge exactly then.
+
+So: a new command, `rbx vars`, dumping the expanded package vars, spawned by
+the extension.
+
+### Why this may spawn rbx when the extension otherwise must not
+
+The testset-view design states the rule: the extension is a pure reader, it
+never spawns rbx, "because every rbx invocation has side effects on the package
+cache and could race a run already in flight".
+
+That rule is about side effects, and `rbx vars` has none. It needs
+`find_problem_package_or_die` (`package.py:77`), which reaches
+`find_problem_package` -- `load_yaml_model` on the file, nothing more -- and
+`Package.expanded_vars` (`schema.py:1407`), which is pure computation over that
+model. Nothing on the path calls `get_problem_cache_dir` (`package.py:145`, the
+function that does the `mkdir` and holds the fingerprint), takes a file lock, or
+writes anything. `within_problem` only changes directory and sets an issue
+level.
+
+This is a property to keep, not merely to observe, so it is a test: running
+`rbx vars` in a package with no `.box/` leaves it with no `.box/`.
+
+`rbx visualize` is the extension's existing precedent for spawning at all
+(`visualize.ts:19`), and brings the discovery path this feature reuses.
+
+## D3. Components
+
+Python, one new lazy command:
+
+| piece | where |
+| --- | --- |
+| `rbx vars [--json]` | new module under `rbx/box/cli/commands/` |
+| `ENTRIES` row | `rbx/box/cli/__init__.py`, mirroring `help=`/`rich_help_panel=`/`hidden=` |
+
+The `ENTRIES` row is not optional bookkeeping -- `tests/rbx/box/lazy_cli_test.py`
+pins the table against the modules, and `--help` renders from the table without
+importing the module. Output is the flat dotted-key map,
+`{"N.max": 100000, "A.max": 1000000000}`, i.e. `Package.expanded_vars` verbatim.
+
+Extension, following the pure/impure split every `src/rbx/*.ts` module already
+observes:
+
+| piece | where | kind |
+| --- | --- | --- |
+| ref scanner | `src/rbx/statementVars.ts` + `.test.ts` | pure, `node --test` |
+| vars cache | alongside `ArtifactStore` | impure |
+| hint provider | new host file | impure |
+
+The scanner takes document text and a var map and returns `{offset, text}`. It
+finds `\VAR{...}` occurrences, and accepts an expression only when it is a plain
+dotted name, optionally `vars.`-prefixed, optionally followed by a filter
+pipeline it ignores. Anything else -- a `g.`/`p.`/`problem.`/`contest.`/`groups.`
+prefix, arithmetic, a call, a conditional -- yields no hint. A name absent from
+the map also yields no hint, which incidentally makes a typo visible as the one
+reference on the line that has no badge.
+
+The provider is an `InlayHintsProvider`: a native affordance, so it obeys the
+user's editor-wide inlay setting and toggle. It is gated twice -- on a new
+`rbx.statementVarHints` boolean in `contributes.configuration`, and on
+`declared.assetFor(uri)?.role === 'statement'`, since the manifest is the
+authority on which files are statements (and covers `tutorials` too) in a way
+globbing `*.rbx.tex` is not.
+
+The vars cache memoizes per package root, resolves the binary through
+`rbx/executable.ts` (setting, then `PATH`, then a login-shell probe, validated
+by `--version`, cached per root), and is invalidated by the **existing**
+`**/problem.rbx.yml` watcher and its 200 ms debounce. The spawn is therefore
+paid on save, not on keystroke.
+
+## D4. Data flow
+
+```
+problem.rbx.yml saved
+  -> existing watcher, 200 ms debounce
+  -> vars cache invalidated for that root
+  -> onDidChangeInlayHints fires
+  -> VS Code re-requests hints for visible statement editors
+  -> provider reads cached vars (spawning rbx vars once if cold)
+  -> scanner maps refs to values
+  -> hints render after each \VAR{...}
+```
+
+## D5. Every failure is an absent badge
+
+There is no error surface. A missing rbx binary, a non-zero exit (invalid YAML,
+or the var cycle `expand_vars` detects), unparseable JSON, and an unknown var
+name all resolve to "no hint". The feature is a reading aid; a wrong number
+defeats it, and a diagnostic for it would duplicate what `rbx build` already
+reports properly.
+
+## D6. Testing
+
+`statementVars.test.ts` covers the scanner: shorthand and long form, a filter
+pipeline, several refs on one line, the `%#` comment prefix, an escaped `\\VAR`,
+each rejected scope prefix, and an unknown name.
+
+Python covers the command's contract: the JSON shape and dotted-key flattening
+over a `pkg_from_testdata` package, and the no-side-effect property from D2.
+
+## Not in v1
+
+Markdown statements (`rbxmd` uses `{{ }}`, a different delimiter set), group and
+contest scopes, and validation-derived constraint info. `rbx vars` is shaped so
+that each is an extension of the same path rather than a redesign: a group flag
+serves group scope, and the scanner's rejected-prefix list is where the others
+would be admitted.

--- a/docs/plans/2026-08-28-vscode-statement-var-hints.md
+++ b/docs/plans/2026-08-28-vscode-statement-var-hints.md
@@ -1,0 +1,806 @@
+# Inline statement var hints Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Show the expanded value of a package var beside each `\VAR{...}` reference in a statement file, as a VS Code inlay hint.
+
+**Architecture:** A new read-only `rbx vars --json` command dumps `Package.expanded_vars` as a flat dotted-key map. The VS Code extension spawns it once per package root, caches the result, invalidates on the existing `problem.rbx.yml` watcher, and an `InlayHintsProvider` renders values beside root-scope references. All decidable logic lives in `vscode`-free modules under `src/rbx/` with `node --test` coverage.
+
+**Tech Stack:** Python 3 / Typer / Pydantic v2 / pytest on the rbx side; TypeScript / VS Code API / `node --test` on the extension side.
+
+**Design:** `docs/plans/2026-08-28-vscode-statement-var-hints-design.md`. Read it before starting; it records why the badge shows only the raw value at problem-root scope.
+
+---
+
+## Background you need
+
+**What a var is.** `problem.rbx.yml` has a `vars:` block of nested primitives. rbx flattens it to dotted keys and expands `` py`<expr>` `` values against the other vars:
+
+```yaml
+vars:
+  N:
+    max: "py`10**5`"
+  A:
+    max: 1000000000
+```
+
+becomes `{"N.max": 100000, "A.max": 1000000000}` via `Package.expanded_vars` (`rbx/box/schema.py:1406`).
+
+**What a statement looks like.** rbxTeX is LaTeX-flavoured Jinja. `\VAR{...}` is an expression, `%#` a line comment (`rbx/box/statements/latex_jinja.py:23-33`). Both `\VAR{N.max}` and `\VAR{vars.N.max}` mean the same package var.
+
+**Lazy CLI.** `rbx/box/cli/__init__.py` holds `ENTRIES`, a table of `LazyCommand` rows naming `'module:attr'`. A command's module is imported only when invoked. **A new command needs a row there**, carrying the same `help=`/`rich_help_panel=`/`hidden=` the module declares — `tests/rbx/box/lazy_cli_test.py::test_table_matches_what_the_target_declares` fails otherwise.
+
+**Extension shape.** Every `src/rbx/*.ts` module is `vscode`-free and unit-tested; host files import `vscode` and are not. Run extension tests with `npm test` from `vscode/` (it builds to `out-test/` first).
+
+---
+
+## Task 1: `rbx vars --json` command
+
+**Files:**
+- Create: `rbx/box/cli/commands/vars_cmd.py`
+- Modify: `rbx/box/cli/__init__.py` (add one `ENTRIES` row)
+- Test: `tests/rbx/box/vars_cmd_test.py`
+
+**Step 1: Look at the conventions you must match**
+
+Read `rbx/box/cli/commands/config_cmds.py:1-30` — note the module docstring stating it is registered lazily, `app = typer.Typer(cls=annotations.AliasGroup)`, and the `@app.command(...)` decorator carrying `rich_help_panel` and `help`.
+
+Read `rbx/box/cli/__init__.py:115` (the `header` row) as the shape to copy.
+
+**Step 2: Write the failing test**
+
+Test packages live in `rbx/testdata/`, and the marker takes the path under it —
+`@pytest.mark.test_pkg('problems/interactive')`. That package's block is:
+
+```yaml
+vars:
+  N:
+    min: 1
+    max: 1000000
+```
+
+so the expanded map is exactly `{'N.min': 1, 'N.max': 1000000}`.
+
+Create `tests/rbx/box/vars_cmd_test.py`:
+
+```python
+import json
+import pathlib
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box.cli import app
+
+runner = CliRunner()
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_vars_json_dumps_expanded_dotted_keys(pkg_from_testdata: pathlib.Path):
+    result = runner.invoke(app, ['vars', '--json'])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'N.min': 1, 'N.max': 1000000}
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_vars_json_creates_no_cache_dir(pkg_from_testdata: pathlib.Path):
+    """The extension spawns this while the user types; it must stay read-only.
+
+    `get_problem_cache_dir` is what mkdirs the cache; nothing on the
+    `rbx vars` path may reach it.
+    """
+    from rbx.box.package import get_problem_cache_path
+
+    cache = get_problem_cache_path(pkg_from_testdata)
+    assert not cache.exists()
+
+    result = runner.invoke(app, ['vars', '--json'])
+
+    assert result.exit_code == 0, result.output
+    assert not cache.exists()
+```
+
+Note that `pkg_from_testdata` copies the package to a clean dir, `cd`s into it,
+and calls `clear_all_functools_cache()` — which matters here, because both
+`find_problem_package` and `get_expanded_vars_for_group` are `functools.cache`d.
+
+**Step 3: Run the test to verify it fails**
+
+```bash
+uv run pytest tests/rbx/box/vars_cmd_test.py -v
+```
+
+Expected: FAIL — `rbx vars` is not a command yet, so the runner exits non-zero with a "No such command" style message.
+
+**Step 4: Write the command**
+
+Create `rbx/box/cli/commands/vars_cmd.py`:
+
+```python
+"""`rbx vars`.
+
+Registered lazily from `rbx.box.cli.ENTRIES`, so this module is imported
+only when one of its commands is invoked. A command added here needs a row
+there too.
+
+This command is deliberately read-only: it loads `problem.rbx.yml` and
+expands its vars, and touches nothing else. The VS Code extension spawns it
+while the user edits, so anything that creates or locks the package cache
+would make it unsafe to call. See
+`docs/plans/2026-08-28-vscode-statement-var-hints-design.md`.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from rbx import annotations, console
+from rbx.box import package
+
+app = typer.Typer(cls=annotations.AliasGroup)
+
+
+@app.command(
+    'vars',
+    rich_help_panel='Configuration',
+    help='Show the expanded vars of this problem.',
+)
+@package.within_problem
+def vars_command(
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            '--json',
+            help='Print the vars as a JSON object of dotted keys.',
+        ),
+    ] = False,
+):
+    expanded = package.find_problem_package_or_die().expanded_vars
+    if json_output:
+        typer.echo(json.dumps(expanded))
+        return
+    for name, value in sorted(expanded.items()):
+        console.console.print(f'[item]{name}[/item] = {value}')
+```
+
+**Step 5: Add the `ENTRIES` row**
+
+In `rbx/box/cli/__init__.py`, next to the `header` row:
+
+```python
+    LazyCommand(
+        'vars',
+        'rbx.box.cli.commands.vars_cmd:app',
+        help='Show the expanded vars of this problem.',
+        rich_help_panel='Configuration',
+    ),
+```
+
+The `help=` string must match the module's `help=` **character for character**.
+
+**Step 6: Run the tests**
+
+```bash
+uv run pytest tests/rbx/box/vars_cmd_test.py tests/rbx/box/lazy_cli_test.py -v
+```
+
+Expected: PASS. If `test_table_matches_what_the_target_declares[vars]` fails, the two `help=`/`rich_help_panel=` strings disagree.
+
+**Step 7: Verify by hand**
+
+```bash
+cd rbx/testdata/problems/interactive && uv run rbx vars --json && ls -a | grep -c '^\.box$' || echo "no .box created"
+```
+
+Expected: a JSON object on stdout, and no `.box` directory.
+
+**Step 8: Lint and commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/cli/commands/vars_cmd.py rbx/box/cli/__init__.py tests/rbx/box/vars_cmd_test.py
+git commit -m "feat(cli): add rbx vars to dump the expanded package vars"
+```
+
+---
+
+## Task 2: The pure reference scanner
+
+**Files:**
+- Create: `vscode/src/rbx/statementVars.ts`
+- Test: `vscode/src/rbx/statementVars.test.ts`
+
+**Step 1: Read the pattern you are copying**
+
+`vscode/src/rbx/decoration.ts` + `decoration.test.ts` — a pure decide-function and its `node --test` suite. Yours has the same shape: data in, plain objects out, no `vscode` import.
+
+**Step 2: Write the failing test**
+
+Create `vscode/src/rbx/statementVars.test.ts`:
+
+```typescript
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import { scanStatementVars } from './statementVars';
+
+const VARS = { 'N.max': 100000, 'A.max': 1000000000, flag: true, name: 'foo' };
+
+const scan = (text: string) => scanStatementVars(text, VARS);
+
+test('the shorthand and the long form both resolve', () => {
+  assert.deepStrictEqual(scan('$N \\le \\VAR{N.max}$'), [
+    { end: 20, text: '100000' },
+  ]);
+  assert.deepStrictEqual(
+    scan('$N \\le \\VAR{vars.N.max}$').map((hint) => hint.text),
+    ['100000'],
+  );
+});
+
+test('a filter pipeline is ignored, the raw value is shown', () => {
+  assert.deepStrictEqual(
+    scan('\\VAR{N.max | sci}').map((hint) => hint.text),
+    ['100000'],
+  );
+});
+
+test('several references on one line each get a hint', () => {
+  assert.deepStrictEqual(
+    scan('$\\VAR{N.max}$ and $\\VAR{A.max}$').map((hint) => hint.text),
+    ['100000', '1000000000'],
+  );
+});
+
+test('non-root scopes are left alone', () => {
+  for (const expression of [
+    'g.N.max',
+    'groups.g.vars.N.max',
+    'p.N.max',
+    'problem.N.max',
+    'contest.year',
+  ]) {
+    assert.deepStrictEqual(scan(`\\VAR{${expression}}`), [], expression);
+  }
+});
+
+test('expressions that are not a plain name are left alone', () => {
+  for (const expression of ['N.max + 1', 'len(x)', "N.max if x else 'y'", '']) {
+    assert.deepStrictEqual(scan(`\\VAR{${expression}}`), [], expression);
+  }
+});
+
+test('an unknown name gets no hint, which is how a typo shows up', () => {
+  assert.deepStrictEqual(scan('\\VAR{N.mx}'), []);
+});
+
+test('a commented line is skipped', () => {
+  assert.deepStrictEqual(scan('%# $\\VAR{N.max}$'), []);
+});
+
+test('an escaped VAR is not a reference', () => {
+  assert.deepStrictEqual(scan('\\\\VAR{N.max}'), []);
+});
+
+test('non-numeric values render as themselves', () => {
+  assert.deepStrictEqual(
+    scan('\\VAR{flag} \\VAR{name}').map((hint) => hint.text),
+    ['true', 'foo'],
+  );
+});
+
+test('the hint sits just after the closing brace', () => {
+  const text = 'abc \\VAR{N.max} def';
+  const [hint] = scan(text);
+  assert.strictEqual(text[hint.end - 1], '}');
+});
+```
+
+**Step 3: Run it to verify it fails**
+
+```bash
+cd vscode && npm test
+```
+
+Expected: FAIL — `Cannot find module './statementVars'`.
+
+**Step 4: Write the implementation**
+
+Create `vscode/src/rbx/statementVars.ts`:
+
+```typescript
+/**
+ * Which `\VAR{...}` references in a statement get a value badge.
+ *
+ * Pure: no `vscode` import, so `node --test` covers it directly.
+ *
+ * Only *problem-root* references are badged -- `\VAR{N.max}` and
+ * `\VAR{vars.N.max}`. A group reference (`\VAR{g.N.max}`) renders a different
+ * value per loop iteration, so a single badge would have to lie or to name the
+ * group; contest and problem scopes resolve against var sets this map does not
+ * hold. Every one of those, and every expression that is not a plain dotted
+ * name, yields no hint: an absent badge is never wrong.
+ *
+ * See docs/plans/2026-08-28-vscode-statement-var-hints-design.md (D1).
+ */
+
+/** A var value, as `rbx vars --json` emits it. */
+export type VarValue = number | boolean | string;
+
+/** The expanded package vars, keyed by dotted name. */
+export type Vars = Readonly<Record<string, VarValue>>;
+
+export interface VarHint {
+  /** Offset just past the reference's closing brace. */
+  readonly end: number;
+  /** The value, rendered for display. */
+  readonly text: string;
+}
+
+/** Scopes whose values this map does not hold. See the module comment. */
+const FOREIGN_SCOPE = /^(vars\.)?(g|p|problem|contest|groups)\./;
+
+/** A plain dotted name, with an optional filter pipeline we ignore. */
+const REFERENCE = /^\s*([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*)\s*(\|[^}]*)?$/;
+
+const OCCURRENCE = /\\VAR\{([^}]*)\}/g;
+
+function isCommented(text: string, offset: number): boolean {
+  const lineStart = text.lastIndexOf('\n', offset - 1) + 1;
+  return /^\s*%/.test(text.slice(lineStart, offset));
+}
+
+function isEscaped(text: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let i = offset - 1; i >= 0 && text[i] === '\\'; i -= 1) {
+    backslashes += 1;
+  }
+  // The match itself consumed one backslash, so an odd count before it means
+  // the `\VAR` was written as a literal `\\VAR`.
+  return backslashes % 2 === 1;
+}
+
+function render(value: VarValue): string {
+  return typeof value === 'string' ? value : String(value);
+}
+
+export function scanStatementVars(text: string, vars: Vars): VarHint[] {
+  const hints: VarHint[] = [];
+  OCCURRENCE.lastIndex = 0;
+
+  for (let match = OCCURRENCE.exec(text); match; match = OCCURRENCE.exec(text)) {
+    const start = match.index;
+    if (isEscaped(text, start) || isCommented(text, start)) {
+      continue;
+    }
+
+    const expression = match[1];
+    if (FOREIGN_SCOPE.test(expression.trim())) {
+      continue;
+    }
+
+    const parsed = REFERENCE.exec(expression);
+    if (!parsed) {
+      continue;
+    }
+
+    const name = parsed[1].replace(/^vars\./, '');
+    const value = Object.prototype.hasOwnProperty.call(vars, name)
+      ? vars[name]
+      : undefined;
+    if (value === undefined) {
+      continue;
+    }
+
+    hints.push({ end: start + match[0].length, text: render(value) });
+  }
+
+  return hints;
+}
+```
+
+**Step 5: Run the tests**
+
+```bash
+cd vscode && npm test
+```
+
+Expected: PASS, all cases.
+
+**Step 6: Typecheck, lint and commit**
+
+```bash
+cd vscode && npm run typecheck && npm run lint
+git add vscode/src/rbx/statementVars.ts vscode/src/rbx/statementVars.test.ts
+git commit -m "feat(vscode): scan statement files for root-scope var references"
+```
+
+---
+
+## Task 3: Extract the rbx spawn helper
+
+`visualize.ts` holds the `run()` spawn wrapper, the `resolved` per-root cache, `validate()` and `resolveCandidate()`. Task 4 needs all of them. Copying them would create a second executable-resolution path that can drift.
+
+**Files:**
+- Create: `vscode/src/rbxProcess.ts`
+- Modify: `vscode/src/visualize.ts`
+
+**Step 1: Read what you are moving**
+
+`vscode/src/visualize.ts:19-125` — `SpawnResult`, `run()`, `PROBE_TIMEOUT_MS`, the `resolved` map, `resetRbxExecutables()`, `validate()`, `resolveCandidate()`, and whatever follows `resolveCandidate` up to the point where visualize-specific logic starts (read past line 125 to find the boundary; the exported "resolve an rbx for this root" function is the last thing to move).
+
+**Step 2: Move them verbatim**
+
+Create `vscode/src/rbxProcess.ts` containing exactly those pieces, exporting `SpawnResult`, `run`, `resetRbxExecutables`, and the per-root resolver. Keep the doc comments; move the doctrine paragraph from `visualize.ts`'s header into the new module, since it is now the shared justification.
+
+Delete them from `visualize.ts` and import from `./rbxProcess` instead.
+
+**Step 3: Verify nothing else referenced them**
+
+```bash
+cd vscode && grep -rn "resetRbxExecutables" src/
+```
+
+Every hit must now import from `./rbxProcess`. Check `extension.ts` and `commands.ts` in particular.
+
+**Step 4: Typecheck and test**
+
+```bash
+cd vscode && npm run typecheck && npm run lint && npm test
+```
+
+Expected: PASS, with no behaviour change — this is a pure move.
+
+**Step 5: Commit**
+
+```bash
+git add vscode/src/rbxProcess.ts vscode/src/visualize.ts
+git commit -m "refactor(vscode): extract the rbx spawn and discovery helper"
+```
+
+---
+
+## Task 4: The vars cache
+
+**Files:**
+- Create: `vscode/src/statementVarsIndex.ts`
+- Test: `vscode/src/rbx/varsPayload.test.ts` (+ `vscode/src/rbx/varsPayload.ts`)
+
+Parsing and validating the command's stdout is decidable without `vscode`, so it goes in a pure module; the spawning and caching do not.
+
+**Step 1: Write the failing test for the payload parser**
+
+Create `vscode/src/rbx/varsPayload.test.ts`:
+
+```typescript
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import { parseVarsPayload } from './varsPayload';
+
+test('a flat dotted map is accepted', () => {
+  assert.deepStrictEqual(parseVarsPayload('{"N.max": 100000, "ok": true}'), {
+    'N.max': 100000,
+    ok: true,
+  });
+});
+
+test('malformed or unexpected output yields no vars, never a throw', () => {
+  for (const stdout of ['', 'not json', '[]', 'null', '{"a": {"b": 1}}', '{"a": [1]}']) {
+    assert.strictEqual(parseVarsPayload(stdout), undefined, stdout);
+  }
+});
+
+test('leading noise before the object is tolerated', () => {
+  // A shell wrapper or a venv activation can print before rbx does.
+  assert.deepStrictEqual(parseVarsPayload('warning: x\n{"N.max": 5}'), {
+    'N.max': 5,
+  });
+});
+```
+
+**Step 2: Run it to verify it fails**
+
+```bash
+cd vscode && npm test
+```
+
+Expected: FAIL — module not found.
+
+**Step 3: Implement the parser**
+
+Create `vscode/src/rbx/varsPayload.ts`:
+
+```typescript
+/**
+ * Reading `rbx vars --json`.
+ *
+ * Every malformed shape resolves to `undefined` rather than throwing: the
+ * feature degrades to "no badges", never to an error the user has to dismiss.
+ */
+import { VarValue, Vars } from './statementVars';
+
+function isVarValue(value: unknown): value is VarValue {
+  return (
+    typeof value === 'number' || typeof value === 'boolean' || typeof value === 'string'
+  );
+}
+
+export function parseVarsPayload(stdout: string): Vars | undefined {
+  const start = stdout.indexOf('{');
+  if (start < 0) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout.slice(start));
+  } catch {
+    return undefined;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(parsed as Record<string, unknown>);
+  if (!entries.every(([, value]) => isVarValue(value))) {
+    return undefined;
+  }
+  return Object.fromEntries(entries) as Vars;
+}
+```
+
+**Step 4: Run the tests**
+
+```bash
+cd vscode && npm test
+```
+
+Expected: PASS.
+
+**Step 5: Write the cache**
+
+Create `vscode/src/statementVarsIndex.ts`. Model it on `src/declared.ts` (a `Map` keyed by package root, an `onDidChange` `EventEmitter`, a lookup method, `dispose`). It must:
+
+- hold `Map<string, Promise<Vars | undefined>>` keyed by package root;
+- on a miss, resolve the rbx binary for that root and `run(rbx, ['vars', '--json'], root, TIMEOUT)`, then `parseVarsPayload(result.stdout)`; a spawn error, a non-zero exit code, or an unparseable payload all store `undefined`;
+- expose `varsFor(root: string): Promise<Vars | undefined>`;
+- expose `invalidate(root: string)` clearing that entry and firing `onDidChange`;
+- log failures once per root via `./log` — this is the only place a failure is visible, and it must not repeat on every keystroke.
+
+Use a 10 s timeout constant; `rbx vars` only parses YAML.
+
+**Step 6: Wire invalidation**
+
+In `vscode/src/extension.ts`, find the existing `**/problem.rbx.yml` watcher (near the other watchers, ~lines 200-320) and add `statementVars.invalidate(root)` beside the existing `data.invalidate(root)`. Do not add a new watcher.
+
+**Step 7: Typecheck and commit**
+
+```bash
+cd vscode && npm run typecheck && npm run lint && npm test
+git add vscode/src/rbx/varsPayload.ts vscode/src/rbx/varsPayload.test.ts vscode/src/statementVarsIndex.ts vscode/src/extension.ts
+git commit -m "feat(vscode): cache the expanded vars of each problem package"
+```
+
+---
+
+## Task 5: The inlay hint provider
+
+**Files:**
+- Create: `vscode/src/statementVarHints.ts`
+- Modify: `vscode/package.json` (one `contributes.configuration` entry)
+- Modify: `vscode/src/extension.ts` (registration)
+
+**Step 1: Read the registration template**
+
+`vscode/src/solutionLens.ts:74-95` (`registerSolutionLens`) — register the provider, subscribe to the index's `onDidChange`, subscribe to `onDidChangeConfiguration` filtered by `affectsConfiguration(SETTING)`, and fire the provider's own event. Copy that structure exactly.
+
+**Step 2: Add the setting**
+
+In `vscode/package.json`, beside `rbx.solutionCodeLens` in `contributes.configuration.properties`:
+
+```json
+"rbx.statementVarHints": {
+  "type": "boolean",
+  "default": true,
+  "description": "Show the expanded value of each var referenced in a statement file."
+}
+```
+
+**Step 3: Write the provider**
+
+Create `vscode/src/statementVarHints.ts`:
+
+```typescript
+/**
+ * The value of a var, shown beside the `\VAR{...}` that references it.
+ *
+ * An `InlayHintsProvider` rather than a text decoration, so the hints obey the
+ * editor's own inlay setting and toggle. What gets a hint is decided by the
+ * pure `rbx/statementVars.ts`; this file only asks and draws.
+ */
+import * as vscode from 'vscode';
+
+import { DeclaredIndex } from './declared';
+import { scanStatementVars } from './rbx/statementVars';
+import { StatementVarsIndex } from './statementVarsIndex';
+
+const SETTING = 'rbx.statementVarHints';
+
+function enabled(): boolean {
+  return vscode.workspace.getConfiguration().get<boolean>(SETTING, true);
+}
+
+class StatementVarHintsProvider implements vscode.InlayHintsProvider {
+  private readonly changed = new vscode.EventEmitter<void>();
+  readonly onDidChangeInlayHints = this.changed.event;
+
+  constructor(
+    private readonly declared: DeclaredIndex,
+    private readonly vars: StatementVarsIndex,
+  ) {}
+
+  async provideInlayHints(
+    document: vscode.TextDocument,
+    range: vscode.Range,
+  ): Promise<vscode.InlayHint[]> {
+    if (!enabled()) {
+      return [];
+    }
+    // The manifest is the authority on which files are statements; it also
+    // covers tutorials, which globbing `*.rbx.tex` would miss.
+    const asset = this.declared.assetFor(document.uri);
+    if (asset?.role !== 'statement') {
+      return [];
+    }
+
+    const root = this.declared.rootFor(document.uri);
+    if (root === undefined) {
+      return [];
+    }
+    const vars = await this.vars.varsFor(root);
+    if (vars === undefined) {
+      return [];
+    }
+
+    const text = document.getText();
+    return scanStatementVars(text, vars)
+      .map((hint) => ({ hint, position: document.positionAt(hint.end) }))
+      .filter(({ position }) => range.contains(position))
+      .map(({ hint, position }) => {
+        const inlay = new vscode.InlayHint(position, ` ${hint.text}`);
+        inlay.paddingLeft = true;
+        return inlay;
+      });
+  }
+
+  refresh(): void {
+    this.changed.fire();
+  }
+
+  dispose(): void {
+    this.changed.dispose();
+  }
+}
+
+export function registerStatementVarHints(
+  context: vscode.ExtensionContext,
+  declared: DeclaredIndex,
+  vars: StatementVarsIndex,
+): StatementVarHintsProvider {
+  const provider = new StatementVarHintsProvider(declared, vars);
+  context.subscriptions.push(
+    provider,
+    // Every file on disk: which ones are statements is a fact about the
+    // manifest, not about the language.
+    vscode.languages.registerInlayHintsProvider({ scheme: 'file' }, provider),
+    declared.onDidChange(() => provider.refresh()),
+    vars.onDidChange(() => provider.refresh()),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration(SETTING)) {
+        provider.refresh();
+      }
+    }),
+  );
+  return provider;
+}
+```
+
+**Step 4: Resolve the package root for a document**
+
+The provider calls `this.declared.rootFor(document.uri)`. Check whether `DeclaredIndex` already exposes the package root of an asset:
+
+```bash
+cd vscode && grep -n "root" src/declared.ts
+```
+
+If `DeclaredAsset` already carries the root, use that field and drop `rootFor`. If not, add a `rootFor(uri)` method to `DeclaredIndex` returning the package root the asset was declared in — the index already knows it, since it is built per discovered `problem.rbx.yml`.
+
+**Step 5: Register it**
+
+In `vscode/src/extension.ts:activate()`, construct the `StatementVarsIndex` and call `registerStatementVarHints(context, declared, statementVars)` beside the existing `registerSolutionLens(...)` call.
+
+**Step 6: Typecheck, lint, test**
+
+```bash
+cd vscode && npm run typecheck && npm run lint && npm test
+```
+
+Expected: PASS.
+
+**Step 7: Verify in a real editor**
+
+```bash
+./run-extension.sh
+```
+
+In the Extension Development Host, open a problem package that has a `vars:` block, open its statement `.rbx.tex`, and confirm:
+- values appear after `\VAR{N.max}` and `\VAR{vars.N.max}`;
+- nothing appears after `\VAR{g.N.max}`;
+- editing `vars:` in `problem.rbx.yml` and saving updates the hints within ~1 s;
+- toggling `rbx.statementVarHints` off removes them;
+- the editor's own "Toggle Inlay Hints" also removes them.
+
+**Step 8: Commit**
+
+```bash
+git add vscode/src/statementVarHints.ts vscode/src/extension.ts vscode/src/declared.ts vscode/package.json
+git commit -m "feat(vscode): show expanded var values inline in statements"
+```
+
+---
+
+## Task 6: Documentation
+
+**Files:**
+- Modify: `vscode/README.md`
+- Modify: `docs/` — find the page that documents the extension's features
+
+**Step 1: Find where extension features are documented**
+
+```bash
+grep -rln "solutionCodeLens\|decorateExplorer" docs/ vscode/README.md
+```
+
+**Step 2: Write the entry**
+
+Follow `docs/plans/docs-writing-style-guide.md`. Introduce the concept before using it: a reader meets "statement files reference vars" before they meet "the extension shows their values". State the limits plainly — problem-root references only, raw value regardless of filter, requires `rbx` on `PATH` or in the `rbx.executable` setting.
+
+**Step 3: Verify the docs build**
+
+```bash
+uv run mkdocs build
+```
+
+Expected: builds. Ignore pre-existing unrelated warnings; do not use `--strict`.
+
+**Step 4: Revert the regenerated CLI reference if it changed**
+
+`mkdocs build` rewrites the checked-in CLI reference. Since Task 1 added a command, the regenerated file legitimately differs — check the diff and keep **only** the `rbx vars` addition:
+
+```bash
+git diff docs/
+```
+
+**Step 5: Commit**
+
+```bash
+git add docs/ vscode/README.md
+git commit -m "docs: document the statement var hints in the vscode extension"
+```
+
+---
+
+## Final verification
+
+```bash
+uv run pytest tests/rbx/box/vars_cmd_test.py tests/rbx/box/lazy_cli_test.py -v
+cd vscode && npm run typecheck && npm run lint && npm test
+```
+
+Do **not** run the full Python suite — it is slow and produces spurious sandbox wall-timeout failures. Run only the files this change touches.
+
+Then open a PR against `main`.

--- a/docs/plans/2026-08-29-statement-filter-targets-design.md
+++ b/docs/plans/2026-08-29-statement-filter-targets-design.md
@@ -1,0 +1,137 @@
+# Target-aware statement filters, and honouring them in the var hints
+
+The inline var hints ship showing the *raw* value of a reference, filter or no
+filter: `\VAR{N.max | sci}` badges `100000` while the built statement typesets
+`10^{5}`. That was
+[a deliberate retreat](2026-08-28-vscode-statement-var-hints-design.md) -- the
+alternative on the table was porting `scientific_notation` to TypeScript, which
+buys a second implementation of a function whose rules are all edge case.
+
+There is a third option, and it is better than either: let rbx render the whole
+expression, and teach the filter what it is rendering *for*.
+
+## D1. The target belongs to the filter, not to the caller
+
+`sci` is not a function with one right answer. Its *rules* -- when to abbreviate
+at all, when to pull out a multiplier, when to keep a remainder, when to decline
+and print the integer -- are a property of the number. Its *formatting* is a
+property of the medium:
+
+| medium | `200000 | sci` |
+| --- | --- |
+| LaTeX (PDF) | `2 \times 10^{5}` |
+| a VS Code inlay hint | `2×10⁵` |
+
+Today `add_builtin_filters(j2_env)` installs one flavour, and every environment
+gets LaTeX. The change is to pass what the environment is for:
+
+```python
+add_builtin_filters(j2_env, target=FilterTarget.LATEX)
+```
+
+The rules stay in one place and keep one set of tests; only a small formatter
+differs per target. This is the same reasoning that kept the badge from
+re-implementing expansion: one source of truth, rendered per consumer.
+
+### Markdown keeps LaTeX, deliberately
+
+An earlier draft of this design called the Markdown environment a bug, on the
+grounds that it installs LaTeX-flavoured filters and therefore emits
+`2 \times 10^{5}` into a `.md` statement. That is wrong. A Markdown statement
+puts its constraints in `$...$` math, rendered by MathJax or KaTeX, so LaTeX is
+exactly what belongs there.
+
+`MARKDOWN` is still a distinct target value, mapping to the LaTeX formatter.
+Not because it differs today, but because "these two are the same" is a fact
+worth being able to change in one line, and because a reader who finds only
+`LATEX` and `TEXT` would reasonably wonder which one Markdown got.
+
+## D2. What the TEXT target renders
+
+Superscript digits for the exponent, `×` for the multiplication, and otherwise
+identical decisions to LaTeX:
+
+| value | LATEX | TEXT |
+| --- | --- | --- |
+| `100000 | sci` | `10^{5}` | `10⁵` |
+| `200000 | sci` | `2 \times 10^{5}` | `2×10⁵` |
+| `10**18 + 7 | rsci` | `10^{18} + 7` | `10¹⁸ + 7` |
+| `100007 | sci` | `100007` | `100007` |
+| `532 | sci` | `532` | `532` |
+
+`escape` under TEXT is the identity: a badge is not a document, and there is
+nothing to escape into. `parent` and `stem` are about paths and do not vary.
+
+The two must agree on every *decision*, and that is testable: the same table
+drives both, and a case that abbreviates in one abbreviates in the other.
+
+## D3. Only a filtered reference costs a spawn
+
+The extension already holds a per-package map of expanded vars, one `rbx vars
+--json` per package root, invalidated by the manifest watcher. A plain
+`\VAR{N.max}` is answered from that map with no process at all, and that is the
+overwhelmingly common case.
+
+A *filtered* reference cannot be: `| sci` is Jinja, and evaluating Jinja is
+rbx's job. So the split is by reference shape --
+
+- no pipeline: the bulk map, unchanged, instant;
+- a pipeline: an expression rbx must render.
+
+which keeps the cost proportional to how much of the statement actually uses
+filters, rather than making every reference pay for the few that do.
+
+The scanner already parses the pipeline in order to ignore it. It stops
+ignoring it. Root scope still applies: an expression is sent only if it is a
+plain dotted name plus a pipeline, so nothing arbitrary is ever handed to a
+renderer.
+
+## D4. The command
+
+```
+rbx vars --render --target text
+```
+
+Expressions arrive on **stdin**, one per line; the result is a JSON object
+keyed by the expression, values already rendered:
+
+```json
+{"N.max | sci": "10⁵", "A.max | rsci": "2×10⁹ + 7"}
+```
+
+Stdin rather than repeated `--render` flags because `|` in an argument is a
+quoting trap in every shell, and because a statement with two dozen filtered
+references should still be one call.
+
+An expression that fails to render -- an unknown filter, a bad argument, a name
+that is not there -- is **absent from the map** rather than an error. The
+extension draws no badge for it, which is D5 of the original design unchanged:
+absent is never wrong. `rbx vars --render` still exits 0 in that case; a
+non-zero exit is reserved for "this package could not be read at all", which is
+the signal the extension already treats as "no badges anywhere".
+
+## D5. Caching, and what typing does
+
+Rendered expressions cache per `(package root, expression)`, **including the
+ones that failed**. That last part is what makes typing survivable: the moment
+a setter types `\VAR{N.max | sc`, that is a syntactically fine expression which
+renders to nothing, and without a negative cache every keystroke would spawn a
+process to be told so again.
+
+Unresolved expressions from a document are collected and sent in one spawn.
+Hints for everything already known render immediately; `onDidChangeInlayHints`
+fires when the batch returns, and the ones that resolved appear. The manifest
+watcher drops the whole per-root cache, expressions included, since a changed
+`vars` block changes what they render to.
+
+## D6. Testing
+
+The load-bearing test is that **LaTeX output does not move**. A table of
+`scientific_notation`'s awkward inputs -- `100007` declining, `532` declining,
+`0`, negatives, an exact power, a multiplier, a remainder under `rsci` -- is
+asserted against its current output, and the same table drives the TEXT target
+so the two cannot disagree about a decision while differing in formatting.
+
+Beyond that: the scanner keeps pipelines and still refuses foreign scopes; the
+payload parser accepts the render map; and `rbx vars --render` is covered for
+the empty-input, unknown-filter and unknown-name cases.

--- a/docs/plans/2026-08-29-statement-filter-targets.md
+++ b/docs/plans/2026-08-29-statement-filter-targets.md
@@ -1,0 +1,342 @@
+# Target-aware statement filters Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the statement filters render per target, so the VS Code var hints can honour `| sci`, `| rsci` and every other filter without a second implementation.
+
+**Architecture:** `add_builtin_filters(env, target)` selects a formatter, never the rules. `rbx vars --render --target text` renders whole expressions through the real Jinja environment, reading them from stdin. The extension keeps its bulk var map for unfiltered references and asks rbx only about filtered ones, caching every answer — including failures — per `(package root, expression)`.
+
+**Tech Stack:** Python 3 / Jinja2 / Typer / pytest; TypeScript / VS Code API / `node --test`.
+
+**Design:** `docs/plans/2026-08-29-statement-filter-targets-design.md`. Read it first.
+
+---
+
+## The constraint that outranks everything
+
+**LaTeX output must not move.** These filters render statements people ship. The
+current behaviour, captured from the installed code, is the golden table:
+
+| value | `sci` | `rsci` |
+| --- | --- | --- |
+| `0` | `0` | `0` |
+| `1` | `1` | `1` |
+| `10` | `10` | `10` |
+| `532` | `532` | `532` |
+| `9999` | `9999` | `9999` |
+| `10000` | `10^{4}` | `10^{4}` |
+| `100000` | `10^{5}` | `10^{5}` |
+| `100007` | `100007` | `10^{5} + 7` |
+| `200000` | `2 \times 10^{5}` | `2 \times 10^{5}` |
+| `250000` | `250000` | `250000` |
+| `1000000007` | `1000000007` | `10^{9} + 7` |
+| `10**18 + 7` | `1000000000000000007` | `10^{18} + 7` |
+| `-100000` | `-10^{5}` | `-10^{5}` |
+| `10**21` | `10^{21}` | `10^{21}` |
+
+Note `250000` and `100007` **decline** under `sci` — the rules refuse an
+abbreviation that is not shorter or not clean. Those two rows are the ones a
+careless refactor breaks.
+
+---
+
+## Task 1: Target-aware filters
+
+**Files:**
+- Modify: `rbx/box/statements/latex_jinja.py`
+- Test: `tests/rbx/box/statements/filter_targets_test.py` (check whether a statements test dir already exists: `ls tests/rbx/box/statements/`; if not, create it with an `__init__.py` if its siblings have one)
+
+**Step 1: Pin today's behaviour before changing anything**
+
+Write the golden table above as a parametrised test against the CURRENT
+functions, and run it. It must pass before you touch the implementation — that
+is what makes it a regression test rather than a description of whatever you
+end up writing.
+
+```python
+import pytest
+
+from rbx.box.statements.latex_jinja import (
+    rest_scientific_notation,
+    scientific_notation,
+)
+
+GOLDEN = [
+    (0, '0', '0'),
+    (1, '1', '1'),
+    (10, '10', '10'),
+    (532, '532', '532'),
+    (9999, '9999', '9999'),
+    (10000, '10^{4}', '10^{4}'),
+    (100000, '10^{5}', '10^{5}'),
+    (100007, '100007', '10^{5} + 7'),
+    (200000, r'2 \times 10^{5}', r'2 \times 10^{5}'),
+    (250000, '250000', '250000'),
+    (1000000007, '1000000007', '10^{9} + 7'),
+    (10**18 + 7, '1000000000000000007', '10^{18} + 7'),
+    (-100000, '-10^{5}', '-10^{5}'),
+    (10**21, '10^{21}', '10^{21}'),
+]
+
+
+@pytest.mark.parametrize(('value', 'sci', 'rsci'), GOLDEN)
+def test_latex_scientific_notation_is_unchanged(value, sci, rsci):
+    assert scientific_notation(value) == sci
+    assert rest_scientific_notation(value) == rsci
+```
+
+Run: `uv run pytest tests/rbx/box/statements/filter_targets_test.py -v`
+Expected: PASS, before any change.
+
+**Step 2: Introduce the target**
+
+Add to `latex_jinja.py`:
+
+```python
+class FilterTarget(enum.Enum):
+    """What a filter is formatting for.
+
+    The *rules* a filter applies -- when `sci` abbreviates, when it declines --
+    are a property of the value and never vary. Only the spelling does: a PDF
+    wants `2 \\times 10^{5}`, a VS Code inlay hint wants `2×10⁵` because it
+    cannot typeset maths.
+
+    MARKDOWN maps to the LaTeX formatter and is not redundant: a Markdown
+    statement puts its constraints in `$...$` math, so LaTeX is correct there.
+    Naming it separately means the day it stops being correct is a one-line
+    change rather than an archaeology exercise.
+    """
+
+    LATEX = 'latex'
+    MARKDOWN = 'markdown'
+    TEXT = 'text'
+```
+
+**Step 3: Split formatting out of the rules**
+
+`scientific_notation` currently decides and formats in one pass. Keep ONE copy
+of the decisions and give it a formatter. The shape to aim for:
+
+- a helper that returns the decision — declined, or `(mult, exp, rem)`;
+- per-target formatting of that decision.
+
+Do not restructure more than that. In particular keep `_process_zeroes`, the
+`zeroes` threshold, the two "decline" branches and the negative-number
+recursion exactly as they behave now. The Step 1 test is your proof.
+
+Superscript mapping for TEXT: `0123456789` → `⁰¹²³⁴⁵⁶⁷⁸⁹`, `\times` → `×`, and
+no braces. `10^{18} + 7` becomes `10¹⁸ + 7` — the ` + 7` keeps its spaces.
+
+**Step 4: Extend the golden test to the TEXT target**
+
+Add the expected TEXT column and assert it. Every row where LaTeX declines must
+also decline in TEXT — that is the invariant the design calls out, so assert it
+directly rather than only via the table:
+
+```python
+@pytest.mark.parametrize(('value', 'sci', 'rsci'), GOLDEN)
+def test_text_and_latex_agree_on_whether_to_abbreviate(value, sci, rsci):
+    """The rules are the value's; only the spelling is the medium's."""
+    latex_declined = sci == str(value)
+    text_declined = scientific_notation(value, target=FilterTarget.TEXT) == str(value)
+    assert latex_declined == text_declined
+```
+
+**Step 5: Make `escape` target-aware and install by target**
+
+`escape_latex_str_if_str` under TEXT is the identity — a badge is not a
+document. `parent`/`stem` do not vary.
+
+Change the signature to `add_builtin_filters(j2_env, target=FilterTarget.LATEX)`
+and pass the target explicitly at all three call sites in this file: `LATEX`,
+`LATEX`, and `MARKDOWN` for `render_markdown_template_blocks`. Defaulting the
+parameter keeps any out-of-tree caller working; grep first to confirm there are
+none: `grep -rn "add_builtin_filters" --include="*.py" . | grep -v .venv`.
+
+**Step 6: Verify nothing downstream moved**
+
+```bash
+uv run pytest tests/rbx/box/statements/ -v
+```
+Expected: PASS. If a statement test fails, the refactor changed LaTeX output — fix the refactor, not the test.
+
+**Step 7: Lint and commit**
+
+```bash
+uv run ruff check --fix . && uv run ruff format .
+git add rbx/box/statements/latex_jinja.py tests/rbx/box/statements/filter_targets_test.py
+git commit -m "feat(statements): render builtin filters per target"
+```
+
+---
+
+## Task 2: `rbx vars --render`
+
+**Files:**
+- Modify: `rbx/box/cli/commands/vars_cmd.py`
+- Modify: `rbx/box/cli/__init__.py` only if the `ENTRIES` help text changes (it should not)
+- Test: `tests/rbx/box/vars_cmd_test.py`
+
+**Step 1: Write the failing tests**
+
+Add to the existing test file. Expressions arrive on stdin, one per line;
+output is a JSON object keyed by the expression. Use `CliRunner(input=...)`.
+
+```python
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_evaluates_filters_for_the_text_target(pkg_from_testdata):
+    result = runner.invoke(
+        app, ['vars', '--render', '--target', 'text'], input='N.max | sci\nN.max\n'
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        'N.max | sci': '10⁶',
+        'N.max': '1000000',
+    }
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_omits_an_expression_it_cannot_evaluate(pkg_from_testdata):
+    """Absent, not an error: the extension draws no badge and moves on."""
+    result = runner.invoke(
+        app,
+        ['vars', '--render', '--target', 'text'],
+        input='N.max | nosuchfilter\nN.typo\nN.max\n',
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'N.max': '1000000'}
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_with_no_expressions_is_an_empty_object(pkg_from_testdata):
+    result = runner.invoke(app, ['vars', '--render'], input='')
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {}
+```
+
+**VERIFY the expected values first** — `problems/interactive` has `N.min: 1`,
+`N.max: 1000000`, so `sci` gives `10^{6}` → `10⁶`. Confirm with:
+`cd rbx/testdata/problems/interactive && uv run rbx vars --json`
+
+**Step 2:** Run them; expect FAIL (no `--render` option).
+
+**Step 3: Implement**
+
+- `--render` (bool) and `--target` (an enum-typed option defaulting to `text`; Typer renders a Python enum as a choice).
+- With `--render`: read stdin, strip, drop blank lines, de-duplicate while preserving order.
+- Build a Jinja environment the same way the statement renderer does, with `add_builtin_filters(env, target)`, and render each expression as `{{ <expr> }}` against the package's expanded vars.
+- Collect successes; on ANY per-expression exception, skip that expression. Do not let one bad expression fail the command.
+- Emit `json.dumps(rendered)` — note the values here are already strings.
+
+Reuse rather than reinvent: look at how `latex_jinja` builds its environment
+(`J2_ARGS`, `StrictChainableUndefined`) and match it, since the whole point is
+that the badge agrees with the statement.
+
+Keep the existing `--json` behaviour untouched.
+
+**Step 4:** Run the tests; expect PASS. Then the full file plus the lazy-CLI and drift tests:
+
+```bash
+uv run pytest tests/rbx/box/vars_cmd_test.py tests/rbx/box/lazy_cli_test.py tests/rbx/box/completion/drift_test.py -v
+```
+
+Adding options changes the completion spec — regenerate it exactly as the
+existing `rbx vars` entry was:
+`uv run python -m rbx.box.completion.serialize && uv run ruff format rbx/box/completion/_spec.py`
+and confirm the diff is only this command's new options.
+
+**Step 5: Verify by hand**
+
+```bash
+cd rbx/testdata/problems/interactive
+printf 'N.max | sci\nN.max\nN.max | nosuchfilter\n' | uv run rbx vars --render --target text
+printf 'N.max | sci\n' | uv run rbx vars --render --target latex
+```
+Expected: `10⁶` for text, `10^{6}` for latex, the bad filter absent, exit 0 both times.
+
+**Step 6: Lint and commit** — `feat(cli): render statement expressions with rbx vars --render`
+
+---
+
+## Task 3: The scanner keeps pipelines
+
+**Files:**
+- Modify: `vscode/src/rbx/statementVars.ts`
+- Test: `vscode/src/rbx/statementVars.test.ts`
+
+Today `scanStatementVars` matches a plain dotted name plus an optional pipeline
+and **discards** the pipeline, returning `{end, text}`. It must now report the
+expression so the caller can decide whether it needs rendering.
+
+**Step 1: Write the failing tests.** The return type gains the expression and
+whether it is filtered. Suggested shape — adapt if you find better:
+
+```typescript
+{ end: number; text?: string; expression: string; filtered: boolean }
+```
+
+Cover: an unfiltered reference still resolves from the map with no expression
+to render; a filtered one reports the full normalised expression; the `vars.`
+prefix is stripped in the expression sent to rbx (or NOT — decide, and pin it
+with a test, since rbx accepts both and the cache key should be stable);
+whitespace around the pipe is normalised so `N.max|sci` and `N.max | sci` share
+one cache entry; and every existing rejection (foreign scope, non-name
+expression, comment, escape) still yields nothing.
+
+**Step 2-4:** Fail, implement, pass. Run `cd vscode && npm test`.
+
+**Step 5: Commit** — `feat(vscode): report the filter pipeline of a var reference`
+
+---
+
+## Task 4: Rendering cache and provider wiring
+
+**Files:**
+- Modify: `vscode/src/statementVarsIndex.ts` (or a sibling — your call, argue it)
+- Modify: `vscode/src/statementVarHints.ts`
+- Test: extend `vscode/src/rbx/varsPayload.test.ts` for the render map
+
+**What it must do:**
+
+- `renderedFor(root, expressions): Promise<Map<string, string>>` — answers from cache, spawns once for the unknown remainder, writes stdin.
+- **Cache failures.** An expression rbx omitted is cached as "no value". Typing `\VAR{N.max | sc` must ask once, not once per keystroke. Say in a comment why.
+- One spawn per batch, not per expression.
+- The manifest watcher already drops the per-root entry; make sure it drops rendered expressions too — a changed `vars` block changes what they render to.
+- The provider renders known hints immediately and fires `onDidChangeInlayHints` when a batch lands. It must not block the whole document's hints on one slow spawn.
+
+**Reuse:** `rbxProcess.run` takes `(command, args, cwd, timeoutMs)` — check whether it can write stdin; if not, extend it minimally and say so.
+
+Verify: `cd vscode && npm run typecheck && npm test`.
+
+**Commit** — `feat(vscode): honour statement filters in the var hints`
+
+---
+
+## Task 5: Documentation
+
+**Files:** `docs/tools/vscode.md`, `docs/setters/variables.md`, `docs/setters/reference/cli.md`
+
+The vscode page currently states the badge shows the raw value under a filter —
+that becomes false. Fix it, and show the `10⁵` form. Document
+`rbx vars --render` on the variables page beside `rbx vars --json`.
+
+`mkdocs build` regenerates the CLI reference and the checked-in copy is badly
+stale — hand-insert only this command's new options, exactly as the `rbx vars`
+entry was added. Verify with `uv run mkdocs build` (not `--strict`; the ~6
+warnings are pre-existing).
+
+**Commit** — `docs: document filter-aware statement var hints`
+
+---
+
+## Final verification
+
+```bash
+uv run pytest tests/rbx/box/statements/ tests/rbx/box/vars_cmd_test.py tests/rbx/box/lazy_cli_test.py tests/rbx/box/completion/drift_test.py -v
+cd vscode && npm run typecheck && npm test
+```
+
+Do NOT run the full Python suite. Then push to the existing PR #803 branch.

--- a/docs/setters/cheatsheet.md
+++ b/docs/setters/cheatsheet.md
@@ -22,6 +22,7 @@ Where a command has a page of its own, the :material-open-in-new: next to it tak
 | Print a summary of the problem | `rbx summary` |
 | Print the expanded variables of the problem [:material-open-in-new:](/setters/variables#seeing-the-expanded-values) | `rbx vars` |
 | Print the expanded variables as JSON | `rbx vars --json` |
+| Print what statement expressions read from stdin render to [:material-open-in-new:](/setters/variables#seeing-the-expanded-values) | `rbx vars --render` |
 | Use dynamic timing to estimate time limits [:material-open-in-new:](/setters/profiling) | `rbx time` |
 | Estimate time limits skipping the language picker [:material-open-in-new:](/setters/profiling#language-groups) | `rbx time -a` |
 | Estimate limits and write them into a profile [:material-open-in-new:](/setters/profiling#limits-profiles) | `rbx time -p icpc -i` |

--- a/docs/setters/cheatsheet.md
+++ b/docs/setters/cheatsheet.md
@@ -20,6 +20,8 @@ Where a command has a page of its own, the :material-open-in-new: next to it tak
 | Generate all testcases [:material-open-in-new:](/setters/testset#building-the-testset) | `rbx build` |
 | Generate all testcases and their visualizations [:material-open-in-new:](/setters/testset/visualizers) | `rbx build --visualize` |
 | Print a summary of the problem | `rbx summary` |
+| Print the expanded variables of the problem [:material-open-in-new:](/setters/variables#seeing-the-expanded-values) | `rbx vars` |
+| Print the expanded variables as JSON | `rbx vars --json` |
 | Use dynamic timing to estimate time limits [:material-open-in-new:](/setters/profiling) | `rbx time` |
 | Estimate time limits skipping the language picker [:material-open-in-new:](/setters/profiling#language-groups) | `rbx time -a` |
 | Estimate limits and write them into a profile [:material-open-in-new:](/setters/profiling#limits-profiles) | `rbx time -p icpc -i` |

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -350,6 +350,8 @@ rbx vars [OPTIONS]
 | Name | Type | Description | Default |
 | :--- | :--- | :--- | :--- |
 | `--json` | BOOLEAN | Print the vars as a JSON object of dotted keys and string values. | `False` |
+| `--render` | BOOLEAN | Read statement expressions from stdin, one per line, and print a JSON object mapping each to what it renders to. | `False` |
+| `--target` | [FilterTarget][rbx.box.statements.latex_jinja.FilterTarget] | What the --render expressions are being formatted for. Ignored without --render. | `FilterTarget.TEXT` |
 
 
 ---

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -338,6 +338,22 @@ rbx header [OPTIONS]
 
 ---
 
+## vars
+
+Show the expanded vars of this problem.
+
+**Usage:**
+```bash
+rbx vars [OPTIONS]
+```
+
+| Name | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `--json` | BOOLEAN | Print the vars as a JSON object of dotted keys and string values. | `False` |
+
+
+---
+
 ## environment (env)
 
 Set or show the current box environment.

--- a/docs/setters/variables.md
+++ b/docs/setters/variables.md
@@ -167,3 +167,34 @@ Variables can also be used in [generator expressions](/setters/stress-testing/#g
 rbx stress -g "gen [1..<N.max>]" -f "[sols/wa.cpp] ~ INCORRECT"
 ```
 
+## Seeing the expanded values
+
+The value you write is not always the value {{rbx}} ends up using: a
+``py`...` `` expression has to be evaluated, and one variable can be defined in
+terms of another. `rbx vars` prints what is left after all of that -- the very
+same values your validators, checkers and statements see. On the
+``py`...` `` package from [Defining variables](#defining-variables), it prints:
+
+<!--termynal-->
+
+```bash
+$ rbx vars
+M.max = 200000
+N.max = 100000
+```
+
+Pass `--json` and you get the same map as a JSON object, keyed by dotted name.
+Every value crosses as a **string**, never as a JSON number, so that a bound
+like ``py`10**18 + 7` `` survives a JSON parser exactly instead of being
+quietly rounded to the nearest float.
+
+```bash
+$ rbx vars --json
+{"N.max": "100000", "M.max": "200000"}
+```
+
+!!! tip "Right there in your statement"
+
+    The [VS Code extension](../tools/vscode.md#variables-in-a-statement) reads
+    this to show you what each `\VAR{...}` in a statement expands to, beside
+    the reference itself.

--- a/docs/setters/variables.md
+++ b/docs/setters/variables.md
@@ -193,8 +193,32 @@ $ rbx vars --json
 {"N.max": "100000", "M.max": "200000"}
 ```
 
+A value and what a statement *shows* for it are two different things, though --
+that is exactly what a filter like `sci` sits in the middle of. `--render`
+answers the second question: it reads statement expressions from stdin, one per
+line, and prints a JSON object mapping each one to the text it renders to.
+
+```bash
+$ printf 'N.max\nM.max | sci\n' | rbx vars --render
+{"N.max": "100000", "M.max | sci": "2×10⁵"}
+```
+
+`--target` picks the spelling of that text, never the rules the filter follows:
+
+| Target | What `sci` spells `M.max` as |
+| ------ | ---------------------------- |
+| `text` (the default) | `2×10⁵` -- plain text, for somewhere that cannot typeset maths |
+| `latex` | `2 \times 10^{5}` -- what a {{rbxTeX}} statement puts in the PDF |
+| `markdown` | the same as `latex`, since a Markdown statement writes its constraints inside `$...$` |
+
+An expression {{rbx}} cannot render -- an unknown filter, a name no variable
+answers to -- is left out of the map instead of guessed at, and named on
+`stderr`. The command still exits 0, so one bad expression does not cost you
+the rest.
+
 !!! tip "Right there in your statement"
 
     The [VS Code extension](../tools/vscode.md#variables-in-a-statement) reads
-    this to show you what each `\VAR{...}` in a statement expands to, beside
-    the reference itself.
+    both of these to show you what each `\VAR{...}` in a statement expands to,
+    beside the reference itself -- `--json` for a bare reference, `--render`
+    for a filtered one.

--- a/docs/tools/vscode.md
+++ b/docs/tools/vscode.md
@@ -10,9 +10,12 @@ a terminal does, and does not care which editor you use; the extension gives
 you VS Code's own diff, its editors and its Problems panel, and it does not
 take over the terminal you are typing `rbx` into.
 
-!!! note "It never runs rbx for you"
+!!! note "It never builds or runs for you"
     Execution stays in the terminal. You type `rbx run`; the extension watches
-    the package and renders whatever lands there.
+    the package and renders whatever lands there. It does call {{rbx}} itself
+    for a couple of small things -- drawing a visualization, asking what a
+    variable expands to -- and for those it has to find an `rbx` to call, which
+    [Finding rbx](#finding-rbx) covers.
 
 ## Installing
 
@@ -156,6 +159,65 @@ your desktop associates with the file.
     answer. Visualizing what a *solution* printed is not available in the
     extension yet -- use `rbx ui` for that.
 
+## Variables in a statement
+
+While you are editing a statement, every `\VAR{...}` that names one of the
+package's [variables](../setters/variables.md) is followed by what that
+variable expands to, so a constraints block reads as its numbers without
+`problem.rbx.yml` open beside it.
+
+```{.latex .no-copy}
+\item $1 \le N \le \VAR{N.max}$    100000
+\item $1 \le a_i \le \VAR{A.max}$  1000000000
+```
+
+The greyed numbers on the right are not in the file: they are VS Code's own
+**inlay hints**, which means `editor.inlayHints.enabled` turns them off along
+with every other extension's, and `rbx.statementVarHints` turns off just these.
+
+The values come from `rbx vars`, which only reads `problem.rbx.yml` -- so they
+are right while you type, and do not wait for a `rbx build` or a
+`rbx statements build`.
+
+A hint is shown only where it can be exactly right, and there are four places
+it deliberately is not:
+
+- **Problem-root references only.** `\VAR{N.max}` and `\VAR{vars.N.max}` are
+  the ones that get a value. A group reference such as `\VAR{g.N.max}` almost
+  always sits inside a `\BLOCK{for g in groups}` loop and renders a different
+  number per group, so a single hint would have to lie or to name a group;
+  `\VAR{p.N.max}`, `\VAR{problem.N.max}` and `\VAR{contest.year}` resolve
+  against variable sets that are not this problem's own. None of them get a
+  hint.
+- **The raw value, whatever the filter does.** `\VAR{N.max | sci}` typesets as
+  `10^5` in the built statement but hints `100000`. The filter decides how the
+  number is *typeset*; the hint answers what the number *is*.
+- **Nothing is ever guessed.** A name no variable answers to, an expression
+  that is not a plain dotted name, a commented-out line, an escaped `\\VAR` --
+  all get nothing. An absent hint is never a wrong one, and it is a useful
+  tell: a misspelled variable is the one reference on the line with no number
+  next to it.
+- **Only what the manifest calls a statement.** `problem.rbx.yml`'s
+  `statements` and `tutorials` are hinted. A contest statement declared in
+  `contest.rbx.yml`, and the LaTeX template a statement is rendered into, are
+  not -- they are not problem statements, and their variables are not this
+  package's.
+
+## Finding rbx
+
+Drawing a visualization and reading a statement's variables both call {{rbx}},
+so the extension has to find one. It tries `PATH` first and then asks a login
+shell, because the extension host inherits the `PATH` of whatever launched VS
+Code -- open the editor from Finder or the Dock rather than from a terminal and
+that `PATH` is a bare one, without the `~/.local/bin` that `uv tool install`
+and `pipx` write into.
+
+If neither finds it, point `rbx.executable` at the binary. The setting is
+per-folder, so a workspace holding packages on different {{rbx}} versions can
+give each one its own.
+
+Everything else keeps working without an `rbx` to call: the views read files.
+
 ## Settings
 
 Every surface above can be turned off or adjusted on its own. Search for
@@ -164,5 +226,7 @@ Every surface above can be turned off or adjusted on its own. Search for
 | Setting | Default | Does |
 |---|---|---|
 | `rbx.compilationDiagnostics` | `true` | Report compiler warnings and failures in the Problems panel |
+| `rbx.statementVarHints` | `true` | Show what each `\VAR{...}` in a statement expands to, beside the reference |
+| `rbx.executable` | *(empty)* | The `rbx` to call, when finding it automatically does not work |
 | `rbx.solutionLabel` | `trimmed` | How much of a solution's path the run view shows: `full`, `trimmed` or `basename` |
 | `rbx.testcaseLayout` | `below` | Where the second testcase pane is *first* placed: `below` or `beside` |

--- a/docs/tools/vscode.md
+++ b/docs/tools/vscode.md
@@ -179,7 +179,25 @@ The values come from `rbx vars`, which only reads `problem.rbx.yml` -- so they
 are right while you type, and do not wait for a `rbx build` or a
 `rbx statements build`.
 
-A hint is shown only where it can be exactly right, and there are four places
+A reference piped through a
+[filter](../setters/statements/context.md#filters) is hinted as what the filter
+makes of it, not as the bare number underneath. {{rbx}} renders the expression
+itself, so the hint agrees with the statement whatever you pipe through --
+`sci`, `rsci`, or any {{Jinja2}} builtin such as `upper` or `round(2)`:
+
+```{.latex .no-copy}
+\item $1 \le N \le \VAR{N.max | sci}$      10⁵
+\item $1 \le a_i \le \VAR{A.max | sci}$    10⁹
+\item Answers modulo \VAR{MOD | rsci}      10⁹ + 7
+```
+
+An inlay hint cannot typeset maths, so it spells the same value in plain text:
+superscript digits and `×` where the built statement gets `^{}` and `\times`.
+Only the spelling changes. What a filter *decides* is the same in both places,
+so `sci` leaving `250000` as its digits in the PDF leaves it as its digits in
+the hint too.
+
+A hint is shown only where it can be exactly right, and there are three places
 it deliberately is not:
 
 - **Problem-root references only.** `\VAR{N.max}` and `\VAR{vars.N.max}` are
@@ -189,12 +207,12 @@ it deliberately is not:
   `\VAR{p.N.max}`, `\VAR{problem.N.max}` and `\VAR{contest.year}` resolve
   against variable sets that are not this problem's own. None of them get a
   hint.
-- **The raw value, whatever the filter does.** `\VAR{N.max | sci}` typesets as
-  `10^5` in the built statement but hints `100000`. The filter decides how the
-  number is *typeset*; the hint answers what the number *is*.
 - **Nothing is ever guessed.** A name no variable answers to, an expression
   that is not a plain dotted name, a commented-out line, an escaped `\\VAR` --
-  all get nothing. An absent hint is never a wrong one, and it is a useful
+  all get nothing, and neither does a half-typed pipeline like
+  `\VAR{N.max |}`. A filter over a name that does not exist gets nothing
+  either: the name is looked up before anything is rendered, so a typo never
+  costs a render. An absent hint is never a wrong one, and it is a useful
   tell: a misspelled variable is the one reference on the line with no number
   next to it.
 - **Only what the manifest calls a statement.** `problem.rbx.yml`'s

--- a/rbx/box/cli/__init__.py
+++ b/rbx/box/cli/__init__.py
@@ -116,6 +116,12 @@ _COMMANDS = [
         rich_help_panel='Configuration',
     ),
     LazyCommand(
+        'vars',
+        'rbx.box.cli.commands.vars_cmd:app',
+        help='Show the expanded vars of this problem.',
+        rich_help_panel='Configuration',
+    ),
+    LazyCommand(
         'environment, env',
         'rbx.box.cli.commands.config_cmds:app',
         help='Set or show the current box environment.',

--- a/rbx/box/cli/commands/vars_cmd.py
+++ b/rbx/box/cli/commands/vars_cmd.py
@@ -54,7 +54,8 @@ def vars_command(
         latex_jinja.FilterTarget,
         typer.Option(
             '--target',
-            help='What the rendered expressions are being formatted for.',
+            help='What the --render expressions are being formatted for. '
+            'Ignored without --render.',
         ),
         # TEXT, because the only caller is the VS Code inlay hint, which cannot
         # typeset maths. A caller that wants the statement's own spelling asks
@@ -123,21 +124,42 @@ def _render_from_stdin(expanded: fields.Vars, target: latex_jinja.FilterTarget) 
     # ``py`...``` var in `problem.rbx.yml`, which this command expands before it
     # renders anything.
     env = latex_jinja.make_jinja_env(target, syntax=latex_jinja.JinjaSyntax.LATEX)
-    # `\VAR{N.max}` is shorthand for `\VAR{vars.N.max}` (see
-    # `statements/context._lift`), and the scanner may send either spelling.
+    # Half of `statements/context._lift`: the vars wrapper bound both under
+    # `vars` and lifted to the top level, because `\VAR{N.max}` is shorthand for
+    # `\VAR{vars.N.max}` and the scanner may send either spelling. The other
+    # half -- the `lang`/`languages`/`params`/`contest`/`problem` names that
+    # `problem_jinja_kwargs` lifts alongside it -- is out of reach here: those
+    # come from a resolved statement, which this command deliberately does not
+    # load. So `problem.title` and `params.foo` render to nothing and are
+    # dropped. That gap cannot reach a badge: the extension's scanner rejects a
+    # `problem.`/`contest.`/`p.`/`g.`-prefixed expression before it is ever sent.
     wrapper = latex_jinja.JinjaDictWrapper.from_dict(dict(expanded), wrapper_key='vars')
     namespace = {**wrapper, 'vars': wrapper}
 
     rendered: Dict[str, str] = {}
     for expression in _read_expressions():
         try:
-            # Wrapped in the statement's own `\VAR{...}`, not `{{ ... }}`: an
-            # expression is only worth a badge if a statement could hold it, so
-            # it is lexed by the delimiters a statement is lexed by.
+            # Wrapped in `\VAR{...}` rather than `{{ ... }}` because an rbxTeX
+            # statement holds it that way. This is not universal -- a Markdown
+            # statement renders under `JinjaSyntax.PLAIN`, so `--target markdown`
+            # lexes with delimiters that statement does not use -- but the two
+            # lexers differ only in where the expression ends, and Jinja balances
+            # brackets before honouring an end delimiter, so an expression that
+            # closes its own brackets (every expression a scanner can extract)
+            # lexes identically either way.
             rendered[expression] = env.from_string(f'\\VAR{{{expression}}}').render(
                 **namespace
             )
-        except Exception:
+        except Exception as err:
+            # stdout is the JSON map, so stderr is free: name the expression and
+            # the error. Without this a bug inside a filter is indistinguishable
+            # from a typo in the expression -- both are just a badge that never
+            # appears -- and neither leaves a trace to diagnose.
+            console.stderr_console.print(
+                f'[warning]Could not render[/warning] '
+                f'{rich.markup.escape(expression)}[warning]:[/warning] '
+                f'{type(err).__name__}: {rich.markup.escape(str(err))}'
+            )
             continue
     # `ensure_ascii=False` so `10⁵` crosses as itself; the consumer reads UTF-8.
     return json.dumps(rendered, ensure_ascii=False)

--- a/rbx/box/cli/commands/vars_cmd.py
+++ b/rbx/box/cli/commands/vars_cmd.py
@@ -12,12 +12,14 @@ would make it unsafe to call. See
 """
 
 import json
+import math
 from typing import Annotated
 
+import rich.markup
 import typer
 
 from rbx import annotations, console
-from rbx.box import package
+from rbx.box import fields, package
 
 app = typer.Typer(cls=annotations.AliasGroup)
 
@@ -39,7 +41,39 @@ def vars_command(
 ):
     expanded = package.find_problem_package_or_die().expanded_vars
     if json_output:
-        typer.echo(json.dumps(expanded))
+        typer.echo(_dump_json(expanded))
         return
     for name, value in sorted(expanded.items()):
-        console.console.print(f'[item]{name}[/item] = {value}')
+        # Both halves are setter-controlled YAML rendered as markup, so a var
+        # named or valued with brackets would otherwise style the output or
+        # blow up with a MarkupError.
+        escaped_name = rich.markup.escape(name)
+        escaped_value = rich.markup.escape(str(value))
+        console.console.print(f'[item]{escaped_name}[/item] = {escaped_value}')
+
+
+def _dump_json(expanded: fields.Vars) -> str:
+    """Serialize the vars, refusing to emit anything `JSON.parse` would reject.
+
+    `json.dumps` writes bare `Infinity`/`NaN` for a non-finite float, which is
+    not JSON. The consumer is a spawned process reading stdout, so a clean
+    non-zero exit is far more useful to it than a payload that fails to parse.
+    """
+    try:
+        return json.dumps(expanded, allow_nan=False)
+    except ValueError as e:
+        offenders = sorted(
+            name
+            for name, value in expanded.items()
+            if isinstance(value, float) and not math.isfinite(value)
+        )
+        detail = (
+            f'non-finite values in {", ".join(offenders)}'
+            if offenders
+            else str(e)  # Not the non-finite case: say whatever json said.
+        )
+        console.console.print(
+            f'[error]Cannot serialize the vars of this problem to JSON: '
+            f'{rich.markup.escape(detail)}.[/error]'
+        )
+        raise typer.Exit(1) from None

--- a/rbx/box/cli/commands/vars_cmd.py
+++ b/rbx/box/cli/commands/vars_cmd.py
@@ -35,7 +35,7 @@ def vars_command(
         bool,
         typer.Option(
             '--json',
-            help='Print the vars as a JSON object of dotted keys.',
+            help='Print the vars as a JSON object of dotted keys and string values.',
         ),
     ] = False,
 ):
@@ -53,29 +53,41 @@ def vars_command(
 
 
 def _dump_json(expanded: fields.Vars) -> str:
-    """Serialize the vars, refusing to emit anything `JSON.parse` would reject.
+    """Serialize the vars as a flat map of dotted name to *display string*.
 
-    `json.dumps` writes bare `Infinity`/`NaN` for a non-finite float, which is
-    not JSON. The consumer is a spawned process reading stdout, so a clean
-    non-zero exit is far more useful to it than a payload that fails to parse.
+    Every value crosses as a JSON string holding the text the statement would
+    show, never as a JSON number. The only consumer -- the VS Code extension --
+    wants display text and never does arithmetic on these, and a JSON number
+    cannot carry the text losslessly: `JSON.parse` produces IEEE doubles, so
+    `10**18 + 7` (a plausible bound) would come back as `1000000000000000000`
+    and the extension would badge a *wrong* value with full confidence, and
+    `10**21` would come back spelled `1e+21`. Rendering here is exact for
+    arbitrarily large ints and keeps float formatting out of the boundary.
+
+    `str` is the right renderer because it is what Jinja itself calls on a
+    value with no filter, so the badge shows exactly what `\\VAR{...}` will:
+    an `int` becomes its full decimal expansion, a `str` itself, a `float` its
+    `repr`, and a `bool` `True`/`False`. Note that last one is deliberately
+    *not* the `1`/`0` of `fields.render_var_on_command_line`: that spelling
+    exists for testlib/jngen argument parsing, not for statement display.
     """
-    try:
-        return json.dumps(expanded, allow_nan=False)
-    except ValueError as e:
-        offenders = sorted(
-            name
-            for name, value in expanded.items()
-            if isinstance(value, float) and not math.isfinite(value)
+    offenders = sorted(
+        name
+        for name, value in expanded.items()
+        if isinstance(value, float) and not math.isfinite(value)
+    )
+    if offenders:
+        # `str(float('inf'))` is a perfectly good JSON string, so this no longer
+        # has to be rejected -- but an infinite bound is a package bug, and the
+        # consumer degrades cleanly on a non-zero exit, so keep surfacing it.
+        detail = (
+            f'{offenders[0]} has a non-finite value'
+            if len(offenders) == 1
+            else f'{", ".join(offenders)} have non-finite values'
         )
-        if not offenders:
-            # Not the non-finite case: say whatever json said.
-            detail = str(e)
-        elif len(offenders) == 1:
-            detail = f'{offenders[0]} has a non-finite value'
-        else:
-            detail = f'{", ".join(offenders)} have non-finite values'
         console.console.print(
             f'[error]Cannot serialize the vars of this problem to JSON: '
             f'{rich.markup.escape(detail)}.[/error]'
         )
-        raise typer.Exit(1) from None
+        raise typer.Exit(1)
+    return json.dumps({name: str(value) for name, value in expanded.items()})

--- a/rbx/box/cli/commands/vars_cmd.py
+++ b/rbx/box/cli/commands/vars_cmd.py
@@ -7,19 +7,24 @@ there too.
 This command is deliberately read-only: it loads `problem.rbx.yml` and
 expands its vars, and touches nothing else. The VS Code extension spawns it
 while the user edits, so anything that creates or locks the package cache
-would make it unsafe to call. See
+would make it unsafe to call. `--render` holds to the same bargain: it renders
+expressions in-process through the statement Jinja environment, and builds no
+statement. See
 `docs/plans/2026-08-28-vscode-statement-var-hints-design.md`.
 """
 
 import json
 import math
-from typing import Annotated
+import sys
+from typing import Annotated, Dict, List
 
+import jinja2
 import rich.markup
 import typer
 
 from rbx import annotations, console
 from rbx.box import fields, package
+from rbx.box.statements import latex_jinja
 
 app = typer.Typer(cls=annotations.AliasGroup)
 
@@ -38,8 +43,37 @@ def vars_command(
             help='Print the vars as a JSON object of dotted keys and string values.',
         ),
     ] = False,
+    render: Annotated[
+        bool,
+        typer.Option(
+            '--render',
+            help='Read statement expressions from stdin, one per line, and print '
+            'a JSON object mapping each to what it renders to.',
+        ),
+    ] = False,
+    target: Annotated[
+        latex_jinja.FilterTarget,
+        typer.Option(
+            '--target',
+            help='What the rendered expressions are being formatted for.',
+        ),
+        # TEXT, because the only caller is the VS Code inlay hint, which cannot
+        # typeset maths. A caller that wants the statement's own spelling asks
+        # for it; one that forgets gets the answer that is at least readable.
+    ] = latex_jinja.FilterTarget.TEXT,
 ):
+    if render and json_output:
+        # They name two different output shapes over the same stdout. Letting
+        # one win silently would hand the caller a map it did not ask for.
+        console.console.print(
+            '[error]--render and --json cannot be used together.[/error]'
+        )
+        raise typer.Exit(1)
+
     expanded = package.find_problem_package_or_die().expanded_vars
+    if render:
+        typer.echo(_render_from_stdin(expanded, target))
+        return
     if json_output:
         typer.echo(_dump_json(expanded))
         return
@@ -50,6 +84,78 @@ def vars_command(
         escaped_name = rich.markup.escape(name)
         escaped_value = rich.markup.escape(str(value))
         console.console.print(f'[item]{escaped_name}[/item] = {escaped_value}')
+
+
+def _read_expressions() -> List[str]:
+    """Read the expressions to render off stdin, one per line.
+
+    Stdin rather than a repeatable flag: `|` is a quoting trap in every shell,
+    and a statement with two dozen filtered references should cost one spawn.
+    Blank lines are dropped and the order of first appearance is kept, so a
+    bound repeated across a statement is rendered once and keyed once.
+
+    Reading from a terminal blocks until EOF, which is the usual bargain for a
+    filter (`cat`, `jq`); a human poking at it by hand ends the list with
+    Ctrl-D.
+    """
+    seen: Dict[str, None] = {}
+    for line in sys.stdin.read().splitlines():
+        expression = line.strip()
+        if expression:
+            seen.setdefault(expression, None)
+    return list(seen)
+
+
+def _render_environment(target: latex_jinja.FilterTarget) -> jinja2.Environment:
+    """The environment a statement renders under, minus the file loader.
+
+    Same delimiters, same strict undefined, same filters -- the badge is only
+    worth showing if it agrees with the statement, and the way to guarantee
+    that is to render under the same environment rather than a lookalike.
+
+    This environment is **not** sandboxed, exactly like the statement one: an
+    expression can reach whatever the namespace exposes. That is not a new
+    boundary. Anyone who can pipe expressions in can already run arbitrary
+    Python through a ``py`...``` var in `problem.rbx.yml`, which this command
+    expands before it renders anything.
+    """
+    env = jinja2.Environment(
+        **latex_jinja.J2_ARGS,  # type: ignore[arg-type]
+        undefined=latex_jinja.StrictChainableUndefined,
+    )
+    latex_jinja.add_builtin_filters(env, target=target)
+    latex_jinja.add_builtin_tests(env)
+    return env
+
+
+def _render_from_stdin(expanded: fields.Vars, target: latex_jinja.FilterTarget) -> str:
+    """Render each expression read from stdin, dropping the ones that fail.
+
+    An expression that does not render -- an unknown filter, a bad argument, a
+    name that is not there -- is simply absent from the map, and the command
+    still exits 0. The consumer draws no badge for what it does not get back,
+    which is always a safe answer; a non-zero exit is reserved for a package
+    that could not be read at all, and would cost every other badge too.
+    """
+    env = _render_environment(target)
+    # `\VAR{N.max}` is shorthand for `\VAR{vars.N.max}` (see
+    # `statements/context._lift`), and the scanner may send either spelling.
+    wrapper = latex_jinja.JinjaDictWrapper.from_dict(dict(expanded), wrapper_key='vars')
+    namespace = {**wrapper, 'vars': wrapper}
+
+    rendered: Dict[str, str] = {}
+    for expression in _read_expressions():
+        try:
+            # Wrapped in the statement's own `\VAR{...}`, not `{{ ... }}`: an
+            # expression is only worth a badge if a statement could hold it, so
+            # it is lexed by the delimiters a statement is lexed by.
+            rendered[expression] = env.from_string(f'\\VAR{{{expression}}}').render(
+                **namespace
+            )
+        except Exception:
+            continue
+    # `ensure_ascii=False` so `10⁵` crosses as itself; the consumer reads UTF-8.
+    return json.dumps(rendered, ensure_ascii=False)
 
 
 def _dump_json(expanded: fields.Vars) -> str:

--- a/rbx/box/cli/commands/vars_cmd.py
+++ b/rbx/box/cli/commands/vars_cmd.py
@@ -65,7 +65,9 @@ def _dump_json(expanded: fields.Vars) -> str:
     arbitrarily large ints and keeps float formatting out of the boundary.
 
     `str` is the right renderer because it is what Jinja itself calls on a
-    value with no filter, so the badge shows exactly what `\\VAR{...}` will:
+    value with no filter, so the badge shows exactly what an unfiltered
+    `\\VAR{...}` will (a filtered one renders differently by design -- the
+    badge answers "what number is this?", not "what will this typeset as"):
     an `int` becomes its full decimal expansion, a `str` itself, a `float` its
     `repr`, and a `bool` `True`/`False`. Note that last one is deliberately
     *not* the `1`/`0` of `fields.render_var_on_command_line`: that spelling

--- a/rbx/box/cli/commands/vars_cmd.py
+++ b/rbx/box/cli/commands/vars_cmd.py
@@ -1,0 +1,45 @@
+"""`rbx vars`.
+
+Registered lazily from `rbx.box.cli.ENTRIES`, so this module is imported
+only when one of its commands is invoked. A command added here needs a row
+there too.
+
+This command is deliberately read-only: it loads `problem.rbx.yml` and
+expands its vars, and touches nothing else. The VS Code extension spawns it
+while the user edits, so anything that creates or locks the package cache
+would make it unsafe to call. See
+`docs/plans/2026-08-28-vscode-statement-var-hints-design.md`.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from rbx import annotations, console
+from rbx.box import package
+
+app = typer.Typer(cls=annotations.AliasGroup)
+
+
+@app.command(
+    'vars',
+    rich_help_panel='Configuration',
+    help='Show the expanded vars of this problem.',
+)
+@package.within_problem
+def vars_command(
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            '--json',
+            help='Print the vars as a JSON object of dotted keys.',
+        ),
+    ] = False,
+):
+    expanded = package.find_problem_package_or_die().expanded_vars
+    if json_output:
+        typer.echo(json.dumps(expanded))
+        return
+    for name, value in sorted(expanded.items()):
+        console.console.print(f'[item]{name}[/item] = {value}')

--- a/rbx/box/cli/commands/vars_cmd.py
+++ b/rbx/box/cli/commands/vars_cmd.py
@@ -18,7 +18,6 @@ import math
 import sys
 from typing import Annotated, Dict, List
 
-import jinja2
 import rich.markup
 import typer
 
@@ -106,28 +105,6 @@ def _read_expressions() -> List[str]:
     return list(seen)
 
 
-def _render_environment(target: latex_jinja.FilterTarget) -> jinja2.Environment:
-    """The environment a statement renders under, minus the file loader.
-
-    Same delimiters, same strict undefined, same filters -- the badge is only
-    worth showing if it agrees with the statement, and the way to guarantee
-    that is to render under the same environment rather than a lookalike.
-
-    This environment is **not** sandboxed, exactly like the statement one: an
-    expression can reach whatever the namespace exposes. That is not a new
-    boundary. Anyone who can pipe expressions in can already run arbitrary
-    Python through a ``py`...``` var in `problem.rbx.yml`, which this command
-    expands before it renders anything.
-    """
-    env = jinja2.Environment(
-        **latex_jinja.J2_ARGS,  # type: ignore[arg-type]
-        undefined=latex_jinja.StrictChainableUndefined,
-    )
-    latex_jinja.add_builtin_filters(env, target=target)
-    latex_jinja.add_builtin_tests(env)
-    return env
-
-
 def _render_from_stdin(expanded: fields.Vars, target: latex_jinja.FilterTarget) -> str:
     """Render each expression read from stdin, dropping the ones that fail.
 
@@ -137,7 +114,15 @@ def _render_from_stdin(expanded: fields.Vars, target: latex_jinja.FilterTarget) 
     which is always a safe answer; a non-zero exit is reserved for a package
     that could not be read at all, and would cost every other badge too.
     """
-    env = _render_environment(target)
+    # The statement's own environment, minus the file loader: the badge is only
+    # worth showing if it agrees with the statement, and the way to guarantee
+    # that is to build it with the statement's factory rather than a lookalike.
+    # Not sandboxed, exactly like the statement one -- an expression can reach
+    # whatever the namespace exposes. That is not a new boundary: anyone who can
+    # pipe expressions in can already run arbitrary Python through a
+    # ``py`...``` var in `problem.rbx.yml`, which this command expands before it
+    # renders anything.
+    env = latex_jinja.make_jinja_env(target, syntax=latex_jinja.JinjaSyntax.LATEX)
     # `\VAR{N.max}` is shorthand for `\VAR{vars.N.max}` (see
     # `statements/context._lift`), and the scanner may send either spelling.
     wrapper = latex_jinja.JinjaDictWrapper.from_dict(dict(expanded), wrapper_key='vars')

--- a/rbx/box/cli/commands/vars_cmd.py
+++ b/rbx/box/cli/commands/vars_cmd.py
@@ -67,11 +67,13 @@ def _dump_json(expanded: fields.Vars) -> str:
             for name, value in expanded.items()
             if isinstance(value, float) and not math.isfinite(value)
         )
-        detail = (
-            f'non-finite values in {", ".join(offenders)}'
-            if offenders
-            else str(e)  # Not the non-finite case: say whatever json said.
-        )
+        if not offenders:
+            # Not the non-finite case: say whatever json said.
+            detail = str(e)
+        elif len(offenders) == 1:
+            detail = f'{offenders[0]} has a non-finite value'
+        else:
+            detail = f'{", ".join(offenders)} have non-finite values'
         console.console.print(
             f'[error]Cannot serialize the vars of this problem to JSON: '
             f'{rich.markup.escape(detail)}.[/error]'

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -898,6 +898,30 @@ SPEC = {
             ],
         },
         {
+            'help': 'Show the expanded vars of this problem.',
+            'is_group': False,
+            'name': 'vars',
+            'panel': 'Configuration',
+            'params': [
+                {
+                    'help': 'Print the vars as a JSON object of dotted keys.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--json'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Show this message and exit.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--help'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+            ],
+        },
+        {
             'help': 'Set or show the current box environment.',
             'is_group': False,
             'name': 'environment, env',

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -913,6 +913,26 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': 'Read statement expressions from stdin, one per line, and print '
+                    'a JSON object mapping each to what it renders to.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--render'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'What the rendered expressions are being formatted for.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--target'],
+                    'takes_value': True,
+                    'value': {
+                        'choices': ['latex', 'markdown', 'text'],
+                        'kind': 'choice',
+                    },
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -904,7 +904,8 @@ SPEC = {
             'panel': 'Configuration',
             'params': [
                 {
-                    'help': 'Print the vars as a JSON object of dotted keys.',
+                    'help': 'Print the vars as a JSON object of dotted keys and string '
+                    'values.',
                     'kind': 'option',
                     'multiple': False,
                     'names': ['--json'],

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -922,7 +922,8 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
-                    'help': 'What the rendered expressions are being formatted for.',
+                    'help': 'What the --render expressions are being formatted for. Ignored '
+                    'without --render.',
                     'kind': 'option',
                     'multiple': False,
                     'names': ['--target'],

--- a/rbx/box/statements/latex_jinja.py
+++ b/rbx/box/statements/latex_jinja.py
@@ -96,9 +96,14 @@ class FilterTarget(enum.Enum):
     cannot typeset maths.
 
     MARKDOWN maps to the LaTeX formatter and is not redundant: a Markdown
-    statement puts its constraints in `$...$` math, so LaTeX is correct there.
-    Naming it separately means the day it stops being correct is a one-line
-    change rather than an archaeology exercise.
+    statement puts its constraints in `$...$` math, so LaTeX is what `sci` and
+    `rsci` should emit there. Naming it separately means the day that stops
+    being correct is a one-line change rather than an archaeology exercise.
+
+    That claim covers `sci`/`rsci` only. The target also picks `escape`, and
+    under MARKDOWN that is still the inherited LaTeX escaping (`a_b` -> `a\\_b`,
+    a backslash -> `\\textbackslash{}`), which nobody has examined against a
+    Markdown body outside math. Whether it is right there is out of scope here.
     """
 
     LATEX = 'latex'
@@ -119,6 +124,11 @@ def escape_latex_str_if_str(value):
     return value
 
 
+def _no_escape(value: Any) -> Any:
+    """The `escape` filter for output that is not embedded in a markup document."""
+    return value
+
+
 def _process_zeroes(value: int) -> Tuple[int, int, int]:
     cnt = 0
 
@@ -129,7 +139,7 @@ def _process_zeroes(value: int) -> Tuple[int, int, int]:
     return acc, cnt, value - acc * 10**cnt
 
 
-def _scientific_decision(
+def _decide_scientific_notation(
     value: int,
     zeroes: int,
     rest: bool,
@@ -153,24 +163,26 @@ def _scientific_decision(
     return mult, exp, rem
 
 
-def _format_scientific_latex(mult: int, exp: int, rem: int) -> str:
+def _format_scientific_latex(mult: int, exp: int) -> str:
+    """Spell `mult * 10^exp` as maths. The ` + rem` tail is added by the caller."""
     res = '10' if exp == 1 else f'10^{{{exp}}}'
     if mult > 1:
         res = f'{mult} \\times {res}'
-    if rem > 0:
-        res = f'{res} + {rem}'
     return res
 
 
 _SUPERSCRIPT_DIGITS = str.maketrans('0123456789', '⁰¹²³⁴⁵⁶⁷⁸⁹')
 
 
-def _format_scientific_text(mult: int, exp: int, rem: int) -> str:
+def _format_scientific_text(mult: int, exp: int) -> str:
+    """Spell `mult * 10^exp` as plain text. The ` + rem` tail is added by the caller."""
     res = '10' if exp == 1 else '10' + str(exp).translate(_SUPERSCRIPT_DIGITS)
     if mult > 1:
+        # Tight, where the LaTeX spelling is `2 \times 10^{5}`. Not an
+        # inconsistency: math mode discards source spaces and `\times` sets its
+        # own, so the PDF shows the same tightness either way. Here `×` is the
+        # glyph, and every space around it would be shown.
         res = f'{mult}×{res}'
-    if rem > 0:
-        res = f'{res} + {rem}'
     return res
 
 
@@ -188,17 +200,26 @@ def scientific_notation(
     if value == 0:
         return '0'
     if value < 0:
-        # `rest` is deliberately not forwarded: a negative number has never
-        # kept a remainder, and this must not start doing so.
+        # `rest` is not forwarded, so `rsci(-100007)` is `-100007` rather than
+        # the negation of `10^{5} + 7`. That asymmetry is pre-existing, and it
+        # is kept bug-for-bug because this refactor's one constraint is that
+        # shipped statement output does not move. Changing it is a fine thing
+        # to want; it belongs in its own commit, with its own golden row and a
+        # changelog line.
         return f'-{scientific_notation(-value, zeroes=zeroes, target=target)}'
 
-    decision = _scientific_decision(value, zeroes=zeroes, rest=rest)
+    decision = _decide_scientific_notation(value, zeroes=zeroes, rest=rest)
     if decision is None:
         return str(value)
     mult, exp, rem = decision
     if target is FilterTarget.TEXT:
-        return _format_scientific_text(mult, exp, rem)
-    return _format_scientific_latex(mult, exp, rem)
+        res = _format_scientific_text(mult, exp)
+    else:
+        res = _format_scientific_latex(mult, exp)
+    if rem > 0:
+        # Target-independent: every target spells the remainder the same way.
+        res = f'{res} + {rem}'
+    return res
 
 
 def rest_scientific_notation(
@@ -353,17 +374,14 @@ class JinjaDictWrapper(dict):
             )
 
 
-def _identity(value: Any) -> Any:
-    return value
-
-
 def add_builtin_filters(
     j2_env: jinja2.Environment,
     target: FilterTarget = FilterTarget.LATEX,
 ):
-    # A badge is not a document: there is nothing to escape into under TEXT.
+    # TEXT output is not embedded in a markup document, so there is nothing to
+    # escape for.
     j2_env.filters['escape'] = (
-        _identity if target is FilterTarget.TEXT else escape_latex_str_if_str
+        _no_escape if target is FilterTarget.TEXT else escape_latex_str_if_str
     )
     j2_env.filters['sci'] = functools.partial(scientific_notation, target=target)
     j2_env.filters['rsci'] = functools.partial(rest_scientific_notation, target=target)

--- a/rbx/box/statements/latex_jinja.py
+++ b/rbx/box/statements/latex_jinja.py
@@ -3,6 +3,8 @@ that overrides Jinja2 defaults to make it work more seamlessly
 with Latex.
 """
 
+import enum
+import functools
 import pathlib
 import re
 import typing
@@ -83,6 +85,28 @@ REGEX_BACKSLASH = re.compile(r'(?<!\\)\\(?!{})'.format(ESCAPE_CHARS_OR))
 
 
 ######################################################################
+# Filter targets
+######################################################################
+class FilterTarget(enum.Enum):
+    """What a filter is formatting for.
+
+    The *rules* a filter applies -- when `sci` abbreviates, when it declines --
+    are a property of the value and never vary. Only the spelling does: a PDF
+    wants `2 \\times 10^{5}`, a VS Code inlay hint wants `2×10⁵` because it
+    cannot typeset maths.
+
+    MARKDOWN maps to the LaTeX formatter and is not redundant: a Markdown
+    statement puts its constraints in `$...$` math, so LaTeX is correct there.
+    Naming it separately means the day it stops being correct is a one-line
+    change rather than an archaeology exercise.
+    """
+
+    LATEX = 'latex'
+    MARKDOWN = 'markdown'
+    TEXT = 'text'
+
+
+######################################################################
 # Declare module functions
 ######################################################################
 def escape_latex_str_if_str(value):
@@ -105,10 +129,57 @@ def _process_zeroes(value: int) -> Tuple[int, int, int]:
     return acc, cnt, value - acc * 10**cnt
 
 
+def _scientific_decision(
+    value: int,
+    zeroes: int,
+    rest: bool,
+) -> Optional[Tuple[int, int, int]]:
+    """Decide how to abbreviate a positive integer, or decline.
+
+    Returns the `(mult, exp, rem)` of `mult * 10^exp + rem`, or None when the
+    number should be printed as-is. These are the rules of the value, shared by
+    every target; only the spelling of the answer varies.
+    """
+    mult, exp, rem = _process_zeroes(value)
+    if exp < zeroes:
+        return None
+    if not rest and rem > 0:
+        # Should not convert numbers like 100007 to 10^5 + 7,
+        # unless rest is true.
+        return None
+    if rem > 0 and len(str(rem)) + 1 >= len(str(value)):
+        # Should not convert numbers like 532 to 5*10^2 + 32.
+        return None
+    return mult, exp, rem
+
+
+def _format_scientific_latex(mult: int, exp: int, rem: int) -> str:
+    res = '10' if exp == 1 else f'10^{{{exp}}}'
+    if mult > 1:
+        res = f'{mult} \\times {res}'
+    if rem > 0:
+        res = f'{res} + {rem}'
+    return res
+
+
+_SUPERSCRIPT_DIGITS = str.maketrans('0123456789', '⁰¹²³⁴⁵⁶⁷⁸⁹')
+
+
+def _format_scientific_text(mult: int, exp: int, rem: int) -> str:
+    res = '10' if exp == 1 else '10' + str(exp).translate(_SUPERSCRIPT_DIGITS)
+    if mult > 1:
+        res = f'{mult}×{res}'
+    if rem > 0:
+        res = f'{res} + {rem}'
+    return res
+
+
 def scientific_notation(
     value: Union[int, jinja2.Undefined],
     zeroes: int = 4,
     rest: bool = False,
+    *,
+    target: FilterTarget = FilterTarget.LATEX,
 ) -> Union[str, jinja2.Undefined]:
     if jinja2.is_undefined(value):
         return typing.cast(jinja2.Undefined, value)
@@ -117,31 +188,26 @@ def scientific_notation(
     if value == 0:
         return '0'
     if value < 0:
-        return f'-{scientific_notation(-value, zeroes=zeroes)}'
+        # `rest` is deliberately not forwarded: a negative number has never
+        # kept a remainder, and this must not start doing so.
+        return f'-{scientific_notation(-value, zeroes=zeroes, target=target)}'
 
-    mult, exp, rem = _process_zeroes(value)
-    if exp < zeroes:
+    decision = _scientific_decision(value, zeroes=zeroes, rest=rest)
+    if decision is None:
         return str(value)
-    res = '10' if exp == 1 else f'10^{{{exp}}}'
-    if not rest and rem > 0:
-        # Should not convert numbers like 100007 to 10^5 + 7,
-        # unless rest is true.
-        return str(value)
-    if rem > 0 and len(str(rem)) + 1 >= len(str(value)):
-        # Should not convert numbers like 532 to 5*10^2 + 32.
-        return str(value)
-    if mult > 1:
-        res = f'{mult} \\times {res}'
-    if rem > 0:
-        res = f'{res} + {rem}'
-    return res
+    mult, exp, rem = decision
+    if target is FilterTarget.TEXT:
+        return _format_scientific_text(mult, exp, rem)
+    return _format_scientific_latex(mult, exp, rem)
 
 
 def rest_scientific_notation(
     value: Union[int, jinja2.Undefined],
     zeroes: int = 4,
+    *,
+    target: FilterTarget = FilterTarget.LATEX,
 ) -> Union[str, jinja2.Undefined]:
-    return scientific_notation(value, zeroes=zeroes, rest=True)
+    return scientific_notation(value, zeroes=zeroes, rest=True, target=target)
 
 
 def path_parent(path: pathlib.Path) -> pathlib.Path:
@@ -287,10 +353,20 @@ class JinjaDictWrapper(dict):
             )
 
 
-def add_builtin_filters(j2_env: jinja2.Environment):
-    j2_env.filters['escape'] = escape_latex_str_if_str
-    j2_env.filters['sci'] = scientific_notation
-    j2_env.filters['rsci'] = rest_scientific_notation
+def _identity(value: Any) -> Any:
+    return value
+
+
+def add_builtin_filters(
+    j2_env: jinja2.Environment,
+    target: FilterTarget = FilterTarget.LATEX,
+):
+    # A badge is not a document: there is nothing to escape into under TEXT.
+    j2_env.filters['escape'] = (
+        _identity if target is FilterTarget.TEXT else escape_latex_str_if_str
+    )
+    j2_env.filters['sci'] = functools.partial(scientific_notation, target=target)
+    j2_env.filters['rsci'] = functools.partial(rest_scientific_notation, target=target)
     j2_env.filters['parent'] = path_parent
     j2_env.filters['stem'] = path_stem
 
@@ -333,7 +409,7 @@ def render_latex_template(path_templates, template_filename, template_vars=None)
         **J2_ARGS,
         undefined=StrictChainableUndefined,
     )
-    add_builtin_filters(j2_env)
+    add_builtin_filters(j2_env, target=FilterTarget.LATEX)
     add_builtin_tests(j2_env)
     template = j2_env.get_template(template_filename)
     try:
@@ -360,7 +436,7 @@ def render_latex_template_blocks(
         **J2_ARGS,
         undefined=StrictChainableUndefined,
     )
-    add_builtin_filters(j2_env)
+    add_builtin_filters(j2_env, target=FilterTarget.LATEX)
     add_builtin_tests(j2_env)
     template = j2_env.get_template(template_filename)
     ctx = template.new_context(var_dict)  # type: ignore
@@ -391,7 +467,7 @@ def render_markdown_template_blocks(
         **J2_MD_ARGS,  # type: ignore
         undefined=StrictChainableUndefined,
     )
-    add_builtin_filters(j2_env)
+    add_builtin_filters(j2_env, target=FilterTarget.MARKDOWN)
     add_builtin_tests(j2_env)
     template = j2_env.get_template(template_filename)
     ctx = template.new_context(var_dict)  # type: ignore

--- a/rbx/box/statements/latex_jinja.py
+++ b/rbx/box/statements/latex_jinja.py
@@ -111,6 +111,23 @@ class FilterTarget(enum.Enum):
     TEXT = 'text'
 
 
+class JinjaSyntax(enum.Enum):
+    """Which delimiters a template is lexed with.
+
+    A separate axis from `FilterTarget`, because the two really do vary
+    independently: `rbx vars --render` lexes with the LaTeX delimiters (an
+    expression is only worth rendering if a statement could hold it) while
+    formatting for TEXT. Collapsing them into one `markdown=True` flag would
+    make that combination unsayable.
+    """
+
+    LATEX = 'latex'
+    """`\\VAR{...}`, `\\BLOCK{...}`, `%-`: the rbxTeX flavour (`J2_ARGS`)."""
+
+    PLAIN = 'plain'
+    """Jinja's own `{{ ... }}` / `{% ... %}` (`J2_MD_ARGS`)."""
+
+
 ######################################################################
 # Declare module functions
 ######################################################################
@@ -396,6 +413,39 @@ def add_builtin_tests(j2_env: jinja2.Environment):
     j2_env.tests['nonnull'] = test_var_nonnull
 
 
+_SYNTAX_ARGS: Dict[JinjaSyntax, Dict[str, Any]] = {
+    JinjaSyntax.LATEX: J2_ARGS,
+    JinjaSyntax.PLAIN: J2_MD_ARGS,
+}
+
+
+def make_jinja_env(
+    target: FilterTarget = FilterTarget.LATEX,
+    *,
+    syntax: JinjaSyntax = JinjaSyntax.LATEX,
+    loader: Optional[jinja2.BaseLoader] = None,
+) -> jinja2.Environment:
+    """The environment a statement renders under.
+
+    Everything that renders a statement -- or claims to agree with one, as the
+    var hints do -- goes through here, so "same filters, same tests, same
+    undefined" is one function rather than a convention repeated at each call
+    site. Only `target` and `syntax` may differ, and they are independent: see
+    `JinjaSyntax`.
+
+    The environment is **not** sandboxed. That is not new and not incidental:
+    templates are setter-authored files from the package being built.
+    """
+    j2_env = jinja2.Environment(
+        loader=loader,
+        **_SYNTAX_ARGS[syntax],  # type: ignore[arg-type]
+        undefined=StrictChainableUndefined,
+    )
+    add_builtin_filters(j2_env, target=target)
+    add_builtin_tests(j2_env)
+    return j2_env
+
+
 def _handle_rendering_undefined(
     err: jinja2.UndefinedError,
 ) -> str:
@@ -422,13 +472,11 @@ def render_latex_template(path_templates, template_filename, template_vars=None)
         defaults to None for case when no values need to be passed
     """
     var_dict = template_vars if template_vars else {}
-    j2_env = jinja2.Environment(
+    j2_env = make_jinja_env(
+        FilterTarget.LATEX,
+        syntax=JinjaSyntax.LATEX,
         loader=jinja2.FileSystemLoader(path_templates),
-        **J2_ARGS,
-        undefined=StrictChainableUndefined,
     )
-    add_builtin_filters(j2_env, target=FilterTarget.LATEX)
-    add_builtin_tests(j2_env)
     template = j2_env.get_template(template_filename)
     try:
         return template.render(**var_dict)  # type: ignore
@@ -449,13 +497,11 @@ def render_latex_template_blocks(
         defaults to None for case when no values need to be passed
     """
     var_dict = template_vars if template_vars else {}
-    j2_env = jinja2.Environment(
+    j2_env = make_jinja_env(
+        FilterTarget.LATEX,
+        syntax=JinjaSyntax.LATEX,
         loader=jinja2.FileSystemLoader(path_templates),
-        **J2_ARGS,
-        undefined=StrictChainableUndefined,
     )
-    add_builtin_filters(j2_env, target=FilterTarget.LATEX)
-    add_builtin_tests(j2_env)
     template = j2_env.get_template(template_filename)
     ctx = template.new_context(var_dict)  # type: ignore
     try:
@@ -480,13 +526,11 @@ def render_markdown_template_blocks(
         defaults to None for case when no values need to be passed
     """
     var_dict = template_vars if template_vars else {}
-    j2_env = jinja2.Environment(
+    j2_env = make_jinja_env(
+        FilterTarget.MARKDOWN,
+        syntax=JinjaSyntax.PLAIN,
         loader=jinja2.FileSystemLoader(path_templates),
-        **J2_MD_ARGS,  # type: ignore
-        undefined=StrictChainableUndefined,
     )
-    add_builtin_filters(j2_env, target=FilterTarget.MARKDOWN)
-    add_builtin_tests(j2_env)
     template = j2_env.get_template(template_filename)
     ctx = template.new_context(var_dict)  # type: ignore
     try:

--- a/run-extension.sh
+++ b/run-extension.sh
@@ -22,6 +22,28 @@
 # if node_modules is missing), because a development host pointed at a checkout
 # that was never built fails on activation with a missing dist/extension.js.
 # Pass --no-build to skip that when you already have `npm run watch` going.
+#
+# The host is also pinned to the *same checkout's* rbx, because half of what the
+# extension does is read what rbx wrote and the other half is now run rbx --
+# `rbx visualize`, and `rbx vars` behind the statement var hints. Loading the
+# TypeScript from a branch while calling whatever rbx is on PATH tests a pairing
+# that exists nowhere, and fails quietly: the extension treats a command it
+# cannot run as "no data" and draws nothing, which looks like a feature that
+# does not work rather than a CLI that is too old.
+#
+# Pinning is a setting (`rbx.executable`) written into a per-worktree profile
+# under --user-data-dir, not a PATH export, because a PATH export does not
+# survive the trip. The `code` CLI hands off to an already-running instance over
+# IPC, and the window it opens inherits that instance's environment rather than
+# this shell's -- so exporting PATH works only when no editor is running, which
+# is the kind of "works on my machine" this script exists to remove. A distinct
+# --user-data-dir also forces a separate instance, so the handoff never happens.
+#
+# The profile lives in the cache directory rather than the worktree, so no
+# checkout gains an untracked directory, and it persists per worktree: the theme
+# you pick in a development host is still there next time. Your installed
+# extensions still load (--extensions-dir is left alone). Pass --no-pin-rbx to
+# launch with your normal profile and whatever rbx the extension finds itself.
 
 set -euo pipefail
 
@@ -68,6 +90,60 @@ _re_editor_app() {
 }
 
 _re_editors="code cursor windsurf codium code-insiders"
+
+# --- pinning the host to this checkout's rbx --------------------------------
+# Where a worktree's own rbx lives once `uv sync` has run in it. Editable, so it
+# is the branch's Python, not a copy of it.
+_re_rbx_path() {
+  echo "$1/.venv/bin/rbx"
+}
+
+# The profile directory for one (worktree, editor) pair.
+#
+# Keyed by the worktree's full path, because two worktrees of the same repo have
+# the same basename often enough (a PR checkout and the branch it came from),
+# and per editor because VS Code and its forks do not share a profile format
+# they both promise to honour. Kept in the cache directory: it is regenerable,
+# and putting it in the worktree would show up in `git status` forever.
+_re_profile_dir() {
+  _re_pd_wt="$1"
+  _re_pd_editor="$2"
+  _re_pd_key="$(printf '%s' "$_re_pd_wt" | shasum | cut -c1-8)"
+  echo "${XDG_CACHE_HOME:-$HOME/.cache}/rbx/run-extension/$_re_pd_editor/$(basename "$_re_pd_wt")-$_re_pd_key"
+}
+
+# Write `rbx.executable` into a profile without disturbing anything else in it.
+#
+# Merged rather than overwritten because this runs on every launch and the
+# profile is meant to persist: clobbering it would throw away the theme, the
+# window layout and every other thing the last development host learned. Python
+# does the merge -- a JSON file that VS Code also writes is not a thing to edit
+# with sed.
+_re_seed_profile() {
+  _re_sp_dir="$1"
+  _re_sp_rbx="$2"
+  mkdir -p "$_re_sp_dir/User"
+  RBX_SEED_SETTINGS="$_re_sp_dir/User/settings.json" RBX_SEED_PATH="$_re_sp_rbx" python3 - <<'PY'
+import json
+import os
+import pathlib
+
+settings = pathlib.Path(os.environ['RBX_SEED_SETTINGS'])
+current = {}
+if settings.is_file():
+    try:
+        current = json.loads(settings.read_text() or '{}')
+    except json.JSONDecodeError:
+        # A profile VS Code left mid-write, or one hand-edited into invalid
+        # JSON. Rewriting it from scratch loses less than refusing to launch.
+        current = {}
+    if not isinstance(current, dict):
+        current = {}
+
+current['rbx.executable'] = os.environ['RBX_SEED_PATH']
+settings.write_text(json.dumps(current, indent=2) + '\n')
+PY
+}
 
 # Which editor's integrated terminal we are in, if any. TERM_PROGRAM=vscode is
 # set by VS Code *and every fork*, so the app path is what tells them apart —
@@ -119,6 +195,8 @@ $(wt_name_help '  ')
                         contest.rbx.yml, else nothing
   -n, --no-build        do not build first (use with 'npm run watch')
   -c, --clean           disable your other extensions in the development host
+      --no-pin-rbx      use your normal profile, and whatever rbx the extension
+                        finds, instead of this checkout's .venv/bin/rbx
   -p, --print           print the command instead of running it
   -h, --help            this message
 EOF
@@ -131,6 +209,7 @@ _re_folder=""
 _re_build=1
 _re_clean=0
 _re_print=0
+_re_pin=1
 
 _re_need_value() {
   if [ "$2" -lt 2 ]; then
@@ -155,6 +234,7 @@ while [ "$#" -gt 0 ]; do
       ;;
     -n|--no-build) _re_build=0 ;;
     -c|--clean) _re_clean=1 ;;
+    --no-pin-rbx) _re_pin=0 ;;
     -p|--print) _re_print=1 ;;
     -h|--help) _re_usage; exit 0 ;;
     --) shift; _re_name="${1:-}"; break ;;
@@ -232,11 +312,33 @@ if [ ! -f "$_re_ext/dist/extension.js" ]; then
   exit 1
 fi
 
+# --- resolve this checkout's rbx --------------------------------------------
+# Missing is normal, not an error: a checkout whose venv was never built still
+# runs the extension fine, and everything that does not shell out to rbx works.
+# Say so once, with the fix, rather than failing or staying silent.
+_re_rbx=""
+if [ "$_re_pin" -eq 1 ]; then
+  _re_rbx="$(_re_rbx_path "$_re_wt")"
+  if [ ! -x "$_re_rbx" ]; then
+    echo "$WT_PROG: no rbx at $_re_rbx — the host will use whatever rbx it finds" >&2
+    echo "$WT_PROG: run 'uv sync' in $_re_wt to pin it, or pass --no-pin-rbx to silence this" >&2
+    _re_rbx=""
+  elif ! command -v python3 >/dev/null 2>&1; then
+    echo "$WT_PROG: python3 is required to seed the development profile — not pinning rbx" >&2
+    _re_rbx=""
+  fi
+fi
+
 # --- launch -----------------------------------------------------------------
 for _re_key in $_re_editor_keys; do
   _re_cmd="$(_re_editor_command "$_re_key")"
 
   set -- --new-window --extensionDevelopmentPath="$_re_ext"
+  if [ -n "$_re_rbx" ]; then
+    _re_profile="$(_re_profile_dir "$_re_wt" "$_re_key")"
+    _re_seed_profile "$_re_profile" "$_re_rbx"
+    set -- "$@" --user-data-dir="$_re_profile"
+  fi
   if [ "$_re_clean" -eq 1 ]; then
     set -- "$@" --disable-extensions
   fi
@@ -251,5 +353,8 @@ for _re_key in $_re_editor_keys; do
   fi
 
   echo "$WT_PROG: launching $(_re_editor_label "$_re_key") with $_re_ext${_re_folder:+ on $_re_folder}"
+  if [ -n "$_re_rbx" ]; then
+    echo "$WT_PROG: rbx pinned to $_re_rbx"
+  fi
   "$_re_cmd" "$@"
 done

--- a/tests/rbx/box/statements/filter_targets_test.py
+++ b/tests/rbx/box/statements/filter_targets_test.py
@@ -51,16 +51,15 @@ def test_text_scientific_notation(value, sci, rsci, text_sci, text_rsci):
 def test_text_and_latex_agree_on_whether_to_abbreviate(
     value, sci, rsci, text_sci, text_rsci
 ):
-    """The rules are the value's; only the spelling is the medium's."""
-    latex_declined = sci == str(value)
-    text_declined = scientific_notation(value, target=FilterTarget.TEXT) == str(value)
-    assert latex_declined == text_declined
+    """The rules are the value's; only the spelling is the medium's.
 
-    latex_rest_declined = rsci == str(value)
-    text_rest_declined = rest_scientific_notation(
-        value, target=FilterTarget.TEXT
-    ) == str(value)
-    assert latex_rest_declined == text_rest_declined
+    Read purely off the table, so a failure points at the mistyped row rather
+    than at the code the other two tests already pin. The `== str(value)`
+    detector assumes an abbreviation never spells itself: with a low `zeroes`
+    one can (`sci(10, 1)` is `'10'`), which no row here triggers.
+    """
+    assert (sci == str(value)) == (text_sci == str(value))
+    assert (rsci == str(value)) == (text_rsci == str(value))
 
 
 def test_markdown_target_formats_as_latex():
@@ -93,16 +92,19 @@ def _render(target: FilterTarget, source: str, **kwargs) -> str:
 
 
 @pytest.mark.parametrize(
-    ('target', 'expected'),
+    ('target', 'expected', 'rest_expected'),
     [
-        (FilterTarget.LATEX, r'2 \times 10^{5}'),
-        (FilterTarget.MARKDOWN, r'2 \times 10^{5}'),
-        (FilterTarget.TEXT, '2×10⁵'),
+        (FilterTarget.LATEX, r'2 \times 10^{5}', '10^{5} + 7'),
+        (FilterTarget.MARKDOWN, r'2 \times 10^{5}', '10^{5} + 7'),
+        (FilterTarget.TEXT, '2×10⁵', '10⁵ + 7'),
     ],
 )
-def test_sci_filter_is_installed_per_target(target, expected):
+def test_sci_filter_is_installed_per_target(target, expected, rest_expected):
     assert _render(target, '{{ n | sci }}', n=200000) == expected
-    assert _render(target, '{{ n | rsci }}', n=200000) == expected
+    # 100007, where `sci` and `rsci` disagree: `rsci` must be the `rest=True`
+    # flavour, not a second copy of `sci` under another name.
+    assert _render(target, '{{ n | sci }}', n=100007) == '100007'
+    assert _render(target, '{{ n | rsci }}', n=100007) == rest_expected
     # The filter still accepts `zeroes` positionally.
     assert _render(target, '{{ n | sci(9) }}', n=200000) == '200000'
 

--- a/tests/rbx/box/statements/filter_targets_test.py
+++ b/tests/rbx/box/statements/filter_targets_test.py
@@ -1,0 +1,119 @@
+import jinja2
+import pytest
+
+from rbx.box.statements.latex_jinja import (
+    FilterTarget,
+    add_builtin_filters,
+    rest_scientific_notation,
+    scientific_notation,
+)
+
+# (value, LaTeX sci, LaTeX rsci, TEXT sci, TEXT rsci)
+GOLDEN = [
+    (0, '0', '0', '0', '0'),
+    (1, '1', '1', '1', '1'),
+    (10, '10', '10', '10', '10'),
+    (532, '532', '532', '532', '532'),
+    (9999, '9999', '9999', '9999', '9999'),
+    (10000, '10^{4}', '10^{4}', '10⁴', '10⁴'),
+    (100000, '10^{5}', '10^{5}', '10⁵', '10⁵'),
+    (100007, '100007', '10^{5} + 7', '100007', '10⁵ + 7'),
+    (200000, r'2 \times 10^{5}', r'2 \times 10^{5}', '2×10⁵', '2×10⁵'),
+    (250000, '250000', '250000', '250000', '250000'),
+    (1000000007, '1000000007', '10^{9} + 7', '1000000007', '10⁹ + 7'),
+    (
+        10**18 + 7,
+        '1000000000000000007',
+        '10^{18} + 7',
+        '1000000000000000007',
+        '10¹⁸ + 7',
+    ),
+    (-100000, '-10^{5}', '-10^{5}', '-10⁵', '-10⁵'),
+    (10**21, '10^{21}', '10^{21}', '10²¹', '10²¹'),
+]
+
+
+@pytest.mark.parametrize(('value', 'sci', 'rsci', 'text_sci', 'text_rsci'), GOLDEN)
+def test_latex_scientific_notation_is_unchanged(value, sci, rsci, text_sci, text_rsci):
+    assert scientific_notation(value) == sci
+    assert rest_scientific_notation(value) == rsci
+    assert scientific_notation(value, target=FilterTarget.LATEX) == sci
+    assert rest_scientific_notation(value, target=FilterTarget.LATEX) == rsci
+
+
+@pytest.mark.parametrize(('value', 'sci', 'rsci', 'text_sci', 'text_rsci'), GOLDEN)
+def test_text_scientific_notation(value, sci, rsci, text_sci, text_rsci):
+    assert scientific_notation(value, target=FilterTarget.TEXT) == text_sci
+    assert rest_scientific_notation(value, target=FilterTarget.TEXT) == text_rsci
+
+
+@pytest.mark.parametrize(('value', 'sci', 'rsci', 'text_sci', 'text_rsci'), GOLDEN)
+def test_text_and_latex_agree_on_whether_to_abbreviate(
+    value, sci, rsci, text_sci, text_rsci
+):
+    """The rules are the value's; only the spelling is the medium's."""
+    latex_declined = sci == str(value)
+    text_declined = scientific_notation(value, target=FilterTarget.TEXT) == str(value)
+    assert latex_declined == text_declined
+
+    latex_rest_declined = rsci == str(value)
+    text_rest_declined = rest_scientific_notation(
+        value, target=FilterTarget.TEXT
+    ) == str(value)
+    assert latex_rest_declined == text_rest_declined
+
+
+def test_markdown_target_formats_as_latex():
+    assert scientific_notation(200000, target=FilterTarget.MARKDOWN) == (
+        r'2 \times 10^{5}'
+    )
+    assert rest_scientific_notation(100007, target=FilterTarget.MARKDOWN) == (
+        '10^{5} + 7'
+    )
+
+
+@pytest.mark.parametrize('target', list(FilterTarget))
+def test_undefined_passes_through(target):
+    undefined = jinja2.Undefined(name='N')
+    assert jinja2.is_undefined(scientific_notation(undefined, target=target))
+    assert jinja2.is_undefined(rest_scientific_notation(undefined, target=target))
+
+
+def test_zeroes_stays_the_second_positional_parameter():
+    assert scientific_notation(200000, 5) == r'2 \times 10^{5}'
+    assert scientific_notation(200000, 6) == '200000'
+    assert scientific_notation(200000, 5, target=FilterTarget.TEXT) == '2×10⁵'
+    assert rest_scientific_notation(100007, 6) == '100007'
+
+
+def _render(target: FilterTarget, source: str, **kwargs) -> str:
+    env = jinja2.Environment(autoescape=False)
+    add_builtin_filters(env, target=target)
+    return env.from_string(source).render(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ('target', 'expected'),
+    [
+        (FilterTarget.LATEX, r'2 \times 10^{5}'),
+        (FilterTarget.MARKDOWN, r'2 \times 10^{5}'),
+        (FilterTarget.TEXT, '2×10⁵'),
+    ],
+)
+def test_sci_filter_is_installed_per_target(target, expected):
+    assert _render(target, '{{ n | sci }}', n=200000) == expected
+    assert _render(target, '{{ n | rsci }}', n=200000) == expected
+    # The filter still accepts `zeroes` positionally.
+    assert _render(target, '{{ n | sci(9) }}', n=200000) == '200000'
+
+
+@pytest.mark.parametrize(
+    ('target', 'expected'),
+    [
+        (FilterTarget.LATEX, r'a\_b'),
+        (FilterTarget.MARKDOWN, r'a\_b'),
+        (FilterTarget.TEXT, 'a_b'),
+    ],
+)
+def test_escape_filter_is_installed_per_target(target, expected):
+    assert _render(target, '{{ s | escape }}', s='a_b') == expected

--- a/tests/rbx/box/statements/filter_targets_test.py
+++ b/tests/rbx/box/statements/filter_targets_test.py
@@ -3,7 +3,10 @@ import pytest
 
 from rbx.box.statements.latex_jinja import (
     FilterTarget,
+    JinjaSyntax,
+    StrictChainableUndefined,
     add_builtin_filters,
+    make_jinja_env,
     rest_scientific_notation,
     scientific_notation,
 )
@@ -119,3 +122,25 @@ def test_sci_filter_is_installed_per_target(target, expected, rest_expected):
 )
 def test_escape_filter_is_installed_per_target(target, expected):
     assert _render(target, '{{ s | escape }}', s='a_b') == expected
+
+
+@pytest.mark.parametrize('target', list(FilterTarget))
+def test_make_jinja_env_installs_filters_tests_and_strict_undefined(target):
+    env = make_jinja_env(target)
+    assert env.variable_start_string == r'\VAR{'
+    assert env.undefined is StrictChainableUndefined
+    assert {'sci', 'rsci', 'escape', 'parent', 'stem'} <= set(env.filters)
+    assert {'truthy', 'falsy', 'null', 'nonnull'} <= set(env.tests)
+    assert env.from_string(r'\VAR{n | sci}').render(n=100000) == (
+        '10⁵' if target is FilterTarget.TEXT else '10^{5}'
+    )
+
+
+def test_make_jinja_env_syntax_is_independent_of_target():
+    plain = make_jinja_env(FilterTarget.MARKDOWN, syntax=JinjaSyntax.PLAIN)
+    assert plain.variable_start_string == '{{'
+    assert plain.from_string('{{ n | sci }}').render(n=200000) == r'2 \times 10^{5}'
+
+    # What `rbx vars --render` asks for: LaTeX delimiters, text spelling.
+    latex_text = make_jinja_env(FilterTarget.TEXT, syntax=JinjaSyntax.LATEX)
+    assert latex_text.from_string(r'\VAR{n | sci}').render(n=200000) == '2×10⁵'

--- a/tests/rbx/box/vars_cmd_test.py
+++ b/tests/rbx/box/vars_cmd_test.py
@@ -153,3 +153,92 @@ def test_vars_json_fails_cleanly_on_non_finite_var(
     assert result.exit_code == 1, result.output
     assert 'Infinity' not in result.output
     assert 'huge' in _plain(result.output)
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_evaluates_filters_for_the_text_target(pkg_from_testdata: pathlib.Path):
+    result = runner.invoke(
+        app, ['vars', '--render', '--target', 'text'], input='N.max | sci\nN.max\n'
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        'N.max | sci': '10⁶',
+        'N.max': '1000000',
+    }
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_spells_the_same_expression_differently_per_target(
+    pkg_from_testdata: pathlib.Path,
+):
+    """The whole reason `--target` exists: same rules, different spelling."""
+    result = runner.invoke(
+        app, ['vars', '--render', '--target', 'latex'], input='N.max | sci\n'
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'N.max | sci': '10^{6}'}
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_reaches_the_vars_namespace_too(pkg_from_testdata: pathlib.Path):
+    """`\\VAR{N.max}` is shorthand for `\\VAR{vars.N.max}`; both must render."""
+    result = runner.invoke(app, ['vars', '--render'], input='vars.N.max | sci\n')
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'vars.N.max | sci': '10⁶'}
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_omits_an_expression_it_cannot_evaluate(pkg_from_testdata: pathlib.Path):
+    """Absent, not an error: the extension draws no badge and moves on."""
+    result = runner.invoke(
+        app,
+        ['vars', '--render', '--target', 'text'],
+        input='N.max | nosuchfilter\nN.typo\nN.max\n',
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'N.max': '1000000'}
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_with_no_expressions_is_an_empty_object(pkg_from_testdata: pathlib.Path):
+    result = runner.invoke(app, ['vars', '--render'], input='')
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {}
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_asks_once_for_a_repeated_expression(pkg_from_testdata: pathlib.Path):
+    """A statement repeats a bound; the map is keyed by expression regardless."""
+    result = runner.invoke(
+        app, ['vars', '--render'], input='N.max | sci\n\n  N.max | sci  \n'
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'N.max | sci': '10⁶'}
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_refuses_to_be_combined_with_json(pkg_from_testdata: pathlib.Path):
+    """Two different output shapes; picking one silently would mislead."""
+    result = runner.invoke(app, ['vars', '--render', '--json'], input='N.max\n')
+
+    assert result.exit_code == 1, result.output
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_render_creates_no_cache_dir(pkg_from_testdata: pathlib.Path):
+    """Rendering pulls in the statements module; it must stay read-only too."""
+    from rbx.box.package import get_problem_cache_path
+
+    cache = get_problem_cache_path(pkg_from_testdata)
+    assert not cache.exists()
+
+    result = runner.invoke(app, ['vars', '--render'], input='N.max | sci\n')
+
+    assert result.exit_code == 0, result.output
+    assert not cache.exists()

--- a/tests/rbx/box/vars_cmd_test.py
+++ b/tests/rbx/box/vars_cmd_test.py
@@ -1,12 +1,33 @@
 import json
 import pathlib
+import re
 
 import pytest
 from typer.testing import CliRunner
 
 from rbx.box.cli import app
+from rbx.box.testing import testing_package
 
 runner = CliRunner()
+
+
+_ANSI = re.compile(r'\x1b\[[0-9;]*m')
+
+
+def _plain(output: str) -> str:
+    """Drop the styling Rich adds, leaving the text the setter would read."""
+    return _ANSI.sub('', output)
+
+
+def _with_vars(pkg: testing_package.TestingPackage, vars) -> None:
+    """Give the package these vars, and a preset the CLI will accept.
+
+    `TestingPreset` writes its `preset.rbx.yml` without a `min_version`, which
+    the root callback refuses before any command runs.
+    """
+    pkg.preset.yml.min_version = '1.0.0'
+    pkg.preset.save()
+    pkg.set_vars(vars)
 
 
 @pytest.mark.test_pkg('problems/interactive')
@@ -33,3 +54,52 @@ def test_vars_json_creates_no_cache_dir(pkg_from_testdata: pathlib.Path):
 
     assert result.exit_code == 0, result.output
     assert not cache.exists()
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_vars_prints_readable_output_without_json(pkg_from_testdata: pathlib.Path):
+    result = runner.invoke(app, ['vars'])
+
+    assert result.exit_code == 0, result.output
+    assert 'N.max = 1000000' in _plain(result.output)
+    assert 'N.min = 1' in _plain(result.output)
+
+
+def test_vars_does_not_render_markup_in_var_values(
+    testing_pkg: testing_package.TestingPackage,
+):
+    """Var values are setter YAML, not markup.
+
+    Rich would style `[bold]...[/bold]` away and raise on `[/nope]`, so both
+    have to survive to the output verbatim.
+    """
+    _with_vars(
+        testing_pkg,
+        {
+            'styled': '[bold]weight[/bold]',
+            'broken': 'a [/nope] b',
+        },
+    )
+
+    result = runner.invoke(app, ['vars'])
+
+    assert result.exit_code == 0, result.output
+    assert 'styled = [bold]weight[/bold]' in _plain(result.output)
+    assert 'broken = a [/nope] b' in _plain(result.output)
+
+
+def test_vars_json_fails_cleanly_on_non_finite_var(
+    testing_pkg: testing_package.TestingPackage,
+):
+    """`json.dumps` would emit bare `Infinity`, which `JSON.parse` rejects.
+
+    The extension degrades on a non-zero exit, so failing is right; what it
+    must not do is hand back a payload that cannot be parsed.
+    """
+    _with_vars(testing_pkg, {'huge': 'py`float("inf")`'})
+
+    result = runner.invoke(app, ['vars', '--json'])
+
+    assert result.exit_code == 1, result.output
+    assert 'Infinity' not in result.output
+    assert 'huge' in _plain(result.output)

--- a/tests/rbx/box/vars_cmd_test.py
+++ b/tests/rbx/box/vars_cmd_test.py
@@ -1,0 +1,35 @@
+import json
+import pathlib
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box.cli import app
+
+runner = CliRunner()
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_vars_json_dumps_expanded_dotted_keys(pkg_from_testdata: pathlib.Path):
+    result = runner.invoke(app, ['vars', '--json'])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'N.min': 1, 'N.max': 1000000}
+
+
+@pytest.mark.test_pkg('problems/interactive')
+def test_vars_json_creates_no_cache_dir(pkg_from_testdata: pathlib.Path):
+    """The extension spawns this while the user types; it must stay read-only.
+
+    `get_problem_cache_dir` is what mkdirs the cache; nothing on the
+    `rbx vars` path may reach it.
+    """
+    from rbx.box.package import get_problem_cache_path
+
+    cache = get_problem_cache_path(pkg_from_testdata)
+    assert not cache.exists()
+
+    result = runner.invoke(app, ['vars', '--json'])
+
+    assert result.exit_code == 0, result.output
+    assert not cache.exists()

--- a/tests/rbx/box/vars_cmd_test.py
+++ b/tests/rbx/box/vars_cmd_test.py
@@ -204,6 +204,20 @@ def test_render_omits_an_expression_it_cannot_evaluate(pkg_from_testdata: pathli
 
 
 @pytest.mark.test_pkg('problems/interactive')
+def test_render_reports_what_it_dropped_on_stderr(pkg_from_testdata: pathlib.Path):
+    """Dropping silently would make a bug in a filter undiagnosable.
+
+    stdout carries the JSON map, so the diagnosis goes to stderr, where it
+    cannot corrupt what the extension parses.
+    """
+    result = runner.invoke(app, ['vars', '--render'], input='N.max | nosuchfilter\n')
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {}
+    assert 'nosuchfilter' in _plain(result.stderr)
+
+
+@pytest.mark.test_pkg('problems/interactive')
 def test_render_with_no_expressions_is_an_empty_object(pkg_from_testdata: pathlib.Path):
     result = runner.invoke(app, ['vars', '--render'], input='')
 
@@ -213,13 +227,19 @@ def test_render_with_no_expressions_is_an_empty_object(pkg_from_testdata: pathli
 
 @pytest.mark.test_pkg('problems/interactive')
 def test_render_asks_once_for_a_repeated_expression(pkg_from_testdata: pathlib.Path):
-    """A statement repeats a bound; the map is keyed by expression regardless."""
+    """A statement repeats a bound; the map is keyed by expression regardless.
+
+    The keys come back in order of first appearance -- not that a consumer of a
+    JSON object should care, but the docstring promises it, so it is pinned.
+    """
     result = runner.invoke(
-        app, ['vars', '--render'], input='N.max | sci\n\n  N.max | sci  \n'
+        app, ['vars', '--render'], input='N.max | sci\n\n  N.min  \nN.max | sci\n'
     )
 
     assert result.exit_code == 0, result.output
-    assert json.loads(result.stdout) == {'N.max | sci': '10⁶'}
+    parsed = json.loads(result.stdout)
+    assert parsed == {'N.max | sci': '10⁶', 'N.min': '1'}
+    assert list(parsed) == ['N.max | sci', 'N.min']
 
 
 @pytest.mark.test_pkg('problems/interactive')

--- a/tests/rbx/box/vars_cmd_test.py
+++ b/tests/rbx/box/vars_cmd_test.py
@@ -37,7 +37,54 @@ def test_vars_json_dumps_expanded_dotted_keys(pkg_from_testdata: pathlib.Path):
     result = runner.invoke(app, ['vars', '--json'])
 
     assert result.exit_code == 0, result.output
-    assert json.loads(result.stdout) == {'N.min': 1, 'N.max': 1000000}
+    assert json.loads(result.stdout) == {'N.min': '1', 'N.max': '1000000'}
+
+
+def test_vars_json_preserves_ints_too_large_for_a_double(
+    testing_pkg: testing_package.TestingPackage,
+):
+    """The whole reason values cross as strings.
+
+    `10**18 + 7` is a plausible bound and is not representable as an IEEE
+    double: emitted as a JSON number, `JSON.parse` would hand the extension
+    `1000000000000000000` and it would badge a wrong value with full
+    confidence. Rendering in Python keeps every digit.
+    """
+    testing_pkg.set_vars({'MOD': 'py`10**18 + 7`'})
+
+    result = runner.invoke(app, ['vars', '--json'])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'MOD': '1000000000000000007'}
+
+
+def test_vars_json_renders_values_as_jinja_would(
+    testing_pkg: testing_package.TestingPackage,
+):
+    """The badge predicts what the statement will show, so it must match Jinja.
+
+    Notably a bool is `True`/`False` here, not the `1`/`0` that
+    `render_var_on_command_line` produces -- that spelling is about testlib and
+    jngen argument parsing, not about what `\\VAR{flag}` renders to.
+    """
+    testing_pkg.set_vars(
+        {
+            'flag': True,
+            'off': False,
+            'ratio': 1.5,
+            'label': 'foo',
+        }
+    )
+
+    result = runner.invoke(app, ['vars', '--json'])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        'flag': 'True',
+        'off': 'False',
+        'ratio': '1.5',
+        'label': 'foo',
+    }
 
 
 @pytest.mark.test_pkg('problems/interactive')
@@ -92,10 +139,12 @@ def test_vars_does_not_render_markup_in_var_values(
 def test_vars_json_fails_cleanly_on_non_finite_var(
     testing_pkg: testing_package.TestingPackage,
 ):
-    """`json.dumps` would emit bare `Infinity`, which `JSON.parse` rejects.
+    """An infinite bound is a package bug, so it is surfaced rather than badged.
 
-    The extension degrades on a non-zero exit, so failing is right; what it
-    must not do is hand back a payload that cannot be parsed.
+    `str(float('inf'))` would serialize fine now that values cross as strings,
+    but `inf` is never a bound a setter meant to write. The extension degrades
+    on a non-zero exit, so failing is the useful answer; what it must not do is
+    quietly hand back a badge reading `inf`.
     """
     testing_pkg.set_vars({'huge': 'py`float("inf")`'})
 

--- a/tests/rbx/box/vars_cmd_test.py
+++ b/tests/rbx/box/vars_cmd_test.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import re
+from unittest import mock
 
 import pytest
 from typer.testing import CliRunner
@@ -15,19 +16,20 @@ _ANSI = re.compile(r'\x1b\[[0-9;]*m')
 
 
 def _plain(output: str) -> str:
-    """Drop the styling Rich adds, leaving the text the setter would read."""
+    """Drop the styling, leaving the text the setter would read.
+
+    The console disables Rich's highlighter, but it still emits SGR codes for
+    the `item` style and for its own `info` default style.
+    """
     return _ANSI.sub('', output)
 
 
-def _with_vars(pkg: testing_package.TestingPackage, vars) -> None:
-    """Give the package these vars, and a preset the CLI will accept.
-
-    `TestingPreset` writes its `preset.rbx.yml` without a `min_version`, which
-    the root callback refuses before any command runs.
-    """
-    pkg.preset.yml.min_version = '1.0.0'
-    pkg.preset.save()
-    pkg.set_vars(vars)
+@pytest.fixture(autouse=True)
+def _skip_preset_check():
+    # The root Typer callback checks the active preset's compatibility, which is
+    # unrelated to the wiring under test and fails for the bare testing package.
+    with mock.patch('rbx.box.presets.check_active_preset_compatibility'):
+        yield
 
 
 @pytest.mark.test_pkg('problems/interactive')
@@ -73,12 +75,11 @@ def test_vars_does_not_render_markup_in_var_values(
     Rich would style `[bold]...[/bold]` away and raise on `[/nope]`, so both
     have to survive to the output verbatim.
     """
-    _with_vars(
-        testing_pkg,
+    testing_pkg.set_vars(
         {
             'styled': '[bold]weight[/bold]',
             'broken': 'a [/nope] b',
-        },
+        }
     )
 
     result = runner.invoke(app, ['vars'])
@@ -96,7 +97,7 @@ def test_vars_json_fails_cleanly_on_non_finite_var(
     The extension degrades on a non-zero exit, so failing is right; what it
     must not do is hand back a payload that cannot be parsed.
     """
-    _with_vars(testing_pkg, {'huge': 'py`float("inf")`'})
+    testing_pkg.set_vars({'huge': 'py`float("inf")`'})
 
     result = runner.invoke(app, ['vars', '--json'])
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -499,7 +499,7 @@
           "type": "string",
           "default": "",
           "scope": "resource",
-          "markdownDescription": "Full path to the `rbx` executable to run when visualizing a testcase. Leave empty to find it automatically: the extension tries `PATH` first, then asks a login shell, because the extension host's `PATH` is the one VS Code was launched with and often omits `~/.local/bin`."
+          "markdownDescription": "Full path to the `rbx` executable, used when visualizing a testcase and when reading a problem's vars for statement hints. Leave empty to find it automatically: the extension tries `PATH` first, then asks a login shell, because the extension host's `PATH` is the one VS Code was launched with and often omits `~/.local/bin`."
         }
       }
     }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -452,15 +452,15 @@
           "default": true,
           "markdownDescription": "Show what `problem.rbx.yml` declares a solution to do on a CodeLens above its first line."
         },
-        "rbx.statementVarHints": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show what each `\\VAR{...}` in a statement expands to, beside the reference."
-        },
         "rbx.solutionStatus": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Show what `problem.rbx.yml` declares a solution to do in the language status area, which stays visible while you scroll."
+        },
+        "rbx.statementVarHints": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show what each `\\VAR{...}` in a statement expands to, beside the reference."
         },
         "rbx.compilationDiagnostics": {
           "type": "boolean",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -452,6 +452,11 @@
           "default": true,
           "markdownDescription": "Show what `problem.rbx.yml` declares a solution to do on a CodeLens above its first line."
         },
+        "rbx.statementVarHints": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show what each `\\VAR{...}` in a statement expands to, beside the reference."
+        },
         "rbx.solutionStatus": {
           "type": "boolean",
           "default": true,

--- a/vscode/src/declared.ts
+++ b/vscode/src/declared.ts
@@ -16,19 +16,31 @@ import { DeclaredAsset, parseManifest } from './rbx/manifest';
 import { readYamlFile } from './rbx/store';
 import { RunDataProvider } from './runData';
 
+/** A declaration, and the package whose manifest made it. */
+interface Declared {
+  readonly asset: DeclaredAsset;
+  /**
+   * The root of the package that declared it, which is also the directory rbx
+   * has to be asked in about anything else that package holds. Kept alongside
+   * the asset rather than recomputed from the file's own path: a declared path
+   * may be absolute, and then nothing about it says which root claimed it.
+   */
+  readonly root: string;
+}
+
 export class DeclaredIndex {
   private readonly changed = new vscode.EventEmitter<void>();
   /** Fired after every re-read, whether or not anything actually moved. */
   readonly onDidChange: vscode.Event<void> = this.changed.event;
 
-  private index = new Map<string, DeclaredAsset>();
+  private index = new Map<string, Declared>();
 
   constructor(private readonly data: RunDataProvider) {}
 
   /** Re-read every discovered package's manifest. */
   async refresh(): Promise<void> {
     const packages = await this.data.discovered();
-    const next = new Map<string, DeclaredAsset>();
+    const next = new Map<string, Declared>();
     for (const pkg of packages) {
       await this.indexPackage(pkg, next);
     }
@@ -39,7 +51,7 @@ export class DeclaredIndex {
 
   private async indexPackage(
     pkg: PackageLayout,
-    into: Map<string, DeclaredAsset>,
+    into: Map<string, Declared>,
   ): Promise<void> {
     const raw = await readYamlFile(manifestPath(pkg));
     if (raw === undefined) {
@@ -48,18 +60,26 @@ export class DeclaredIndex {
     for (const asset of parseManifest(raw)) {
       // Declared paths are relative to the package root. `resolve` also leaves
       // an absolute one alone, which rbx permits and some packages use.
-      into.set(path.resolve(pkg.root, asset.path), asset);
+      into.set(path.resolve(pkg.root, asset.path), { asset, root: pkg.root });
     }
   }
 
+  /** What `uri` is declared as, or `undefined` for a file no manifest names. */
+  assetFor(uri: vscode.Uri): DeclaredAsset | undefined {
+    return this.declaredFor(uri)?.asset;
+  }
+
+  /** The root of the package that declares `uri`, if any package does. */
+  rootFor(uri: vscode.Uri): string | undefined {
+    return this.declaredFor(uri)?.root;
+  }
+
   /**
-   * What `uri` is declared as, or `undefined` for a file no manifest names.
-   *
    * Anything that is not a file on disk is undeclared by construction:
    * artifacts opened through the extension's own read-only scheme are not
    * workspace files and must never be drawn as if they were.
    */
-  assetFor(uri: vscode.Uri): DeclaredAsset | undefined {
+  private declaredFor(uri: vscode.Uri): Declared | undefined {
     return uri.scheme === 'file' ? this.index.get(uri.fsPath) : undefined;
   }
 

--- a/vscode/src/declared.ts
+++ b/vscode/src/declared.ts
@@ -17,7 +17,7 @@ import { readYamlFile } from './rbx/store';
 import { RunDataProvider } from './runData';
 
 /** A declaration, and the package whose manifest made it. */
-interface Declared {
+export interface Declared {
   readonly asset: DeclaredAsset;
   /**
    * The root of the package that declared it, which is also the directory rbx
@@ -66,20 +66,20 @@ export class DeclaredIndex {
 
   /** What `uri` is declared as, or `undefined` for a file no manifest names. */
   assetFor(uri: vscode.Uri): DeclaredAsset | undefined {
-    return this.declaredFor(uri)?.asset;
-  }
-
-  /** The root of the package that declares `uri`, if any package does. */
-  rootFor(uri: vscode.Uri): string | undefined {
-    return this.declaredFor(uri)?.root;
+    return this.declarationFor(uri)?.asset;
   }
 
   /**
+   * What `uri` is declared as and by which package, or `undefined` for a file
+   * no manifest names. For callers that need the root as well as the asset:
+   * both come from the one lookup, and a caller holding one already knows the
+   * other is there.
+   *
    * Anything that is not a file on disk is undeclared by construction:
    * artifacts opened through the extension's own read-only scheme are not
    * workspace files and must never be drawn as if they were.
    */
-  private declaredFor(uri: vscode.Uri): Declared | undefined {
+  declarationFor(uri: vscode.Uri): Declared | undefined {
     return uri.scheme === 'file' ? this.index.get(uri.fsPath) : undefined;
   }
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -269,9 +269,9 @@ export function activate(context: vscode.ExtensionContext): void {
   // their contents, so it needs a full rediscovery.
   //
   // A manifest being *edited* changes no root, and so does not concern the run
-  // view at all -- but it is exactly what the badges and banners are drawn
-  // from, which is why the index is re-read on all three events and the run
-  // view on only two.
+  // view at all -- but it is exactly what the badges, the banners and the
+  // statement var hints are drawn from, which is why the indexes are re-read on
+  // all three events and the run view on only two.
   const manifests = vscode.workspace.createFileSystemWatcher(`**/${PROBLEM_MANIFEST}`);
   // The choices are rebuilt after every rediscovery, not just at startup: a
   // package appearing or disappearing changes what the dropdown can offer, and

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -23,6 +23,7 @@ import { RunDataProvider } from './runData';
 import { RunViewProvider } from './runView';
 import { registerSolutionLens } from './solutionLens';
 import { registerSolutionStatus } from './solutionStatus';
+import { StatementVarsIndex } from './statementVarsIndex';
 import { TestsetPanel } from './testsetPanel';
 import { TestsetViewProvider } from './testsetView';
 import { openVisualization } from './visualizationPanel';
@@ -110,6 +111,10 @@ export function activate(context: vscode.ExtensionContext): void {
   });
   const declared = new DeclaredIndex(data);
   context.subscriptions.push(declared);
+  // Populated lazily, on the first hint request in a statement, and dropped
+  // whenever the manifest it was expanded from changes (the watcher below).
+  const statementVars = new StatementVarsIndex();
+  context.subscriptions.push(statementVars);
   registerDecorations(context, declared);
   registerSolutionLens(context, declared);
   registerSolutionStatus(context, declared);
@@ -277,9 +282,23 @@ export function activate(context: vscode.ExtensionContext): void {
       .then(() => active.refresh())
       .then(() => declared.refresh());
   };
-  manifests.onDidCreate(rediscover);
-  manifests.onDidDelete(rediscover);
-  manifests.onDidChange(() => void declared.refresh());
+  // A third reader of the same events: the vars an edited manifest expands to.
+  // All three, on the manifest's own directory, because that directory *is* the
+  // package root `rbx vars` is asked in -- a created or deleted manifest drops
+  // an entry that would otherwise answer for a package that no longer exists.
+  const revars = (uri: vscode.Uri) => statementVars.invalidate(path.dirname(uri.fsPath));
+  manifests.onDidCreate((uri) => {
+    revars(uri);
+    rediscover();
+  });
+  manifests.onDidDelete((uri) => {
+    revars(uri);
+    rediscover();
+  });
+  manifests.onDidChange((uri) => {
+    revars(uri);
+    void declared.refresh();
+  });
   context.subscriptions.push(
     manifests,
     vscode.workspace.onDidChangeWorkspaceFolders(rediscover),

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -2,9 +2,9 @@
  * Extension entry point.
  *
  * The extension is a pure reader (design D2/D3): the user runs `rbx run` in the
- * terminal and this watches what lands under `.rbx/runs`. It never spawns rbx,
- * because every rbx invocation has side effects on the package cache and could
- * race a run already in flight.
+ * terminal and this watches what lands under `.rbx/runs`. It never drives a
+ * build; the only rbx it spawns is read-only, idempotent work behind a feature
+ * that asked for it -- see rbxProcess.ts for what makes that safe.
  */
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -23,6 +23,7 @@ import { RunDataProvider } from './runData';
 import { RunViewProvider } from './runView';
 import { registerSolutionLens } from './solutionLens';
 import { registerSolutionStatus } from './solutionStatus';
+import { registerStatementVarHints } from './statementVarHints';
 import { StatementVarsIndex } from './statementVarsIndex';
 import { TestsetPanel } from './testsetPanel';
 import { TestsetViewProvider } from './testsetView';
@@ -118,6 +119,7 @@ export function activate(context: vscode.ExtensionContext): void {
   registerDecorations(context, declared);
   registerSolutionLens(context, declared);
   registerSolutionStatus(context, declared);
+  registerStatementVarHints(context, declared, statementVars);
   // Fed by the same `onDidChange` the run view is, so the Problems entries and
   // the Compilation Findings panel can never describe different runs.
   registerDiagnostics(context, data);

--- a/vscode/src/rbx/pendingRenders.test.ts
+++ b/vscode/src/rbx/pendingRenders.test.ts
@@ -1,0 +1,41 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import { pendingRenders } from './pendingRenders';
+import { VarHint } from './statementVars';
+
+function filtered(expression: string): VarHint {
+  return { end: 0, expression, filtered: true };
+}
+
+function resolved(expression: string, text: string): VarHint {
+  return { end: 0, expression, filtered: false, text };
+}
+
+test('only filtered references are asked about', () => {
+  const hints = [resolved('N.max', '100000'), filtered('N.max | sci')];
+  assert.deepStrictEqual(pendingRenders(hints, new Map()), ['N.max | sci']);
+});
+
+test('an expression already rendered is not asked about again', () => {
+  const rendered = new Map([['N.max | sci', '10⁵']]);
+  const hints = [filtered('N.max | sci'), filtered('M.max | sci')];
+  assert.deepStrictEqual(pendingRenders(hints, rendered), ['M.max | sci']);
+});
+
+test('a bound repeated across a statement is asked about once', () => {
+  // The canonical spelling is what the scanner emits, so two references
+  // written `N.max|sci` and `N.max | sci` arrive here already identical.
+  const hints = [filtered('N.max | sci'), filtered('N.max | sci')];
+  assert.deepStrictEqual(pendingRenders(hints, new Map()), ['N.max | sci']);
+});
+
+test('first-appearance order is kept', () => {
+  const hints = [filtered('b | sci'), filtered('a | sci'), filtered('b | sci')];
+  assert.deepStrictEqual(pendingRenders(hints, new Map()), ['b | sci', 'a | sci']);
+});
+
+test('nothing filtered means nothing to ask', () => {
+  assert.deepStrictEqual(pendingRenders([resolved('N.max', '5')], new Map()), []);
+  assert.deepStrictEqual(pendingRenders([], new Map()), []);
+});

--- a/vscode/src/rbx/pendingRenders.ts
+++ b/vscode/src/rbx/pendingRenders.ts
@@ -1,0 +1,42 @@
+/**
+ * Which filtered references a document still has to ask rbx about.
+ *
+ * Pure: no `vscode` import, so `node --test` covers it directly. It lives here
+ * rather than beside the scanner because the scanner answers "what does this
+ * text reference", which is a question about the text alone; this answers "what
+ * is left to render", which is a question about the text *and* what has already
+ * come back.
+ */
+import { VarHint } from './statementVars';
+
+/**
+ * The expressions of `hints` that no rendered text is known for yet.
+ *
+ * Unfiltered hints are never here: their text came with the bulk var map and
+ * costs no render. The result is deduplicated, keeping first-appearance order,
+ * because a statement repeats a bound as often as it states one and a batch
+ * should carry it once.
+ *
+ * `rendered` holds only the expressions that came back *with* text. One that
+ * rbx declined to render is therefore returned again on the next call -- that
+ * is deliberate, and it is not a re-spawn: the cache behind `renderedFor`
+ * remembers having asked, so a repeat of an expression it already failed is
+ * answered from memory. Keeping that knowledge out of here is what lets this
+ * function stay a question about *text*, with one map to consult rather than
+ * two.
+ */
+export function pendingRenders(
+  hints: readonly VarHint[],
+  rendered: ReadonlyMap<string, string>,
+): string[] {
+  const pending: string[] = [];
+  const seen = new Set<string>();
+  for (const hint of hints) {
+    if (!hint.filtered || rendered.has(hint.expression) || seen.has(hint.expression)) {
+      continue;
+    }
+    seen.add(hint.expression);
+    pending.push(hint.expression);
+  }
+  return pending;
+}

--- a/vscode/src/rbx/statementVars.test.ts
+++ b/vscode/src/rbx/statementVars.test.ts
@@ -1,0 +1,119 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import { scanStatementVars, Vars } from './statementVars';
+
+const VARS: Vars = {
+  'N.max': 100000,
+  'A.max': 1000000000,
+  flag: true,
+  name: 'foo',
+};
+
+const scan = (text: string) => scanStatementVars(text, VARS);
+
+test('the shorthand and the long form both resolve', () => {
+  assert.deepStrictEqual(scan('$N \\le \\VAR{N.max}$'), [{ end: 18, text: '100000' }]);
+  assert.deepStrictEqual(
+    scan('$N \\le \\VAR{vars.N.max}$').map((hint) => hint.text),
+    ['100000'],
+  );
+});
+
+test('a filter pipeline is ignored, the raw value is shown', () => {
+  assert.deepStrictEqual(
+    scan('\\VAR{N.max | sci}').map((hint) => hint.text),
+    ['100000'],
+  );
+});
+
+test('several references on one line each get a hint', () => {
+  assert.deepStrictEqual(
+    scan('$\\VAR{N.max}$ and $\\VAR{A.max}$').map((hint) => hint.text),
+    ['100000', '1000000000'],
+  );
+});
+
+test('non-root scopes are left alone', () => {
+  for (const expression of [
+    'g.N.max',
+    'groups.g.vars.N.max',
+    'p.N.max',
+    'problem.N.max',
+    'contest.year',
+    'vars.problem.N.max',
+  ]) {
+    assert.deepStrictEqual(scan(`\\VAR{${expression}}`), [], expression);
+  }
+});
+
+test('expressions that are not a plain name are left alone', () => {
+  for (const expression of ['N.max + 1', 'len(x)', "N.max if x else 'y'", '']) {
+    assert.deepStrictEqual(scan(`\\VAR{${expression}}`), [], expression);
+  }
+});
+
+test('an unknown name gets no hint, which is how a typo shows up', () => {
+  assert.deepStrictEqual(scan('\\VAR{N.mx}'), []);
+});
+
+test('a name inherited from Object.prototype is not a var', () => {
+  for (const expression of ['constructor', 'toString', 'hasOwnProperty']) {
+    assert.deepStrictEqual(scan(`\\VAR{${expression}}`), [], expression);
+  }
+});
+
+test('a commented line is skipped', () => {
+  assert.deepStrictEqual(scan('%# $\\VAR{N.max}$'), []);
+  assert.deepStrictEqual(scan('  % $\\VAR{N.max}$'), []);
+});
+
+test('a comment opened mid-line is skipped too', () => {
+  assert.deepStrictEqual(scan('$N$ is bounded. % TODO: \\VAR{N.max}'), []);
+});
+
+test('an escaped percent does not open a comment', () => {
+  assert.deepStrictEqual(
+    scan('50\\% of \\VAR{N.max}').map((hint) => hint.text),
+    ['100000'],
+  );
+  // A literal backslash before the percent: the percent is a real comment.
+  assert.deepStrictEqual(scan('a \\\\% b \\VAR{N.max}'), []);
+});
+
+test('an escaped VAR is not a reference', () => {
+  assert.deepStrictEqual(scan('\\\\VAR{N.max}'), []);
+  // ...but a literal backslash followed by a real reference still is.
+  assert.deepStrictEqual(
+    scan('\\\\\\VAR{N.max}').map((hint) => hint.text),
+    ['100000'],
+  );
+});
+
+test('non-numeric values render as themselves', () => {
+  assert.deepStrictEqual(
+    scan('\\VAR{flag} \\VAR{name}').map((hint) => hint.text),
+    ['true', 'foo'],
+  );
+});
+
+test('the hint sits just after the closing brace', () => {
+  const text = 'abc \\VAR{N.max} def';
+  const [hint] = scan(text);
+  assert.strictEqual(text[hint.end - 1], '}');
+});
+
+test('offsets are absolute across lines, and a comment ends at its newline', () => {
+  const text = '% $\\VAR{A.max}$\n$N \\le \\VAR{N.max}$\n';
+  const hints = scan(text);
+  assert.deepStrictEqual(
+    hints.map((hint) => hint.text),
+    ['100000'],
+  );
+  assert.strictEqual(text.slice(hints[0].end - 6, hints[0].end), 'N.max}');
+});
+
+test('scanning is repeatable, so no regex state leaks between calls', () => {
+  const text = '\\VAR{N.max} \\VAR{A.max}';
+  assert.deepStrictEqual(scan(text), scan(text));
+});

--- a/vscode/src/rbx/statementVars.test.ts
+++ b/vscode/src/rbx/statementVars.test.ts
@@ -35,18 +35,75 @@ const VARS: Vars = {
 const scan = (text: string) => scanStatementVars(text, VARS);
 
 test('the shorthand and the long form both resolve', () => {
-  assert.deepStrictEqual(scan('$N \\le \\VAR{N.max}$'), [{ end: 18, text: '100000' }]);
+  assert.deepStrictEqual(scan('$N \\le \\VAR{N.max}$'), [
+    { end: 18, expression: 'N.max', filtered: false, text: '100000' },
+  ]);
   assert.deepStrictEqual(
     scan('$N \\le \\VAR{vars.N.max}$').map((hint) => hint.text),
     ['100000'],
   );
 });
 
-test('a filter pipeline is ignored, the raw value is shown', () => {
+test('an unfiltered reference carries the expression it was resolved from', () => {
+  assert.deepStrictEqual(scan('$N \\le \\VAR{vars.N.max}$'), [
+    { end: 23, expression: 'N.max', filtered: false, text: '100000' },
+  ]);
+});
+
+test('a filtered reference is reported without a value, for rendering', () => {
+  // The raw value would be a lie under a filter: `sci` typesets `100000` as
+  // `10^{5}`. The caller renders `expression` instead of badging `text`.
+  assert.deepStrictEqual(scan('\\VAR{N.max | sci}'), [
+    { end: 17, expression: 'N.max | sci', filtered: true },
+  ]);
+});
+
+test('the same pipeline spelled differently is one expression', () => {
+  const spellings = [
+    '\\VAR{N.max|sci}',
+    '\\VAR{N.max | sci}',
+    '\\VAR{N.max |sci}',
+    '\\VAR{N.max| sci}',
+    '\\VAR{  N.max   |   sci  }',
+    '\\VAR{N.max\n | sci}',
+  ];
+  for (const text of spellings) {
+    assert.deepStrictEqual(
+      scan(text).map((hint) => hint.expression),
+      ['N.max | sci'],
+      text,
+    );
+  }
+});
+
+test('the `vars.` prefix is dropped from the expression too', () => {
+  // rbx's renderer accepts both spellings, so dropping the prefix costs
+  // nothing and lets the two share one cache entry.
   assert.deepStrictEqual(
-    scan('\\VAR{N.max | sci}').map((hint) => hint.text),
-    ['100000'],
+    scan('\\VAR{vars.N.max | sci}').map((hint) => hint.expression),
+    ['N.max | sci'],
   );
+});
+
+test('a multi-stage pipeline is captured whole', () => {
+  assert.deepStrictEqual(
+    scan('\\VAR{N.max|sci|upper}').map((hint) => hint.expression),
+    ['N.max | sci | upper'],
+  );
+});
+
+test('filter arguments survive', () => {
+  assert.deepStrictEqual(
+    scan("\\VAR{N.max | sci(9)} \\VAR{label | default('x|y')}").map((hint) => hint.expression),
+    ['N.max | sci(9)', "label | default('x|y')"],
+  );
+});
+
+test('a pipeline over an unknown name gets no hint either', () => {
+  // The base of a filtered reference is the very value being rendered, so a
+  // name the map does not hold is as hopeless here as it is unfiltered -- and
+  // rendering it would cost a process to find that out.
+  assert.deepStrictEqual(scan('\\VAR{N.mx | sci}'), []);
 });
 
 test('several references on one line each get a hint', () => {
@@ -142,8 +199,8 @@ test('a reference wrapped across a newline still resolves', () => {
   // `[^}]*` spans newlines, while `isCommented` only inspects the line the
   // reference opens on.
   assert.deepStrictEqual(
-    scan('$N \\le \\VAR{N.max\n | sci}$').map((hint) => hint.text),
-    ['100000'],
+    scan('$N \\le \\VAR{N.max\n | sci}$').map((hint) => hint.expression),
+    ['N.max | sci'],
   );
 });
 

--- a/vscode/src/rbx/statementVars.test.ts
+++ b/vscode/src/rbx/statementVars.test.ts
@@ -34,12 +34,22 @@ const VARS: Vars = {
 
 const scan = (text: string) => scanStatementVars(text, VARS);
 
+/**
+ * The badge texts of a scan, a filtered reference contributing none.
+ *
+ * `VarHint` carries `text` only on its unfiltered arm, so this narrows once
+ * here rather than at every assertion. A reference that unexpectedly turned
+ * filtered shows up as a missing text, which is what these tests watch for.
+ */
+const texts = (source: string) =>
+  scan(source).flatMap((hint) => (hint.filtered ? [] : [hint.text]));
+
 test('the shorthand and the long form both resolve', () => {
   assert.deepStrictEqual(scan('$N \\le \\VAR{N.max}$'), [
     { end: 18, expression: 'N.max', filtered: false, text: '100000' },
   ]);
   assert.deepStrictEqual(
-    scan('$N \\le \\VAR{vars.N.max}$').map((hint) => hint.text),
+    texts('$N \\le \\VAR{vars.N.max}$'),
     ['100000'],
   );
 });
@@ -99,6 +109,37 @@ test('filter arguments survive', () => {
   );
 });
 
+test('a quoted pipeline keys on itself, spacing and all', () => {
+  // The documented exception to one-spelling-one-key: respacing a pipeline
+  // that holds a quote could rewrite a string argument, so only the space
+  // before the first pipe is imposed and the rest stands as written. Two
+  // spellings, two renders of the same thing -- time, not correctness.
+  assert.deepStrictEqual(
+    scan("\\VAR{label|default('x|y')} \\VAR{label |   default('x|y')}").map(
+      (hint) => hint.expression,
+    ),
+    ["label |default('x|y')", "label |   default('x|y')"],
+  );
+});
+
+test('an expression that would still hold a newline gets no hint', () => {
+  // Expressions cross to `rbx vars --render` one per line of stdin and come
+  // back as the keys of its reply, so a newline would split one request into
+  // two that nothing can answer. Respacing launders the newline around a pipe,
+  // but not one inside an argument or anywhere in a quoted pipeline.
+  for (const text of ["\\VAR{label | default('x')\n | upper}", '\\VAR{N.max | sci(9,\n 3)}']) {
+    assert.deepStrictEqual(scan(text), [], text);
+  }
+});
+
+test('a pipeline with an empty stage gets no hint', () => {
+  // `N.max |` is what every half-typed filter looks like, and neither it nor
+  // `N.max ||sci` is an expression rbx could render.
+  for (const text of ['\\VAR{N.max |}', '\\VAR{N.max ||sci}', '\\VAR{N.max | | sci}']) {
+    assert.deepStrictEqual(scan(text), [], text);
+  }
+});
+
 test('a pipeline over an unknown name gets no hint either', () => {
   // The base of a filtered reference is the very value being rendered, so a
   // name the map does not hold is as hopeless here as it is unfiltered -- and
@@ -108,7 +149,7 @@ test('a pipeline over an unknown name gets no hint either', () => {
 
 test('several references on one line each get a hint', () => {
   assert.deepStrictEqual(
-    scan('$\\VAR{N.max}$ and $\\VAR{A.max}$').map((hint) => hint.text),
+    texts('$\\VAR{N.max}$ and $\\VAR{A.max}$'),
     ['100000', '1000000000'],
   );
 });
@@ -153,7 +194,7 @@ test('a comment opened mid-line is skipped too', () => {
 
 test('an escaped percent does not open a comment', () => {
   assert.deepStrictEqual(
-    scan('50\\% of \\VAR{N.max}').map((hint) => hint.text),
+    texts('50\\% of \\VAR{N.max}'),
     ['100000'],
   );
   // A literal backslash before the percent: the percent is a real comment.
@@ -164,14 +205,14 @@ test('an escaped VAR is not a reference', () => {
   assert.deepStrictEqual(scan('\\\\VAR{N.max}'), []);
   // ...but a literal backslash followed by a real reference still is.
   assert.deepStrictEqual(
-    scan('\\\\\\VAR{N.max}').map((hint) => hint.text),
+    texts('\\\\\\VAR{N.max}'),
     ['100000'],
   );
 });
 
 test('non-numeric values are shown verbatim', () => {
   assert.deepStrictEqual(
-    scan('\\VAR{flag} \\VAR{label}').map((hint) => hint.text),
+    texts('\\VAR{flag} \\VAR{label}'),
     ['True', 'foo'],
   );
 });
@@ -181,7 +222,7 @@ test('an integer too large for a double keeps every digit', () => {
   // come back from `JSON.parse` as 1000000000000000000, and the badge would
   // confidently show a bound the statement does not have.
   assert.deepStrictEqual(
-    scan('$N \\le \\VAR{BIG.max}$').map((hint) => hint.text),
+    texts('$N \\le \\VAR{BIG.max}$'),
     ['1000000000000000007'],
   );
 });
@@ -190,7 +231,7 @@ test('a root var named exactly `g` still resolves', () => {
   // FOREIGN_SCOPE only claims `g.`, with the dot: `g` alone is an ordinary
   // root var, and refusing it would cost a badge for nothing.
   assert.deepStrictEqual(
-    scan('\\VAR{g}').map((hint) => hint.text),
+    texts('\\VAR{g}'),
     ['3'],
   );
 });
@@ -213,10 +254,7 @@ test('the hint sits just after the closing brace', () => {
 test('offsets are absolute across lines, and a comment ends at its newline', () => {
   const text = '% $\\VAR{A.max}$\n$N \\le \\VAR{N.max}$\n';
   const hints = scan(text);
-  assert.deepStrictEqual(
-    hints.map((hint) => hint.text),
-    ['100000'],
-  );
+  assert.deepStrictEqual(texts(text), ['100000']);
   assert.strictEqual(text.slice(hints[0].end - 6, hints[0].end), 'N.max}');
 });
 

--- a/vscode/src/rbx/statementVars.test.ts
+++ b/vscode/src/rbx/statementVars.test.ts
@@ -4,10 +4,18 @@ import { test } from 'node:test';
 import { scanStatementVars, Vars } from './statementVars';
 
 /**
- * The foreign-scope keys are deliberately *resolvable*. A nested var block
- * named `g` really does flatten to the key `g.N.max` in `rbx vars --json`, so
- * without them the scope guard would be untestable: every foreign name would
- * be turned away by the lookup rather than by the guard.
+ * The foreign-scope keys are deliberately *resolvable*, so that the scope
+ * guard is what turns them away rather than the lookup -- otherwise the guard
+ * would be untestable.
+ *
+ * Only the `g.` and `p.` keys are reachable in a real payload: a nested var
+ * block named `g` really does flatten to `g.N.max` in `rbx vars --json`. The
+ * `problem.`/`contest.`/`groups.`/`vars.problem.` ones cannot occur, because
+ * those roots sit in `RESERVED_STATEMENT_VAR_NAMES`; they are here purely to
+ * prove the GUARD rejects them, not to stand in for anything rbx could emit.
+ *
+ * Values are strings because that is what `rbx vars --json` emits -- see the
+ * `Vars` doc comment.
  */
 const VARS: Vars = {
   'N.max': '100000',
@@ -15,6 +23,7 @@ const VARS: Vars = {
   'BIG.max': '1000000000000000007',
   flag: 'True',
   label: 'foo',
+  g: '3',
   'g.N.max': '7',
   'groups.g.vars.N.max': '7',
   'p.N.max': '7',
@@ -117,6 +126,24 @@ test('an integer too large for a double keeps every digit', () => {
   assert.deepStrictEqual(
     scan('$N \\le \\VAR{BIG.max}$').map((hint) => hint.text),
     ['1000000000000000007'],
+  );
+});
+
+test('a root var named exactly `g` still resolves', () => {
+  // FOREIGN_SCOPE only claims `g.`, with the dot: `g` alone is an ordinary
+  // root var, and refusing it would cost a badge for nothing.
+  assert.deepStrictEqual(
+    scan('\\VAR{g}').map((hint) => hint.text),
+    ['3'],
+  );
+});
+
+test('a reference wrapped across a newline still resolves', () => {
+  // `[^}]*` spans newlines, while `isCommented` only inspects the line the
+  // reference opens on.
+  assert.deepStrictEqual(
+    scan('$N \\le \\VAR{N.max\n | sci}$').map((hint) => hint.text),
+    ['100000'],
   );
 });
 

--- a/vscode/src/rbx/statementVars.test.ts
+++ b/vscode/src/rbx/statementVars.test.ts
@@ -3,11 +3,23 @@ import { test } from 'node:test';
 
 import { scanStatementVars, Vars } from './statementVars';
 
+/**
+ * The foreign-scope keys are deliberately *resolvable*. A nested var block
+ * named `g` really does flatten to the key `g.N.max` in `rbx vars --json`, so
+ * without them the scope guard would be untestable: every foreign name would
+ * be turned away by the lookup rather than by the guard.
+ */
 const VARS: Vars = {
   'N.max': 100000,
   'A.max': 1000000000,
   flag: true,
   name: 'foo',
+  'g.N.max': 7,
+  'groups.g.vars.N.max': 7,
+  'p.N.max': 7,
+  'problem.N.max': 7,
+  'contest.year': 7,
+  'vars.problem.N.max': 7,
 };
 
 const scan = (text: string) => scanStatementVars(text, VARS);

--- a/vscode/src/rbx/statementVars.test.ts
+++ b/vscode/src/rbx/statementVars.test.ts
@@ -10,16 +10,17 @@ import { scanStatementVars, Vars } from './statementVars';
  * be turned away by the lookup rather than by the guard.
  */
 const VARS: Vars = {
-  'N.max': 100000,
-  'A.max': 1000000000,
-  flag: true,
-  name: 'foo',
-  'g.N.max': 7,
-  'groups.g.vars.N.max': 7,
-  'p.N.max': 7,
-  'problem.N.max': 7,
-  'contest.year': 7,
-  'vars.problem.N.max': 7,
+  'N.max': '100000',
+  'A.max': '1000000000',
+  'BIG.max': '1000000000000000007',
+  flag: 'True',
+  label: 'foo',
+  'g.N.max': '7',
+  'groups.g.vars.N.max': '7',
+  'p.N.max': '7',
+  'problem.N.max': '7',
+  'contest.year': '7',
+  'vars.problem.N.max': '7',
 };
 
 const scan = (text: string) => scanStatementVars(text, VARS);
@@ -102,10 +103,20 @@ test('an escaped VAR is not a reference', () => {
   );
 });
 
-test('non-numeric values render as themselves', () => {
+test('non-numeric values are shown verbatim', () => {
   assert.deepStrictEqual(
-    scan('\\VAR{flag} \\VAR{name}').map((hint) => hint.text),
-    ['true', 'foo'],
+    scan('\\VAR{flag} \\VAR{label}').map((hint) => hint.text),
+    ['True', 'foo'],
+  );
+});
+
+test('an integer too large for a double keeps every digit', () => {
+  // The reason values cross as strings at all: as a JSON number this would
+  // come back from `JSON.parse` as 1000000000000000000, and the badge would
+  // confidently show a bound the statement does not have.
+  assert.deepStrictEqual(
+    scan('$N \\le \\VAR{BIG.max}$').map((hint) => hint.text),
+    ['1000000000000000007'],
   );
 });
 

--- a/vscode/src/rbx/statementVars.ts
+++ b/vscode/src/rbx/statementVars.ts
@@ -29,8 +29,17 @@ interface VarReference {
   readonly end: number;
   /**
    * The canonical expression this reference asks for, ready to hand to
-   * `rbx vars --render`. Stripped of any `vars.` prefix and respaced around
-   * each pipe, so that spellings differing only there are one cache key.
+   * `rbx vars --render`. Stripped of any `vars.` prefix, respaced around each
+   * pipe, and guaranteed to hold no newline -- it crosses to rbx as one line
+   * of stdin and comes back as a key, so a newline in it would be a request
+   * nothing could answer.
+   *
+   * Two spellings that differ only in the spacing around a pipe are therefore
+   * one cache key -- *except* where the pipeline holds a quote, which
+   * `canonicalize` leaves internally verbatim rather than risk rewriting a
+   * string argument. `label|default('x|y')` and `label | default('x|y')` are
+   * two keys and two renders of the same thing. That is a deliberate trade:
+   * a duplicated render costs time, a corrupted expression costs correctness.
    */
   readonly expression: string;
 }
@@ -49,12 +58,6 @@ export interface ResolvedVarHint extends VarReference {
  */
 export interface FilteredVarHint extends VarReference {
   readonly filtered: true;
-  /**
-   * Never set. Declared so that `hint.text` on the union is `string |
-   * undefined` -- a caller that reads it without narrowing is told it may be
-   * missing, instead of being told the property does not exist at all.
-   */
-  readonly text?: undefined;
 }
 
 /**
@@ -167,24 +170,49 @@ function lookup(vars: Vars, name: string): string | undefined {
 }
 
 /**
- * One canonical spelling of `name | pipeline`, so that `N.max|sci`,
- * `N.max | sci` and a pipeline wrapped across lines are one cache key rather
- * than three renders of the same thing.
+ * One canonical spelling of `name | pipeline`, or `undefined` for a pipeline
+ * this scanner refuses to ask rbx about.
  *
- * Only the whitespace *around* each pipe is rewritten. Whitespace inside a
- * filter's arguments is left as written -- collapsing it could change what a
- * string argument means, and the worst it costs is a second cache entry for
- * `sci( 9 )` beside `sci(9)`. A pipeline holding a quote is left alone
- * entirely: a `|` inside a string argument is a literal, and spacing it out
- * would corrupt the expression the renderer is handed.
+ * The spelling exists so that `N.max|sci`, `N.max | sci` and a pipeline
+ * wrapped across lines are one cache key rather than three renders of the same
+ * thing. Only the whitespace *around* each pipe is rewritten; whitespace inside
+ * a filter's arguments is left as written, because collapsing it could change
+ * what a string argument means, and the worst it costs is a second cache entry
+ * for `sci( 9 )` beside `sci(9)`.
+ *
+ * A pipeline holding a quote is left internally verbatim -- a `|` inside a
+ * string argument is a literal, and respacing it would corrupt the expression
+ * the renderer is handed. Only the single space joining the name to the first
+ * pipe is imposed there, so `label|default('x|y')` canonicalizes to
+ * `label |default('x|y')` and keys separately from `label | default('x|y')`.
+ *
+ * Two pipelines are refused outright:
+ *
+ * - one with an empty stage (`N.max |`, the state of every half-typed filter,
+ *   and `N.max ||sci`). Neither is a Jinja expression, so the render could only
+ *   fail, and rejecting them here also spares the caller a double space that
+ *   respacing `||` would otherwise produce. The check splits on `|`, which is
+ *   only unambiguous when no quote is present, so a quoted pipeline skips it --
+ *   at worst one wasted render for something like `N.max | 'x' |`.
+ * - one whose canonical form still holds a newline. Expressions cross to
+ *   `rbx vars --render` one per line of stdin and come back as the keys of its
+ *   reply, so a newline would split one request into two unanswerable ones.
+ *   Respacing launders the newline in `N.max\n | sci`, but not the one in
+ *   `sci(9,\n 3)` or in any quoted pipeline, which is exactly why the check is
+ *   made on the finished expression rather than trusted to the respacing.
  */
-function canonicalize(name: string, pipeline: string | undefined): string {
+function canonicalize(name: string, pipeline: string | undefined): string | undefined {
   if (pipeline === undefined) {
     return name;
   }
   const stages = pipeline.trim();
-  const spaced = /['"]/.test(stages) ? stages : stages.replace(/\s*\|\s*/g, ' | ').trim();
-  return `${name} ${spaced}`;
+  const quoted = /['"]/.test(stages);
+  if (!quoted && stages.split('|').some((stage, index) => index > 0 && stage.trim() === '')) {
+    return undefined;
+  }
+  const spaced = quoted ? stages : stages.replace(/\s*\|\s*/g, ' | ').trim();
+  const expression = `${name} ${spaced}`;
+  return expression.includes('\n') ? undefined : expression;
 }
 
 export function scanStatementVars(text: string, vars: Vars): VarHint[] {
@@ -227,8 +255,15 @@ export function scanStatementVars(text: string, vars: Vars): VarHint[] {
       continue;
     }
 
-    const end = start + match[0].length;
+    // A pipeline `canonicalize` refuses yields no hint at all, rather than a
+    // bare-name hint: the badge would then show the unfiltered value, which is
+    // the very lie this scanner reports the pipeline to avoid.
     const expression = canonicalize(name, pipeline);
+    if (expression === undefined) {
+      continue;
+    }
+
+    const end = start + match[0].length;
     hints.push(
       pipeline === undefined
         ? { end, expression, filtered: false, text: value }

--- a/vscode/src/rbx/statementVars.ts
+++ b/vscode/src/rbx/statementVars.ts
@@ -13,16 +13,21 @@
  * See docs/plans/2026-08-28-vscode-statement-var-hints-design.md (D1).
  */
 
-/** A var value, as `rbx vars --json` emits it. */
-export type VarValue = number | boolean | string;
-
-/** The expanded package vars, keyed by dotted name. */
-export type Vars = Readonly<Record<string, VarValue>>;
+/**
+ * The expanded package vars, keyed by dotted name.
+ *
+ * Values are strings, not numbers: `rbx vars --json` renders each one to the
+ * text the statement will show and emits *that*. A JSON number would be an
+ * IEEE double by the time `JSON.parse` was done with it, so a bound like
+ * `10**18 + 7` would silently badge as `1000000000000000000` and `10**21` as
+ * `1e+21`. Nothing here does arithmetic on a value, so text is all it needs.
+ */
+export type Vars = Readonly<Record<string, string>>;
 
 export interface VarHint {
   /** Offset just past the reference's closing brace. */
   readonly end: number;
-  /** The value, rendered for display. */
+  /** The value's display text, verbatim from `rbx vars --json`. */
   readonly text: string;
 }
 
@@ -87,12 +92,8 @@ function isEscaped(text: string, offset: number): boolean {
   return backslashesBefore(text, offset) % 2 === 1;
 }
 
-function render(value: VarValue): string {
-  return typeof value === 'string' ? value : String(value);
-}
-
 /** The value `name` holds, or `undefined` if the map does not hold it. */
-function lookup(vars: Vars, name: string): VarValue | undefined {
+function lookup(vars: Vars, name: string): string | undefined {
   // Own-property only: a name like `constructor` or `toString` is a typo, not
   // a var, and must not resolve to whatever `Object.prototype` carries.
   return Object.prototype.hasOwnProperty.call(vars, name) ? vars[name] : undefined;
@@ -123,7 +124,7 @@ export function scanStatementVars(text: string, vars: Vars): VarHint[] {
       continue;
     }
 
-    hints.push({ end: start + match[0].length, text: render(value) });
+    hints.push({ end: start + match[0].length, text: value });
   }
 
   return hints;

--- a/vscode/src/rbx/statementVars.ts
+++ b/vscode/src/rbx/statementVars.ts
@@ -29,10 +29,19 @@ export interface VarHint {
 /**
  * Scopes whose values this map does not hold. See the module comment.
  *
- * Safe to claim these names outright: rbx rejects a top-level var that collides
- * with a template namespace key (`vars`, `problem`, `contest`, `groups`, ...),
- * so no legitimate root var can be spelled `problem.x` or `groups.x`. The short
- * aliases `g` and `p` are the loop and problem bindings the templates use.
+ * The two halves of this list are claimed on different grounds:
+ *
+ * - `problem`, `contest`, `groups` and `vars` are rbx's own. All four sit in
+ *   `RESERVED_STATEMENT_VAR_NAMES` (rbx/box/fields.py), which rejects a
+ *   top-level var that would shadow a template namespace key, so no legitimate
+ *   root var can ever be spelled `problem.x` or `groups.x`. Claiming them
+ *   costs nothing.
+ * - `g` and `p` are only *conventional* -- the aliases a template author
+ *   happens to bind in `\BLOCK{for g in groups}`. rbx reserves neither, so a
+ *   root var genuinely named `g` is legal and `\VAR{g.max}` would then lose a
+ *   badge it could have had. That is a deliberate false negative: badging a
+ *   loop variable with a root value would be a lie, and under D5 an absent
+ *   badge is never wrong.
  */
 const FOREIGN_SCOPE = /^(vars\.)?(g|p|problem|contest|groups)\./;
 

--- a/vscode/src/rbx/statementVars.ts
+++ b/vscode/src/rbx/statementVars.ts
@@ -1,0 +1,121 @@
+/**
+ * Which `\VAR{...}` references in a statement get a value badge.
+ *
+ * Pure: no `vscode` import, so `node --test` covers it directly.
+ *
+ * Only *problem-root* references are badged -- `\VAR{N.max}` and
+ * `\VAR{vars.N.max}`. A group reference (`\VAR{g.N.max}`) renders a different
+ * value per loop iteration, so a single badge would have to lie or to name the
+ * group; contest and problem scopes resolve against var sets this map does not
+ * hold. Every one of those, and every expression that is not a plain dotted
+ * name, yields no hint: an absent badge is never wrong.
+ *
+ * See docs/plans/2026-08-28-vscode-statement-var-hints-design.md (D1).
+ */
+
+/** A var value, as `rbx vars --json` emits it. */
+export type VarValue = number | boolean | string;
+
+/** The expanded package vars, keyed by dotted name. */
+export type Vars = Readonly<Record<string, VarValue>>;
+
+export interface VarHint {
+  /** Offset just past the reference's closing brace. */
+  readonly end: number;
+  /** The value, rendered for display. */
+  readonly text: string;
+}
+
+/**
+ * Scopes whose values this map does not hold. See the module comment.
+ *
+ * Safe to claim these names outright: rbx rejects a top-level var that collides
+ * with a template namespace key (`vars`, `problem`, `contest`, `groups`, ...),
+ * so no legitimate root var can be spelled `problem.x` or `groups.x`. The short
+ * aliases `g` and `p` are the loop and problem bindings the templates use.
+ */
+const FOREIGN_SCOPE = /^(vars\.)?(g|p|problem|contest|groups)\./;
+
+/** A plain dotted name, with an optional filter pipeline we ignore. */
+const REFERENCE = /^\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*(?:\|[^}]*)?$/;
+
+const OCCURRENCE = /\\VAR\{([^}]*)\}/g;
+
+/** How many backslashes immediately precede `offset`. */
+function backslashesBefore(text: string, offset: number): number {
+  let count = 0;
+  for (let i = offset - 1; i >= 0 && text[i] === '\\'; i -= 1) {
+    count += 1;
+  }
+  return count;
+}
+
+/**
+ * Whether a comment already runs at `offset`.
+ *
+ * Both comment syntaxes a statement can use open with a percent -- LaTeX's `%`
+ * and rbxTeX's Jinja line comment `%#` -- and both run to the end of the line,
+ * so one unescaped percent earlier on the line is enough. `\%` is a literal
+ * percent and opens nothing; `\\%` is a literal backslash and then a comment,
+ * hence the parity check.
+ */
+function isCommented(text: string, offset: number): boolean {
+  const lineStart = text.lastIndexOf('\n', offset - 1) + 1;
+  for (let i = lineStart; i < offset; i += 1) {
+    if (text[i] === '%' && backslashesBefore(text, i) % 2 === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Whether the backslash at `offset` is itself escaped, making the `\VAR` a
+ * literal rather than a reference. An odd run of backslashes before it means
+ * the last one pairs off with the one the match consumed.
+ */
+function isEscaped(text: string, offset: number): boolean {
+  return backslashesBefore(text, offset) % 2 === 1;
+}
+
+function render(value: VarValue): string {
+  return typeof value === 'string' ? value : String(value);
+}
+
+/** The value `name` holds, or `undefined` if the map does not hold it. */
+function lookup(vars: Vars, name: string): VarValue | undefined {
+  // Own-property only: a name like `constructor` or `toString` is a typo, not
+  // a var, and must not resolve to whatever `Object.prototype` carries.
+  return Object.prototype.hasOwnProperty.call(vars, name) ? vars[name] : undefined;
+}
+
+export function scanStatementVars(text: string, vars: Vars): VarHint[] {
+  const hints: VarHint[] = [];
+  const occurrence = new RegExp(OCCURRENCE);
+
+  for (let match = occurrence.exec(text); match; match = occurrence.exec(text)) {
+    const start = match.index;
+    if (isEscaped(text, start) || isCommented(text, start)) {
+      continue;
+    }
+
+    const expression = match[1].trim();
+    if (FOREIGN_SCOPE.test(expression)) {
+      continue;
+    }
+
+    const parsed = REFERENCE.exec(expression);
+    if (!parsed) {
+      continue;
+    }
+
+    const value = lookup(vars, parsed[1].replace(/^vars\./, ''));
+    if (value === undefined) {
+      continue;
+    }
+
+    hints.push({ end: start + match[0].length, text: render(value) });
+  }
+
+  return hints;
+}

--- a/vscode/src/rbx/statementVars.ts
+++ b/vscode/src/rbx/statementVars.ts
@@ -24,12 +24,47 @@
  */
 export type Vars = Readonly<Record<string, string>>;
 
-export interface VarHint {
+interface VarReference {
   /** Offset just past the reference's closing brace. */
   readonly end: number;
+  /**
+   * The canonical expression this reference asks for, ready to hand to
+   * `rbx vars --render`. Stripped of any `vars.` prefix and respaced around
+   * each pipe, so that spellings differing only there are one cache key.
+   */
+  readonly expression: string;
+}
+
+/** A bare `\VAR{N.max}`: the bulk vars map already holds its value. */
+export interface ResolvedVarHint extends VarReference {
+  readonly filtered: false;
   /** The value's display text, verbatim from `rbx vars --json`. */
   readonly text: string;
 }
+
+/**
+ * A `\VAR{N.max | sci}`: the raw value would be a lie, because the filter is
+ * exactly what decides how the statement typesets it. Only `rbx vars --render`
+ * can say what this shows, so no text is carried here.
+ */
+export interface FilteredVarHint extends VarReference {
+  readonly filtered: true;
+  /**
+   * Never set. Declared so that `hint.text` on the union is `string |
+   * undefined` -- a caller that reads it without narrowing is told it may be
+   * missing, instead of being told the property does not exist at all.
+   */
+  readonly text?: undefined;
+}
+
+/**
+ * Two shapes discriminated on `filtered`, rather than one with a `text` that
+ * is sometimes there: the two cases are answered from different places -- the
+ * map already in hand versus a render -- and this way the compiler, not a
+ * comment, is what stops a caller from badging a filtered reference with a
+ * value nobody computed.
+ */
+export type VarHint = ResolvedVarHint | FilteredVarHint;
 
 /**
  * Scopes whose values this map does not hold. See the module comment.
@@ -56,17 +91,19 @@ export interface VarHint {
 const FOREIGN_SCOPE = /^(vars\.)?(g|p|problem|contest|groups)\./;
 
 /**
- * A plain dotted name, with an optional filter pipeline we ignore.
+ * A plain dotted name, and the filter pipeline it is piped through, if any.
  *
  * Anchored at both ends and matched against the *trimmed* expression, so a
- * leading `\s*` would be dead and is not here. The trailing `\s*` is load
- * bearing: it absorbs the space before the pipe in `N.max | sci`.
+ * leading `\s*` would be dead and is not here. The `\s*` between the two groups
+ * is load bearing: it absorbs the space before the pipe in `N.max | sci`.
  *
  * The pipeline's `[^}]*` can never actually meet a `}` -- `OCCURRENCE` stopped
  * at the first one -- but it is kept over `.*` because it also matches a
- * newline, and a filter pipeline may well be wrapped across lines.
+ * newline, and a filter pipeline may well be wrapped across lines. Everything
+ * else a pipeline may hold rides along in it: further stages, and filter
+ * arguments such as `sci(9)` or `default('x')`.
  */
-const REFERENCE = /^([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*(?:\|[^}]*)?$/;
+const REFERENCE = /^([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*(\|[^}]*)?$/;
 
 /**
  * One `\VAR{...}` reference and the expression inside it.
@@ -129,6 +166,27 @@ function lookup(vars: Vars, name: string): string | undefined {
   return Object.hasOwn(vars, name) ? vars[name] : undefined;
 }
 
+/**
+ * One canonical spelling of `name | pipeline`, so that `N.max|sci`,
+ * `N.max | sci` and a pipeline wrapped across lines are one cache key rather
+ * than three renders of the same thing.
+ *
+ * Only the whitespace *around* each pipe is rewritten. Whitespace inside a
+ * filter's arguments is left as written -- collapsing it could change what a
+ * string argument means, and the worst it costs is a second cache entry for
+ * `sci( 9 )` beside `sci(9)`. A pipeline holding a quote is left alone
+ * entirely: a `|` inside a string argument is a literal, and spacing it out
+ * would corrupt the expression the renderer is handed.
+ */
+function canonicalize(name: string, pipeline: string | undefined): string {
+  if (pipeline === undefined) {
+    return name;
+  }
+  const stages = pipeline.trim();
+  const spaced = /['"]/.test(stages) ? stages : stages.replace(/\s*\|\s*/g, ' | ').trim();
+  return `${name} ${spaced}`;
+}
+
 export function scanStatementVars(text: string, vars: Vars): VarHint[] {
   const hints: VarHint[] = [];
   // A fresh regex per scan: a `/g` one carries `lastIndex` between calls, so
@@ -141,22 +199,41 @@ export function scanStatementVars(text: string, vars: Vars): VarHint[] {
       continue;
     }
 
-    const expression = match[1].trim();
-    if (FOREIGN_SCOPE.test(expression)) {
+    const inner = match[1].trim();
+    if (FOREIGN_SCOPE.test(inner)) {
       continue;
     }
 
-    const parsed = REFERENCE.exec(expression);
+    const parsed = REFERENCE.exec(inner);
     if (!parsed) {
       continue;
     }
 
-    const value = lookup(vars, parsed[1].replace(/^vars\./, ''));
+    // The prefix is dropped from the expression too, not just from the lookup:
+    // rbx's renderer resolves `N.max` and `vars.N.max` alike, so the shorter
+    // spelling is a stable key both forms of the reference can share.
+    const name = parsed[1].replace(/^vars\./, '');
+    const pipeline = parsed[2];
+
+    // The name is checked against the map even when a pipeline follows. The
+    // base of a filtered reference is the value being filtered, so a name the
+    // map does not hold is as hopeless here as it is bare -- rendering it would
+    // spend a process to learn that a typo is a typo. It does cost the odd
+    // legitimate badge (`\VAR{x | default(5)}` over an undefined `x`, or a name
+    // bound by a `\BLOCK{set}` in the template), which is the side D5 says to
+    // err on, and which a bare reference to such a name already loses.
+    const value = lookup(vars, name);
     if (value === undefined) {
       continue;
     }
 
-    hints.push({ end: start + match[0].length, text: value });
+    const end = start + match[0].length;
+    const expression = canonicalize(name, pipeline);
+    hints.push(
+      pipeline === undefined
+        ? { end, expression, filtered: false, text: value }
+        : { end, expression, filtered: true },
+    );
   }
 
   return hints;

--- a/vscode/src/rbx/statementVars.ts
+++ b/vscode/src/rbx/statementVars.ts
@@ -39,8 +39,13 @@ export interface VarHint {
  * - `problem`, `contest`, `groups` and `vars` are rbx's own. All four sit in
  *   `RESERVED_STATEMENT_VAR_NAMES` (rbx/box/fields.py), which rejects a
  *   top-level var that would shadow a template namespace key, so no legitimate
- *   root var can ever be spelled `problem.x` or `groups.x`. Claiming them
- *   costs nothing.
+ *   root var can ever be spelled `problem.x` or `groups.x`. That makes these
+ *   four *redundant today*: the lookup below would miss such a name anyway,
+ *   because no payload can contain it. They are kept for legibility -- the
+ *   list reads as "the scopes a statement can name" -- and so that relaxing
+ *   the reserved list does not quietly turn them into wrong badges. Note that
+ *   `problems` is just as reserved and is *not* here, which is the tell that
+ *   this list is a readable summary rather than a mirror of that frozenset.
  * - `g` and `p` are only *conventional* -- the aliases a template author
  *   happens to bind in `\BLOCK{for g in groups}`. rbx reserves neither, so a
  *   root var genuinely named `g` is legal and `\VAR{g.max}` would then lose a
@@ -50,9 +55,26 @@ export interface VarHint {
  */
 const FOREIGN_SCOPE = /^(vars\.)?(g|p|problem|contest|groups)\./;
 
-/** A plain dotted name, with an optional filter pipeline we ignore. */
-const REFERENCE = /^\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*(?:\|[^}]*)?$/;
+/**
+ * A plain dotted name, with an optional filter pipeline we ignore.
+ *
+ * Anchored at both ends and matched against the *trimmed* expression, so a
+ * leading `\s*` would be dead and is not here. The trailing `\s*` is load
+ * bearing: it absorbs the space before the pipe in `N.max | sci`.
+ *
+ * The pipeline's `[^}]*` can never actually meet a `}` -- `OCCURRENCE` stopped
+ * at the first one -- but it is kept over `.*` because it also matches a
+ * newline, and a filter pipeline may well be wrapped across lines.
+ */
+const REFERENCE = /^([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*(?:\|[^}]*)?$/;
 
+/**
+ * One `\VAR{...}` reference and the expression inside it.
+ *
+ * `[^}]*` stops at the first closing brace, so a reference holding a `}` (a
+ * dict literal, say) is not matched as a whole and simply gets no badge. It
+ * spans newlines, which `.` would not.
+ */
 const OCCURRENCE = /\\VAR\{([^}]*)\}/g;
 
 /** How many backslashes immediately precede `offset`. */
@@ -67,11 +89,19 @@ function backslashesBefore(text: string, offset: number): number {
 /**
  * Whether a comment already runs at `offset`.
  *
- * Both comment syntaxes a statement can use open with a percent -- LaTeX's `%`
+ * The comment syntaxes a statement can use open with a percent -- LaTeX's `%`
  * and rbxTeX's Jinja line comment `%#` -- and both run to the end of the line,
  * so one unescaped percent earlier on the line is enough. `\%` is a literal
  * percent and opens nothing; `\\%` is a literal backslash and then a comment,
  * hence the parity check.
+ *
+ * This is a heuristic, not a parse, and it errs toward silence in both known
+ * directions. A Jinja *line statement* opens with `%-`
+ * (`line_statement_prefix`, rbx/box/statements/latex_jinja.py), which is not a
+ * comment, yet a `\VAR{...}` on such a line is treated as commented and loses
+ * its badge. A literal percent inside `\verb|%|` or a verbatim environment
+ * likewise suppresses a legitimate hint on the rest of that line. Both are
+ * missing badges rather than wrong ones, which D5 allows.
  */
 function isCommented(text: string, offset: number): boolean {
   const lineStart = text.lastIndexOf('\n', offset - 1) + 1;
@@ -96,11 +126,13 @@ function isEscaped(text: string, offset: number): boolean {
 function lookup(vars: Vars, name: string): string | undefined {
   // Own-property only: a name like `constructor` or `toString` is a typo, not
   // a var, and must not resolve to whatever `Object.prototype` carries.
-  return Object.prototype.hasOwnProperty.call(vars, name) ? vars[name] : undefined;
+  return Object.hasOwn(vars, name) ? vars[name] : undefined;
 }
 
 export function scanStatementVars(text: string, vars: Vars): VarHint[] {
   const hints: VarHint[] = [];
+  // A fresh regex per scan: a `/g` one carries `lastIndex` between calls, so
+  // sharing the constant would leak where the previous scan stopped.
   const occurrence = new RegExp(OCCURRENCE);
 
   for (let match = occurrence.exec(text); match; match = occurrence.exec(text)) {

--- a/vscode/src/rbx/varsPayload.test.ts
+++ b/vscode/src/rbx/varsPayload.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert';
+import { test } from 'node:test';
+
+import { parseVarsPayload } from './varsPayload';
+
+test('a flat map of display strings is accepted', () => {
+  assert.deepStrictEqual(parseVarsPayload('{"N.max": "100000", "flag": "True"}'), {
+    'N.max': '100000',
+    flag: 'True',
+  });
+});
+
+test('malformed or unexpected output yields no vars, never a throw', () => {
+  for (const stdout of ['', 'not json', '[]', 'null', '{"a": {"b": 1}}', '{"a": [1]}']) {
+    assert.strictEqual(parseVarsPayload(stdout), undefined, stdout);
+  }
+});
+
+test('a nested object of strings is rejected too', () => {
+  // The one shape a retry loop could mistake for a payload: skipping past the
+  // outer brace would find a perfectly well-formed flat map inside, and badge
+  // `b` with a value no statement can reference.
+  assert.strictEqual(parseVarsPayload('{"a": {"b": "1"}}'), undefined);
+});
+
+test('a non-string value is rejected rather than coerced', () => {
+  // The contract is display strings. A number here means the CLI changed
+  // shape, and coercing it would reintroduce the precision bug that made
+  // the contract strings in the first place.
+  assert.strictEqual(parseVarsPayload('{"N.max": 100000}'), undefined);
+});
+
+test('leading noise before the object is tolerated', () => {
+  // A shell wrapper or a venv activation can print before rbx does.
+  assert.deepStrictEqual(parseVarsPayload('warning: x\n{"N.max": "5"}'), {
+    'N.max': '5',
+  });
+});
+
+test('a brace inside the leading noise does not hide the payload', () => {
+  assert.deepStrictEqual(parseVarsPayload('warning: {weird}\n{"N.max": "5"}'), {
+    'N.max': '5',
+  });
+});
+
+test('an empty var block is a valid, empty result', () => {
+  assert.deepStrictEqual(parseVarsPayload('{}'), {});
+});
+
+test('a var spelled like a prototype key stays an own property', () => {
+  // `Object.hasOwn` is how statementVars.ts looks a name up, so a var named
+  // `__proto__` has to survive parsing as an own property rather than being
+  // swallowed by the setter -- and must not reshape the object's prototype.
+  const vars = parseVarsPayload('{"__proto__": "1", "constructor": "2"}');
+  assert.ok(vars !== undefined);
+  assert.ok(Object.hasOwn(vars, '__proto__'));
+  assert.strictEqual(Object.hasOwn(vars, 'toString'), false);
+  assert.strictEqual(vars['constructor'], '2');
+});

--- a/vscode/src/rbx/varsPayload.test.ts
+++ b/vscode/src/rbx/varsPayload.test.ts
@@ -25,9 +25,12 @@ test('a nested object of strings is rejected too', () => {
 
 test('a non-string value is rejected rather than coerced', () => {
   // The contract is display strings. A number here means the CLI changed
-  // shape, and coercing it would reintroduce the precision bug that made
-  // the contract strings in the first place.
-  assert.strictEqual(parseVarsPayload('{"N.max": 100000}'), undefined);
+  // shape, and coercing it would reintroduce the precision bug that made the
+  // contract strings in the first place -- this bound is a plausible modulus
+  // and JSON.parse cannot carry it, as the assertion below shows.
+  const modulus = '1000000000000000007';
+  assert.strictEqual(JSON.parse(`{"N": ${modulus}}`).N.toString(), '1000000000000000000');
+  assert.strictEqual(parseVarsPayload(`{"N.max": ${modulus}}`), undefined);
 });
 
 test('leading noise before the object is tolerated', () => {
@@ -41,6 +44,12 @@ test('a brace inside the leading noise does not hide the payload', () => {
   assert.deepStrictEqual(parseVarsPayload('warning: {weird}\n{"N.max": "5"}'), {
     'N.max': '5',
   });
+});
+
+test('trailing noise drops the payload rather than salvaging it', () => {
+  // The stated limit: only leading noise is tolerated. Output after the object
+  // means something wrote over rbx's stdout, and no badges beats guessing.
+  assert.strictEqual(parseVarsPayload('{"N.max": "5"}\nwarning: x'), undefined);
 });
 
 test('an empty var block is a valid, empty result', () => {

--- a/vscode/src/rbx/varsPayload.test.ts
+++ b/vscode/src/rbx/varsPayload.test.ts
@@ -80,6 +80,23 @@ test('the cursor escape rbx really emits does not eat the payload', () => {
   });
 });
 
+test('the render map is read by this same parser', () => {
+  // `rbx vars --render` prints the same flat map of strings, keyed by the
+  // expression rather than by a name -- pipes, spaces and all. Nothing here
+  // cares which it is. The superscripts arrive as themselves because the
+  // command dumps its JSON with ensure_ascii=False and this reads UTF-8.
+  assert.deepStrictEqual(
+    parseVarsPayload('{"N.max | sci": "10⁵", "M.max | rsci": "2×10⁹ + 7"}'),
+    { 'N.max | sci': '10⁵', 'M.max | rsci': '2×10⁹ + 7' },
+  );
+});
+
+test('an empty render map is a valid answer, not a failure', () => {
+  // What every expression failing to render looks like: the command drops each
+  // one and still exits 0, so `{}` is the whole payload.
+  assert.deepStrictEqual(parseVarsPayload('{}\n\u001b[?25h'), {});
+});
+
 test('colour sequences around the payload are stripped too', () => {
   assert.deepStrictEqual(parseVarsPayload('\u001b[32m{"N.max": "5"}\u001b[0m\n'), {
     'N.max': '5',

--- a/vscode/src/rbx/varsPayload.test.ts
+++ b/vscode/src/rbx/varsPayload.test.ts
@@ -66,3 +66,22 @@ test('a var spelled like a prototype key stays an own property', () => {
   assert.strictEqual(Object.hasOwn(vars, 'toString'), false);
   assert.strictEqual(vars['constructor'], '2');
 });
+
+test('the cursor escape rbx really emits does not eat the payload', () => {
+  // Not hypothetical: with FORCE_COLOR set in the environment the editor
+  // inherited, Rich restores the cursor on exit and rbx's stdout ends with a
+  // show-cursor sequence. Captured verbatim from a real `rbx vars --json`.
+  // Left unstripped it fails JSON.parse and the feature draws nothing at all
+  // -- on some machines and not others, depending on how the editor started.
+  const real = '{"A.min": "0", "A.max": "2147483647"}\n\u001b[?25h';
+  assert.deepStrictEqual(parseVarsPayload(real), {
+    'A.min': '0',
+    'A.max': '2147483647',
+  });
+});
+
+test('colour sequences around the payload are stripped too', () => {
+  assert.deepStrictEqual(parseVarsPayload('\u001b[32m{"N.max": "5"}\u001b[0m\n'), {
+    'N.max': '5',
+  });
+});

--- a/vscode/src/rbx/varsPayload.ts
+++ b/vscode/src/rbx/varsPayload.ts
@@ -18,8 +18,15 @@ import { Vars } from './statementVars';
  * moves on to the next. A payload that parses and then turns out to be the
  * wrong shape is the CLI's answer, and looking deeper into it would find the
  * inner map of `{"a": {"b": "1"}}` and badge a var no statement can name.
+ *
+ * Only *leading* noise is tolerated. Anything printed after the object makes
+ * the slice fail to parse, and every later `{` starts even further inside it,
+ * so the payload is dropped whole. That is a considered limit rather than an
+ * oversight: rbx prints the object last, trailing output would mean something
+ * wrote over its stdout, and under D5 no badges beats guessing which half of
+ * the stream was the answer.
  */
-function parseLeadingObject(stdout: string): unknown | undefined {
+function parseLeadingObject(stdout: string): unknown {
   for (let start = stdout.indexOf('{'); start >= 0; start = stdout.indexOf('{', start + 1)) {
     try {
       return JSON.parse(stdout.slice(start));
@@ -36,6 +43,9 @@ export function parseVarsPayload(stdout: string): Vars | undefined {
     return undefined;
   }
 
+  // Deliberately out here, not inside `parseLeadingObject`'s loop: a shape
+  // mismatch must end the read, not resume the scan. Retrying from the next
+  // brace would step *into* `{"a": {"b": "1"}}` and accept the inner map.
   const entries = Object.entries(parsed as Record<string, unknown>);
   if (!entries.every(([, value]) => typeof value === 'string')) {
     return undefined;

--- a/vscode/src/rbx/varsPayload.ts
+++ b/vscode/src/rbx/varsPayload.ts
@@ -19,14 +19,25 @@ import { Vars } from './statementVars';
  * wrong shape is the CLI's answer, and looking deeper into it would find the
  * inner map of `{"a": {"b": "1"}}` and badge a var no statement can name.
  *
- * Only *leading* noise is tolerated. Anything printed after the object makes
- * the slice fail to parse, and every later `{` starts even further inside it,
- * so the payload is dropped whole. That is a considered limit rather than an
- * oversight: rbx prints the object last, trailing output would mean something
- * wrote over its stdout, and under D5 no badges beats guessing which half of
- * the stream was the answer.
+ * Terminal escape sequences are stripped first, because rbx really does emit
+ * one after the payload: Rich restores the cursor on exit, so stdout ends
+ * `}\n\x1b[?25h` whenever `FORCE_COLOR` is set in the environment the editor
+ * inherited. That is invisible in a terminal and fatal to `JSON.parse`, and it
+ * depends on how the user launched their editor rather than on anything the
+ * extension does -- exactly the kind of failure that would present as "the
+ * feature does nothing on my machine".
+ *
+ * Other *trailing* noise is still not tolerated. Anything else printed after
+ * the object makes the slice fail to parse, and every later `{` starts further
+ * inside it, so the payload is dropped whole. That remains a considered limit:
+ * rbx prints the object last, so trailing text would mean something wrote over
+ * its stdout, and under D5 no badges beats guessing which half of the stream
+ * was the answer.
  */
-function parseLeadingObject(stdout: string): unknown {
+const ANSI_ESCAPE = /\u001b\[[0-9;?]*[ -\/]*[@-~]/g;
+
+function parseLeadingObject(raw: string): unknown {
+  const stdout = raw.replace(ANSI_ESCAPE, '');
   for (let start = stdout.indexOf('{'); start >= 0; start = stdout.indexOf('{', start + 1)) {
     try {
       return JSON.parse(stdout.slice(start));

--- a/vscode/src/rbx/varsPayload.ts
+++ b/vscode/src/rbx/varsPayload.ts
@@ -1,0 +1,48 @@
+/**
+ * Reading `rbx vars --json`.
+ *
+ * Every malformed shape resolves to `undefined` rather than throwing: the
+ * feature degrades to "no badges", never to an error the user has to dismiss.
+ *
+ * Pure: no `vscode` import, so `node --test` covers it directly.
+ */
+import { Vars } from './statementVars';
+
+/**
+ * The payload's own text, with whatever printed before it dropped.
+ *
+ * rbx emits the object on a line of its own, but it is not necessarily the
+ * first line: a shell wrapper, a venv activation or a deprecation warning can
+ * print first, and that noise may itself contain a brace. So each `{` is tried
+ * in turn until one starts something that parses -- but only a *syntax* error
+ * moves on to the next. A payload that parses and then turns out to be the
+ * wrong shape is the CLI's answer, and looking deeper into it would find the
+ * inner map of `{"a": {"b": "1"}}` and badge a var no statement can name.
+ */
+function parseLeadingObject(stdout: string): unknown | undefined {
+  for (let start = stdout.indexOf('{'); start >= 0; start = stdout.indexOf('{', start + 1)) {
+    try {
+      return JSON.parse(stdout.slice(start));
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+export function parseVarsPayload(stdout: string): Vars | undefined {
+  const parsed = parseLeadingObject(stdout);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(parsed as Record<string, unknown>);
+  if (!entries.every(([, value]) => typeof value === 'string')) {
+    return undefined;
+  }
+  // `fromEntries` *defines* each key, so a var named `__proto__` lands as an
+  // own property rather than being swallowed by the prototype setter, and the
+  // result's prototype is left alone. `statementVars.ts` looks names up with
+  // `Object.hasOwn`, so that is exactly what it needs to find.
+  return Object.fromEntries(entries) as Vars;
+}

--- a/vscode/src/rbxProcess.ts
+++ b/vscode/src/rbxProcess.ts
@@ -44,8 +44,9 @@ export interface SpawnResult {
  *
  * `stdin` is optional and, when omitted, the child's stdin is left exactly as
  * it was before this parameter existed: a pipe nobody writes to and nobody
- * closes. Only a caller that passes text changes anything, which is what keeps
- * `rbx visualize` -- the other caller -- byte-for-byte unaffected.
+ * closes. Only a caller that passes text changes anything, which is what leaves
+ * every other caller -- `rbx visualize`, `rbx vars --json`, and the `--version`
+ * and login-shell probes below -- running as it did.
  */
 export function run(
   command: string,

--- a/vscode/src/rbxProcess.ts
+++ b/vscode/src/rbxProcess.ts
@@ -1,0 +1,150 @@
+/**
+ * Spawning `rbx`, and finding the `rbx` to spawn.
+ *
+ * The extension is a pure reader everywhere else (design D2/D3). Spawning rbx
+ * at all is a deliberate exception, narrowed to read-only, idempotent work the
+ * user explicitly asked for. It does not drive the build -- there is still no
+ * Build button, and `rbx build` / `rbx run` stay in the terminal.
+ *
+ * The doctrine reversal is safe in a way the original rationale did not know:
+ * rbx cache directories take a *shared* session lock and support any number of
+ * concurrent processes, and a cache is only ever emptied under an *exclusive*
+ * lock that waits for (or refuses) live holders. So this cannot corrupt a run
+ * in flight. The one hazard left -- a version-skewed rbx clearing the cache and
+ * forcing a surprise rebuild -- rbx itself refuses, with exit code 3.
+ *
+ * Everything decidable without `vscode` lives in rbx/executable.ts, which
+ * `node --test` covers.
+ */
+import { spawn } from 'child_process';
+import * as os from 'os';
+import * as vscode from 'vscode';
+
+import { log } from './log';
+import {
+  RbxCandidate,
+  loginShellProbe,
+  parseLoginShellPath,
+  rbxCandidates,
+} from './rbx/executable';
+
+/** How long the login-shell probe may take before we give up on it. */
+const PROBE_TIMEOUT_MS = 5_000;
+
+export interface SpawnResult {
+  readonly code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  /** Set when the process could not be started at all (typically ENOENT). */
+  readonly spawnError?: NodeJS.ErrnoException;
+}
+
+export function run(
+  command: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<SpawnResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { cwd, shell: false });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const finish = (result: SpawnResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill();
+      finish({
+        code: null,
+        stdout,
+        stderr: `${stderr}\nTimed out after ${timeoutMs}ms.`,
+      });
+    }, timeoutMs);
+
+    child.stdout?.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', (error) => {
+      finish({ code: null, stdout, stderr, spawnError: error });
+    });
+    child.on('close', (code) => {
+      finish({ code, stdout, stderr });
+    });
+  });
+}
+
+/**
+ * The resolved `rbx` for a package root.
+ *
+ * Cached per root rather than per session, and never populated with a candidate
+ * that has not answered: a stale binary on `PATH` must fall through to the
+ * login shell rather than being locked in for the rest of the session.
+ */
+const resolved = new Map<string, string>();
+
+export function resetRbxExecutables(): void {
+  resolved.clear();
+}
+
+/** Whether this candidate is an rbx that actually runs. */
+async function validate(command: string, root: string): Promise<boolean> {
+  const result = await run(command, ['--version'], root, PROBE_TIMEOUT_MS);
+  return result.spawnError === undefined && result.code === 0;
+}
+
+async function resolveCandidate(
+  candidate: RbxCandidate,
+  root: string,
+): Promise<string | undefined> {
+  if (candidate.source !== 'login-shell') {
+    return (await validate(candidate.command, root)) ? candidate.command : undefined;
+  }
+
+  // Resolved in the package root so direnv/mise/a project `.venv` answer for
+  // *this* package.
+  const shell = process.env.SHELL ?? '/bin/sh';
+  if (os.platform() === 'win32') {
+    // No login-shell equivalent worth guessing at; the setting is the answer.
+    return undefined;
+  }
+  const probe = loginShellProbe(shell);
+  const result = await run(probe.command, probe.args, root, PROBE_TIMEOUT_MS);
+  const found = parseLoginShellPath(result.stdout);
+  if (found === undefined) {
+    return undefined;
+  }
+  return (await validate(found, root)) ? found : undefined;
+}
+
+export async function resolveRbx(root: string): Promise<string | undefined> {
+  const cached = resolved.get(root);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const configured = vscode.workspace
+    .getConfiguration('rbx', vscode.Uri.file(root))
+    .get<string>('executable');
+
+  for (const candidate of rbxCandidates(configured)) {
+    const command = await resolveCandidate(candidate, root);
+    if (command !== undefined) {
+      log(`Resolved rbx for ${root} via ${candidate.source}: ${command}`);
+      resolved.set(root, command);
+      return command;
+    }
+    log(`rbx not usable for ${root} via ${candidate.source}.`);
+  }
+  return undefined;
+}

--- a/vscode/src/rbxProcess.ts
+++ b/vscode/src/rbxProcess.ts
@@ -39,14 +39,33 @@ export interface SpawnResult {
   readonly spawnError?: NodeJS.ErrnoException;
 }
 
+/**
+ * Run `command` and collect what it printed.
+ *
+ * `stdin` is optional and, when omitted, the child's stdin is left exactly as
+ * it was before this parameter existed: a pipe nobody writes to and nobody
+ * closes. Only a caller that passes text changes anything, which is what keeps
+ * `rbx visualize` -- the other caller -- byte-for-byte unaffected.
+ */
 export function run(
   command: string,
   args: string[],
   cwd: string,
   timeoutMs: number,
+  stdin?: string,
 ): Promise<SpawnResult> {
   return new Promise((resolve) => {
     const child = spawn(command, args, { cwd, shell: false });
+
+    if (stdin !== undefined) {
+      // Swallowed, not reported: a child that exits without draining its input
+      // leaves this write to fail with EPIPE, and an unhandled `error` on the
+      // stream would throw out of the event loop. Whatever went wrong shows up
+      // as the exit code and stderr below, which is what the caller reads.
+      child.stdin?.on('error', () => undefined);
+      child.stdin?.end(stdin);
+    }
+
     let stdout = '';
     let stderr = '';
     let settled = false;

--- a/vscode/src/statementVarHints.ts
+++ b/vscode/src/statementVarHints.ts
@@ -4,13 +4,13 @@
  * ## Why an inlay hint
  *
  * The value belongs *between* two characters of the line rather than on a line
- * of its own, which is exactly what an inlay hint is: the editor reserves
- * horizontal space for it, so nothing is drawn over the LaTeX. A decoration's
- * `after` attachment could paint the same text, but only at the end of a line
- * -- there is no way to attach one mid-line -- and a constraints block routinely
- * names two bounds on one line. Inlay hints also come with a user-facing
- * toggle, a hover, and the editor's own re-request on every document change,
- * none of which a decoration gets for free.
+ * of its own, which is what an inlay hint is: the editor reserves horizontal
+ * space for it and pushes the rest of the line along, so nothing is drawn over
+ * the LaTeX. An `after` decoration on a zero-width range could paint the same
+ * text in the same place, but it would be ours to maintain -- one editor at a
+ * time, redrawn by hand on every edit, scroll and theme change, and with no
+ * `editor.inlayHints.enabled` for the setter to turn off. The hint API does
+ * all of that, and asks us only to answer a range.
  */
 import * as vscode from 'vscode';
 
@@ -68,9 +68,9 @@ export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
       // `hint.end` is the offset just past the closing brace, so the hint sits
       // immediately after `}` and never inside the reference.
       const position = document.positionAt(hint.end);
-      // Inclusive at both ends, which is the forgiving side to err on: a hint
-      // exactly on the boundary is drawn rather than dropped, and the editor
-      // accepts hints outside the range it asked for anyway.
+      // `contains` is inclusive at both ends, which is the side to err on: a
+      // reference ending exactly on the boundary keeps its hint rather than
+      // falling between two adjacent requests.
       if (!range.contains(position)) {
         continue;
       }
@@ -107,8 +107,9 @@ export function registerStatementVarHints(
   context.subscriptions.push(
     provider,
     // Every file on disk, because which ones are statements is a fact about
-    // the manifest rather than about the language: rbxTeX, plain LaTeX and
-    // Markdown are all spelled by different language ids.
+    // the manifest rather than about the language: a statement can be written
+    // in anything rbx can convert, and `.rbx.tex` has no language id of its
+    // own to select on.
     vscode.languages.registerInlayHintsProvider({ scheme: 'file' }, provider),
     // Both indexes, because either can be the one that changed. The vars index
     // answers what a reference expands to; the declared index answers whether

--- a/vscode/src/statementVarHints.ts
+++ b/vscode/src/statementVarHints.ts
@@ -7,10 +7,11 @@
  * of its own, which is what an inlay hint is: the editor reserves horizontal
  * space for it and pushes the rest of the line along, so nothing is drawn over
  * the LaTeX. An `after` decoration on a zero-width range could paint the same
- * text in the same place, but it would be ours to maintain -- one editor at a
- * time, redrawn by hand on every edit, scroll and theme change, and with no
- * `editor.inlayHints.enabled` for the setter to turn off. The hint API does
- * all of that, and asks us only to answer a range.
+ * text in the same place, but it would be ours to place and to place again: a
+ * decoration is set on one editor at a time, so every split, every newly
+ * revealed statement and every re-scan is ours to drive. And it would carry no
+ * `editor.inlayHints.enabled` for a setter who wants the numbers out of the
+ * way. The hint API asks us only to answer a range.
  */
 import * as vscode from 'vscode';
 
@@ -37,23 +38,28 @@ export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
     if (!enabled()) {
       return [];
     }
-    // The manifest is the authority on which files are statements; it also
-    // covers tutorials, which globbing `*.rbx.tex` would miss.
-    if (this.declared.assetFor(document.uri)?.role !== 'statement') {
-      return [];
-    }
-    const root = this.declared.rootFor(document.uri);
-    if (root === undefined) {
+    // The manifest is the authority on which files are statements, because the
+    // extension does not decide it: a statement is whatever `problem.rbx.yml`
+    // names as one, in any format rbx converts. `StatementType.extension`
+    // (rbx/box/statements/schema.py) alone spells `.rbx.tex`, `.md`, `.rbx.md`
+    // and `.jinja.md`, so no glob over extensions is the same question.
+    const declared = this.declared.declarationFor(document.uri);
+    if (declared?.asset.role !== 'statement') {
       return [];
     }
 
+    // Neither check is needed for correctness -- VS Code drops a cancelled
+    // request's result whatever we hand back. They are early-outs. The first
+    // matters most: typing hands a provider an already-cancelled token quite
+    // routinely, and answering it immediately skips the round-trip below.
+    if (token.isCancellationRequested) {
+      return [];
+    }
     // Never rejects -- `StatementVarsIndex.varsFor` catches its own failures
     // and answers `undefined` -- so there is nothing here to guard against.
-    const vars = await this.vars.varsFor(root);
-    // The await is the only suspension point, and the first request for a cold
-    // package waits on a process spawn behind it. By the time it answers, the
-    // editor may well have asked again for a range that has since scrolled or
-    // been edited; returning hints for the old one is what the token is for.
+    // It is also the only suspension point, and a cold package waits on a
+    // process spawn behind it, which is time enough to be cancelled twice.
+    const vars = await this.vars.varsFor(declared.root);
     if (vars === undefined || token.isCancellationRequested) {
       return [];
     }
@@ -75,10 +81,13 @@ export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
         continue;
       }
       const inlay = new vscode.InlayHint(position, hint.text);
-      // The editor's own leading gap, rather than a space in the label: a
-      // space would be padding *inside* the hint's own background, and would
-      // stack with this if both were used.
+      // The editor's own gaps, rather than spaces in the label: a space would
+      // be padding *inside* the hint's own background, and would stack with
+      // these if both were used. Both sides, because a reference is as often
+      // followed by a `$` or a `\)` as by a space, and a badge with a gap on
+      // one side only reads as lopsided.
       inlay.paddingLeft = true;
+      inlay.paddingRight = true;
       hints.push(inlay);
     }
     return hints;

--- a/vscode/src/statementVarHints.ts
+++ b/vscode/src/statementVarHints.ts
@@ -71,6 +71,12 @@ export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
     // is a few kilobytes of prose, so the scan is not worth optimizing -- but a
     // pathologically large one would pay for it on every keystroke.
     for (const hint of scanStatementVars(document.getText(), vars)) {
+      // A filtered reference carries no text: what it shows is whatever the
+      // pipeline makes of the value, which only `rbx vars --render` knows. It
+      // is skipped until that render is wired up.
+      if (hint.filtered) {
+        continue;
+      }
       // `hint.end` is the offset just past the closing brace, so the hint sits
       // immediately after `}` and never inside the reference.
       const position = document.positionAt(hint.end);

--- a/vscode/src/statementVarHints.ts
+++ b/vscode/src/statementVarHints.ts
@@ -16,6 +16,7 @@
 import * as vscode from 'vscode';
 
 import { DeclaredIndex } from './declared';
+import { pendingRenders } from './rbx/pendingRenders';
 import { scanStatementVars } from './rbx/statementVars';
 import { StatementVarsIndex } from './statementVarsIndex';
 
@@ -70,11 +71,30 @@ export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
     // edge, and offsets from a slice would all need shifting back. A statement
     // is a few kilobytes of prose, so the scan is not worth optimizing -- but a
     // pathologically large one would pay for it on every keystroke.
-    for (const hint of scanStatementVars(document.getText(), vars)) {
-      // A filtered reference carries no text: what it shows is whatever the
-      // pipeline makes of the value, which only `rbx vars --render` knows. It
-      // is skipped until that render is wired up.
-      if (hint.filtered) {
+    const scanned = scanStatementVars(document.getText(), vars);
+    // The index's map itself, which a batch settling later writes into. The
+    // loop below never suspends, so every hint in one pass is still drawn
+    // against the same contents.
+    const rendered = this.vars.renderedNow(declared.root);
+
+    // Started before the hints are built and deliberately not awaited. What is
+    // already known is drawn now; whatever this batch adds arrives via the
+    // change event, which makes VS Code ask again.
+    //
+    // Over the whole document, not just `range`: VS Code asks range by range as
+    // the setter scrolls, and one spawn covering the file is cheaper than one
+    // per viewport -- the expressions outside it are the ones the next request
+    // would ask for anyway.
+    this.startRendering(declared.root, pendingRenders(scanned, rendered));
+
+    for (const hint of scanned) {
+      // A filtered reference carries no text of its own: what it shows is
+      // whatever the pipeline makes of the value, which only a render knows.
+      // An expression not in the map is either still in flight or one rbx
+      // declined to render, and both draw nothing -- an absent badge is never
+      // wrong (D5).
+      const text = hint.filtered ? rendered.get(hint.expression) : hint.text;
+      if (text === undefined) {
         continue;
       }
       // `hint.end` is the offset just past the closing brace, so the hint sits
@@ -86,7 +106,7 @@ export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
       if (!range.contains(position)) {
         continue;
       }
-      const inlay = new vscode.InlayHint(position, hint.text);
+      const inlay = new vscode.InlayHint(position, text);
       // The editor's own gaps, rather than spaces in the label: a space would
       // be padding *inside* the hint's own background, and would stack with
       // these if both were used. Both sides, because a reference is as often
@@ -97,6 +117,38 @@ export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
       hints.push(inlay);
     }
     return hints;
+  }
+
+  /**
+   * Render `expressions` in the background and re-ask for the hints if any of
+   * them came back with text.
+   *
+   * Firing the event is what makes the newly rendered badges appear, and it is
+   * also what could loop: the fire brings VS Code straight back into
+   * `provideInlayHints`. It terminates because the fire is conditional on a
+   * *new* render landing. The next request sees those expressions in the
+   * snapshot and does not ask for them, and the ones rbx declined are absent
+   * from the batch's result, so asking for them again resolves to an empty map
+   * off the cache -- no spawn and, crucially, no second fire.
+   *
+   * The cancellation token is deliberately not consulted. The batch is a fact
+   * about the package, not about this request: it is worth caching whoever
+   * asked, and the event is worth firing even if the request that started it
+   * was cancelled a keystroke later -- there is a live document showing badges
+   * that are now stale by omission.
+   */
+  private startRendering(root: string, expressions: string[]): void {
+    if (expressions.length === 0) {
+      return;
+    }
+    // Not awaited, so the hints above are not held up by a spawn, and safe to
+    // leave unhandled: `renderedFor` never rejects -- the spawn behind it
+    // catches its own failures and answers with an empty map.
+    void this.vars.renderedFor(root, expressions).then((batch) => {
+      if (batch.size > 0) {
+        this.changed.fire();
+      }
+    });
   }
 
   /** Re-ask VS Code for the hints, after the vars changed or a setting did. */

--- a/vscode/src/statementVarHints.ts
+++ b/vscode/src/statementVarHints.ts
@@ -1,0 +1,127 @@
+/**
+ * Shows what each `\VAR{...}` in a statement expands to, beside the reference.
+ *
+ * ## Why an inlay hint
+ *
+ * The value belongs *between* two characters of the line rather than on a line
+ * of its own, which is exactly what an inlay hint is: the editor reserves
+ * horizontal space for it, so nothing is drawn over the LaTeX. A decoration's
+ * `after` attachment could paint the same text, but only at the end of a line
+ * -- there is no way to attach one mid-line -- and a constraints block routinely
+ * names two bounds on one line. Inlay hints also come with a user-facing
+ * toggle, a hover, and the editor's own re-request on every document change,
+ * none of which a decoration gets for free.
+ */
+import * as vscode from 'vscode';
+
+import { DeclaredIndex } from './declared';
+import { scanStatementVars } from './rbx/statementVars';
+import { StatementVarsIndex } from './statementVarsIndex';
+
+const SETTING = 'rbx.statementVarHints';
+
+export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
+  private readonly changed = new vscode.EventEmitter<void>();
+  readonly onDidChangeInlayHints: vscode.Event<void> = this.changed.event;
+
+  constructor(
+    private readonly declared: DeclaredIndex,
+    private readonly vars: StatementVarsIndex,
+  ) {}
+
+  async provideInlayHints(
+    document: vscode.TextDocument,
+    range: vscode.Range,
+    token: vscode.CancellationToken,
+  ): Promise<vscode.InlayHint[]> {
+    if (!enabled()) {
+      return [];
+    }
+    // The manifest is the authority on which files are statements; it also
+    // covers tutorials, which globbing `*.rbx.tex` would miss.
+    if (this.declared.assetFor(document.uri)?.role !== 'statement') {
+      return [];
+    }
+    const root = this.declared.rootFor(document.uri);
+    if (root === undefined) {
+      return [];
+    }
+
+    // Never rejects -- `StatementVarsIndex.varsFor` catches its own failures
+    // and answers `undefined` -- so there is nothing here to guard against.
+    const vars = await this.vars.varsFor(root);
+    // The await is the only suspension point, and the first request for a cold
+    // package waits on a process spawn behind it. By the time it answers, the
+    // editor may well have asked again for a range that has since scrolled or
+    // been edited; returning hints for the old one is what the token is for.
+    if (vars === undefined || token.isCancellationRequested) {
+      return [];
+    }
+
+    const hints: vscode.InlayHint[] = [];
+    // The whole document is scanned and the result filtered, rather than the
+    // requested range being sliced out: a reference may straddle the range's
+    // edge, and offsets from a slice would all need shifting back. A statement
+    // is a few kilobytes of prose, so the scan is not worth optimizing -- but a
+    // pathologically large one would pay for it on every keystroke.
+    for (const hint of scanStatementVars(document.getText(), vars)) {
+      // `hint.end` is the offset just past the closing brace, so the hint sits
+      // immediately after `}` and never inside the reference.
+      const position = document.positionAt(hint.end);
+      // Inclusive at both ends, which is the forgiving side to err on: a hint
+      // exactly on the boundary is drawn rather than dropped, and the editor
+      // accepts hints outside the range it asked for anyway.
+      if (!range.contains(position)) {
+        continue;
+      }
+      const inlay = new vscode.InlayHint(position, hint.text);
+      // The editor's own leading gap, rather than a space in the label: a
+      // space would be padding *inside* the hint's own background, and would
+      // stack with this if both were used.
+      inlay.paddingLeft = true;
+      hints.push(inlay);
+    }
+    return hints;
+  }
+
+  /** Re-ask VS Code for the hints, after the vars changed or a setting did. */
+  refresh(): void {
+    this.changed.fire();
+  }
+
+  dispose(): void {
+    this.changed.dispose();
+  }
+}
+
+function enabled(): boolean {
+  return vscode.workspace.getConfiguration().get<boolean>(SETTING, true);
+}
+
+export function registerStatementVarHints(
+  context: vscode.ExtensionContext,
+  declared: DeclaredIndex,
+  vars: StatementVarsIndex,
+): StatementVarHintsProvider {
+  const provider = new StatementVarHintsProvider(declared, vars);
+  context.subscriptions.push(
+    provider,
+    // Every file on disk, because which ones are statements is a fact about
+    // the manifest rather than about the language: rbxTeX, plain LaTeX and
+    // Markdown are all spelled by different language ids.
+    vscode.languages.registerInlayHintsProvider({ scheme: 'file' }, provider),
+    // Both indexes, because either can be the one that changed. The vars index
+    // answers what a reference expands to; the declared index answers whether
+    // this file is a statement at all, and it is empty until the first
+    // discovery finishes -- without this, a statement open at startup would
+    // show nothing until it was next edited.
+    vars.onDidChange(() => provider.refresh()),
+    declared.onDidChange(() => provider.refresh()),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration(SETTING)) {
+        provider.refresh();
+      }
+    }),
+  );
+  return provider;
+}

--- a/vscode/src/statementVarsIndex.ts
+++ b/vscode/src/statementVarsIndex.ts
@@ -1,0 +1,107 @@
+/**
+ * The expanded vars of each problem package, keyed by absolute package root.
+ *
+ * Asking rbx costs a process spawn, and the answer is consulted on every inlay
+ * hint request -- i.e. on every keystroke in a statement file. So it is asked
+ * once per package and kept until the manifest that produced it changes.
+ *
+ * `rbx vars --json` is read-only by construction (rbx/box/cli/commands/
+ * vars_cmd.py): it expands `problem.rbx.yml` and touches nothing else, which
+ * is what makes it safe to run while the setter is typing.
+ */
+import * as vscode from 'vscode';
+
+import { log } from './log';
+import { Vars } from './rbx/statementVars';
+import { parseVarsPayload } from './rbx/varsPayload';
+import { resolveRbx, run } from './rbxProcess';
+
+/**
+ * How long `rbx vars` may take before we give up on it.
+ *
+ * Its own constant, between the login-shell probe's 5s and visualize's 120s:
+ * the command only parses a YAML file and expands its vars, so anything near
+ * this bound is a stuck interpreter rather than slow work.
+ */
+const TIMEOUT_MS = 10_000;
+
+export class StatementVarsIndex {
+  private readonly changed = new vscode.EventEmitter<void>();
+  /** Fired when a package's vars are dropped, so hints can be re-requested. */
+  readonly onDidChange: vscode.Event<void> = this.changed.event;
+
+  /**
+   * The *promise* per root, not the resolved value.
+   *
+   * A cold start typically has several hint requests in flight at once (one
+   * per visible statement editor), and caching the value would let each of
+   * them miss and spawn its own rbx. Caching the promise makes them share the
+   * single spawn the first one started.
+   *
+   * Nothing ever writes a resolved value back into this map, which is what
+   * makes `invalidate` during a spawn safe: the stale promise has no way to
+   * overwrite the entry a later miss put there. Its result is simply dropped.
+   */
+  private readonly index = new Map<string, Promise<Vars | undefined>>();
+
+  /** The vars of the package at `root`, or `undefined` if rbx could not say. */
+  varsFor(root: string): Promise<Vars | undefined> {
+    const cached = this.index.get(root);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const pending = this.load(root);
+    this.index.set(root, pending);
+    return pending;
+  }
+
+  /**
+   * Drop what is cached for `root` and announce it.
+   *
+   * This is also what re-arms the logging. `load` -- the only place that logs
+   * -- runs once per cache entry, and a failed load caches its `undefined` like
+   * any other answer, so a package with no rbx installed writes one line here
+   * and stays silent until a manifest change drops the entry again. Nothing
+   * about a hint request can make it log.
+   */
+  invalidate(root: string): void {
+    this.index.delete(root);
+    this.changed.fire();
+  }
+
+  private async load(root: string): Promise<Vars | undefined> {
+    const rbx = await resolveRbx(root);
+    if (rbx === undefined) {
+      log(`No usable rbx for ${root}; statement var hints are off there.`);
+      return undefined;
+    }
+
+    const result = await run(rbx, ['vars', '--json'], root, TIMEOUT_MS);
+    if (result.spawnError !== undefined || result.code !== 0) {
+      // A bad package is the common case here -- `rbx vars` exits non-zero on
+      // one -- and it is the setter's own half-typed manifest, not a bug to
+      // report. The stderr says which, for when it is not.
+      log(`rbx vars failed in ${root} (exit ${result.code}): ${result.stderr.trim()}`);
+      return undefined;
+    }
+
+    const vars = parseVarsPayload(result.stdout);
+    if (vars === undefined) {
+      log(`Could not read the vars rbx printed for ${root}.`);
+      return undefined;
+    }
+    return vars;
+  }
+
+  /**
+   * A spawn already in flight is left to finish.
+   *
+   * `run` hands back no handle to kill, and there is nothing to kill it for:
+   * the command writes nothing, and its own timeout bounds it at
+   * `TIMEOUT_MS`. Its result resolves into a map nothing reads any more.
+   */
+  dispose(): void {
+    this.index.clear();
+    this.changed.dispose();
+  }
+}

--- a/vscode/src/statementVarsIndex.ts
+++ b/vscode/src/statementVarsIndex.ts
@@ -8,6 +8,14 @@
  * `rbx vars --json` is read-only by construction (rbx/box/cli/commands/
  * vars_cmd.py): it expands `problem.rbx.yml` and touches nothing else, which
  * is what makes it safe to run while the setter is typing.
+ *
+ * A *filtered* reference is not in that map -- what `\VAR{N.max | sci}` shows
+ * is whatever the pipeline makes of the value, and evaluating Jinja is rbx's
+ * job. So this also holds the second cache: expressions, rendered by `rbx vars
+ * --render --target text`, which builds no statement and holds to the same
+ * read-only bargain. It is keyed per expression rather than per package because
+ * a statement only pays for the filters it actually uses. See
+ * docs/plans/2026-08-29-statement-filter-targets-design.md (D3, D5).
  */
 import * as vscode from 'vscode';
 
@@ -17,13 +25,50 @@ import { parseVarsPayload } from './rbx/varsPayload';
 import { resolveRbx, run } from './rbxProcess';
 
 /**
- * How long `rbx vars` may take before we give up on it.
+ * How long `rbx vars` may take before we give up on it, rendering or not.
  *
  * Its own constant, between the login-shell probe's 5s and visualize's 120s:
- * the command only parses a YAML file and expands its vars, so anything near
- * this bound is a stuck interpreter rather than slow work.
+ * the command parses a YAML file, expands its vars and -- under `--render` --
+ * evaluates a handful of Jinja expressions against them, so anything near this
+ * bound is a stuck interpreter rather than slow work. The same bound covers
+ * both because the rendering is the cheap half of what `--render` does; the
+ * package load it shares with `--json` is the rest.
  */
 const VARS_TIMEOUT_MS = 10_000;
+
+/** Shared because it is only ever read: nothing rendered, and nothing will be. */
+const EMPTY: ReadonlyMap<string, string> = new Map();
+
+/**
+ * What is known about the filtered expressions of one package root.
+ *
+ * Two maps rather than one because they answer two different questions, and
+ * the provider needs them at two different times: `text` is read synchronously
+ * while hints are being built, and cannot be a map of promises; `asked` is what
+ * makes a second request for an expression free, and has to cover the ones
+ * still in flight as well as the ones that settled.
+ */
+interface RootRenders {
+  /**
+   * Every expression this root has been asked about, settled or in flight,
+   * mapped to the text it rendered to -- or to `undefined` for one rbx left out
+   * of its answer.
+   *
+   * **Failures are cached exactly like successes**, and that is the point of
+   * this map. A setter halfway through typing `\VAR{N.max | sc` has written a
+   * syntactically fine expression that renders to nothing, and it stays on
+   * screen for as long as it takes to type the rest: without a memory of having
+   * asked, every keystroke would spawn a process to be told the same thing
+   * again.
+   */
+  readonly asked: Map<string, Promise<string | undefined>>;
+  /**
+   * The subset that came back with text, readable without awaiting anything.
+   *
+   * Written only where a batch settles, so it cannot drift from `asked`.
+   */
+  readonly text: Map<string, string>;
+}
 
 export class StatementVarsIndex {
   private readonly changed = new vscode.EventEmitter<void>();
@@ -44,6 +89,17 @@ export class StatementVarsIndex {
    */
   private readonly index = new Map<string, Promise<Vars | undefined>>();
 
+  /**
+   * What each root's filtered expressions render to.
+   *
+   * Kept in this class rather than a sibling one because it is the same cache
+   * with a finer key: both halves are the expansion of one `problem.rbx.yml`,
+   * both are dropped by the same manifest change, and a sibling would need the
+   * same root, the same invalidation call and the same change event wired
+   * through `extension.ts` a second time to say nothing new.
+   */
+  private readonly renders = new Map<string, RootRenders>();
+
   /** The vars of the package at `root`, or `undefined` if rbx could not say. */
   varsFor(root: string): Promise<Vars | undefined> {
     const cached = this.index.get(root);
@@ -53,6 +109,74 @@ export class StatementVarsIndex {
     const pending = this.load(root);
     this.index.set(root, pending);
     return pending;
+  }
+
+  /**
+   * The rendered text known for `root` right now, keyed by expression.
+   *
+   * Synchronous and never waits: it is what a hint request can draw without
+   * paying for a spawn. An expression missing from it is unasked, still in
+   * flight, or one rbx declined to render, and all three mean the same thing to
+   * a caller -- no badge. Which of the three it is decides only whether a batch
+   * is worth starting, and `renderedFor` answers that itself.
+   */
+  renderedNow(root: string): ReadonlyMap<string, string> {
+    return this.renders.get(root)?.text ?? EMPTY;
+  }
+
+  /**
+   * What `expressions` render to in the package at `root`.
+   *
+   * Answered from cache wherever possible; whatever is left over goes to rbx in
+   * a single spawn, however many expressions that is. Expressions rbx did not
+   * render are absent from the result, exactly as they are absent from its own
+   * answer.
+   *
+   * Never rejects: `render` catches every way the spawn can fail and answers
+   * with an empty map, and the bookkeeping around it cannot throw. That matters
+   * because a caller leaves this promise unawaited, to keep the rest of its
+   * hints from waiting on a process.
+   */
+  async renderedFor(root: string, expressions: string[]): Promise<Map<string, string>> {
+    const entry = this.rootRenders(root);
+
+    const missing = expressions.filter((expression) => !entry.asked.has(expression));
+    if (missing.length > 0) {
+      // Written into the entry this call captured, never into whatever
+      // `this.renders` holds by then. That is what makes an `invalidate` during
+      // a spawn safe: it detaches this object from the map, and the answer
+      // lands in something nobody reads any more rather than resurrecting vars
+      // the manifest has moved on from.
+      const batch = this.render(root, missing).then((rendered) => {
+        for (const [expression, text] of rendered) {
+          entry.text.set(expression, text);
+        }
+        return rendered;
+      });
+      // Each expression gets its own promise off the one batch, so a later
+      // request naming some of these and some new ones shares this spawn for
+      // the overlap instead of asking again.
+      for (const expression of missing) {
+        entry.asked.set(
+          expression,
+          batch.then((rendered) => rendered.get(expression)),
+        );
+      }
+    }
+
+    const settled = await Promise.all(
+      expressions.map(async (expression) => {
+        const text = await entry.asked.get(expression);
+        return [expression, text] as const;
+      }),
+    );
+    const result = new Map<string, string>();
+    for (const [expression, text] of settled) {
+      if (text !== undefined) {
+        result.set(expression, text);
+      }
+    }
+    return result;
   }
 
   /**
@@ -69,7 +193,82 @@ export class StatementVarsIndex {
    */
   invalidate(root: string): void {
     this.index.delete(root);
+    // The renders go with the vars: a changed `vars` block changes what
+    // `N.max | sci` renders to just as surely as what `N.max` expands to, and
+    // keeping the expressions would badge the old bound under the new manifest.
+    this.renders.delete(root);
     this.changed.fire();
+  }
+
+  private rootRenders(root: string): RootRenders {
+    const existing = this.renders.get(root);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const created: RootRenders = { asked: new Map(), text: new Map() };
+    this.renders.set(root, created);
+    return created;
+  }
+
+  /**
+   * Ask rbx to render `expressions`, in one spawn.
+   *
+   * Same failure posture as `load`, and the same reason for the whole body
+   * being wrapped: an expression rbx could not answer for is simply absent from
+   * the map, and so is every expression when the process itself failed. The
+   * caller cannot tell the two apart, and does not need to -- both draw no
+   * badge, and both are remembered so the next keystroke does not ask again.
+   */
+  private async render(
+    root: string,
+    expressions: string[],
+  ): Promise<ReadonlyMap<string, string>> {
+    try {
+      const rbx = await resolveRbx(root);
+      if (rbx === undefined) {
+        log(`No usable rbx for ${root}; filtered statement var hints are off there.`);
+        return EMPTY;
+      }
+
+      const result = await run(
+        rbx,
+        ['vars', '--render', '--target', 'text'],
+        root,
+        VARS_TIMEOUT_MS,
+        // One per line, which is how the command reads them; `run` closes the
+        // pipe after this write, which is the EOF it reads up to. The trailing
+        // newline is only tidiness -- the command splits lines and drops the
+        // blank one it produces.
+        `${expressions.join('\n')}\n`,
+      );
+      if (result.spawnError !== undefined) {
+        log(`Could not start rbx in ${root}: ${result.spawnError.message}`);
+        return EMPTY;
+      }
+      if (result.code !== 0) {
+        // Reserved for "the package could not be read at all": an expression
+        // that merely fails to render leaves the exit code 0 and drops out of
+        // the map, and rbx names it on stderr.
+        log(
+          `rbx vars --render failed in ${root} (exit ${result.code ?? 'none'}): ` +
+            result.stderr.trim(),
+        );
+        return EMPTY;
+      }
+
+      // The same flat map of strings `--json` prints, so the same reader: the
+      // keys are expressions rather than names, which nothing in there cares
+      // about.
+      const rendered = parseVarsPayload(result.stdout);
+      if (rendered === undefined) {
+        log(`Could not read the renders rbx printed for ${root}.`);
+        return EMPTY;
+      }
+      return new Map(Object.entries(rendered));
+    } catch (error) {
+      log(`Asking rbx to render expressions for ${root} threw: ${String(error)}`);
+      return EMPTY;
+    }
   }
 
   private async load(root: string): Promise<Vars | undefined> {
@@ -130,6 +329,7 @@ export class StatementVarsIndex {
    */
   dispose(): void {
     this.index.clear();
+    this.renders.clear();
     this.changed.dispose();
   }
 }

--- a/vscode/src/statementVarsIndex.ts
+++ b/vscode/src/statementVarsIndex.ts
@@ -23,7 +23,7 @@ import { resolveRbx, run } from './rbxProcess';
  * the command only parses a YAML file and expands its vars, so anything near
  * this bound is a stuck interpreter rather than slow work.
  */
-const TIMEOUT_MS = 10_000;
+const VARS_TIMEOUT_MS = 10_000;
 
 export class StatementVarsIndex {
   private readonly changed = new vscode.EventEmitter<void>();
@@ -58,11 +58,14 @@ export class StatementVarsIndex {
   /**
    * Drop what is cached for `root` and announce it.
    *
-   * This is also what re-arms the logging. `load` -- the only place that logs
-   * -- runs once per cache entry, and a failed load caches its `undefined` like
-   * any other answer, so a package with no rbx installed writes one line here
-   * and stays silent until a manifest change drops the entry again. Nothing
-   * about a hint request can make it log.
+   * This is also what bounds the logging. Asking a root once produces a
+   * handful of lines -- `resolveRbx` logs each candidate it rejects, of which
+   * there are up to three, and `load` logs whatever went wrong after that --
+   * and a failed load caches its `undefined` like any successful answer. So a
+   * package with no rbx installed writes that handful once and then stays
+   * silent however much the setter types, until a manifest change drops the
+   * entry and the next request pays for a fresh look. `resolveRbx` does not
+   * cache its own failures; only this cache bounds them.
    */
   invalidate(root: string): void {
     this.index.delete(root);
@@ -70,35 +73,60 @@ export class StatementVarsIndex {
   }
 
   private async load(root: string): Promise<Vars | undefined> {
-    const rbx = await resolveRbx(root);
-    if (rbx === undefined) {
-      log(`No usable rbx for ${root}; statement var hints are off there.`);
-      return undefined;
-    }
+    // The whole body, because a *rejection* is the one failure mode that is
+    // not an absent badge: it would be cached like any other answer, re-thrown
+    // into every later hint request for this root, and -- because the promise
+    // is cached before it settles -- surface as an unhandledRejection with no
+    // handler attached yet. Nothing below is expected to throw today, but D5
+    // asks that every failure degrade to no badge, and that has to hold for
+    // whatever line is added here next, not only for the ones proved safe now.
+    try {
+      const rbx = await resolveRbx(root);
+      if (rbx === undefined) {
+        log(`No usable rbx for ${root}; statement var hints are off there.`);
+        return undefined;
+      }
 
-    const result = await run(rbx, ['vars', '--json'], root, TIMEOUT_MS);
-    if (result.spawnError !== undefined || result.code !== 0) {
-      // A bad package is the common case here -- `rbx vars` exits non-zero on
-      // one -- and it is the setter's own half-typed manifest, not a bug to
-      // report. The stderr says which, for when it is not.
-      log(`rbx vars failed in ${root} (exit ${result.code}): ${result.stderr.trim()}`);
-      return undefined;
-    }
+      const result = await run(rbx, ['vars', '--json'], root, VARS_TIMEOUT_MS);
+      // Split from the exit code below because `run` spells both failures with
+      // a null code, and a process that never started wrote no stderr either:
+      // the error is the only thing that says what happened.
+      if (result.spawnError !== undefined) {
+        log(`Could not start rbx in ${root}: ${result.spawnError.message}`);
+        return undefined;
+      }
+      if (result.code !== 0) {
+        // A bad package is the common case here -- `rbx vars` exits non-zero
+        // on one -- and it is the setter's own half-typed manifest, not a bug
+        // to report. A null code that reaches here is the timeout, which `run`
+        // reports in the stderr it hands back.
+        log(
+          `rbx vars failed in ${root} (exit ${result.code ?? 'none'}): ` +
+            result.stderr.trim(),
+        );
+        return undefined;
+      }
 
-    const vars = parseVarsPayload(result.stdout);
-    if (vars === undefined) {
-      log(`Could not read the vars rbx printed for ${root}.`);
+      const vars = parseVarsPayload(result.stdout);
+      if (vars === undefined) {
+        log(`Could not read the vars rbx printed for ${root}.`);
+        return undefined;
+      }
+      return vars;
+    } catch (error) {
+      log(`Asking rbx for the vars of ${root} threw: ${String(error)}`);
       return undefined;
     }
-    return vars;
   }
 
   /**
    * A spawn already in flight is left to finish.
    *
    * `run` hands back no handle to kill, and there is nothing to kill it for:
-   * the command writes nothing, and its own timeout bounds it at
-   * `TIMEOUT_MS`. Its result resolves into a map nothing reads any more.
+   * the command writes nothing, and every spawn a load makes -- the probes
+   * `resolveRbx` runs as much as `rbx vars` itself -- carries its own timeout,
+   * so the whole thing is bounded. Its result resolves into a map nothing
+   * reads any more.
    */
   dispose(): void {
     this.index.clear();

--- a/vscode/src/visualize.ts
+++ b/vscode/src/visualize.ts
@@ -1,32 +1,18 @@
 /**
  * Running `rbx visualize` from the editor.
  *
- * The extension is a pure reader everywhere else (design D2/D3). This is the
- * one deliberate exception, narrowed to: a read-only, idempotent, per-testcase
- * artifact the user explicitly asked for. It does not drive the build -- there
- * is still no Build button, and `rbx build` / `rbx run` stay in the terminal.
+ * This is a read-only, idempotent, per-testcase artifact the user explicitly
+ * asked for. It does not drive the build -- there is still no Build button, and
+ * `rbx build` / `rbx run` stay in the terminal. Spawning rbx at all, and finding
+ * the rbx to spawn, live in rbxProcess.ts.
  *
- * The doctrine reversal is safe in a way the original rationale did not know:
- * rbx cache directories take a *shared* session lock and support any number of
- * concurrent processes, and a cache is only ever emptied under an *exclusive*
- * lock that waits for (or refuses) live holders. So this cannot corrupt a run
- * in flight. The one hazard left -- a version-skewed rbx clearing the cache and
- * forcing a surprise rebuild -- rbx itself refuses, with exit code 3.
- *
- * Everything decidable without `vscode` lives in rbx/visualizeRun.ts and
- * rbx/executable.ts, which `node --test` covers.
+ * Everything decidable without `vscode` lives in rbx/visualizeRun.ts, which
+ * `node --test` covers.
  */
-import { spawn } from 'child_process';
-import * as os from 'os';
 import * as vscode from 'vscode';
 
 import { log } from './log';
-import {
-  RbxCandidate,
-  loginShellProbe,
-  parseLoginShellPath,
-  rbxCandidates,
-} from './rbx/executable';
+import { resolveRbx, run } from './rbxProcess';
 import {
   VisualizeOutcome,
   VisualizeRequest,
@@ -37,127 +23,6 @@ import { openVisualization } from './visualizationPanel';
 
 /** How long a visualizer may run before we stop waiting for it. */
 const VISUALIZE_TIMEOUT_MS = 120_000;
-
-/** How long the login-shell probe may take before we give up on it. */
-const PROBE_TIMEOUT_MS = 5_000;
-
-interface SpawnResult {
-  readonly code: number | null;
-  readonly stdout: string;
-  readonly stderr: string;
-  /** Set when the process could not be started at all (typically ENOENT). */
-  readonly spawnError?: NodeJS.ErrnoException;
-}
-
-function run(
-  command: string,
-  args: string[],
-  cwd: string,
-  timeoutMs: number,
-): Promise<SpawnResult> {
-  return new Promise((resolve) => {
-    const child = spawn(command, args, { cwd, shell: false });
-    let stdout = '';
-    let stderr = '';
-    let settled = false;
-
-    const finish = (result: SpawnResult) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timer);
-      resolve(result);
-    };
-
-    const timer = setTimeout(() => {
-      child.kill();
-      finish({
-        code: null,
-        stdout,
-        stderr: `${stderr}\nTimed out after ${timeoutMs}ms.`,
-      });
-    }, timeoutMs);
-
-    child.stdout?.on('data', (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr?.on('data', (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on('error', (error) => {
-      finish({ code: null, stdout, stderr, spawnError: error });
-    });
-    child.on('close', (code) => {
-      finish({ code, stdout, stderr });
-    });
-  });
-}
-
-/**
- * The resolved `rbx` for a package root.
- *
- * Cached per root rather than per session, and never populated with a candidate
- * that has not answered: a stale binary on `PATH` must fall through to the
- * login shell rather than being locked in for the rest of the session.
- */
-const resolved = new Map<string, string>();
-
-export function resetRbxExecutables(): void {
-  resolved.clear();
-}
-
-/** Whether this candidate is an rbx that actually runs. */
-async function validate(command: string, root: string): Promise<boolean> {
-  const result = await run(command, ['--version'], root, PROBE_TIMEOUT_MS);
-  return result.spawnError === undefined && result.code === 0;
-}
-
-async function resolveCandidate(
-  candidate: RbxCandidate,
-  root: string,
-): Promise<string | undefined> {
-  if (candidate.source !== 'login-shell') {
-    return (await validate(candidate.command, root)) ? candidate.command : undefined;
-  }
-
-  // Resolved in the package root so direnv/mise/a project `.venv` answer for
-  // *this* package.
-  const shell = process.env.SHELL ?? '/bin/sh';
-  if (os.platform() === 'win32') {
-    // No login-shell equivalent worth guessing at; the setting is the answer.
-    return undefined;
-  }
-  const probe = loginShellProbe(shell);
-  const result = await run(probe.command, probe.args, root, PROBE_TIMEOUT_MS);
-  const found = parseLoginShellPath(result.stdout);
-  if (found === undefined) {
-    return undefined;
-  }
-  return (await validate(found, root)) ? found : undefined;
-}
-
-async function resolveRbx(root: string): Promise<string | undefined> {
-  const cached = resolved.get(root);
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  const configured = vscode.workspace
-    .getConfiguration('rbx', vscode.Uri.file(root))
-    .get<string>('executable');
-
-  for (const candidate of rbxCandidates(configured)) {
-    const command = await resolveCandidate(candidate, root);
-    if (command !== undefined) {
-      log(`Resolved rbx for ${root} via ${candidate.source}: ${command}`);
-      resolved.set(root, command);
-      return command;
-    }
-    log(`rbx not usable for ${root} via ${candidate.source}.`);
-  }
-  return undefined;
-}
 
 /**
  * One in-flight visualization per package.


### PR DESCRIPTION
Closes #797.

In a statement file, each `\VAR{...}` that names a package var now gets a VS Code inlay hint showing its expanded value, so a setter reading a constraints block sees the actual numbers without opening `problem.rbx.yml`:

```latex
\item $1 \le N \le \VAR{N.max}$        100000
\item $1 \le a_i \le \VAR{A.max}$      1000000000
```

Design and plan: `docs/plans/2026-08-28-vscode-statement-var-hints{-design,}.md`.

## How it works

A new read-only `rbx vars [--json]` prints the problem's expanded vars; the extension spawns it once per package root, caches the result, and invalidates on the existing `problem.rbx.yml` watcher. Values therefore stay correct **while you edit** — they do not come from build artifacts, so no build is required and nothing goes stale.

| piece | file |
| --- | --- |
| `rbx vars [--json]` | `rbx/box/cli/commands/vars_cmd.py` |
| reference scanner (pure, `node --test`) | `vscode/src/rbx/statementVars.ts` |
| payload parser (pure) | `vscode/src/rbx/varsPayload.ts` |
| spawn/discovery, extracted from `visualize.ts` | `vscode/src/rbxProcess.ts` |
| per-root cache | `vscode/src/statementVarsIndex.ts` |
| the provider | `vscode/src/statementVarHints.ts` |

## Deliberate limits

- **Problem-root references only.** `\VAR{g.N.max}` gets nothing: it usually sits in a `\BLOCK{for ...}` loop and renders a different value per group, so one badge would have to lie or name a group. `p.`/`problem.`/`contest.` likewise.
- **The raw value, even under a filter.** `\VAR{N.max | sci}` typesets `10^{5}` but badges `100000`. The filter decides typesetting; the badge answers "what number is this?".
- **Nothing is guessed.** Unknown name, non-dotted expression, commented line, escaped `\\VAR` — no badge. An absent badge is never wrong, and a misspelled var shows up as the one reference on the line without one.
- Only manifest-declared statements and tutorials, so contest-level statements and templates get none.

## Two decisions worth a reviewer's attention

**1. The extension spawns rbx, which the testset-view design forbids.** That rule says the extension is a pure reader "because every rbx invocation has side effects on the package cache and could race a run already in flight". `rbx vars` has no side effects: it calls `find_problem_package_or_die` (a YAML load) and `expanded_vars` (pure computation), and nothing on that path reaches `get_problem_cache_dir`. That is enforced by a test, not just asserted — `test_vars_json_creates_no_cache_dir`. `visualize.ts` already records that the rule's stated rationale is outdated anyway: rbx cache dirs take a *shared* session lock, so concurrent processes cannot corrupt a run.

**2. `--json` emits display strings, not JSON numbers.** `{"N.max": "100000"}`. Found in review: values reach the badge through `JSON.parse`, so a bound like `` py`10**18 + 7` `` came back as `1000000000000000000` — a *silently wrong* badge, the one failure mode the design rules out — and `10**21` rendered as `1e+21`. Python has the exact integer; rendering there is lossless.

## Testing

506 extension tests (`npm test`), 49 Python tests across `vars_cmd_test.py`, `lazy_cli_test.py` and `completion/drift_test.py`. Every guard in the scanner is mutation-tested — each one was verified to make a test fail when removed.

**Not visually verified.** No Extension Development Host was available. Worth a human eye on: badge padding (gaps on both sides, neither doubled, not flush against a closing `$`), and that a statement already open at window load gets its hints once discovery finishes without needing an edit.

## Pre-existing issues found, not fixed here

- `resetRbxExecutables` has **no callers**, so changing `rbx.executable` does not invalidate the resolved-binary cache until a window reload.
- `run()`'s timeout sends SIGTERM without awaiting exit, orphaning a process that ignores it.
- `TestingPreset.initialize` omits `min_version`, so every CLI-driven `testing_pkg` test needs a mock — now nine of them.
- `docs/setters/reference/cli.md` is badly stale: a full regeneration is a 1363-line reformat. Only the `rbx vars` entry was hand-inserted here (+16 lines). Worth regenerating deliberately in its own commit.
- `enabled()` is now the fifth verbatim copy of the same config read, and four `register*` bodies are near-identical — a shared helper is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9XLMd9MNBmMgAhLp6uJ66
