### PR TITLE
feat(ui): persist each/on command panes and let runs be resumed

### DIFF
--- a/docs/plans/2026-08-28-command-pane-run-history-design.md
+++ b/docs/plans/2026-08-28-command-pane-run-history-design.md
@@ -86,7 +86,7 @@ after the resize.
 Contest-rooted, beside the existing problem-level cache:
 
 ```
-<contest root>/.box/runs/
+<contest root>/.rbx/runs/
   20260828-141233-a3f1/
     run.yml
     0/0.ansi        # tab 0 (problem A), sub-command 0
@@ -117,7 +117,9 @@ class RunStore(Protocol):
 redundancy against a wiped `.box` -- is then a second implementation plus a merge in the
 picker, not a refactor. Nothing outside the store module knows where runs live.
 
-A consequence worth stating: history under `.box/` is destroyed by a cache wipe. That is
+The directory is `rbx.config.CACHE_DIR_NAME` (`.rbx`), not a new one.
+
+A consequence worth stating: history under the cache is destroyed by a wipe. That is
 accepted for now, and is precisely what the global fallback would later mitigate.
 
 ### Manifest
@@ -143,8 +145,13 @@ reopened and added commands to does not sink to the bottom of the list.
 
 ## Reopening
 
-`_build_command_argvs_or_die` currently rejects an empty command with `EmptyCommandError`.
-That is the hook: an empty command means "show me history" rather than an error.
+An empty command means "show me history" rather than running nothing.
+
+**The picker must not cost the blank session.** No-argument `each` already opened an empty
+app to type commands into (`test_each_without_args_opens_an_empty_app`), so replacing it
+outright with history would have removed a working feature. Instead the picker's first row
+is **"Start a new session"**, and a contest with no recorded history skips the picker and
+opens the blank session exactly as before. History is offered, never imposed.
 
 `rbx contest on`'s `problems` argument becomes **optional**. Bare `rbx contest on` behaves
 like bare `rbx contest each` and lists every run; `rbx contest on A` with no command lists
@@ -153,8 +160,9 @@ only runs that touched problem `A`.
 The picker is a small standalone app that returns a run id, following the `rbxReviewApp`
 pattern (run the app, read a result attribute synchronously). Each row shows the start
 timestamp, the command chain, the problems involved, and the aggregate status icon --
-`_STATUS_MARKUP` already exists for that. With no runs recorded it prints a plain message and
-exits non-zero.
+`STATUS_MARKUP` already exists for that. Bare `rbx contest on`, which has no problem set to
+open a blank session over, is the one case that reports "no recorded runs" and exits
+non-zero.
 
 Selecting a run starts an ordinary `rbxCommandApp` whose tabs and sub-commands come from the
 manifest and whose panes load their `.ansi` file instead of executing. There is no read-only
@@ -182,7 +190,8 @@ sub.task_id = task.task_id
 along for free: `chained` is persisted, so if a resumed command fails, `_skip_rest_of_chain`
 aborts the rest of that tab's chain just as it did originally.
 
-Two verbs, both on the sidebar alongside the existing `!`, `l` and `?`:
+Two verbs, both on the sidebar alongside the existing `!`, `l` and `?`, and both listed in
+the app's `HelpModal`:
 
 - **`r` -- retry** re-runs the single sub-command currently on screen. It names one command
   in one tab, so it needs no scope prompt.
@@ -222,6 +231,19 @@ attempt completes. Only the latest attempt is kept.
 
 None of this is specific to reopened runs. A live session where a chain aborted on one
 problem resumes by the same path, without quitting first.
+
+## What the implementation added
+
+Three things the design did not anticipate, all recorded in `rbx/box/ui/CLAUDE.md`:
+
+- **`CommandStatus` moved to its own module** (`command_status.py`). The history persists it
+  and the app imports the history, so leaving the enum in `command_app.py` would have been a
+  cycle.
+- **Dumps store `\n`, terminals need `\r\n`.** `to_terminal_input()` is the adapter; without
+  it every restored line starts where the previous one ended rather than at column zero.
+- **Resume resets every pane before enqueueing any.** Enqueueing as it went left a window in
+  which a fast failure completed while later links of its chain were still unqueued, and
+  `_skip_rest_of_chain` cancels only tasks already in the queue.
 
 ## Testing
 

--- a/docs/plans/2026-08-28-command-pane-run-history-design.md
+++ b/docs/plans/2026-08-28-command-pane-run-history-design.md
@@ -161,9 +161,46 @@ manifest and whose panes load their `.ansi` file instead of executing. There is 
 mode: the shell input works, `cwd`/`prefix` come from the manifest, and commands typed into a
 reopened session append to that same run directory under the same rules as a fresh one.
 
-Sub-commands persisted as `PENDING` or `RUNNING` -- the app was quit mid-chain -- load as
-`SKIPPED`. They are not re-queued, and marking them skipped is honest about what happened
-rather than leaving a pending command that will never start.
+A sub-command is never reloaded as `PENDING` or `RUNNING`: nothing is executing when a run
+is opened, and leaving a pending command that will never start would be a lie. `PENDING`
+loads as `SKIPPED` (it never began) and `RUNNING` loads as a new `INTERRUPTED` status (it
+began, its partial output was dumped on unmount, and its exit code is unknown). Both are
+terminal, so `TabState.is_idle` and `aggregate_status` stay correct -- and the two are kept
+distinct because resuming treats them differently.
+
+## Resuming
+
+Re-running a command needs nothing the manifest does not already hold. Enqueueing is:
+
+```python
+sub.status = CommandStatus.PENDING
+task = self._task_queue.enqueue(sub.shell_command, terminal_id=tab_index)
+sub.task_id = task.task_id
+```
+
+`TaskReady` then drives `pane.execute()` exactly as for a first run. Chain semantics come
+along for free: `chained` is persisted, so if a resumed command fails, `_skip_rest_of_chain`
+aborts the rest of that tab's chain just as it did originally.
+
+Two verbs:
+
+- **Retry** re-runs a single sub-command, the one on screen.
+- **Resume** re-queues every sub-command **not in `SUCCESS`** -- `FAILED`, `SKIPPED` and
+  `INTERRUPTED` alike -- in their original order, across every tab. This is the
+  "`each build` over twelve problems, three failed, fix them, carry on" case, and it is why
+  resume is run-wide rather than per-tab. Successful work is never repeated.
+
+Resume deliberately includes `FAILED`: you resume *because* you fixed what failed, so
+starting after the failure point would skip the command you actually wanted re-run.
+
+`execute()` appends to the terminal state rather than clearing it, so re-running a
+sub-command that already has output would concatenate two attempts in one pane. A retried
+sub-command therefore gets a fresh pane mounted under the same id -- the same remove/mount
+`_queue_command_in_tab` already performs -- and its `.ansi` file is overwritten when the new
+attempt completes. Only the latest attempt is kept.
+
+None of this is specific to reopened runs. A live session where a chain aborted on one
+problem resumes by the same path, without quitting first.
 
 ## Testing
 
@@ -184,3 +221,9 @@ rather than leaving a pending command that will never start.
   `on A` filters to runs touching `A`.
 - **Continuation.** A command queued into a reopened run lands in that run's directory and is
   present when it is reopened again.
+- **Load states.** A run persisted mid-chain reloads with `RUNNING` as `INTERRUPTED` and
+  `PENDING` as `SKIPPED`, and the tab reports itself idle.
+- **Resume.** Over a run with a mix of statuses, only the non-`SUCCESS` sub-commands are
+  enqueued, in order; a resumed command that fails again skips the rest of its chain.
+- **Retry hygiene.** Re-running a sub-command that already has output leaves the pane
+  holding only the new attempt, and its stored `.ansi` matches.

--- a/docs/plans/2026-08-28-command-pane-run-history-design.md
+++ b/docs/plans/2026-08-28-command-pane-run-history-design.md
@@ -182,13 +182,34 @@ sub.task_id = task.task_id
 along for free: `chained` is persisted, so if a resumed command fails, `_skip_rest_of_chain`
 aborts the rest of that tab's chain just as it did originally.
 
-Two verbs:
+Two verbs, both on the sidebar alongside the existing `!`, `l` and `?`:
 
-- **Retry** re-runs a single sub-command, the one on screen.
-- **Resume** re-queues every sub-command **not in `SUCCESS`** -- `FAILED`, `SKIPPED` and
-  `INTERRUPTED` alike -- in their original order, across every tab. This is the
-  "`each build` over twelve problems, three failed, fix them, carry on" case, and it is why
-  resume is run-wide rather than per-tab. Successful work is never repeated.
+- **`r` -- retry** re-runs the single sub-command currently on screen. It names one command
+  in one tab, so it needs no scope prompt.
+- **`R` -- resume** re-queues every sub-command **not in `SUCCESS`** -- `FAILED`, `SKIPPED`
+  and `INTERRUPTED` alike -- in their original order. Successful work is never repeated.
+
+Resume does not pick a scope for you. It reuses the affordance `!` already established:
+pressing it mounts a `Menu` in `#command-input-container` with the same three choices, in
+the same order and with the same accelerators.
+
+| Key | Item | Behaviour |
+|-----|------|-----------|
+| `1` | Resume this tab | The active problem only. |
+| `2` | Resume all tabs | Every problem in the run -- the `each build` over twelve problems, three failed, fix them, carry on case. |
+| `3` | Resume selected tabs | Pushes `TabSelectorModal` for a multi-select, exactly as `run_selected_tabs` does. |
+
+The handler is the one already written for commands: `_on_menu_selected` dispatches on
+`event.action`, and `run_selected_tabs` already routes through `TabSelectorModal` with a
+callback taking the chosen indices. Resume adds `resume_this_tab` / `resume_all_tabs` /
+`resume_selected_tabs` beside them, and `_pending_command` gains a sibling holding the
+pending *verb* so one menu handler can serve both.
+
+Each item carries its count -- "Resume all tabs (7 commands)" -- so the blast radius is
+visible before committing to it, and tabs with nothing to resume are silently excluded from
+the totals. When nothing anywhere is resumable, `R` raises a toast instead of an empty menu.
+The `TabSelectorModal` rows are labelled through `_make_tab_label`, so each carries its
+aggregate status icon and you can see at a glance which problems actually failed.
 
 Resume deliberately includes `FAILED`: you resume *because* you fixed what failed, so
 starting after the failure point would skip the command you actually wanted re-run.
@@ -223,7 +244,10 @@ problem resumes by the same path, without quitting first.
   present when it is reopened again.
 - **Load states.** A run persisted mid-chain reloads with `RUNNING` as `INTERRUPTED` and
   `PENDING` as `SKIPPED`, and the tab reports itself idle.
+- **Resume scope.** Each of the three menu items enqueues exactly the tabs it names, and a
+  tab whose sub-commands all succeeded is untouched by any of them.
 - **Resume.** Over a run with a mix of statuses, only the non-`SUCCESS` sub-commands are
   enqueued, in order; a resumed command that fails again skips the rest of its chain.
+- **Empty resume.** `R` with nothing resumable notifies and mounts no menu.
 - **Retry hygiene.** Re-running a sub-command that already has output leaves the pane
   holding only the new attempt, and its stored `.ansi` matches.

