### PR TITLE
revert(packaging): comment out the contest variant prefix

### DIFF
--- a/rbx/box/packaging/packager.py
+++ b/rbx/box/packaging/packager.py
@@ -76,13 +76,15 @@ class BasePackager(ABC):
 
     @classmethod
     def package_basename(cls):
-        """`[<variant>-][<letter>-]<name>`: what this package is called.
+        """`[<letter>-]<name>`: what this package is called.
 
-        A contest variant is a *different contest* that happens to share problem
-        directories with its siblings, so its id is part of the name: without it
-        two variants of the same problem produce the same basename, and whatever
-        consumes it -- an artifact on disk, a remote problem id -- has one
-        variant overwrite the other.
+        The variant prefix is commented out below for now, so two variants of
+        the same problem share a basename again. When it is back, the name is
+        `[<variant>-][<letter>-]<name>`: a contest variant is a *different
+        contest* that happens to share problem directories with its siblings, so
+        its id belongs in the name -- without it whatever consumes the basename
+        -- an artifact on disk, a remote problem id -- has one variant overwrite
+        the other.
 
         A classmethod because `rbx package moj --upload` resolves the remote
         problem id from this *before* the build, and so before there is an
@@ -91,10 +93,12 @@ class BasePackager(ABC):
         pkg = package.find_problem_package_or_die()
         shortname = naming.get_problem_shortname_or_require()
         basename = f'{shortname}-{pkg.name}' if shortname is not None else pkg.name
-        variant_id = naming.get_selected_contest_variant_id()
-        if variant_id is None:
-            return basename
-        return f'{variant_id}-{basename}'
+        # Variant prefix temporarily disabled -- see #798.
+        # variant_id = naming.get_selected_contest_variant_id()
+        # if variant_id is None:
+        #     return basename
+        # return f'{variant_id}-{basename}'
+        return basename
 
     def statement_types(self) -> List[StatementType]:
         return [StatementType.PDF]

--- a/tests/rbx/box/packaging/test_packager_naming.py
+++ b/tests/rbx/box/packaging/test_packager_naming.py
@@ -79,13 +79,19 @@ def _setup_ambiguous_problem(tmp_path: pathlib.Path) -> None:
     os.chdir(tmp_path / 'A')
 
 
+_VARIANT_PREFIX_DISABLED = pytest.mark.skip(
+    reason='The variant prefix is commented out in BasePackager.package_basename.'
+)
+
+
 class TestBasePackagerBasename:
-    """The basename carries the selected contest variant.
+    """The basename would carry the selected contest variant.
 
     A variant is a *different contest* that shares problem directories with its
     siblings, so two variants of a problem would otherwise produce the same
     basename -- and the artifacts and remote ids built from it would overwrite
-    each other.
+    each other. The prefix is currently commented out, so the two tests that
+    assert it are skipped alongside it.
     """
 
     def _base_packager(self) -> PkgPackager:
@@ -95,12 +101,14 @@ class TestBasePackagerBasename:
         packager.testcase_entries = []
         return packager
 
+    @_VARIANT_PREFIX_DISABLED
     def test_prefixes_the_selected_variant(self, tmp_path: pathlib.Path):
         _setup_ambiguous_problem(tmp_path)
         selected_variant_id_var.set('div2')
 
         assert self._base_packager().package_basename() == 'div2-A-prob-a'
 
+    @_VARIANT_PREFIX_DISABLED
     def test_two_variants_of_the_same_problem_differ(self, tmp_path: pathlib.Path):
         _setup_ambiguous_problem(tmp_path)
 


### PR DESCRIPTION
Disables the codepath introduced by #798 without removing it.

`BasePackager.package_basename` returns `[<letter>-]<name>` again; the three lines that prepended the selected contest variant id are commented out in place, and `naming.get_selected_contest_variant_id` is left untouched so re-enabling is a matter of uncommenting.

The two tests that assert the prefix (`test_prefixes_the_selected_variant`, `test_two_variants_of_the_same_problem_differ`) are skipped rather than deleted, for the same reason. The rest of the module still passes: 6 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4ahpaZ3guZrWHuXo9LWXh