### PR TITLE
fix(moj): package problems with no samples instead of refusing them

### DIFF
--- a/docs/setters/packaging/moj.md
+++ b/docs/setters/packaging/moj.md
@@ -84,6 +84,9 @@ A few things to keep in mind:
 - MOJ **builds the examples section itself** from the sample tests, so your statement must not
   have one of its own. {{rbx}} refuses to package a statement MOJ would render with warnings,
   rather than shipping it and letting you find out on the server.
+- A problem **without sample tests** packages fine, and its statement simply shows no examples.
+  {{rbx}} tells MOJ so explicitly, and warns you when it does -- left to its own devices, MOJ
+  would fall back to publishing your first two *secret* tests as the examples.
 - MOJ requires an **input** and an **output** section, and {{rbx}} always emits them, even when
   the corresponding block is empty.
 - Figures are embedded into the rendered HTML, so a PDF figure (which is what TikZ

--- a/rbx/box/packaging/moj/CLAUDE.md
+++ b/rbx/box/packaging/moj/CLAUDE.md
@@ -15,9 +15,11 @@ It extends `BasePackager` directly and shares no code with BOCA.
 The previous packager (a `BocaPackager` subclass) targeted a shape MOJ no longer
 accepts: it authored a time limit MOJ *measures*, bundled a private copy of the
 checker bridge that MOJ banned, emitted `docs/enunciado.pdf` (not a recognized
-format), and named every test `001`/`002`, so a package had **no samples** and failed
-validation outright. Interactive problems are the one thing it covered that this one
-does not yet — see [Out of scope](#out-of-scope).
+format), and named every test `001`/`002`, so a package had **no samples** and MOJ
+published its first two secret tests as the statement's examples (see [Samples are
+optional, leaking them is not](#samples-are-optional-leaking-them-is-not)).
+Interactive problems are the one thing it covered that this one does not yet — see
+[Out of scope](#out-of-scope).
 
 ## The two rules that shape everything
 
@@ -254,6 +256,28 @@ group's index in `problem.rbx.yml`. Two properties are load-bearing:
   digits (`t01_easy_001` → `t01_easy_`) and compares against `${PAT%\**}` of each glob
   (`t01_easy_*` → `t01_easy_`), then falls back to a real glob match.
 
+### Samples are optional, leaking them is not
+
+MOJ does **not** require samples. `validate-problem.sh` checks `examples_present`,
+which counts any `tests/input`/`tests/output` pair of any name -- it has never looked
+at `sample*`. What does look is `gen-problem-json.sh`, which picks the statement's
+examples in three tiers:
+
+1. the names listed in the package's root **`samples`** file, else
+2. `tests/input/sample*` (all of them), else
+3. the **first `SAMPLE_LIMIT` (default 2) entries** of `tests/input`.
+
+Tier 3 is the trap: a sample-less package gets two *secret* tests -- input and
+expected output both -- rendered into the public statement. So `_write_tests` emits an
+**empty `samples` file** when, and only when, the package has no samples: tier 1 with
+an empty list means no examples and no leak. With samples, tier 2 already picks
+exactly the right tests, and a `samples` file would be a second source of truth to
+drift out of sync with `naming.testcase_name`.
+
+Tier 1 is an undocumented branch of `gen-problem-json.sh` -- mojtools' README only
+ever documents examples as `tests/input/sample*` -- so it is worth re-checking against
+upstream when the packager is next revised.
+
 ## Scoring
 
 `tests/score` is emitted for POINTS problems only; BINARY gets none, so MOJ scores by
@@ -372,8 +396,10 @@ What the packager owes the gate (`validate-problem.sh`):
 - **No title.** `render-statement.sh` injects the `<h1>` from `display_title` and
   strips a legacy `% Title` first line.
 - **No examples section and no ``` fence** -- both land in `render_warnings`,
-  since MOJ builds the examples itself from `tests/input/sample*`. `check_moj_gate`
-  refuses to package rather than shipping a statement that warns.
+  since MOJ builds the examples itself from `tests/input/sample*` (or from none at
+  all; see [Samples are optional, leaking them is
+  not](#samples-are-optional-leaking-them-is-not)). `check_moj_gate` refuses to
+  package rather than shipping a statement that warns.
 
 ### `--language`
 

--- a/rbx/box/packaging/moj/naming.py
+++ b/rbx/box/packaging/moj/naming.py
@@ -5,7 +5,10 @@ from typing import List, Sequence
 from rbx.box.exception import RbxException
 
 # Samples must be named `sample*`: MOJ picks the statement's examples from
-# tests/input/sample*, and `validate-problem.sh` hard-fails a package without any.
+# tests/input/sample*. A package with no samples is legal -- `validate-problem.sh`
+# only requires one input/output pair, of any name -- but then MOJ falls back to
+# publishing the first two tests as examples, so the packager pins that case with an
+# empty `samples` file (see `MojPackager._write_empty_samples_pin`).
 SAMPLE_PREFIX = 'sample'
 SAMPLES_GLOB = 'sample*'
 

--- a/rbx/box/packaging/moj/packager.py
+++ b/rbx/box/packaging/moj/packager.py
@@ -1127,16 +1127,36 @@ class MojPackager(BasePackager):
                 (outputs_path / name).touch()
 
         if not has_sample:
-            console.console.print(
-                '[error]This problem has no testcases in the [item]samples[/item] '
-                'group, but MOJ requires at least one.[/error]\n'
-                "[error]MOJ builds the statement's examples from "
-                '[item]tests/input/sample*[/item], and [item]validate-problem.sh[/item] '
-                'hard-fails a package without any.[/error]'
-            )
-            raise typer.Exit(1)
+            self._write_empty_samples_pin(into_path)
 
         return seen_groups
+
+    def _write_empty_samples_pin(self, into_path: pathlib.Path) -> None:
+        """Pin the statement to *no* examples, for a package with no samples.
+
+        MOJ does not require samples -- `validate-problem.sh` only asks for at least
+        one input/output pair, of any name. What it does is pick the statement's
+        examples in three tiers (`gen-problem-json.sh`):
+
+            1. the names listed in the package's root `samples` file, else
+            2. `tests/input/sample*` (all of them), else
+            3. the FIRST `SAMPLE_LIMIT` (default 2) entries of `tests/input`.
+
+        Tier 3 is the trap: with no samples, MOJ publishes two *secret* tests --
+        input and expected output both -- as the statement's worked examples. An
+        empty `samples` file takes tier 1 with an empty list, so no examples are
+        rendered and no test leaks. Only emitted when there are no samples; with
+        samples, tier 2 already picks exactly the right tests, and a `samples` file
+        would be one more thing that can drift out of sync with the test names.
+        """
+        (into_path / 'samples').write_text('')
+        console.console.print(
+            '[warning]This problem has no testcases in the [item]samples[/item] '
+            'group, so its MOJ statement will show no examples.[/warning]\n'
+            '[warning]Emitted an empty [item]samples[/item] file to say so: without '
+            'it, MOJ would publish the first two [item]secret[/item] tests as the '
+            'statement examples.[/warning]'
+        )
 
     def _write_score(self, into_path: pathlib.Path, seen_groups: List[str]) -> None:
         """Write `tests/score` for POINTS problems.

--- a/tests/rbx/box/packaging/moj/test_packager.py
+++ b/tests/rbx/box/packaging/moj/test_packager.py
@@ -369,14 +369,35 @@ def test_every_input_has_a_paired_output(moj_package):
     assert inputs == outputs
 
 
-def test_refuses_a_package_without_samples(testing_pkg, tmp_path):
+def test_packages_without_samples_pinning_the_statement_to_no_examples(
+    testing_pkg, tmp_path, capsys
+):
+    # MOJ does not require samples: `validate-problem.sh` only asks for one
+    # input/output pair, of any name. But `gen-problem-json.sh` falls back to
+    # publishing the first two tests as the statement's examples, so a sample-less
+    # package leaks two SECRET tests. An empty root `samples` file takes the
+    # explicit-list branch with an empty list, and no example is rendered.
     testing_pkg.add_file('check.cpp').write_text(CHECKER)
     testing_pkg.set_checker('check.cpp')
     testing_pkg.add_solution('sol.cpp', outcome='accepted').write_text('int main(){}\n')
     testing_pkg.save()
 
-    with pytest.raises(typer.Exit):
-        run_packager(testing_pkg, tmp_path, build_entries(tmp_path, ['easy']))
+    into_path = run_packager(testing_pkg, tmp_path, build_entries(tmp_path, ['easy']))
+
+    samples = into_path / 'samples'
+    assert samples.is_file()
+    assert samples.read_text() == ''
+    # The tests themselves are still packaged, and none of them is a sample.
+    names = {path.name for path in (into_path / 'tests' / 'input').iterdir()}
+    assert names
+    assert not any(name.startswith('sample') for name in names)
+    assert 'no examples' in capsys.readouterr().out
+
+
+def test_package_with_samples_does_not_pin_the_example_list(moj_package):
+    # With samples present MOJ's `tests/input/sample*` branch already picks exactly
+    # the right tests; a `samples` file would be a second source of truth to drift.
+    assert not (moj_package / 'samples').exists()
 
 
 # -- checker ----------------------------------------------------------------


### PR DESCRIPTION
`rbx package moj` refused any problem with no `samples` group, citing a validation MOJ does not perform. Investigating [mojtools](https://github.com/cd-moj/mojtools) at `d37dc3a` turned the premise around.

## Samples are not required

`validate-problem.sh`'s only test-related hard gate is `examples_present`, which counts **any** `tests/input`/`tests/output` pair, of any name:

```bash
(( npair >= 1 )) && add examples_present 1 "$npair par(es)" || add examples_present 0 "sem pares input/output"
```

`git log -S` over all 177 commits confirms it has counted pairs, never samples, since the pipeline's first commit. The only `sample` mention in that script is a **soft** `render_leak` warning about an unpaired note.

## What actually breaks

`gen-problem-json.sh:127-134` picks the statement's examples in three tiers:

1. the names in the package's root **`samples`** file, else
2. `tests/input/sample*` (all of them), else
3. the **first `SAMPLE_LIMIT` (default 2)** entries of `tests/input`.

Tier 3 is the trap: a sample-less package gets two *secret* tests -- input **and** expected output -- rendered into the public statement.

## The fix

Emit an empty `samples` file when, and only when, the package has no samples. That takes tier 1 with an empty list: no examples, no leak. With samples, tier 2 already picks exactly the right tests, and a `samples` file would be a second source of truth to drift out of sync with `naming.testcase_name`.

The hard error becomes a warning saying the statement will show no examples, and why the file is there.

## Verification

Beyond the unit tests, I ran the real mojtools scripts against a synthetic sample-less package (two secret tests `t01_main_001/002`, `author`, `docs/enunciado.md`, one `sols/good`).

**Without** the `samples` file, in the published statement HTML:

```html
<section class="moj-exemplos"><h2>Exemplos</h2>
<div class="moj-exemplo"><h3>Entrada</h3><pre>2</pre><h3>Saída</h3><pre>4</pre></div>
<div class="moj-exemplo"><h3>Entrada</h3><pre>3</pre><h3>Saída</h3><pre>6</pre></div></section>
```

**With** it: no `moj-exemplos` section at all. `validate-problem.sh` returns 0 with `ok:true`, no failed checks and empty `render_warnings`, both ways.

## Caveat

Tier 1 is an **undocumented** branch -- mojtools' README only ever documents examples as `tests/input/sample*`. Noted in `moj/CLAUDE.md` as worth re-checking upstream; worth reporting there too, along with the tier-3 fallback itself, which is arguably a leak bug on their side.

Also found while investigating, filed separately as #804: `build-and-test.sh:549` matches `sample`/`example` as an unanchored substring of the full input **path**, so a group or problem name containing either leaks raw secret inputs into failure reports.

Closes nothing; complements #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Sfk5exyTMCs3JdcGkeQf7