--- a/docs/plans/2026-08-28-command-pane-run-history-design.md
+++ b/docs/plans/2026-08-28-command-pane-run-history-design.md
@@ -1,0 +1,186 @@
+# Command pane run history
+
+`rbx contest each` and `rbx contest on` open a TUI (`rbxCommandApp`) with one pane per
+problem. When the app exits, everything those commands printed is gone. This design keeps
+it: every finished command's final screen is written to disk, and running `each`/`on` with
+no command re-opens a past session with every pane redrawn.
+
+## Requirements
+
+- Output survives the process. Reopening works in a new shell, days later.
+- Only the **final** state of each command is kept -- no intermediate frames.
+- The restored panes must behave like live ones: `ctrl+v` visual select, `ctrl+y` copy,
+  mouse selection, the sub-command dropdown, tab switching.
+- `each`/`on` with **no forwarded command** open a picker of the 5 most recent runs, newest
+  first, showing each run's start time.
+- A reopened session stays live: new commands typed into it run and are themselves saved
+  into that same run.
+- State is flushed on **every** command completion, so history is useful mid-session and
+  survives a crash.
+
+## What makes this cheap
+
+Three facts about the vendored `toad` terminal decide the design.
+
+`Terminal.write(text)` (`rbx/box/ui/_vendor/toad/widgets/terminal.py:244`) feeds text into
+the ANSI stream parser. It is independent of the pty, so a pane can be filled without
+spawning a process: restoring is `await pane.write(saved_ansi)`.
+
+Selection is defined over the parser's output. `terminal_select.py` navigates
+`Buffer.lines` and highlights through `Terminal._render_line`. A buffer rebuilt by the real
+parser is indistinguishable from one built by a live command, so **copy and visual mode
+work with no new code** -- provided we restore through `write()` rather than reconstructing
+a `Buffer` ourselves.
+
+Each `Buffer.lines[i].content` is a `rich.text.Text` (`_vendor/toad/ansi/_ansi.py:847`), and
+rendering styled `Text` back to SGR-ANSI is a stock rich operation. So the dump direction is
+as short as the load direction.
+
+## Capture format
+
+Three candidates were considered.
+
+**A. ANSI dump of the final scrollback buffer.** On command completion, render every
+`Buffer.lines` entry to SGR-ANSI and write one file per sub-command.
+
+**B. Tee the raw pty byte stream.** Byte-exact, but stores every intermediate frame -- a
+chatty `rbx run` with live tables would write megabytes to reproduce a screen we could
+describe in kilobytes.
+
+**C. Serialize `TerminalState` / `Buffer`.** Needs a bespoke (de)serializer for vendored
+code we do not own, and would have to be kept in step with upstream.
+
+**A is chosen.** It is symmetric with `Terminal.write()`, so one format serves both
+directions; it stores only what the requirements ask for; the files are `cat`-able outside
+the TUI; and it inherits selection support by construction.
+
+### Dumping
+
+```python
+def dump_buffer_to_ansi(buffer: ansi.Buffer) -> str
+```
+
+A `rich.console.Console(file=StringIO(), force_terminal=True, color_system='truecolor',
+width=max(buffer.max_line_width, 1))` prints each line with `no_wrap=True`, `crop=False`,
+`markup=False`, `highlight=False`. Trailing blank lines are trimmed. Rich emits an SGR reset
+at the end of each styled span, so a file truncated by a crash cannot bleed styles into
+whatever is read after it.
+
+Only the scrollback buffer is dumped. A command that finished on the alternate screen (a
+full-screen child TUI) has nothing meaningful to persist there.
+
+### Loading and width
+
+Restoring writes the file into a mounted pane. Lines are stored **unfolded**, so they are
+re-folded at whatever width the pane has when it is shown -- a table drawn at 200 columns
+wraps if reopened in an 80-column window. This is inherent to storing logical lines and is
+accepted.
+
+It also makes ordering a non-issue: `Terminal.update_size()` reflows the buffer on resize,
+so writing into a pane that is still at its fallback width and letting the existing
+`sync_hidden_pane_sizes` machinery resize it afterwards produces the same result as writing
+after the resize.
+
+## Storage
+
+Contest-rooted, beside the existing problem-level cache:
+
+```
+<contest root>/.box/runs/
+  20260828-141233-a3f1/
+    run.yml
+    0/0.ansi        # tab 0 (problem A), sub-command 0
+    0/1.ansi
+    1/0.ansi
+```
+
+The run id is `<timestamp>-<random suffix>`: it sorts chronologically by name, and two
+concurrent `each` invocations cannot collide.
+
+There is no contest-level cache helper today (`package.get_problem_cache_dir` is
+problem-scoped), so this adds `get_contest_cache_dir()` alongside it.
+
+### The `RunStore` seam
+
+Access goes through one interface:
+
+```python
+class RunStore(Protocol):
+    def list_runs(self) -> List[RunManifest]: ...
+    def create_run(self, manifest: RunManifest) -> RunHandle: ...
+    def open_run(self, run_id: str) -> RunHandle: ...
+    def prune(self, keep: int) -> None: ...
+```
+
+`ContestRunStore` is the only implementation shipped. A future machine-global store under
+`get_app_path()` -- keeping the last few runs regardless of which contest they came from, as
+redundancy against a wiped `.box` -- is then a second implementation plus a merge in the
+picker, not a refactor. Nothing outside the store module knows where runs live.
+
+A consequence worth stating: history under `.box/` is destroyed by a cache wipe. That is
+accepted for now, and is precisely what the global fallback would later mitigate.
+
+### Manifest
+
+`run.yml` is a Pydantic model written through the project's existing YAML helpers:
+
+- `run_id`, `started_at`, `updated_at`, contest id (the `-C` selection, if any)
+- per tab: display name, the `ProblemLabelMode` label map, `cwd`, `prefix`
+- per sub-command: name, shell command, status, exit code, `chained`
+
+The picker **displays** `started_at`, as asked, but **sorts** by `updated_at`, so a run you
+reopened and added commands to does not sink to the bottom of the list.
+
+## Write points
+
+- **Run creation.** `run.yml` is written when the app starts, before anything executes.
+- **Every `CommandPane.CommandComplete`.** The app already handles that message to drive
+  `SubCommand.status`; the handler additionally dumps that pane and rewrites `run.yml`. This
+  is the incremental guarantee: history is complete up to the last finished command at all
+  times, whatever happens next.
+- **App unmount.** Every pane holding undumped content is written, so quitting mid-run keeps
+  what was on screen.
+
+## Reopening
+
+`_build_command_argvs_or_die` currently rejects an empty command with `EmptyCommandError`.
+That is the hook: an empty command means "show me history" rather than an error.
+
+`rbx contest on`'s `problems` argument becomes **optional**. Bare `rbx contest on` behaves
+like bare `rbx contest each` and lists every run; `rbx contest on A` with no command lists
+only runs that touched problem `A`.
+
+The picker is a small standalone app that returns a run id, following the `rbxReviewApp`
+pattern (run the app, read a result attribute synchronously). Each row shows the start
+timestamp, the command chain, the problems involved, and the aggregate status icon --
+`_STATUS_MARKUP` already exists for that. With no runs recorded it prints a plain message and
+exits non-zero.
+
+Selecting a run starts an ordinary `rbxCommandApp` whose tabs and sub-commands come from the
+manifest and whose panes load their `.ansi` file instead of executing. There is no read-only
+mode: the shell input works, `cwd`/`prefix` come from the manifest, and commands typed into a
+reopened session append to that same run directory under the same rules as a fresh one.
+
+Sub-commands persisted as `PENDING` or `RUNNING` -- the app was quit mid-chain -- load as
+`SKIPPED`. They are not re-queued, and marking them skipped is honest about what happened
+rather than leaving a pending command that will never start.
+
+## Testing
+
+`tests/rbx/box/ui/` already drives panes headlessly (`test_command_app.py`,
+`test_command_pane_select.py`), so the same fixtures apply.
+
+- **Round trip.** Run a command printing styled output, dump the pane, load it into a fresh
+  pane, assert the plain text and the styles match the original.
+- **Selection after restore.** Enter visual mode on a restored pane and assert
+  `get_selected_text()` returns what the command wrote -- the requirement that motivated
+  format A.
+- **Wrapped lines.** A line longer than the pane restores as one logical line, and re-folds
+  when the pane is resized.
+- **Incremental flush.** After one command of a chain completes, the store already holds that
+  pane and a manifest naming its status.
+- **Manifest and pruning.** Round-trip the model; assert only the newest `keep` runs survive.
+- **Routing.** `each` with no args and `on` with a selector but no command open the picker;
+  `on A` filters to runs touching `A`.
+- **Continuation.** A command queued into a reopened run lands in that run's directory and is
+  present when it is reopened again.

--- a/docs/setters/cheatsheet.md
+++ b/docs/setters/cheatsheet.md
@@ -99,6 +99,8 @@ Where a command has a page of its own, the :material-open-in-new: next to it tak
 | Build problems A to C in the contest            | `rbx contest on A..C build`           |
 | Build every problem but C                       | `rbx contest on '*,!C' build`         |
 | Chain commands for a problem                    | `rbx contest on A build :: run`       |
+| Reopen a past run and read its output           | `rbx contest each`                    |
+| Reopen past runs touching problem A             | `rbx contest on A`                    |
 | Print a summary of the contest                  | `rbx contest summary`                 |
 | List all contests in the current directory      | `rbx contest list`                    |
 | Scaffold a new contest variant                  | `rbx contest add_variant div2`        |

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -1060,14 +1060,14 @@ Run a command in the problem (or in a set of problems) of a context.
 
 **Usage:**
 ```bash
-rbx contest on <PROBLEMS> [OPTIONS]
+rbx contest on [PROBLEMS] [OPTIONS]
 ```
 
 **Arguments:**
 
 | Name | Description | Required |
 | :--- | :--- | :--- |
-| `PROBLEMS` | - | Yes |
+| `PROBLEMS` | - | No |
 
 
 ---

--- a/rbx/box/contest/contest_package.py
+++ b/rbx/box/contest/contest_package.py
@@ -13,6 +13,7 @@ from rbx.box.package import find_problem_package_or_die
 from rbx.box.sanitizers import issue_stack
 from rbx.box.schema import Package
 from rbx.box.yaml_validation import load_yaml_model
+from rbx.config import CACHE_DIR_NAME
 
 YAML_NAME = 'contest.rbx.yml'
 PROBLEM_YAML_NAME = 'problem.rbx.yml'
@@ -114,6 +115,23 @@ def find_contest_root(
     if not (walker / YAML_NAME).is_file():
         return None
     return walker
+
+
+def get_contest_cache_dir(
+    root: pathlib.Path = pathlib.Path(),
+) -> Optional[pathlib.Path]:
+    """The contest-level cache directory, created on demand.
+
+    The problem-level equivalent is `package.get_problem_cache_dir`; contest-wide
+    artifacts (currently the `each`/`on` run history) had nowhere to live.
+    Returns None outside a contest.
+    """
+    contest_root = find_contest_root(root)
+    if contest_root is None:
+        return None
+    cache_dir = contest_root / CACHE_DIR_NAME
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
 
 
 # NOTE: `find_contest_yaml` is `@functools.cache`d. The contextvar fallback

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -437,6 +437,20 @@ def _export_contest_selection() -> None:
         os.environ[contest_state.ENV_VAR] = selection
 
 
+def _offer_run_history(problem_names: Optional[List[str]] = None) -> bool:
+    """Offer to reopen a past `each`/`on` session.
+
+    Reached when there is no command to forward. Returns True once it has shown
+    something; False means the caller should open a blank session instead --
+    either nothing was ever recorded, or the user asked for a new one. No-argument
+    `each` has always opened a blank session, and history must not cost that.
+    """
+    from rbx.box.ui import run_picker
+
+    outcome = run_picker.open_run_history(problem_names)
+    return outcome == run_picker.HANDLED
+
+
 def _build_command_argvs_or_die(
     args: List[str],
 ) -> Tuple[List[List[str]], Optional[str]]:
@@ -467,6 +481,8 @@ def each(ctx: typer.Context, keep_going: bool = KEEP_GOING_OPTION) -> None:
 
     contest = find_contest_package_or_die()
     _export_contest_selection()
+    if not ctx.args and _offer_run_history():
+        return
     argvs, placeholder_prefix = _build_command_argvs_or_die(ctx.args)
     commands = [
         CommandEntry(
@@ -504,15 +520,26 @@ def each(ctx: typer.Context, keep_going: bool = KEEP_GOING_OPTION) -> None:
 def on(
     ctx: typer.Context,
     problems: Annotated[
-        str,
+        Optional[str],
         typer.Argument(
             autocompletion=annotations._adapt('problem'),  # noqa: SLF001
             help=PROBLEM_SELECTOR_HELP,
         ),
-    ],
+    ] = None,
     keep_going: bool = KEEP_GOING_OPTION,
 ) -> None:
     _export_contest_selection()
+    if problems is None:
+        # No selector and nothing to run: history is all that is on offer, since
+        # there is no problem set to open a blank session over.
+        if not _offer_run_history():
+            console.console.print(
+                '[error]No recorded runs found for this contest.[/error]\n'
+                '[status]Pass a problem selector, e.g. '
+                '[item]rbx contest on A build[/item].[/status]'
+            )
+            raise typer.Exit(1)
+        return
     try:
         problems_of_interest = contest_utils.get_problems_of_interest(problems)
     except problem_selector.ProblemSelectorError as e:
@@ -524,6 +551,12 @@ def on(
             f'[error]No problems found in contest matching [item]{problems}[/item].[/error]'
         )
         raise typer.Exit(1)
+
+    if not ctx.args and _offer_run_history(
+        [naming.get_contest_problem_label(p) for p in problems_of_interest]
+    ):
+        # A selector but nothing to run: show this problem's history.
+        return
 
     argvs, placeholder_prefix = _build_command_argvs_or_die(ctx.args)
 

--- a/rbx/box/ui/CLAUDE.md
+++ b/rbx/box/ui/CLAUDE.md
@@ -156,9 +156,14 @@ reopened run -- a `PENDING` that survived the load would leave a tab busy foreve
 **Persistence points.** `_persist()` mirrors the live tabs into the manifest and writes it
 on every status change: at mount, on each `CommandPane.CommandComplete` (which also dumps
 that pane, *before* `notify_complete` releases the terminal to the next queued command), on
-each interactively queued command, and on `on_unmount` -- so quitting mid-run keeps what was
-on screen. History failing to write is never fatal; a session that cannot record itself is
-still a working session.
+each interactively queued command, and in a **`_shutdown` override** -- so quitting mid-run
+keeps what was on screen. That override is deliberate and must not be "cleaned up" into an
+`on_unmount` handler: `App._shutdown` calls `_close_all()` and clears the node registry
+*before* dispatching `Unmount`, so `on_unmount` finds every pane already gone and dumps
+nothing (this was caught by a test, not in review). `_shutdown` is also the one path every
+teardown funnels through -- `exit()` from `q`, an unhandled error, and `run_test`, which
+calls it directly. History failing to write is never fatal; a session that cannot record
+itself is still a working session.
 
 **Resume and retry** need nothing the manifest does not already hold: `shell_command`,
 `chained`, `cwd`, `prefix` and `status` are the entire input set. `r` retries the

--- a/rbx/box/ui/CLAUDE.md
+++ b/rbx/box/ui/CLAUDE.md
@@ -122,6 +122,80 @@ finished left the scroll extents stale and the anchored view scrolled past the r
 the output -- the tail (e.g. a time-limits table) looked eaten. `update_size()` now calls
 `_update_virtual_size()`. Both are covered by `tests/rbx/box/ui/test_command_pane.py`.
 
+## Run history, resume & retry (`run_history.py`, `run_picker.py`, `command_status.py`)
+
+Every command an `each`/`on` session runs leaves its **final screen** on disk, so a session
+can be reopened later with every pane redrawn, and the commands that did not succeed can be
+re-queued. Design: `docs/plans/2026-08-28-command-pane-run-history-design.md`.
+
+The format is **ANSI text**, and that choice is the whole design. `Terminal.write()` feeds
+the same stream parser that built the buffer live, so restoring a pane is one write and the
+restored `Buffer` is indistinguishable from a live one -- which is what makes `ctrl+v`
+select mode, `ctrl+y` and mouse selection work on restored panes **with no code at all**.
+A bespoke buffer snapshot would have needed its own reconstruction and its own way to keep
+selection working. `run_history.dump_buffer` renders each `Buffer.lines` entry (a
+`textual.content.Content`) back to SGR via `style.rich_style.render`; the round trip is
+exact for both text and spans, which `test_run_history.py` pins.
+
+Two consequences worth knowing:
+
+- **Lines are stored unfolded**, so a restored pane re-folds at whatever width it has now.
+  A table drawn at 200 columns wraps if reopened in an 80-column window. This also makes
+  restore order-independent: `Terminal.update_size()` reflows on resize, so writing before
+  the pane learns its real width is fine.
+- **Files hold `\n`; the terminal needs `\r\n`.** `to_terminal_input()` is the adapter, and
+  skipping it leaves every line starting where the previous one ended.
+
+`CommandStatus` lives in `command_status.py` rather than `command_app.py` because the
+history persists it and the app imports the history. It gained **`INTERRUPTED`**: nothing is
+executing when a run is loaded, so `on_load()` maps `RUNNING` -> `INTERRUPTED` (began,
+partial output on disk, no exit code) and `PENDING` -> `SKIPPED` (never began). Both are
+terminal, which is what keeps `TabState.is_idle` and `aggregate_status` honest on a
+reopened run -- a `PENDING` that survived the load would leave a tab busy forever.
+
+**Persistence points.** `_persist()` mirrors the live tabs into the manifest and writes it
+on every status change: at mount, on each `CommandPane.CommandComplete` (which also dumps
+that pane, *before* `notify_complete` releases the terminal to the next queued command), on
+each interactively queued command, and on `on_unmount` -- so quitting mid-run keeps what was
+on screen. History failing to write is never fatal; a session that cannot record itself is
+still a working session.
+
+**Resume and retry** need nothing the manifest does not already hold: `shell_command`,
+`chained`, `cwd`, `prefix` and `status` are the entire input set. `r` retries the
+sub-command on screen; `R` resumes everything **not in `SUCCESS`** (`FAILED` included -- you
+resume because you fixed what failed). Two rules:
+
+- **A retry swaps the pane.** `CommandPane.execute()` appends to the terminal state rather
+  than clearing it, so re-running in place would stack two attempts. `_reset_pane` mounts a
+  fresh pane under the same id and **awaits** the old one's `remove()`, or the two collide
+  on the duplicate id. The stored `.ansi` is dropped with it: only the latest attempt is kept.
+- **Resume resets every pane before enqueueing any.** Otherwise a fast failure could
+  complete while later links of its chain were not yet queued, and `_skip_rest_of_chain`
+  -- which cancels only tasks already in the queue -- would have nothing to cancel.
+
+`R` reuses the `!` prompt's own scope affordance rather than inventing one: the same `Menu`
+in `#command-input-container` offering this tab / all tabs / selected tabs, the third
+pushing `TabSelectorModal`. `_on_menu_selected` dispatches on the action name, so one
+handler serves both verbs; `_pending_menu` records which verb is pending.
+
+**Storage** is `<contest root>/<CACHE_DIR_NAME>/runs/<run-id>/`, reached only through
+`ContestRunStore`. Everything filesystem-shaped lives in that class so a future
+machine-global store (redundancy against a wiped cache) is a second implementation, not a
+refactor. `list_runs` sorts by `updated_at` while the picker *displays* `started_at`, so a
+run you reopen and add to floats back to the top. A manifest that will not parse is skipped,
+never fatal.
+
+**Entry points.** `rbx contest each` / `rbx contest on` with no command to forward open
+`RunPickerApp`. Its first row is **"Start a new session"**, and no recorded history falls
+back the same way -- no-argument `each` has always opened a blank session to type into, and
+history must not cost that (`test_each_without_args_opens_an_empty_app` pins it). `on`'s
+`problems` argument is now optional; given one, the picker is filtered to runs whose tab
+names match, which is why the filter uses `naming.get_contest_problem_label` -- the same
+label the manifest stores.
+
+Tests: `tests/rbx/box/ui/test_run_history.py`, plus the routing cases in
+`tests/rbx/box/contest/test_contest_main.py`.
+
 ## Pane copying & keyboard selection (`terminal_select.py`)
 
 `TerminalSelectMixin` gives a `CommandPane` two things the mouse could not (#717):

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -1,5 +1,5 @@
 import dataclasses
-import enum
+import datetime
 import shlex
 from time import monotonic
 from typing import Dict, List, Optional, Tuple
@@ -20,7 +20,9 @@ from rbx.box.setter_config import (
     get_setter_config,
     set_problem_label,
 )
+from rbx.box.ui import command_status, run_history
 from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
+from rbx.box.ui.command_status import CommandStatus
 from rbx.box.ui.main import rbxBaseApp
 from rbx.box.ui.screens.tab_selector import TabSelectorModal
 from rbx.box.ui.task_queue import Task, TaskQueue
@@ -160,6 +162,8 @@ class HelpModal(ModalScreen[None]):
                 '  [b]tab[/b]         Focus terminal\n'
                 '  [b]![/b]           Open shell input\n'
                 '  [b]\u2190 / \u2192[/b]       Previous / next sub-command\n'
+                '  [b]r[/b]           Retry this command\n'
+                '  [b]R[/b]           Resume everything that did not succeed\n'
                 '  [b]l[/b]           Cycle problem label (name/title/path)\n'
                 '  [b]?[/b]           Show this help\n'
                 '  [b]q[/b]           Quit',
@@ -201,35 +205,11 @@ class HelpModal(ModalScreen[None]):
             )
 
 
-class CommandStatus(enum.Enum):
-    PENDING = 'pending'
-    RUNNING = 'running'
-    SUCCESS = 'success'
-    FAILED = 'failed'
-    SKIPPED = 'skipped'
-
-
-_STATUS_MARKUP = {
-    CommandStatus.PENDING: '[dim]○[/dim]',
-    CommandStatus.RUNNING: '[yellow]●[/yellow]',
-    CommandStatus.SUCCESS: '[green]✓[/green]',
-    CommandStatus.FAILED: '[red]✗[/red]',
-    CommandStatus.SKIPPED: '[dim]⊘[/dim]',
-}
-
-_STATUS_ICON = {
-    CommandStatus.PENDING: '○',
-    CommandStatus.RUNNING: '●',
-    CommandStatus.SUCCESS: '✓',
-    CommandStatus.FAILED: '✗',
-    CommandStatus.SKIPPED: '⊘',
-}
-
-_FINISHED_STATUSES = (
-    CommandStatus.SUCCESS,
-    CommandStatus.FAILED,
-    CommandStatus.SKIPPED,
-)
+# Re-exported so existing importers of `command_app.CommandStatus` keep working;
+# the enum itself lives beside the run history, which persists it.
+_STATUS_MARKUP = command_status.STATUS_MARKUP
+_STATUS_ICON = command_status.STATUS_ICON
+_FINISHED_STATUSES = command_status.FINISHED_STATUSES
 
 
 @dataclasses.dataclass
@@ -271,11 +251,25 @@ class SubCommand:
     shell_command: str
     pane_id: str
     status: CommandStatus = CommandStatus.PENDING
+    exit_code: Optional[int] = None
     task_id: Optional[int] = None
     # Seeded from the CLI as part of a `::` chain. Only chained commands are
     # skipped when an earlier one fails; commands queued interactively always
     # run, so a typo in one does not silently swallow the next.
     chained: bool = False
+
+
+def _subtitle_for(sub: SubCommand) -> str:
+    """What a pane's border says about a command that is no longer running."""
+    if sub.status is CommandStatus.SUCCESS:
+        return 'Done'
+    if sub.status is CommandStatus.FAILED:
+        return f'Exit code: {sub.exit_code}'
+    if sub.status is CommandStatus.SKIPPED:
+        return 'Skipped'
+    if sub.status is CommandStatus.INTERRUPTED:
+        return 'Interrupted'
+    return ''
 
 
 class TabState:
@@ -309,6 +303,22 @@ class TabState:
         shell_command = self.entry.make_raw_shell_command(raw_command)
         return self._append_sub_command(name, shell_command)
 
+    def add_recorded_sub_command(
+        self, record: run_history.SubCommandRecord
+    ) -> SubCommand:
+        """Re-create a sub-command from history.
+
+        The stored `shell_command` is used verbatim: it already had the tab's
+        `cwd`/`prefix` folded into it when it first ran, and re-deriving it
+        would risk resuming something subtly different from what was recorded.
+        """
+        sub = self._append_sub_command(
+            record.name, record.shell_command, chained=record.chained
+        )
+        sub.status = command_status.on_load(record.status)
+        sub.exit_code = record.exit_code
+        return sub
+
     @property
     def active_sub_command_index(self) -> Optional[int]:
         """The sub-command worth showing when this tab is opened.
@@ -336,12 +346,7 @@ class TabState:
         if not self.sub_commands:
             return CommandStatus.PENDING
         statuses = {s.status for s in self.sub_commands}
-        for status in (
-            CommandStatus.FAILED,
-            CommandStatus.SKIPPED,
-            CommandStatus.RUNNING,
-            CommandStatus.PENDING,
-        ):
+        for status in command_status.AGGREGATE_PRECEDENCE:
             if status in statuses:
                 return status
         return CommandStatus.SUCCESS
@@ -430,11 +435,15 @@ class rbxCommandApp(rbxBaseApp):
         commands: List[CommandEntry],
         parallel: bool = False,
         keep_going: bool = False,
+        run_handle: Optional[run_history.RunHandle] = None,
+        restored: bool = False,
     ):
         super().__init__()
         self.commands = commands
         self.parallel = parallel
         self.keep_going = keep_going
+        self._run_handle = run_handle
+        self._restored = restored
         self._tabs: List[TabState] = []
         self._active_tab: int = 0
         self._label_mode: ProblemLabelMode = get_setter_config().ui.problem_label
@@ -444,16 +453,21 @@ class rbxCommandApp(rbxBaseApp):
             on_task_ready=lambda t: self.post_message(self.TaskReady(t)),
         )
         self._pending_command: Optional[str] = None
+        self._pending_menu: Optional[str] = None
         self._pane_size: Tuple[int, int] = (0, 0)
 
         # Initialize tab states and add initial sub-commands.
         for i, cmd in enumerate(commands):
             tab = TabState(entry=cmd, tab_index=i)
-            chained = len(cmd.argvs) > 1
-            for argv in cmd.argvs:
-                if not argv:
-                    continue
-                tab.add_sub_command(name=' '.join(argv), argv=argv, chained=chained)
+            if restored and run_handle is not None:
+                for record in run_handle.manifest.tabs[i].sub_commands:
+                    tab.add_recorded_sub_command(record)
+            else:
+                chained = len(cmd.argvs) > 1
+                for argv in cmd.argvs:
+                    if not argv:
+                        continue
+                    tab.add_sub_command(name=' '.join(argv), argv=argv, chained=chained)
             self._tabs.append(tab)
 
     def compose(self) -> ComposeResult:
@@ -633,11 +647,117 @@ class rbxCommandApp(rbxBaseApp):
         # Initial focus on the sidebar.
         self._focus_sidebar()
 
-        # Enqueue initial commands.
-        for i, tab in enumerate(self._tabs):
+        if self._restored:
+            # Nothing runs on open: the panes are filled from disk and the run
+            # sits idle until the user retries, resumes, or types a command.
+            self._restore_subtitles()
+            self.run_worker(self._restore_panes(), exclusive=False)
+        else:
+            # Enqueue initial commands.
+            for i, tab in enumerate(self._tabs):
+                for sub in tab.sub_commands:
+                    task = self._task_queue.enqueue(sub.shell_command, terminal_id=i)
+                    sub.task_id = task.task_id
+
+        self._persist()
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _persist(self) -> None:
+        """Mirror the live tabs into the manifest and write it out.
+
+        Called on every status change, so history on disk is complete up to the
+        last finished command at all times -- whatever happens to the process
+        next.
+        """
+        if self._run_handle is None:
+            return
+        self._run_handle.manifest.tabs = [
+            run_history.TabRecord(
+                name=tab.entry.display_name,
+                cwd=tab.entry.cwd,
+                prefix=tab.entry.prefix,
+                placeholder_prefix=tab.entry.placeholder_prefix,
+                labels=(
+                    {mode.value: label for mode, label in tab.entry.labels.items()}
+                    if tab.entry.labels
+                    else None
+                ),
+                sub_commands=[
+                    run_history.SubCommandRecord(
+                        name=sub.name,
+                        shell_command=sub.shell_command,
+                        status=sub.status,
+                        exit_code=sub.exit_code,
+                        chained=sub.chained,
+                    )
+                    for sub in tab.sub_commands
+                ],
+            )
+            for tab in self._tabs
+        ]
+        try:
+            self._run_handle.save()
+        except OSError:
+            # History is a convenience; never take the session down for it.
+            pass
+
+    def _dump_pane(self, tab_index: int, sub_index: int, sub: SubCommand) -> None:
+        if self._run_handle is None:
+            return
+        try:
+            pane = self.query_one(f'#{sub.pane_id}', CommandPane)
+        except NoMatches:
+            return
+        try:
+            dumped = run_history.dump_buffer(pane.state.scrollback_buffer)
+        except Exception:
+            return
+        if not dumped:
+            return
+        try:
+            self._run_handle.write_pane(tab_index, sub_index, dumped)
+        except OSError:
+            pass
+
+    def _dump_all_panes(self) -> None:
+        for tab_index, tab in enumerate(self._tabs):
+            for sub_index, sub in enumerate(tab.sub_commands):
+                self._dump_pane(tab_index, sub_index, sub)
+
+    def on_unmount(self) -> None:
+        """Keep whatever was on screen when the app goes away.
+
+        A command still running here never reported an exit code; it is
+        persisted as RUNNING and reloads as INTERRUPTED.
+        """
+        self._dump_all_panes()
+        self._persist()
+
+    def _restore_subtitles(self) -> None:
+        for tab in self._tabs:
             for sub in tab.sub_commands:
-                task = self._task_queue.enqueue(sub.shell_command, terminal_id=i)
-                sub.task_id = task.task_id
+                try:
+                    pane = self.query_one(f'#{sub.pane_id}', CommandPane)
+                except NoMatches:
+                    continue
+                pane.border_subtitle = _subtitle_for(sub)
+
+    async def _restore_panes(self) -> None:
+        for tab_index, tab in enumerate(self._tabs):
+            for sub_index, sub in enumerate(tab.sub_commands):
+                if self._run_handle is None:
+                    return
+                dumped = self._run_handle.read_pane(tab_index, sub_index)
+                if not dumped:
+                    continue
+                try:
+                    pane = self.query_one(f'#{sub.pane_id}', CommandPane)
+                except NoMatches:
+                    continue
+                await pane.write(run_history.to_terminal_input(dumped))
 
     def on_rbx_command_app_task_ready(self, event: TaskReady) -> None:
         task = event.task
@@ -771,6 +891,18 @@ class rbxCommandApp(rbxBaseApp):
             self._select_next_sub_command()
             return
 
+        if event.character == 'r':
+            event.stop()
+            event.prevent_default()
+            self.run_worker(self._retry_current(), exclusive=False)
+            return
+
+        if event.character == 'R':
+            event.stop()
+            event.prevent_default()
+            self._open_resume_menu()
+            return
+
         if event.character == 'l' and self._has_labels():
             event.stop()
             event.prevent_default()
@@ -808,18 +940,22 @@ class rbxCommandApp(rbxBaseApp):
                 if pane.return_code is None:
                     continue
 
+                sub.exit_code = pane.return_code
                 if pane.return_code == 0:
                     sub.status = CommandStatus.SUCCESS
-                    pane.border_subtitle = 'Done'
                 else:
                     sub.status = CommandStatus.FAILED
-                    pane.border_subtitle = f'Exit code: {pane.return_code}'
+                pane.border_subtitle = _subtitle_for(sub)
 
                 if sub.status == CommandStatus.FAILED:
                     self._skip_rest_of_chain(tab_index, sub)
 
                 self._update_sidebar(tab_index)
                 self._refresh_select_if_active(tab_index)
+                # Dump before releasing the terminal: the next command in the
+                # queue may start the moment `notify_complete` returns.
+                self._dump_pane(tab_index, tab.sub_commands.index(sub), sub)
+                self._persist()
                 if sub.task_id is not None:
                     self._task_queue.notify_complete(sub.task_id)
                 return
@@ -868,6 +1004,7 @@ class rbxCommandApp(rbxBaseApp):
 
         task = self._task_queue.enqueue(sub.shell_command, terminal_id=tab_index)
         sub.task_id = task.task_id
+        self._persist()
         return sub
 
     def _show_latest_sub_command(self) -> None:
@@ -897,6 +1034,127 @@ class rbxCommandApp(rbxBaseApp):
         if queued > 0:
             self.notify(f'Command queued in {queued} tab(s)')
 
+    # ------------------------------------------------------------------
+    # Retry and resume
+    # ------------------------------------------------------------------
+
+    def _resumable_in_tab(self, tab_index: int) -> List[Tuple[int, SubCommand]]:
+        return [
+            (i, sub)
+            for i, sub in enumerate(self._tabs[tab_index].sub_commands)
+            if command_status.is_resumable(sub.status)
+        ]
+
+    def _resumable_count(self, tab_indices: List[int]) -> int:
+        return sum(len(self._resumable_in_tab(i)) for i in tab_indices)
+
+    async def _reset_pane(
+        self, tab_index: int, sub_index: int, sub: SubCommand
+    ) -> None:
+        """Give a command a clean slate to run in again.
+
+        `CommandPane.execute` appends to the terminal state rather than
+        clearing it, so re-running in place would stack the new attempt under
+        the old one. Swapping in a fresh pane under the same id is the only way
+        to get an empty terminal, and the stored output goes with it -- only
+        the latest attempt is kept.
+        """
+        container = self.query_one('#command-pane-container', Vertical)
+        displayed = False
+        try:
+            old = self.query_one(f'#{sub.pane_id}', CommandPane)
+        except NoMatches:
+            old = None
+        if old is not None:
+            displayed = old.display
+            # Awaited: mounting the replacement before the old widget is gone
+            # would collide on the duplicate id.
+            await old.remove()
+
+        pane = self._make_pane(sub.pane_id)
+        pane.border_title = sub.name
+        pane.display = displayed
+        await container.mount(pane)
+
+        if self._run_handle is not None:
+            self._run_handle.clear_pane(tab_index, sub_index)
+        sub.status = CommandStatus.PENDING
+        sub.exit_code = None
+
+    def _enqueue_sub(self, tab_index: int, sub: SubCommand) -> None:
+        task = self._task_queue.enqueue(sub.shell_command, terminal_id=tab_index)
+        sub.task_id = task.task_id
+
+    async def _resume_tabs(self, tab_indices: List[int]) -> None:
+        targets: List[Tuple[int, int, SubCommand]] = []
+        for tab_index in tab_indices:
+            for sub_index, sub in self._resumable_in_tab(tab_index):
+                targets.append((tab_index, sub_index, sub))
+        if not targets:
+            self.notify('Nothing to resume')
+            return
+
+        # Every pane is reset before anything is enqueued, so the whole batch is
+        # PENDING by the time the first command can finish. Otherwise a fast
+        # failure could complete while later links of its chain were not yet
+        # queued, and `_skip_rest_of_chain` would have nothing to cancel.
+        for tab_index, sub_index, sub in targets:
+            await self._reset_pane(tab_index, sub_index, sub)
+        for tab_index, _, sub in targets:
+            self._enqueue_sub(tab_index, sub)
+
+        for tab_index in sorted({t for t, _, _ in targets}):
+            self._update_sidebar(tab_index)
+        self._refresh_select_if_active(self._active_tab)
+        self._persist()
+        self.notify(f'Resumed {len(targets)} command(s)')
+
+    async def _retry_current(self) -> None:
+        tab = self._tabs[self._active_tab]
+        select = self.query_one('#command-select', Select)
+        if select.value is Select.BLANK:
+            return
+        sub_index: int = select.value  # type: ignore[assignment]
+        if not 0 <= sub_index < len(tab.sub_commands):
+            return
+        sub = tab.sub_commands[sub_index]
+        if sub.status in (CommandStatus.PENDING, CommandStatus.RUNNING):
+            self.notify('Command is already queued')
+            return
+        await self._reset_pane(self._active_tab, sub_index, sub)
+        self._enqueue_sub(self._active_tab, sub)
+        self._update_sidebar(self._active_tab)
+        self._refresh_select_if_active(self._active_tab)
+        self._persist()
+        self.notify(f'Retrying {sub.name}')
+
+    def _start_resume(self, tab_indices: List[int]) -> None:
+        self.run_worker(self._resume_tabs(tab_indices), exclusive=False)
+
+    def _open_resume_menu(self) -> None:
+        total = self._resumable_count(list(range(len(self._tabs))))
+        if total == 0:
+            self.notify('Nothing to resume')
+            return
+        self._dismiss_menu()
+        self._pending_menu = 'resume'
+        here = self._resumable_count([self._active_tab])
+        menu = Menu(
+            [
+                MenuItem(f'Resume this tab ({here} commands)', 'resume_this_tab', '1'),
+                MenuItem(f'Resume all tabs ({total} commands)', 'resume_all_tabs', '2'),
+                MenuItem('Resume selected tabs', 'resume_selected_tabs', '3'),
+            ],
+        )
+        input_container = self.query_one('#command-input-container', Horizontal)
+        input_container.mount(menu)
+        menu.focus()
+
+    def _on_resume_tabs_selected(self, indices: Optional[List[int]]) -> None:
+        if indices:
+            self._start_resume(indices)
+        self._focus_sidebar()
+
     def _dismiss_menu(self) -> None:
         self._pending_command = None
         for menu in self.query(Menu):
@@ -914,6 +1172,7 @@ class rbxCommandApp(rbxBaseApp):
         self._dismiss_menu()
 
         self._pending_command = raw
+        self._pending_menu = 'run'
         menu = Menu(
             [
                 MenuItem('Run in this tab', 'run_this_tab', '1'),
@@ -930,7 +1189,26 @@ class rbxCommandApp(rbxBaseApp):
         event.stop()
         raw = self._pending_command
         self._pending_command = None
+        self._pending_menu = None
         event.menu.remove()
+
+        if event.action.startswith('resume_'):
+            if event.action == 'resume_selected_tabs':
+                self.push_screen(
+                    TabSelectorModal(
+                        [self._make_tab_label(i) for i in range(len(self._tabs))]
+                    ),
+                    callback=self._on_resume_tabs_selected,
+                )
+                return
+            tab_indices = (
+                [self._active_tab]
+                if event.action == 'resume_this_tab'
+                else list(range(len(self._tabs)))
+            )
+            self._start_resume(tab_indices)
+            self._focus_sidebar()
+            return
 
         if raw is not None and event.action == 'run_selected_tabs':
             tab_names = [tab.entry.display_name for tab in self._tabs]
@@ -951,6 +1229,7 @@ class rbxCommandApp(rbxBaseApp):
     def _on_menu_dismissed(self, event: Menu.Dismissed) -> None:
         event.stop()
         self._pending_command = None
+        self._pending_menu = None
         event.menu.remove()
 
         # Clear input and return to sidebar.
@@ -981,12 +1260,42 @@ class rbxCommandApp(rbxBaseApp):
             self.notify(f'Command queued in {queued} tab(s)')
 
 
+def _create_run_handle() -> Optional[run_history.RunHandle]:
+    """Start recording this run, if we are inside a contest.
+
+    Never fatal: a session that cannot write history is still a working session.
+    """
+    try:
+        from rbx.box.contest import contest_state
+
+        store = run_history.get_contest_run_store()
+        if store is None:
+            return None
+        store.prune()
+        now = datetime.datetime.now()
+        return store.create_run(
+            run_history.RunManifest(
+                run_id=run_history.new_run_id(now),
+                started_at=now,
+                updated_at=now,
+                contest_id=contest_state.resolve_explicit_selection(),
+            )
+        )
+    except Exception:
+        return None
+
+
 def start_command_app(
     commands: List[CommandEntry],
     parallel: bool = False,
     keep_going: bool = False,
 ) -> None:
-    app = rbxCommandApp(commands, parallel=parallel, keep_going=keep_going)
+    app = rbxCommandApp(
+        commands,
+        parallel=parallel,
+        keep_going=keep_going,
+        run_handle=_create_run_handle(),
+    )
     app.run()
 
 

--- a/rbx/box/ui/command_app.py
+++ b/rbx/box/ui/command_app.py
@@ -727,14 +727,23 @@ class rbxCommandApp(rbxBaseApp):
             for sub_index, sub in enumerate(tab.sub_commands):
                 self._dump_pane(tab_index, sub_index, sub)
 
-    def on_unmount(self) -> None:
+    async def _shutdown(self) -> None:
         """Keep whatever was on screen when the app goes away.
 
         A command still running here never reported an exit code; it is
         persisted as RUNNING and reloads as INTERRUPTED.
+
+        This overrides a private hook on purpose. `App._shutdown` calls
+        `_close_all()` and clears the node registry *before* it dispatches
+        `Unmount`, so an `on_unmount` handler finds every pane already gone and
+        dumps nothing (verified: the files were empty). `_shutdown` is also the
+        one path every teardown funnels through -- `exit()` from the `q`
+        binding, an unhandled error, and `run_test`, which calls it directly
+        rather than going through `exit()`.
         """
         self._dump_all_panes()
         self._persist()
+        await super()._shutdown()
 
     def _restore_subtitles(self) -> None:
         for tab in self._tabs:

--- a/rbx/box/ui/command_status.py
+++ b/rbx/box/ui/command_status.py
@@ -1,0 +1,79 @@
+"""Status of a single command in a `rbxCommandApp` pane.
+
+Lives in its own module because both the app (`command_app.py`) and the run
+history it persists (`run_history.py`) need it, and the app imports the history.
+"""
+
+import enum
+
+
+class CommandStatus(enum.Enum):
+    PENDING = 'pending'
+    RUNNING = 'running'
+    SUCCESS = 'success'
+    FAILED = 'failed'
+    SKIPPED = 'skipped'
+    # Was running when the app went away. Its output was dumped on the way out,
+    # but it never reported an exit code, so it is neither a success nor a
+    # failure -- only a candidate for resuming.
+    INTERRUPTED = 'interrupted'
+
+
+STATUS_MARKUP = {
+    CommandStatus.PENDING: '[dim]○[/dim]',
+    CommandStatus.RUNNING: '[yellow]●[/yellow]',
+    CommandStatus.SUCCESS: '[green]✓[/green]',
+    CommandStatus.FAILED: '[red]✗[/red]',
+    CommandStatus.SKIPPED: '[dim]⊘[/dim]',
+    CommandStatus.INTERRUPTED: '[yellow]⚡[/yellow]',
+}
+
+STATUS_ICON = {
+    CommandStatus.PENDING: '○',
+    CommandStatus.RUNNING: '●',
+    CommandStatus.SUCCESS: '✓',
+    CommandStatus.FAILED: '✗',
+    CommandStatus.SKIPPED: '⊘',
+    CommandStatus.INTERRUPTED: '⚡',
+}
+
+FINISHED_STATUSES = (
+    CommandStatus.SUCCESS,
+    CommandStatus.FAILED,
+    CommandStatus.SKIPPED,
+    CommandStatus.INTERRUPTED,
+)
+
+# Order in which a tab's aggregate status is decided: the first one present wins.
+AGGREGATE_PRECEDENCE = (
+    CommandStatus.FAILED,
+    CommandStatus.INTERRUPTED,
+    CommandStatus.SKIPPED,
+    CommandStatus.RUNNING,
+    CommandStatus.PENDING,
+)
+
+
+def is_resumable(status: CommandStatus) -> bool:
+    """Should `resume` re-queue a command in this state?
+
+    Everything that did not succeed, `FAILED` included -- you resume precisely
+    because you fixed what failed, so starting after the failure point would
+    skip the command you wanted re-run.
+    """
+    return status is not CommandStatus.SUCCESS
+
+
+def on_load(status: CommandStatus) -> CommandStatus:
+    """Map a persisted status to what it means once the run is reopened.
+
+    Nothing is executing when a run is loaded, so neither `RUNNING` nor
+    `PENDING` can survive as-is: they would leave a tab reporting itself busy
+    forever. Both become terminal, but stay distinguishable -- an interrupted
+    command has (partial) output on disk, a skipped one never started.
+    """
+    if status is CommandStatus.RUNNING:
+        return CommandStatus.INTERRUPTED
+    if status is CommandStatus.PENDING:
+        return CommandStatus.SKIPPED
+    return status

--- a/rbx/box/ui/run_history.py
+++ b/rbx/box/ui/run_history.py
@@ -1,0 +1,250 @@
+"""Persistence for `rbx contest each` / `rbx contest on` command panes.
+
+Every command run in `rbxCommandApp` leaves its final screen on disk, so a
+session can be reopened later with every pane redrawn -- and so the commands
+that did not succeed can be re-queued.
+
+The format is deliberately ANSI text. `Terminal.write()` feeds the very parser
+that built the buffer in the first place, so restoring a pane is a plain write
+and the restored buffer is indistinguishable from a live one -- which is what
+keeps selection and copying working on it, for free.
+"""
+
+import datetime
+import pathlib
+import random
+import string
+from typing import Dict, List, Optional
+
+import yaml
+from pydantic import BaseModel, Field
+
+from rbx.box.ui import command_status
+from rbx.box.ui._vendor.toad.ansi import _ansi as ansi
+from rbx.box.ui.command_status import CommandStatus
+
+MANIFEST_NAME = 'run.yml'
+RUNS_DIR_NAME = 'runs'
+PANE_SUFFIX = '.ansi'
+
+# How many runs to keep on disk. The picker shows fewer; the extra ones are
+# cheap and mean a burst of short runs does not evict everything interesting.
+DEFAULT_KEEP = 10
+PICKER_LIMIT = 5
+
+
+def dump_buffer(buffer: ansi.Buffer) -> str:
+    """Render a terminal buffer's final state back to ANSI text.
+
+    Lines are stored *unfolded*, so the result re-folds to whatever width the
+    pane has when it is restored, rather than being frozen at the width the
+    command happened to run at.
+    """
+    lines: List[str] = []
+    for record in buffer.lines:
+        parts: List[str] = []
+        for text, style in record.content.render(end=''):
+            if not text:
+                continue
+            parts.append(style.rich_style.render(text))
+        lines.append(''.join(parts))
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if not lines:
+        return ''
+    return '\n'.join(lines) + '\n'
+
+
+def to_terminal_input(dumped: str) -> str:
+    """Adapt a dump for writing back into a terminal.
+
+    The file is stored as ordinary text with `\\n`, but a terminal needs the
+    carriage return to get back to column zero.
+    """
+    return dumped.replace('\n', '\r\n')
+
+
+class SubCommandRecord(BaseModel):
+    name: str
+    shell_command: str
+    status: CommandStatus = CommandStatus.PENDING
+    exit_code: Optional[int] = None
+    chained: bool = False
+
+
+class TabRecord(BaseModel):
+    name: str
+    cwd: Optional[str] = None
+    prefix: Optional[str] = None
+    placeholder_prefix: Optional[str] = None
+    labels: Optional[Dict[str, str]] = None
+    sub_commands: List[SubCommandRecord] = Field(default_factory=list)
+
+
+class RunManifest(BaseModel):
+    run_id: str
+    started_at: datetime.datetime
+    updated_at: datetime.datetime
+    contest_id: Optional[str] = None
+    tabs: List[TabRecord] = Field(default_factory=list)
+
+    @property
+    def command_line(self) -> str:
+        """A one-line description of what this run was started to do."""
+        for tab in self.tabs:
+            if tab.sub_commands:
+                return ' :: '.join(sub.name for sub in tab.sub_commands)
+        return ''
+
+    @property
+    def problem_names(self) -> List[str]:
+        return [tab.name for tab in self.tabs]
+
+
+def new_run_id(now: Optional[datetime.datetime] = None) -> str:
+    """A run id that sorts chronologically and cannot collide.
+
+    Two `each` invocations started in the same second must not share a
+    directory, hence the suffix.
+    """
+    now = now or datetime.datetime.now()
+    suffix = ''.join(random.choices(string.ascii_lowercase + string.digits, k=4))
+    return f'{now.strftime("%Y%m%d-%H%M%S")}-{suffix}'
+
+
+class RunHandle:
+    """One run's directory: its manifest plus a file per pane."""
+
+    def __init__(self, path: pathlib.Path, manifest: RunManifest):
+        self.path = path
+        self.manifest = manifest
+
+    @property
+    def run_id(self) -> str:
+        return self.manifest.run_id
+
+    def pane_path(self, tab_index: int, sub_index: int) -> pathlib.Path:
+        return self.path / str(tab_index) / f'{sub_index}{PANE_SUFFIX}'
+
+    def write_pane(self, tab_index: int, sub_index: int, dumped: str) -> None:
+        path = self.pane_path(tab_index, sub_index)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(dumped, encoding='utf-8')
+
+    def read_pane(self, tab_index: int, sub_index: int) -> Optional[str]:
+        path = self.pane_path(tab_index, sub_index)
+        if not path.is_file():
+            return None
+        try:
+            return path.read_text(encoding='utf-8')
+        except OSError:
+            return None
+
+    def clear_pane(self, tab_index: int, sub_index: int) -> None:
+        """Drop a pane's stored output, for a command about to be re-run."""
+        self.pane_path(tab_index, sub_index).unlink(missing_ok=True)
+
+    def save(self) -> None:
+        self.manifest.updated_at = datetime.datetime.now()
+        self.path.mkdir(parents=True, exist_ok=True)
+        data = self.manifest.model_dump(mode='json')
+        (self.path / MANIFEST_NAME).write_text(
+            yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+            encoding='utf-8',
+        )
+
+
+class ContestRunStore:
+    """Run history kept beside the contest, under its cache directory.
+
+    Everything that touches the filesystem lives here, so a future
+    machine-global store -- keeping the last few runs regardless of which
+    contest they came from, as redundancy against a wiped cache -- is another
+    class implementing the same three methods, not a refactor of the app.
+    """
+
+    def __init__(self, root: pathlib.Path):
+        self.root = root
+
+    def _run_path(self, run_id: str) -> pathlib.Path:
+        return self.root / run_id
+
+    def create_run(self, manifest: RunManifest) -> RunHandle:
+        handle = RunHandle(self._run_path(manifest.run_id), manifest)
+        handle.save()
+        return handle
+
+    def open_run(self, run_id: str) -> Optional[RunHandle]:
+        manifest = self._read_manifest(self._run_path(run_id))
+        if manifest is None:
+            return None
+        return RunHandle(self._run_path(run_id), manifest)
+
+    def list_runs(self, limit: Optional[int] = None) -> List[RunManifest]:
+        """Newest first.
+
+        Sorted by `updated_at`, not `started_at`: reopening an old run and
+        adding a command to it should float it back to the top, even though the
+        picker still shows when it originally started.
+        """
+        if not self.root.is_dir():
+            return []
+        manifests: List[RunManifest] = []
+        for entry in self.root.iterdir():
+            if not entry.is_dir():
+                continue
+            manifest = self._read_manifest(entry)
+            if manifest is not None:
+                manifests.append(manifest)
+        manifests.sort(key=lambda m: m.updated_at, reverse=True)
+        if limit is not None:
+            manifests = manifests[:limit]
+        return manifests
+
+    def prune(self, keep: int = DEFAULT_KEEP) -> None:
+        import shutil
+
+        for manifest in self.list_runs()[keep:]:
+            shutil.rmtree(self._run_path(manifest.run_id), ignore_errors=True)
+
+    def _read_manifest(self, path: pathlib.Path) -> Optional[RunManifest]:
+        """A run we cannot parse is skipped, never fatal.
+
+        History is a convenience; a half-written manifest from a killed session
+        must not stop the picker from listing the rest.
+        """
+        manifest_path = path / MANIFEST_NAME
+        if not manifest_path.is_file():
+            return None
+        try:
+            data = yaml.safe_load(manifest_path.read_text(encoding='utf-8'))
+            return RunManifest.model_validate(data)
+        except Exception:
+            return None
+
+
+def manifest_status(manifest: RunManifest) -> CommandStatus:
+    """The one status that best describes a whole run, for the picker."""
+    statuses = {
+        command_status.on_load(sub.status)
+        for tab in manifest.tabs
+        for sub in tab.sub_commands
+    }
+    if not statuses:
+        return CommandStatus.PENDING
+    for status in command_status.AGGREGATE_PRECEDENCE:
+        if status in statuses:
+            return status
+    return CommandStatus.SUCCESS
+
+
+def get_contest_run_store(
+    root: pathlib.Path = pathlib.Path(),
+) -> Optional[ContestRunStore]:
+    """The run store for the contest `root` sits in, if any."""
+    from rbx.box.contest.contest_package import get_contest_cache_dir
+
+    cache_dir = get_contest_cache_dir(root)
+    if cache_dir is None:
+        return None
+    return ContestRunStore(cache_dir / RUNS_DIR_NAME)

--- a/rbx/box/ui/run_picker.py
+++ b/rbx/box/ui/run_picker.py
@@ -1,0 +1,170 @@
+"""Pick a past `each`/`on` session to reopen.
+
+`rbx contest each` / `rbx contest on` with no command to forward mean "show me
+what I ran before" rather than being an error.
+"""
+
+import pathlib
+from typing import List, Optional
+
+from textual.app import ComposeResult
+from textual.widgets import Footer, Header, Label, ListItem, ListView
+
+from rbx import console
+from rbx.box.setter_config import ProblemLabelMode
+from rbx.box.ui import run_history
+from rbx.box.ui.command_status import STATUS_MARKUP
+from rbx.box.ui.main import rbxBaseApp
+
+# The picker's first row: `each` with no args used to open a blank session to
+# type commands into, and reopening history must not cost that.
+NEW_SESSION = '__new__'
+
+NO_HISTORY = 'none'
+NEW_REQUESTED = 'new'
+HANDLED = 'done'
+
+
+def _row_markup(manifest: run_history.RunManifest) -> str:
+    icon = STATUS_MARKUP[run_history.manifest_status(manifest)]
+    when = manifest.started_at.strftime('%Y-%m-%d %H:%M')
+    problems = ', '.join(manifest.problem_names)
+    command = manifest.command_line or '(no commands)'
+    return f'{icon} [b]{when}[/b]  {command}  [dim]{problems}[/dim]'
+
+
+class RunPickerApp(rbxBaseApp):
+    """A list of past runs; selecting one returns its id."""
+
+    TITLE = 'rbx runs'
+    CSS_PATH = 'css/app.tcss'
+    BINDING_GROUP_TITLE = 'Runs'
+    BINDINGS = [
+        ('q', 'quit', 'Quit'),
+        ('escape', 'quit', 'Quit'),
+    ]
+
+    DEFAULT_CSS = """
+    #run-list {
+        height: 1fr;
+        border: solid $accent;
+    }
+    """
+
+    def __init__(self, manifests: List[run_history.RunManifest]):
+        super().__init__()
+        self._manifests = manifests
+        self.selected_run_id: Optional[str] = None
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Footer()
+        yield ListView(
+            ListItem(Label('[b]+ Start a new session[/b]', markup=True)),
+            *[
+                ListItem(Label(_row_markup(manifest), markup=True))
+                for manifest in self._manifests
+            ],
+            id='run-list',
+        )
+
+    def on_mount(self) -> None:
+        run_list = self.query_one('#run-list', ListView)
+        run_list.border_title = 'Recent runs'
+        run_list.border_subtitle = '[b]enter[/b] open  [b]q[/b] quit'
+        run_list.focus()
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        index = event.list_view.index
+        if index is None:
+            return
+        if index == 0:
+            self.selected_run_id = NEW_SESSION
+            self.exit()
+            return
+        # Row 0 is the "new session" entry, so the manifests are offset by one.
+        manifest_index = index - 1
+        if not 0 <= manifest_index < len(self._manifests):
+            return
+        self.selected_run_id = self._manifests[manifest_index].run_id
+        self.exit()
+
+
+def pick_run(manifests: List[run_history.RunManifest]) -> Optional[str]:
+    app = RunPickerApp(manifests)
+    app.run()
+    return app.selected_run_id
+
+
+def entries_from_manifest(manifest: run_history.RunManifest) -> List['CommandEntry']:  # noqa: F821
+    """Rebuild the tabs of a recorded run.
+
+    `argvs` is left empty on purpose: a restored tab takes its sub-commands from
+    the manifest verbatim, never by re-deriving them.
+    """
+    from rbx.box.ui.command_app import CommandEntry
+
+    entries: List[CommandEntry] = []
+    for tab in manifest.tabs:
+        labels = None
+        if tab.labels:
+            labels = {}
+            for raw_mode, label in tab.labels.items():
+                try:
+                    labels[ProblemLabelMode(raw_mode)] = label
+                except ValueError:
+                    continue
+        entries.append(
+            CommandEntry(
+                argvs=[],
+                name=tab.name,
+                cwd=tab.cwd,
+                prefix=tab.prefix,
+                placeholder_prefix=tab.placeholder_prefix,
+                labels=labels or None,
+            )
+        )
+    return entries
+
+
+def open_run_history(
+    problem_names: Optional[List[str]] = None,
+    root: pathlib.Path = pathlib.Path(),
+) -> str:
+    """Show the picker and reopen whatever is chosen.
+
+    Returns `NO_HISTORY` when there is nothing recorded and `NEW_REQUESTED` when
+    the user picked the new-session row -- in both cases the caller falls back to
+    opening a blank session, which is what no-argument `each` has always done.
+    """
+    from rbx.box.ui.command_app import rbxCommandApp
+
+    store = run_history.get_contest_run_store(root)
+    if store is None:
+        return NO_HISTORY
+
+    manifests = store.list_runs()
+    if problem_names is not None:
+        wanted = set(problem_names)
+        manifests = [m for m in manifests if wanted.intersection(m.problem_names)]
+    manifests = manifests[: run_history.PICKER_LIMIT]
+    if not manifests:
+        return NO_HISTORY
+
+    run_id = pick_run(manifests)
+    if run_id is None:
+        return HANDLED
+    if run_id == NEW_SESSION:
+        return NEW_REQUESTED
+
+    handle = store.open_run(run_id)
+    if handle is None:
+        console.console.print(
+            f'[error]Could not read run [item]{run_id}[/item].[/error]'
+        )
+        return HANDLED
+
+    entries = entries_from_manifest(handle.manifest)
+    app = rbxCommandApp(entries, run_handle=handle, restored=True)
+    app.run()
+    return HANDLED

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -594,6 +594,7 @@ class TestContestEach:
     def test_each_without_args_opens_an_empty_app(
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
+        """With no history recorded, a blank session -- the long-standing behaviour."""
         with mock.patch('rbx.box.ui.command_app.start_command_app') as start_app:
             result = runner.invoke(contest_main.app, ['each'])
 
@@ -601,3 +602,55 @@ class TestContestEach:
         (commands,), _ = start_app.call_args
         assert all(command.argvs == [] for command in commands)
         assert all(command.placeholder_prefix == 'rbx' for command in commands)
+
+    def test_each_without_args_offers_the_run_history(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with (
+            mock.patch(
+                'rbx.box.ui.run_picker.open_run_history', return_value='done'
+            ) as history,
+            mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
+        ):
+            result = runner.invoke(contest_main.app, ['each'])
+
+        assert result.exit_code == 0, result.output
+        history.assert_called_once_with(None)
+        # The picker handled it; no session was started behind it.
+        start_app.assert_not_called()
+
+    def test_each_falls_back_to_a_blank_session_when_asked_for_a_new_one(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with (
+            mock.patch('rbx.box.ui.run_picker.open_run_history', return_value='new'),
+            mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
+        ):
+            result = runner.invoke(contest_main.app, ['each'])
+
+        assert result.exit_code == 0, result.output
+        (commands,), _ = start_app.call_args
+        assert all(command.argvs == [] for command in commands)
+
+    def test_on_with_a_selector_and_no_command_filters_the_history(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with mock.patch(
+            'rbx.box.ui.run_picker.open_run_history', return_value='done'
+        ) as history:
+            result = runner.invoke(contest_main.app, ['on', 'A'])
+
+        assert result.exit_code == 0, result.output
+        (problem_names,), _ = history.call_args
+        # The same label the run manifest stores as the tab name, so the filter
+        # matches on exactly what was recorded.
+        assert problem_names == ['A. prob-a']
+
+    def test_on_without_a_selector_and_no_history_explains_itself(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with mock.patch('rbx.box.ui.run_picker.open_run_history', return_value='none'):
+            result = runner.invoke(contest_main.app, ['on'])
+
+        assert result.exit_code == 1
+        assert 'No recorded runs' in result.output

--- a/tests/rbx/box/ui/test_run_history.py
+++ b/tests/rbx/box/ui/test_run_history.py
@@ -167,6 +167,54 @@ async def test_history_is_flushed_as_each_command_finishes(tmp_path):
     assert statuses == [CommandStatus.SUCCESS, CommandStatus.SUCCESS]
 
 
+async def test_quitting_mid_run_keeps_what_was_on_screen(tmp_path):
+    """The unmount dump: a command still running is not lost, only unfinished."""
+    store = _store(tmp_path)
+    handle = _new_handle(store)
+    app = rbxCommandApp(
+        [
+            CommandEntry(
+                argvs=[
+                    [
+                        sys.executable,
+                        '-u',
+                        '-c',
+                        'print("partial"); import time; time.sleep(30)',
+                    ]
+                ],
+                name='a',
+            )
+        ],
+        parallel=True,
+        run_handle=handle,
+    )
+    async with app.run_test() as pilot:
+        for _ in range(200):
+            await pilot.pause()
+            await asyncio.sleep(0.05)
+            panes = list(app.query(CommandPane))
+            if panes and 'partial' in '\n'.join(_buffer_lines(panes[0])):
+                break
+        else:
+            raise AssertionError('command never printed')
+
+    # The app is gone; the still-running command left its output behind.
+    dumped = handle.read_pane(0, 0)
+    assert dumped is not None and 'partial' in dumped
+
+    reopened = store.open_run(handle.run_id)
+    assert reopened is not None
+    assert reopened.manifest.tabs[0].sub_commands[0].status is CommandStatus.RUNNING
+    # ... and reloads as interrupted rather than as something still going.
+    restored = rbxCommandApp(
+        [CommandEntry(argvs=[], name='a')], run_handle=reopened, restored=True
+    )
+    assert (
+        restored._tabs[0].sub_commands[0].status  # noqa: SLF001
+        is CommandStatus.INTERRUPTED
+    )
+
+
 def test_pending_and_running_load_as_terminal_states(tmp_path):
     store = _store(tmp_path)
     handle = _new_handle(store)

--- a/tests/rbx/box/ui/test_run_history.py
+++ b/tests/rbx/box/ui/test_run_history.py
@@ -1,0 +1,332 @@
+"""Tests for persisted `each`/`on` run history (`rbx.box.ui.run_history`).
+
+The format is ANSI text written back through `Terminal.write()`, so most of
+these assert on a *restored* pane behaving like a live one -- that equivalence
+is the whole reason for the format.
+"""
+
+import asyncio
+import datetime
+import pathlib
+import sys
+from typing import List, Optional
+
+import pytest
+
+from rbx.box.ui import clipboard, run_history
+from rbx.box.ui._vendor.toad.widgets.command_pane import CommandPane
+from rbx.box.ui.command_app import CommandEntry, rbxCommandApp
+from rbx.box.ui.command_status import CommandStatus
+
+
+def _print(*lines: str) -> List[str]:
+    body = '\n'.join(f'print({line!r})' for line in lines)
+    return [sys.executable, '-c', body]
+
+
+def _styled(text: str) -> List[str]:
+    """A command that writes SGR colours, so styles have to survive the trip."""
+    return [sys.executable, '-c', f'print("\\x1b[1;31m{text}\\x1b[0m plain")']
+
+
+async def _finished(pilot, app, panes_expected: int = 1) -> List[CommandPane]:
+    for _ in range(200):
+        await pilot.pause()
+        await asyncio.sleep(0.05)
+        panes = list(app.query(CommandPane))
+        if len(panes) == panes_expected and all(
+            p.return_code is not None for p in panes
+        ):
+            return panes
+    raise AssertionError('commands did not finish in time')
+
+
+def _store(tmp_path: pathlib.Path) -> run_history.ContestRunStore:
+    return run_history.ContestRunStore(tmp_path / 'runs')
+
+
+def _new_handle(
+    store: run_history.ContestRunStore, when: Optional[datetime.datetime] = None
+) -> run_history.RunHandle:
+    when = when or datetime.datetime.now()
+    return store.create_run(
+        run_history.RunManifest(
+            run_id=run_history.new_run_id(when), started_at=when, updated_at=when
+        )
+    )
+
+
+def _buffer_lines(pane: CommandPane) -> List[str]:
+    return [line.content.plain for line in pane.state.scrollback_buffer.lines]
+
+
+def _buffer_spans(pane: CommandPane) -> List[list]:
+    return [
+        [(span.start, span.end, str(span.style)) for span in line.content.spans]
+        for line in pane.state.scrollback_buffer.lines
+    ]
+
+
+async def test_pane_output_is_dumped_and_restores_byte_for_byte(tmp_path):
+    """The core round trip: colours and text both survive."""
+    store = _store(tmp_path)
+    handle = _new_handle(store)
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[_styled('HELLO')], name='a')],
+        parallel=True,
+        run_handle=handle,
+    )
+    async with app.run_test() as pilot:
+        (pane,) = await _finished(pilot, app)
+        await pilot.pause()
+        original_lines = _buffer_lines(pane)
+        original_spans = _buffer_spans(pane)
+
+    assert 'HELLO plain' in '\n'.join(original_lines)
+    dumped = handle.read_pane(0, 0)
+    assert dumped is not None and 'HELLO' in dumped
+
+    reopened = store.open_run(handle.run_id)
+    assert reopened is not None
+    restored_app = rbxCommandApp(
+        [CommandEntry(argvs=[], name='a')], run_handle=reopened, restored=True
+    )
+    async with restored_app.run_test() as pilot:
+        for _ in range(100):
+            await pilot.pause()
+            await asyncio.sleep(0.02)
+            panes = list(restored_app.query(CommandPane))
+            if panes and 'HELLO plain' in '\n'.join(_buffer_lines(panes[0])):
+                break
+        (restored,) = list(restored_app.query(CommandPane))
+        assert _buffer_lines(restored) == original_lines
+        assert _buffer_spans(restored) == original_spans
+
+
+@pytest.fixture
+def copied(monkeypatch) -> List[str]:
+    """Record what a pane copies, at the seam the clipboard is written from."""
+    writes: List[str] = []
+    monkeypatch.setattr(clipboard, 'copy', lambda app, text: writes.append(text))
+    return writes
+
+
+async def test_restored_pane_supports_copying(tmp_path, copied):
+    """Selection is why the format is ANSI rather than a bespoke snapshot."""
+    store = _store(tmp_path)
+    handle = _new_handle(store)
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[_print('alpha', 'beta')], name='a')],
+        parallel=True,
+        run_handle=handle,
+    )
+    async with app.run_test() as pilot:
+        await _finished(pilot, app)
+        await pilot.pause()
+
+    reopened = store.open_run(handle.run_id)
+    assert reopened is not None
+    restored_app = rbxCommandApp(
+        [CommandEntry(argvs=[], name='a')], run_handle=reopened, restored=True
+    )
+    async with restored_app.run_test() as pilot:
+        for _ in range(100):
+            await pilot.pause()
+            await asyncio.sleep(0.02)
+            panes = list(restored_app.query(CommandPane))
+            if panes and 'beta' in '\n'.join(_buffer_lines(panes[0])):
+                break
+        (pane,) = list(restored_app.query(CommandPane))
+        restored_app.set_focus(pane)
+        await pilot.pause()
+        # ctrl+y with no selection copies the whole buffer -- of a pane that was
+        # never driven by a process, only written to from disk.
+        await pilot.press('ctrl+y')
+        await pilot.pause()
+        assert copied == ['alpha\nbeta']
+
+
+async def test_history_is_flushed_as_each_command_finishes(tmp_path):
+    """The incremental guarantee: a finished command is on disk immediately."""
+    store = _store(tmp_path)
+    handle = _new_handle(store)
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[_print('one'), _print('two')], name='a')],
+        parallel=True,
+        run_handle=handle,
+    )
+    async with app.run_test() as pilot:
+        await _finished(pilot, app, panes_expected=2)
+        await pilot.pause()
+        assert handle.read_pane(0, 0) is not None
+        assert 'one' in handle.read_pane(0, 0)
+
+    reopened = store.open_run(handle.run_id)
+    assert reopened is not None
+    statuses = [sub.status for sub in reopened.manifest.tabs[0].sub_commands]
+    assert statuses == [CommandStatus.SUCCESS, CommandStatus.SUCCESS]
+
+
+def test_pending_and_running_load_as_terminal_states(tmp_path):
+    store = _store(tmp_path)
+    handle = _new_handle(store)
+    handle.manifest.tabs = [
+        run_history.TabRecord(
+            name='A',
+            sub_commands=[
+                run_history.SubCommandRecord(
+                    name='build', shell_command='true', status=CommandStatus.RUNNING
+                ),
+                run_history.SubCommandRecord(
+                    name='run', shell_command='true', status=CommandStatus.PENDING
+                ),
+            ],
+        )
+    ]
+    handle.save()
+
+    reopened = store.open_run(handle.run_id)
+    assert reopened is not None
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[], name='A')], run_handle=reopened, restored=True
+    )
+    statuses = [sub.status for sub in app._tabs[0].sub_commands]  # noqa: SLF001
+    assert statuses == [CommandStatus.INTERRUPTED, CommandStatus.SKIPPED]
+    # Nothing is executing, so the tab must not report itself busy.
+    assert app._tabs[0].is_idle  # noqa: SLF001
+
+
+def test_only_non_successful_commands_are_resumable(tmp_path):
+    store = _store(tmp_path)
+    handle = _new_handle(store)
+    handle.manifest.tabs = [
+        run_history.TabRecord(
+            name='A',
+            sub_commands=[
+                run_history.SubCommandRecord(
+                    name='ok', shell_command='true', status=CommandStatus.SUCCESS
+                ),
+                run_history.SubCommandRecord(
+                    name='bad', shell_command='false', status=CommandStatus.FAILED
+                ),
+                run_history.SubCommandRecord(
+                    name='never', shell_command='true', status=CommandStatus.SKIPPED
+                ),
+            ],
+        )
+    ]
+    handle.save()
+    reopened = store.open_run(handle.run_id)
+    assert reopened is not None
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[], name='A')], run_handle=reopened, restored=True
+    )
+    resumable = app._resumable_in_tab(0)  # noqa: SLF001
+    assert [sub.name for _, sub in resumable] == ['bad', 'never']
+
+
+async def test_resume_reruns_only_what_did_not_succeed(tmp_path):
+    store = _store(tmp_path)
+    handle = _new_handle(store)
+    app = rbxCommandApp(
+        [
+            CommandEntry(
+                argvs=[_print('first'), ['sh', '-c', 'exit 3']],
+                name='a',
+            )
+        ],
+        parallel=True,
+        run_handle=handle,
+    )
+    async with app.run_test() as pilot:
+        await _finished(pilot, app, panes_expected=2)
+        await pilot.pause()
+        subs = app._tabs[0].sub_commands  # noqa: SLF001
+        assert [s.status for s in subs] == [
+            CommandStatus.SUCCESS,
+            CommandStatus.FAILED,
+        ]
+        assert subs[1].exit_code == 3
+
+        await app._resume_tabs([0])  # noqa: SLF001
+        # Only the failing one was re-queued; the successful one is untouched.
+        assert subs[0].status is CommandStatus.SUCCESS
+        assert subs[1].status is not CommandStatus.FAILED
+        await _finished(pilot, app, panes_expected=2)
+        assert subs[1].status is CommandStatus.FAILED
+
+
+async def test_retry_gives_the_command_a_clean_pane(tmp_path):
+    """`execute()` appends, so a retry must swap the pane, not reuse it."""
+    store = _store(tmp_path)
+    handle = _new_handle(store)
+    app = rbxCommandApp(
+        [CommandEntry(argvs=[_print('only-once')], name='a')],
+        parallel=True,
+        run_handle=handle,
+    )
+    async with app.run_test() as pilot:
+        await _finished(pilot, app)
+        await pilot.pause()
+        sub = app._tabs[0].sub_commands[0]  # noqa: SLF001
+
+        await app._reset_pane(0, 0, sub)  # noqa: SLF001
+        app._enqueue_sub(0, sub)  # noqa: SLF001
+        (pane,) = await _finished(pilot, app)
+        await pilot.pause()
+
+        text = '\n'.join(_buffer_lines(pane))
+        assert text.count('only-once') == 1
+
+
+def test_list_runs_is_newest_first_and_prunes(tmp_path):
+    store = _store(tmp_path)
+    base = datetime.datetime(2026, 8, 28, 10, 0, 0)
+    handles = []
+    for i in range(4):
+        handle = _new_handle(store, base + datetime.timedelta(minutes=i))
+        # `save()` stamps updated_at with the wall clock, so pin it explicitly.
+        handle.manifest.started_at = base + datetime.timedelta(minutes=i)
+        handle.manifest.updated_at = base + datetime.timedelta(minutes=i)
+        handle.path.mkdir(parents=True, exist_ok=True)
+        import yaml
+
+        (handle.path / run_history.MANIFEST_NAME).write_text(
+            yaml.safe_dump(handle.manifest.model_dump(mode='json'), sort_keys=False)
+        )
+        handles.append(handle)
+
+    listed = store.list_runs()
+    assert [m.run_id for m in listed] == [h.run_id for h in reversed(handles)]
+
+    store.prune(keep=2)
+    assert [m.run_id for m in store.list_runs()] == [
+        handles[3].run_id,
+        handles[2].run_id,
+    ]
+
+
+def test_unreadable_run_is_skipped_not_fatal(tmp_path):
+    store = _store(tmp_path)
+    good = _new_handle(store)
+    broken = store.root / 'broken-run'
+    broken.mkdir(parents=True, exist_ok=True)
+    (broken / run_history.MANIFEST_NAME).write_text('{not: valid: yaml')
+
+    listed = store.list_runs()
+    assert [m.run_id for m in listed] == [good.run_id]
+
+
+@pytest.mark.parametrize(
+    'status,expected',
+    [
+        (CommandStatus.SUCCESS, False),
+        (CommandStatus.FAILED, True),
+        (CommandStatus.SKIPPED, True),
+        (CommandStatus.INTERRUPTED, True),
+    ],
+)
+def test_resume_includes_everything_that_did_not_succeed(status, expected):
+    from rbx.box.ui import command_status
+
+    assert command_status.is_resumable(status) is expected


### PR DESCRIPTION
Every command an `each`/`on` session runs now leaves its **final screen** on disk, so a session can be reopened later with every pane redrawn — and the commands that did not succeed can be re-queued.

Design: [`docs/plans/2026-08-28-command-pane-run-history-design.md`](docs/plans/2026-08-28-command-pane-run-history-design.md).

## Why ANSI text

`Terminal.write()` feeds the same stream parser that built the buffer live, so restoring a pane is one write and the restored `Buffer` is indistinguishable from a live one. That is what makes `ctrl+v` select mode, `ctrl+y` and mouse selection work on restored panes **with no code of their own** — a bespoke buffer snapshot would have needed its own reconstruction *and* its own way to keep selection working. The round trip is exact for text and styles alike; `test_run_history.py` pins both.

## What you get

- **`rbx contest each` / `rbx contest on` with no command** open a picker of the 5 most recent runs, newest first, with start timestamps, the command chain, the problems and an aggregate status icon.
- **`r`** retries the command on screen; **`R`** resumes everything not in `SUCCESS` (`FAILED` included — you resume *because* you fixed what failed), scoped through the same `Menu` + `TabSelectorModal` the `!` prompt already uses: this tab / all tabs / selected tabs.
- **History is flushed on every command completion**, plus on unmount, so it is complete up to the last finished command at all times.
- **A reopened session stays live** and writes back into the same run directory.

## Two decisions worth review

**The picker must not cost the blank session.** No-argument `each` already opened an empty app to type into, so the picker's first row is *"Start a new session"*, and a contest with no recorded history skips the picker entirely and opens the blank session as before. `test_each_without_args_opens_an_empty_app` still passes unchanged.

**`RUNNING`/`PENDING` cannot survive a load.** Nothing is executing when a run is opened, so a surviving `PENDING` would leave a tab reporting itself busy forever. `RUNNING` loads as a new **`INTERRUPTED`** status (began, partial output on disk, no exit code) and `PENDING` as `SKIPPED` (never began). Both terminal, and kept distinct because resume treats them differently.

## Notes

- Storage is `<contest root>/.rbx/runs/`, reached only through `ContestRunStore` — so the machine-global fallback store discussed in the design is a second implementation, not a refactor. A cache wipe currently takes history with it.
- `on`'s `problems` argument is now optional; given one, the picker filters to runs whose tab names match.
- Output is re-folded at the current pane width on replay, since lines are stored unfolded.

## Testing

`uv run pytest tests/rbx/box/ui tests/rbx/box/contest tests/rbx/box/completion tests/rbx/box/lazy_cli_test.py` — 1400 passed. Ruff check and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYt7fphdPWTdtiTVEs13y7
