### PR TITLE
fix(statements): rewrap monospace math before pandoc for MOJ

### DIFF
--- a/rbx/box/statements/CLAUDE.md
+++ b/rbx/box/statements/CLAUDE.md
@@ -198,6 +198,23 @@ so MOJ's `implicit_figures` does not caption every figure "image"). MOJ renders
 statements by running pandoc over them, so that dialect is the target rather than
 a lossy fallback.
 
+It also fixes up the TeX **before** pandoc runs: `rewrap_monospace_math` turns a
+monospace group holding math (`\texttt{A $a_i$ $t_i$}`, `{\tt ...}`,
+`{\ttfamily ...}`) into a single math span, `$\texttt{A}~a_i~t_i$`. pandoc reads
+`\texttt` into a `Code` inline, which holds a *string* and so cannot contain a
+`Math` node; given one it splits the group into siblings instead, dropping the
+monospace and collapsing the separators to `<code></code>`, so MOJ shows the
+reader `Aa_it_i`. It has to happen on the TeX, not on the AST: there the `Code`
+a `\texttt` left is indistinguishable from the one a `\verb` left (same empty
+attr), and the group boundary is already gone. Every other command in the subset
+(`\textbf`, `\emph`, `\underline`, `\sout`, `\textsc`, `\text{sub,super}script`,
+the size switches, `\href`) reads into a container node that nests `Math` fine
+and is left alone; verbatim regions are skipped wholesale, and a group with
+nested markup, display math or an unbalanced delimiter bails untouched. The
+conversion is **not** scoped into `convert_to_polygon_tex`: Polygon renders real
+LaTeX and handles the original correctly, so this is a pandoc fix on the pandoc
+path, and the PDF build is unaffected.
+
 **The block pipeline and asset resolution live in `export.py`, not in the Polygon
 package.** They used to sit in `packaging/polygon/{statement_block_utils,upload}.py`,
 where no other packager could reach them; `export.py` is the whole pipeline —

--- a/rbx/box/statements/CLAUDE.md
+++ b/rbx/box/statements/CLAUDE.md
@@ -198,9 +198,10 @@ so MOJ's `implicit_figures` does not caption every figure "image"). MOJ renders
 statements by running pandoc over them, so that dialect is the target rather than
 a lossy fallback.
 
-It also fixes up the TeX **before** pandoc runs: `rewrap_monospace_math` turns a
-monospace group holding math (`\texttt{A $a_i$ $t_i$}`, `{\tt ...}`,
-`{\ttfamily ...}`) into a single math span, `$\texttt{A}~a_i~t_i$`. pandoc reads
+It also fixes up the TeX **before** pandoc runs, via `monospace_math.py`:
+`rewrap_monospace_math` turns a monospace group holding math
+(`\texttt{A $a_i$ $t_i$}`, `{\tt ...}`, `{\ttfamily ...}`) into a single math
+span, `$\texttt{A}~a_i~t_i$`. pandoc reads
 `\texttt` into a `Code` inline, which holds a *string* and so cannot contain a
 `Math` node; given one it splits the group into siblings instead, dropping the
 monospace and collapsing the separators to `<code></code>`, so MOJ shows the
@@ -214,6 +215,15 @@ nested markup, display math or an unbalanced delimiter bails untouched. The
 conversion is **not** scoped into `convert_to_polygon_tex`: Polygon renders real
 LaTeX and handles the original correctly, so this is a pandoc fix on the pandoc
 path, and the PDF build is unaffected.
+
+`monospace_math.py` is a **leaf module** — pure text in, text out, no rbx
+imports — so it is exhaustively unit-tested without pandoc or a package on disk
+(`tests/.../test_monospace_math.py`: rewrite and bail-out tables, a
+wrapper × body-shape cross product, and four invariants asserted over every
+case — idempotence, `$`/brace balance *preservation*, and that surrounding prose
+is untouched). Those invariants are load-bearing rather than decorative: the
+balance one caught the rewind bug where an unclosed group duplicated the text
+before it.
 
 **The block pipeline and asset resolution live in `export.py`, not in the Polygon
 package.** They used to sit in `packaging/polygon/{statement_block_utils,upload}.py`,

--- a/rbx/box/statements/markdown_export.py
+++ b/rbx/box/statements/markdown_export.py
@@ -20,9 +20,9 @@ nested contexts in a way a regex over ``![image](`` is not, and it gives any
 later fix a home.
 
 A second defect has to be corrected *before* pandoc runs, on the TeX --
-monospace wrappers holding math (see ``rewrap_monospace_math``). So the output
-here is deliberately **not** what a plain ``pandoc -f latex -t markdown`` would
-produce.
+monospace wrappers holding math, which live in ``monospace_math.py``. So the
+output here is deliberately **not** what a plain ``pandoc -f latex -t markdown``
+would produce.
 
 **The goldens in ``tests/.../testdata/markdown_export`` are pandoc-version
 sensitive.** They record what a specific pandoc emits; a diff there means pandoc
@@ -34,6 +34,7 @@ import re
 from typing import Any, Callable, Optional
 
 from rbx import tooling
+from rbx.box.statements.monospace_math import rewrap_monospace_math
 
 
 class MojGateError(ValueError):
@@ -68,205 +69,6 @@ def _fix_images(node: Any, rewrite_url: Optional[Callable[[str], str]]) -> None:
         return
     for value in node.values():
         _fix_images(value, rewrite_url)
-
-
-# The monospace wrappers pandoc reads into a `Code` inline. A pandoc `Code`
-# holds a *string*, so it cannot contain another inline: given math inside one,
-# pandoc has no node to build and splits the group into siblings instead --
-# `\texttt{A $a_i$ $t_i$}` becomes `Code "A "`, `Math a_i`, `Code " "`,
-# `Math t_i`. The math loses its monospace, and the `Code " "` separators
-# collapse to `<code></code>` in HTML, so MOJ shows the reader `Aa_it_i`.
-#
-# Every OTHER command in the Polygon TeX subset is fine and must be left alone:
-# `\textbf`/`\textit`/`\emph`/`\underline`/`\sout`/`\textsc`/`\textsubscript`/
-# `\textsuperscript`, the size switches and `\href` all read into container
-# nodes (Strong, Emph, Span, Link, ...) that nest `Math` correctly.
-_TEXTTT = r'\\texttt[ \t]*(?=\{)'
-_TT_SWITCH = r'\{[ \t]*\\(?:tt|ttfamily)(?![A-Za-z])[ \t]*'
-
-# Scanned rather than parsed with TexSoup, which rbx uses everywhere else it
-# touches TeX. Three measured reasons, all of them about this transform being
-# whitespace- and adjacency-sensitive in a way TexSoup's node list is not:
-#
-# - `find_all('texttt')` descends INTO `\verb|...|` (the `verbatim` environment
-#   is skipped, `\verb` is not), so the literal-region skip below has to be
-#   rebuilt by hand anyway -- and getting it wrong rewrites literal text.
-# - `.contents` drops the adjacency this needs. `\texttt{100\% $n$}` comes back
-#   as `'100'`, `'\%'`, `$n$` -- indistinguishable from `100 \%` except by
-#   re-reading the raw token's trailing space, which is the position arithmetic
-#   `polygon_utils.convert_to_polygon_tex` already carries `_fill_gap` for.
-# - A `{\tt ...}` switch is not a node at all; it runs to the end of its group,
-#   which is the FONT_SWITCHES/BARRIERS problem `polygon_utils` spends ~40 lines
-#   on.
-#
-# The tree would be the right tool if this ever had to *descend* into nested
-# markup instead of bailing on it. It does not.
-#
-# Regions whose content is literal, where a `$` is a dollar sign rather than
-# math and a `\texttt` is six characters of text. Rewriting inside one would be
-# a corruption, not a fix, so the scanner skips over them wholesale.
-_VERB = r'\\verb\*?(?P<delim>[^*\sA-Za-z])'
-_VERBATIM_ENV = r'\\begin\{(?P<env>verbatim|lstlisting)\}'
-
-_SCAN = re.compile(
-    f'(?P<verb>{_VERB})'
-    f'|(?P<env_open>{_VERBATIM_ENV})'
-    f'|(?P<cmd>{_TEXTTT})'
-    f'|(?P<switch>{_TT_SWITCH})'
-)
-
-# A control word (`\alpha`, `\textbf`) in the text part of a monospace group.
-# Only escaped specials (`\%`, `\_` -- backslash then a NON-letter) survive the
-# move into math mode unchanged, so anything else bails out.
-_CONTROL_WORD = re.compile(r'\\[A-Za-z]')
-
-# Bare characters that mean something different inside math than they did in the
-# text-mode group they came from. Braces are in the set because they open a
-# group or a command argument, which is the nested-markup case.
-_UNSAFE_IN_MATH = frozenset('_^%&#{}~')
-
-
-def _read_group(tex: str, start: int) -> Optional[int]:
-    """Index just past the balanced brace group opening at ``tex[start]``.
-
-    ``None`` when the group never closes -- malformed input rbx passes through
-    untouched rather than guessing where it ended.
-    """
-    depth = 0
-    i = start
-    while i < len(tex):
-        char = tex[i]
-        if char == '\\':
-            i += 2
-            continue
-        if char == '{':
-            depth += 1
-        elif char == '}':
-            depth -= 1
-            if depth == 0:
-                return i + 1
-        i += 1
-    return None
-
-
-def _split_on_math(body: str) -> Optional[list]:
-    """``[(is_math, text), ...]`` for a monospace body, or ``None`` to bail.
-
-    Backslash escapes are consumed as a unit, so an escaped ``\\$`` is text and
-    never opens a math run. Display math and an unclosed ``$`` bail.
-    """
-    runs = []
-    text: list = []
-    i = 0
-    while i < len(body):
-        char = body[i]
-        if char == '\\':
-            if i + 1 >= len(body):
-                return None
-            text.append(body[i : i + 2])
-            i += 2
-            continue
-        if char != '$':
-            text.append(char)
-            i += 1
-            continue
-        if body.startswith('$$', i):
-            return None
-        runs.append((False, ''.join(text)))
-        text = []
-        math: list = []
-        i += 1
-        while i < len(body) and body[i] != '$':
-            if body[i] == '\\':
-                if i + 1 >= len(body):
-                    return None
-                math.append(body[i : i + 2])
-                i += 2
-                continue
-            math.append(body[i])
-            i += 1
-        if i >= len(body):
-            return None
-        runs.append((True, ''.join(math)))
-        i += 1
-    runs.append((False, ''.join(text)))
-    return runs
-
-
-def _rewrap_body(body: str) -> Optional[str]:
-    """One monospace body as a single math span, or ``None`` to leave it alone.
-
-    Each whitespace-separated text word becomes its own ``\\texttt{}`` atom and
-    each math run contributes its body bare; the atoms are joined with ``~``.
-    Math mode discards the spaces the source had, so the tie is what keeps the
-    fields of a token like ``A a_i t_i`` visibly apart.
-    """
-    runs = _split_on_math(body)
-    if runs is None or not any(is_math for is_math, _ in runs):
-        return None
-    atoms = []
-    for is_math, run in runs:
-        if is_math:
-            math = run.strip()
-            if not math:
-                return None
-            atoms.append(math)
-            continue
-        if _CONTROL_WORD.search(run):
-            return None
-        for word in run.split():
-            if _UNSAFE_IN_MATH.intersection(re.sub(r'\\.', '', word)):
-                return None
-            atoms.append(f'\\texttt{{{word}}}')
-    return '$' + '~'.join(atoms) + '$' if atoms else None
-
-
-def rewrap_monospace_math(tex: str) -> str:
-    """Rewrite every monospace group that holds math into a single math span.
-
-    ``\\texttt{A $a_i$ $t_i$}`` -> ``$\\texttt{A}~a_i~t_i$``, which pandoc reads
-    as one ``Math`` inline and renders to a single MathML node -- monospace ``A``
-    included, and with real spacing between the fields. See ``_SCAN`` for why
-    this cannot be done on the AST instead: there, the ``Code`` a ``\\texttt``
-    left is indistinguishable from the one a ``\\verb`` left.
-
-    Conservative by construction: a group with no math, with nested markup, with
-    display math or with an unbalanced delimiter is returned untouched, as is
-    anything inside a verbatim region. Rendering such a group imperfectly is a
-    much smaller failure than mangling it.
-    """
-    out = []
-    i = 0
-    while True:
-        hit = _SCAN.search(tex, i)
-        if hit is None:
-            break
-        out.append(tex[i : hit.start()])
-        if hit.group('verb') is not None:
-            closing = tex.find(hit.group('delim'), hit.end())
-            end = len(tex) if closing < 0 else closing + 1
-            out.append(tex[hit.start() : end])
-            i = end
-            continue
-        if hit.group('env_open') is not None:
-            closing = tex.find(f'\\end{{{hit.group("env")}}}', hit.end())
-            end = len(tex) if closing < 0 else closing + len(hit.group('env')) + 6
-            out.append(tex[hit.start() : end])
-            i = end
-            continue
-        if hit.group('cmd') is not None:
-            end = _read_group(tex, hit.end())
-            body_start = hit.end() + 1
-        else:
-            end = _read_group(tex, hit.start())
-            body_start = hit.end()
-        if end is None:
-            break
-        rewrapped = _rewrap_body(tex[body_start : end - 1])
-        out.append(tex[hit.start() : end] if rewrapped is None else rewrapped)
-        i = end
-    out.append(tex[i:])
-    return ''.join(out)
 
 
 def tex_to_markdown(

--- a/rbx/box/statements/markdown_export.py
+++ b/rbx/box/statements/markdown_export.py
@@ -84,6 +84,24 @@ def _fix_images(node: Any, rewrite_url: Optional[Callable[[str], str]]) -> None:
 _TEXTTT = r'\\texttt[ \t]*(?=\{)'
 _TT_SWITCH = r'\{[ \t]*\\(?:tt|ttfamily)(?![A-Za-z])[ \t]*'
 
+# Scanned rather than parsed with TexSoup, which rbx uses everywhere else it
+# touches TeX. Three measured reasons, all of them about this transform being
+# whitespace- and adjacency-sensitive in a way TexSoup's node list is not:
+#
+# - `find_all('texttt')` descends INTO `\verb|...|` (the `verbatim` environment
+#   is skipped, `\verb` is not), so the literal-region skip below has to be
+#   rebuilt by hand anyway -- and getting it wrong rewrites literal text.
+# - `.contents` drops the adjacency this needs. `\texttt{100\% $n$}` comes back
+#   as `'100'`, `'\%'`, `$n$` -- indistinguishable from `100 \%` except by
+#   re-reading the raw token's trailing space, which is the position arithmetic
+#   `polygon_utils.convert_to_polygon_tex` already carries `_fill_gap` for.
+# - A `{\tt ...}` switch is not a node at all; it runs to the end of its group,
+#   which is the FONT_SWITCHES/BARRIERS problem `polygon_utils` spends ~40 lines
+#   on.
+#
+# The tree would be the right tool if this ever had to *descend* into nested
+# markup instead of bailing on it. It does not.
+#
 # Regions whose content is literal, where a `$` is a dollar sign rather than
 # math and a `\texttt` is six characters of text. Rewriting inside one would be
 # a corruption, not a fix, so the scanner skips over them wholesale.

--- a/rbx/box/statements/markdown_export.py
+++ b/rbx/box/statements/markdown_export.py
@@ -19,6 +19,11 @@ alt text triggers ``implicit_figures`` on MOJ's side, captioning every figure
 nested contexts in a way a regex over ``![image](`` is not, and it gives any
 later fix a home.
 
+A second defect has to be corrected *before* pandoc runs, on the TeX --
+monospace wrappers holding math (see ``rewrap_monospace_math``). So the output
+here is deliberately **not** what a plain ``pandoc -f latex -t markdown`` would
+produce.
+
 **The goldens in ``tests/.../testdata/markdown_export`` are pandoc-version
 sensitive.** They record what a specific pandoc emits; a diff there means pandoc
 changed its Markdown writer, not that the expectation was wrong.
@@ -65,6 +70,187 @@ def _fix_images(node: Any, rewrite_url: Optional[Callable[[str], str]]) -> None:
         _fix_images(value, rewrite_url)
 
 
+# The monospace wrappers pandoc reads into a `Code` inline. A pandoc `Code`
+# holds a *string*, so it cannot contain another inline: given math inside one,
+# pandoc has no node to build and splits the group into siblings instead --
+# `\texttt{A $a_i$ $t_i$}` becomes `Code "A "`, `Math a_i`, `Code " "`,
+# `Math t_i`. The math loses its monospace, and the `Code " "` separators
+# collapse to `<code></code>` in HTML, so MOJ shows the reader `Aa_it_i`.
+#
+# Every OTHER command in the Polygon TeX subset is fine and must be left alone:
+# `\textbf`/`\textit`/`\emph`/`\underline`/`\sout`/`\textsc`/`\textsubscript`/
+# `\textsuperscript`, the size switches and `\href` all read into container
+# nodes (Strong, Emph, Span, Link, ...) that nest `Math` correctly.
+_TEXTTT = r'\\texttt[ \t]*(?=\{)'
+_TT_SWITCH = r'\{[ \t]*\\(?:tt|ttfamily)(?![A-Za-z])[ \t]*'
+
+# Regions whose content is literal, where a `$` is a dollar sign rather than
+# math and a `\texttt` is six characters of text. Rewriting inside one would be
+# a corruption, not a fix, so the scanner skips over them wholesale.
+_VERB = r'\\verb\*?(?P<delim>[^*\sA-Za-z])'
+_VERBATIM_ENV = r'\\begin\{(?P<env>verbatim|lstlisting)\}'
+
+_SCAN = re.compile(
+    f'(?P<verb>{_VERB})'
+    f'|(?P<env_open>{_VERBATIM_ENV})'
+    f'|(?P<cmd>{_TEXTTT})'
+    f'|(?P<switch>{_TT_SWITCH})'
+)
+
+# A control word (`\alpha`, `\textbf`) in the text part of a monospace group.
+# Only escaped specials (`\%`, `\_` -- backslash then a NON-letter) survive the
+# move into math mode unchanged, so anything else bails out.
+_CONTROL_WORD = re.compile(r'\\[A-Za-z]')
+
+# Bare characters that mean something different inside math than they did in the
+# text-mode group they came from. Braces are in the set because they open a
+# group or a command argument, which is the nested-markup case.
+_UNSAFE_IN_MATH = frozenset('_^%&#{}~')
+
+
+def _read_group(tex: str, start: int) -> Optional[int]:
+    """Index just past the balanced brace group opening at ``tex[start]``.
+
+    ``None`` when the group never closes -- malformed input rbx passes through
+    untouched rather than guessing where it ended.
+    """
+    depth = 0
+    i = start
+    while i < len(tex):
+        char = tex[i]
+        if char == '\\':
+            i += 2
+            continue
+        if char == '{':
+            depth += 1
+        elif char == '}':
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return None
+
+
+def _split_on_math(body: str) -> Optional[list]:
+    """``[(is_math, text), ...]`` for a monospace body, or ``None`` to bail.
+
+    Backslash escapes are consumed as a unit, so an escaped ``\\$`` is text and
+    never opens a math run. Display math and an unclosed ``$`` bail.
+    """
+    runs = []
+    text: list = []
+    i = 0
+    while i < len(body):
+        char = body[i]
+        if char == '\\':
+            if i + 1 >= len(body):
+                return None
+            text.append(body[i : i + 2])
+            i += 2
+            continue
+        if char != '$':
+            text.append(char)
+            i += 1
+            continue
+        if body.startswith('$$', i):
+            return None
+        runs.append((False, ''.join(text)))
+        text = []
+        math: list = []
+        i += 1
+        while i < len(body) and body[i] != '$':
+            if body[i] == '\\':
+                if i + 1 >= len(body):
+                    return None
+                math.append(body[i : i + 2])
+                i += 2
+                continue
+            math.append(body[i])
+            i += 1
+        if i >= len(body):
+            return None
+        runs.append((True, ''.join(math)))
+        i += 1
+    runs.append((False, ''.join(text)))
+    return runs
+
+
+def _rewrap_body(body: str) -> Optional[str]:
+    """One monospace body as a single math span, or ``None`` to leave it alone.
+
+    Each whitespace-separated text word becomes its own ``\\texttt{}`` atom and
+    each math run contributes its body bare; the atoms are joined with ``~``.
+    Math mode discards the spaces the source had, so the tie is what keeps the
+    fields of a token like ``A a_i t_i`` visibly apart.
+    """
+    runs = _split_on_math(body)
+    if runs is None or not any(is_math for is_math, _ in runs):
+        return None
+    atoms = []
+    for is_math, run in runs:
+        if is_math:
+            math = run.strip()
+            if not math:
+                return None
+            atoms.append(math)
+            continue
+        if _CONTROL_WORD.search(run):
+            return None
+        for word in run.split():
+            if _UNSAFE_IN_MATH.intersection(re.sub(r'\\.', '', word)):
+                return None
+            atoms.append(f'\\texttt{{{word}}}')
+    return '$' + '~'.join(atoms) + '$' if atoms else None
+
+
+def rewrap_monospace_math(tex: str) -> str:
+    """Rewrite every monospace group that holds math into a single math span.
+
+    ``\\texttt{A $a_i$ $t_i$}`` -> ``$\\texttt{A}~a_i~t_i$``, which pandoc reads
+    as one ``Math`` inline and renders to a single MathML node -- monospace ``A``
+    included, and with real spacing between the fields. See ``_SCAN`` for why
+    this cannot be done on the AST instead: there, the ``Code`` a ``\\texttt``
+    left is indistinguishable from the one a ``\\verb`` left.
+
+    Conservative by construction: a group with no math, with nested markup, with
+    display math or with an unbalanced delimiter is returned untouched, as is
+    anything inside a verbatim region. Rendering such a group imperfectly is a
+    much smaller failure than mangling it.
+    """
+    out = []
+    i = 0
+    while True:
+        hit = _SCAN.search(tex, i)
+        if hit is None:
+            break
+        out.append(tex[i : hit.start()])
+        if hit.group('verb') is not None:
+            closing = tex.find(hit.group('delim'), hit.end())
+            end = len(tex) if closing < 0 else closing + 1
+            out.append(tex[hit.start() : end])
+            i = end
+            continue
+        if hit.group('env_open') is not None:
+            closing = tex.find(f'\\end{{{hit.group("env")}}}', hit.end())
+            end = len(tex) if closing < 0 else closing + len(hit.group('env')) + 6
+            out.append(tex[hit.start() : end])
+            i = end
+            continue
+        if hit.group('cmd') is not None:
+            end = _read_group(tex, hit.end())
+            body_start = hit.end() + 1
+        else:
+            end = _read_group(tex, hit.start())
+            body_start = hit.end()
+        if end is None:
+            break
+        rewrapped = _rewrap_body(tex[body_start : end - 1])
+        out.append(tex[hit.start() : end] if rewrapped is None else rewrapped)
+        i = end
+    out.append(tex[i:])
+    return ''.join(out)
+
+
 def tex_to_markdown(
     tex: str, *, rewrite_image_url: Optional[Callable[[str], str]] = None
 ) -> str:
@@ -79,7 +265,9 @@ def tex_to_markdown(
 
     tooling.PANDOC.ensure()
 
-    ast = json.loads(pypandoc.convert_text(tex, 'json', format='latex'))
+    ast = json.loads(
+        pypandoc.convert_text(rewrap_monospace_math(tex), 'json', format='latex')
+    )
     _fix_images(ast, rewrite_image_url)
     return pypandoc.convert_text(json.dumps(ast), 'markdown', format='json')
 

--- a/rbx/box/statements/monospace_math.py
+++ b/rbx/box/statements/monospace_math.py
@@ -1,0 +1,247 @@
+r"""Monospace TeX groups holding math, rewritten as a single math span.
+
+``\texttt{A $a_i$ $t_i$}`` -> ``$\texttt{A}~a_i~t_i$``.
+
+**The defect this exists for.** pandoc's LaTeX reader maps ``\texttt{...}`` to a
+``Code`` inline, and a pandoc ``Code`` holds a *string*: it cannot contain
+another inline. Given math inside the group pandoc has no node to build, so it
+splits the group into siblings instead::
+
+    \texttt{A $a_i$ $t_i$}  ->  Code "A ", Math a_i, Code " ", Math t_i
+
+The math loses its monospace, and the ``Code " "`` separators collapse to an
+empty ``<code></code>`` in HTML -- so a reader of the rendered statement sees
+the fields glued together as ``Aa_it_i``. Rewriting the group into one math span
+gives pandoc a single ``Math`` inline, which reaches MathML intact: monospace
+``A`` included, with real spacing between the fields.
+
+**Why a scanner and not TexSoup**, which rbx uses everywhere else it touches
+TeX. Three measured reasons, all of them about this transform being whitespace-
+and adjacency-sensitive in a way TexSoup's node list is not:
+
+- ``find_all('texttt')`` descends INTO ``\verb|...|`` (the ``verbatim``
+  environment is skipped, ``\verb`` is not), so the literal-region skip has to
+  be rebuilt by hand anyway -- and getting it wrong rewrites literal text.
+- ``.contents`` drops the adjacency this needs. ``\texttt{100\% $n$}`` comes
+  back as ``'100'``, ``'\%'``, ``$n$`` -- indistinguishable from ``100 \%``
+  except by re-reading the raw token's trailing space, which is the position
+  arithmetic ``polygon_utils.convert_to_polygon_tex`` already carries
+  ``_fill_gap`` for.
+- A ``{\tt ...}`` switch is not a node at all; it runs to the end of its
+  enclosing group, which is the ``FONT_SWITCHES``/``BARRIERS`` problem
+  ``polygon_utils`` spends ~40 lines on.
+
+The tree would be the right tool if this ever had to *descend* into nested
+markup instead of bailing on it. It does not. It also cannot be done on pandoc's
+AST, where the ``Code`` a ``\texttt`` left is indistinguishable from the one a
+``\verb`` left (same empty attr triple) and the group boundary is already gone.
+
+**Conservative by construction.** Every uncertain case is returned untouched:
+rendering a group imperfectly is a much smaller failure than mangling it. The
+module is pure text in, text out, with no rbx imports -- so it is testable, and
+reusable by any other consumer that has to hand TeX to pandoc.
+"""
+
+import re
+from typing import List, Optional, Tuple
+
+# The monospace wrappers pandoc reads into a `Code` inline, in both spellings:
+# the command and the font switch. `convert_to_polygon_tex` does NOT fold the
+# switches into `\texttt`, so both really do reach pandoc.
+#
+# Every OTHER command in the Polygon TeX subset is fine and must be left alone:
+# `\textbf`/`\textit`/`\emph`/`\underline`/`\sout`/`\textsc`/`\textsubscript`/
+# `\textsuperscript`, the size switches and `\href` all read into container
+# nodes (Strong, Emph, Span, Link, ...) that nest `Math` correctly.
+MONOSPACE_COMMANDS = ('texttt',)
+MONOSPACE_SWITCHES = ('tt', 'ttfamily')
+
+# Regions whose content is literal, where a `$` is a dollar sign rather than
+# math and a `\texttt` is nine characters of text. Rewriting inside one would be
+# a corruption, not a fix, so the scanner skips over them wholesale.
+LITERAL_ENVIRONMENTS = ('verbatim', 'lstlisting')
+
+_COMMAND = r'\\(?:%s)[ \t]*(?=\{)' % '|'.join(MONOSPACE_COMMANDS)
+_SWITCH = r'\{[ \t]*\\(?:%s)(?![A-Za-z])[ \t]*' % '|'.join(MONOSPACE_SWITCHES)
+_VERB = r'\\verb\*?(?P<delim>[^*\sA-Za-z])'
+_VERBATIM_ENV = r'\\begin\{(?P<env>%s)\}' % '|'.join(LITERAL_ENVIRONMENTS)
+
+_SCAN = re.compile(
+    f'(?P<verb>{_VERB})'
+    f'|(?P<env_open>{_VERBATIM_ENV})'
+    f'|(?P<cmd>{_COMMAND})'
+    f'|(?P<switch>{_SWITCH})'
+)
+
+# A control word (`\alpha`, `\textbf`) in the text part of a monospace group.
+# Only escaped specials (`\%`, `\_` -- backslash then a NON-letter) survive the
+# move into math mode unchanged, so anything else bails out.
+_CONTROL_WORD = re.compile(r'\\[A-Za-z]')
+
+# An escape sequence, dropped before the unsafe-character check below so that an
+# escaped `\%` is not mistaken for the bare `%` it protects.
+_ESCAPE = re.compile(r'\\.')
+
+# Bare characters that mean something different inside math than they did in the
+# text-mode group they came from. Braces are in the set because they open a
+# group or a command argument, which is the nested-markup case.
+_UNSAFE_IN_MATH = frozenset('_^%&#{}~')
+
+# What the atoms of a rewritten group are joined with. Math mode discards the
+# spaces the source had, so the tie is what keeps the fields of a token like
+# `A a_i t_i` visibly apart.
+_JOINER = '~'
+
+
+def _read_group(tex: str, start: int) -> Optional[int]:
+    """Index just past the balanced brace group opening at ``tex[start]``.
+
+    ``None`` when the group never closes -- malformed input is passed through
+    untouched rather than guessing where it ended.
+    """
+    depth = 0
+    i = start
+    while i < len(tex):
+        char = tex[i]
+        if char == '\\':
+            i += 2
+            continue
+        if char == '{':
+            depth += 1
+        elif char == '}':
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return None
+
+
+def _split_on_math(body: str) -> Optional[List[Tuple[bool, str]]]:
+    r"""``[(is_math, text), ...]`` for a monospace body, or ``None`` to bail.
+
+    Backslash escapes are consumed as a unit, so an escaped ``\$`` is text and
+    never opens a math run. Display math and an unclosed ``$`` bail.
+    """
+    runs: List[Tuple[bool, str]] = []
+    text: List[str] = []
+    i = 0
+    while i < len(body):
+        char = body[i]
+        if char == '\\':
+            if i + 1 >= len(body):
+                return None
+            text.append(body[i : i + 2])
+            i += 2
+            continue
+        if char != '$':
+            text.append(char)
+            i += 1
+            continue
+        if body.startswith('$$', i):
+            return None
+        runs.append((False, ''.join(text)))
+        text = []
+        math: List[str] = []
+        i += 1
+        while i < len(body) and body[i] != '$':
+            if body[i] == '\\':
+                if i + 1 >= len(body):
+                    return None
+                math.append(body[i : i + 2])
+                i += 2
+                continue
+            math.append(body[i])
+            i += 1
+        if i >= len(body):
+            return None
+        runs.append((True, ''.join(math)))
+        i += 1
+    runs.append((False, ''.join(text)))
+    return runs
+
+
+def _rewrap_body(body: str) -> Optional[str]:
+    r"""One monospace body as a single math span, or ``None`` to leave it alone.
+
+    Each whitespace-separated text word becomes its own ``\texttt{}`` atom and
+    each math run contributes its body bare.
+    """
+    runs = _split_on_math(body)
+    if runs is None or not any(is_math for is_math, _ in runs):
+        return None
+    atoms = []
+    for is_math, run in runs:
+        if is_math:
+            math = run.strip()
+            if not math:
+                return None
+            atoms.append(math)
+            continue
+        if _CONTROL_WORD.search(run):
+            return None
+        for word in run.split():
+            if _UNSAFE_IN_MATH.intersection(_ESCAPE.sub('', word)):
+                return None
+            atoms.append(f'\\texttt{{{word}}}')
+    return '$' + _JOINER.join(atoms) + '$' if atoms else None
+
+
+def _skip_literal(tex: str, hit: 're.Match') -> int:
+    """Index just past the literal region ``hit`` opened.
+
+    An unterminated region swallows the rest of the input, which is what LaTeX
+    itself would do with it.
+    """
+    if hit.group('verb') is not None:
+        closing = tex.find(hit.group('delim'), hit.end())
+        return len(tex) if closing < 0 else closing + 1
+    closer = f'\\end{{{hit.group("env")}}}'
+    closing = tex.find(closer, hit.end())
+    return len(tex) if closing < 0 else closing + len(closer)
+
+
+def rewrap_monospace_math(tex: str) -> str:
+    r"""Rewrite every monospace group that holds math into a single math span.
+
+    ``\texttt{A $a_i$ $t_i$}`` -> ``$\texttt{A}~a_i~t_i$``. See the module
+    docstring for why, and for why this is a scanner rather than a parse.
+
+    Returned untouched: a group with no math at all (pandoc renders those
+    perfectly), one with nested markup, display math, an unbalanced delimiter or
+    a bare character that would change meaning in math mode -- and anything
+    inside ``\verb`` or a verbatim environment. Text outside a monospace group
+    is never modified, so this is a no-op on input that has none.
+    """
+    out = []
+    i = 0
+    while True:
+        hit = _SCAN.search(tex, i)
+        if hit is None:
+            break
+        out.append(tex[i : hit.start()])
+        if hit.group('verb') is not None or hit.group('env_open') is not None:
+            end = _skip_literal(tex, hit)
+            out.append(tex[hit.start() : end])
+            i = end
+            continue
+        if hit.group('cmd') is not None:
+            # `\texttt{body}` -- the group opens after the command name.
+            end = _read_group(tex, hit.end())
+            body_start = hit.end() + 1
+        else:
+            # `{\tt body}` -- the group is what the switch is scoped by, so it
+            # opened at the match itself.
+            end = _read_group(tex, hit.start())
+            body_start = hit.end()
+        if end is None:
+            # The group never closes. Everything from the command on is passed
+            # through as-is -- and `i` must be rewound to it, since the text
+            # before it has already been emitted and the tail below starts at
+            # `i`. (Leaving `i` where it was duplicated that text.)
+            i = hit.start()
+            break
+        rewrapped = _rewrap_body(tex[body_start : end - 1])
+        out.append(tex[hit.start() : end] if rewrapped is None else rewrapped)
+        i = end
+    out.append(tex[i:])
+    return ''.join(out)

--- a/tests/rbx/box/statements/test_markdown_export.py
+++ b/tests/rbx/box/statements/test_markdown_export.py
@@ -83,6 +83,63 @@ def test_inline_math_survives_untouched():
 
 
 @pytest.mark.parametrize(
+    ('tex', 'expected'),
+    [
+        # The defect: pandoc's `Code` inline holds a string, so a monospace
+        # group with math in it is split into siblings and the separators
+        # collapse to `<code></code>` on MOJ.
+        ('\\texttt{A $a_i$ $t_i$}', '$\\texttt{A}~a_i~t_i$'),
+        ('\\texttt{T $x_i$}', '$\\texttt{T}~x_i$'),
+        # Both spellings reach pandoc: `convert_to_polygon_tex` does not fold
+        # the font switches into `\texttt`.
+        ('{\\tt A $a_i$ B}', '$\\texttt{A}~a_i~\\texttt{B}$'),
+        ('{\\ttfamily x $y$}', '$\\texttt{x}~y$'),
+        # Escaped specials survive the move into math mode.
+        ('\\texttt{100\\% $n$}', '$\\texttt{100\\%}~n$'),
+        # Only the offending group is touched.
+        (
+            '\\texttt{a $x$} e \\texttt{plain} e $y$',
+            '$\\texttt{a}~x$ e \\texttt{plain} e $y$',
+        ),
+    ],
+)
+def test_monospace_math_is_rewrapped_as_one_math_span(tex, expected):
+    assert markdown_export.rewrap_monospace_math(tex) == expected
+
+
+@pytest.mark.parametrize(
+    'tex',
+    [
+        # No math at all: pandoc renders these perfectly as `Code`.
+        '\\texttt{D}',
+        '{\\tt plain}',
+        'no monospace here',
+        # Verbatim regions are literal -- the `$` is a dollar sign and the
+        # `\texttt` is nine characters of text.
+        '\\verb|A $a_i$ \\texttt{q $z$}|',
+        '\\begin{verbatim}\\texttt{a $b$}\\end{verbatim}',
+        '\\begin{lstlisting}\\texttt{a $b$}\\end{lstlisting}',
+        # Nested markup, display math, unsafe bare characters and unbalanced
+        # delimiters all bail: an imperfect render beats a mangled one.
+        '\\texttt{\\textbf{A} $x$}',
+        '\\texttt{x $$y$$}',
+        '\\texttt{a_b $x$}',
+        '\\texttt{unclosed $x}',
+        '\\texttt{empty $ $}',
+    ],
+)
+def test_rewrap_leaves_everything_else_untouched(tex):
+    assert markdown_export.rewrap_monospace_math(tex) == tex
+
+
+def test_rewrapped_monospace_math_reaches_markdown_as_one_span():
+    """The end-to-end shape MOJ reads back: one `$...$`, no split code spans."""
+    out = markdown_export.tex_to_markdown('\\texttt{A $a_i$ $t_i$} is a reply.')
+    assert '$\\texttt{A}~a_i~t_i$' in out
+    assert '`' not in out
+
+
+@pytest.mark.parametrize(
     'block',
     [
         '## Exemplos\n',

--- a/tests/rbx/box/statements/test_markdown_export.py
+++ b/tests/rbx/box/statements/test_markdown_export.py
@@ -115,7 +115,9 @@ def test_monospace_math_is_rewrapped_as_one_math_span(tex, expected):
         '{\\tt plain}',
         'no monospace here',
         # Verbatim regions are literal -- the `$` is a dollar sign and the
-        # `\texttt` is nine characters of text.
+        # `\texttt` is nine characters of text. The `\verb` case is the one a
+        # TexSoup-based implementation gets wrong: `find_all('texttt')`
+        # descends into `\verb|...|`, though not into `verbatim`.
         '\\verb|A $a_i$ \\texttt{q $z$}|',
         '\\begin{verbatim}\\texttt{a $b$}\\end{verbatim}',
         '\\begin{lstlisting}\\texttt{a $b$}\\end{lstlisting}',

--- a/tests/rbx/box/statements/test_markdown_export.py
+++ b/tests/rbx/box/statements/test_markdown_export.py
@@ -82,58 +82,6 @@ def test_inline_math_survives_untouched():
     assert '$n \\le 10^5$' in out
 
 
-@pytest.mark.parametrize(
-    ('tex', 'expected'),
-    [
-        # The defect: pandoc's `Code` inline holds a string, so a monospace
-        # group with math in it is split into siblings and the separators
-        # collapse to `<code></code>` on MOJ.
-        ('\\texttt{A $a_i$ $t_i$}', '$\\texttt{A}~a_i~t_i$'),
-        ('\\texttt{T $x_i$}', '$\\texttt{T}~x_i$'),
-        # Both spellings reach pandoc: `convert_to_polygon_tex` does not fold
-        # the font switches into `\texttt`.
-        ('{\\tt A $a_i$ B}', '$\\texttt{A}~a_i~\\texttt{B}$'),
-        ('{\\ttfamily x $y$}', '$\\texttt{x}~y$'),
-        # Escaped specials survive the move into math mode.
-        ('\\texttt{100\\% $n$}', '$\\texttt{100\\%}~n$'),
-        # Only the offending group is touched.
-        (
-            '\\texttt{a $x$} e \\texttt{plain} e $y$',
-            '$\\texttt{a}~x$ e \\texttt{plain} e $y$',
-        ),
-    ],
-)
-def test_monospace_math_is_rewrapped_as_one_math_span(tex, expected):
-    assert markdown_export.rewrap_monospace_math(tex) == expected
-
-
-@pytest.mark.parametrize(
-    'tex',
-    [
-        # No math at all: pandoc renders these perfectly as `Code`.
-        '\\texttt{D}',
-        '{\\tt plain}',
-        'no monospace here',
-        # Verbatim regions are literal -- the `$` is a dollar sign and the
-        # `\texttt` is nine characters of text. The `\verb` case is the one a
-        # TexSoup-based implementation gets wrong: `find_all('texttt')`
-        # descends into `\verb|...|`, though not into `verbatim`.
-        '\\verb|A $a_i$ \\texttt{q $z$}|',
-        '\\begin{verbatim}\\texttt{a $b$}\\end{verbatim}',
-        '\\begin{lstlisting}\\texttt{a $b$}\\end{lstlisting}',
-        # Nested markup, display math, unsafe bare characters and unbalanced
-        # delimiters all bail: an imperfect render beats a mangled one.
-        '\\texttt{\\textbf{A} $x$}',
-        '\\texttt{x $$y$$}',
-        '\\texttt{a_b $x$}',
-        '\\texttt{unclosed $x}',
-        '\\texttt{empty $ $}',
-    ],
-)
-def test_rewrap_leaves_everything_else_untouched(tex):
-    assert markdown_export.rewrap_monospace_math(tex) == tex
-
-
 def test_rewrapped_monospace_math_reaches_markdown_as_one_span():
     """The end-to-end shape MOJ reads back: one `$...$`, no split code spans."""
     out = markdown_export.tex_to_markdown('\\texttt{A $a_i$ $t_i$} is a reply.')

--- a/tests/rbx/box/statements/test_monospace_math.py
+++ b/tests/rbx/box/statements/test_monospace_math.py
@@ -1,0 +1,225 @@
+r"""Exhaustive tests for the monospace-group rewrite.
+
+The module is pure text in, text out, so this suite is table-driven and needs no
+fixtures, no pandoc and no package on disk. It is organized around the contract
+in three parts: what gets rewritten, what is deliberately left alone, and the
+invariants that hold over *every* case in the first two tables.
+"""
+
+import itertools
+
+import pytest
+
+from rbx.box.statements import monospace_math
+
+REWRITTEN = [
+    # -- the reported defect, in both of its spellings ---------------------
+    ('\\texttt{A $a_i$ $t_i$}', '$\\texttt{A}~a_i~t_i$'),
+    ('\\texttt{T $x_i$}', '$\\texttt{T}~x_i$'),
+    ('{\\tt A $a_i$ B}', '$\\texttt{A}~a_i~\\texttt{B}$'),
+    ('{\\ttfamily x $y$}', '$\\texttt{x}~y$'),
+    # A switch may be spelled with padding; the group is what scopes it.
+    ('{ \\tt A $x$}', '$\\texttt{A}~x$'),
+    ('\\texttt {A $x$}', '$\\texttt{A}~x$'),
+    # -- where the math sits inside the group ------------------------------
+    ('\\texttt{$x$ A}', '$x~\\texttt{A}$'),
+    ('\\texttt{$x$}', '$x$'),
+    ('\\texttt{$x$$y$}', '$x~y$'),
+    ('\\texttt{A $x$ B $y$ C}', '$\\texttt{A}~x~\\texttt{B}~y~\\texttt{C}$'),
+    # -- whitespace collapses into the tie ---------------------------------
+    ('\\texttt{A   $x$}', '$\\texttt{A}~x$'),
+    ('\\texttt{  A $x$  }', '$\\texttt{A}~x$'),
+    ('\\texttt{A\tB $x$}', '$\\texttt{A}~\\texttt{B}~x$'),
+    # -- escaped specials survive the move into math mode ------------------
+    ('\\texttt{100\\% $n$}', '$\\texttt{100\\%}~n$'),
+    ('\\texttt{a\\_b $n$}', '$\\texttt{a\\_b}~n$'),
+    ('\\texttt{\\$ $n$}', '$\\texttt{\\$}~n$'),
+    ('\\texttt{\\& $n$}', '$\\texttt{\\&}~n$'),
+    # -- math bodies are carried through verbatim --------------------------
+    ('\\texttt{A $a_i + t_i$}', '$\\texttt{A}~a_i + t_i$'),
+    ('\\texttt{A $\\frac{1}{2}$}', '$\\texttt{A}~\\frac{1}{2}$'),
+    ('\\texttt{A $ x $}', '$\\texttt{A}~x$'),
+    # -- only the offending group is touched -------------------------------
+    (
+        '\\texttt{a $x$} e \\texttt{plain} e $y$',
+        '$\\texttt{a}~x$ e \\texttt{plain} e $y$',
+    ),
+    (
+        'antes \\texttt{A $x$} meio \\texttt{B $y$} depois',
+        'antes $\\texttt{A}~x$ meio $\\texttt{B}~y$ depois',
+    ),
+    # A literal region next to a rewritable group does not shield it.
+    (
+        '\\verb|$a$| e \\texttt{A $x$}',
+        '\\verb|$a$| e $\\texttt{A}~x$',
+    ),
+    (
+        '\\begin{verbatim}$a$\\end{verbatim}\n\\texttt{A $x$}',
+        '\\begin{verbatim}$a$\\end{verbatim}\n$\\texttt{A}~x$',
+    ),
+]
+
+UNTOUCHED = [
+    # -- nothing to do -----------------------------------------------------
+    '',
+    'no monospace here',
+    'math alone $x$ stays',
+    '\\texttt{D}',
+    '\\texttt{}',
+    '{\\tt plain}',
+    '\\textbf{A $x$}',  # container node: pandoc nests Math fine
+    '\\emph{A $x$}',
+    '\\href{http://x}{A $x$}',
+    # -- literal regions ---------------------------------------------------
+    # `\verb` is the case a TexSoup-based implementation gets wrong:
+    # `find_all('texttt')` descends into it, though not into `verbatim`.
+    '\\verb|A $a_i$ \\texttt{q $z$}|',
+    '\\verb+\\texttt{q $z$}+',
+    '\\verb*|\\texttt{q $z$}|',
+    '\\begin{verbatim}\\texttt{a $b$}\\end{verbatim}',
+    '\\begin{lstlisting}\\texttt{a $b$}\\end{lstlisting}',
+    # Unterminated literal regions swallow the rest, as LaTeX would.
+    '\\verb|\\texttt{a $b$}',
+    '\\begin{verbatim}\\texttt{a $b$}',
+    # -- bail-outs inside an otherwise rewritable group --------------------
+    '\\texttt{\\textbf{A} $x$}',  # nested markup
+    '\\texttt{\\LaTeX $x$}',  # a control word
+    '\\texttt{{A} $x$}',  # a bare group
+    '\\texttt{x $$y$$}',  # display math
+    '\\texttt{a_b $x$}',  # bare subscript
+    '\\texttt{a^b $x$}',  # bare superscript
+    '\\texttt{50% $x$}',  # bare comment character
+    '\\texttt{a&b $x$}',
+    '\\texttt{a#b $x$}',
+    '\\texttt{a~b $x$}',
+    '\\texttt{unclosed $x}',  # unbalanced math
+    '\\texttt{empty $ $}',  # empty math run
+    '\\texttt{A $x$',  # unbalanced group
+    '{\\tt A $x$',
+    '\\texttt{trailing backslash $x$ \\',
+]
+
+
+@pytest.mark.parametrize(('tex', 'expected'), REWRITTEN, ids=range(len(REWRITTEN)))
+def test_monospace_group_with_math_becomes_one_math_span(tex, expected):
+    assert monospace_math.rewrap_monospace_math(tex) == expected
+
+
+@pytest.mark.parametrize('tex', UNTOUCHED, ids=range(len(UNTOUCHED)))
+def test_everything_else_is_returned_verbatim(tex):
+    assert monospace_math.rewrap_monospace_math(tex) == tex
+
+
+# ---------------------------------------------------------------------------
+# Invariants over the whole corpus.
+# ---------------------------------------------------------------------------
+
+CORPUS = [tex for tex, _ in REWRITTEN] + UNTOUCHED
+
+
+@pytest.mark.parametrize('tex', CORPUS, ids=range(len(CORPUS)))
+def test_rewrite_is_idempotent(tex):
+    """A rewritten group has no monospace-with-math left to rewrite.
+
+    This is what makes the transform safe to apply to a block twice -- and it
+    would fail loudly if a rewritten `$\\texttt{A}~x$` were itself seen as a
+    monospace group holding math.
+    """
+    once = monospace_math.rewrap_monospace_math(tex)
+    assert monospace_math.rewrap_monospace_math(once) == once
+
+
+@pytest.mark.parametrize('tex', CORPUS, ids=range(len(CORPUS)))
+def test_math_delimiters_stay_as_balanced_as_they_came_in(tex):
+    """The rewrite never *introduces* an odd `$`.
+
+    An unbalanced delimiter would swallow the rest of the statement into math
+    mode -- the single worst failure this transform could produce. The corpus
+    includes deliberately malformed input, so the invariant is preservation:
+    input that was balanced stays balanced, input that was not is not made
+    worse.
+    """
+    out = monospace_math.rewrap_monospace_math(tex)
+    assert (out.replace('\\$', '').count('$') % 2) == (
+        tex.replace('\\$', '').count('$') % 2
+    )
+
+
+@pytest.mark.parametrize('tex', CORPUS, ids=range(len(CORPUS)))
+def test_braces_stay_as_balanced_as_they_came_in(tex):
+    def imbalance(text: str) -> int:
+        stripped = text.replace('\\{', '').replace('\\}', '')
+        return stripped.count('{') - stripped.count('}')
+
+    assert imbalance(monospace_math.rewrap_monospace_math(tex)) == imbalance(tex)
+
+
+@pytest.mark.parametrize('tex', CORPUS, ids=range(len(CORPUS)))
+def test_surrounding_text_is_preserved(tex):
+    """Prose bracketing a block survives untouched, wherever the block sits."""
+    out = monospace_math.rewrap_monospace_math(f'antes {tex} depois')
+    assert out.startswith('antes ')
+    assert out.endswith(' depois')
+    assert out[6:-7] == monospace_math.rewrap_monospace_math(tex)
+
+
+def test_a_document_with_no_monospace_is_returned_identical():
+    tex = (
+        'Um paragrafo com $x$ e \\textbf{negrito}, uma lista:\n'
+        '\\begin{itemize}\\item $a_i \\le 10^5$\\end{itemize}\n'
+        'e uma imagem \\includegraphics{fig.png}.\n'
+    )
+    assert monospace_math.rewrap_monospace_math(tex) == tex
+
+
+# ---------------------------------------------------------------------------
+# Generated combinations: every body shape crossed with every wrapper, so a
+# regression in one spelling cannot hide behind another being tested.
+# ---------------------------------------------------------------------------
+
+WRAPPERS = [
+    ('\\texttt{', '}'),
+    ('{\\tt ', '}'),
+    ('{\\ttfamily ', '}'),
+]
+
+BODIES = [
+    ('A $x$', '$\\texttt{A}~x$'),
+    ('$x$ A', '$x~\\texttt{A}$'),
+    ('A $x$ B', '$\\texttt{A}~x~\\texttt{B}$'),
+    ('$x$ $y$', '$x~y$'),
+    ('A\\% $x$', '$\\texttt{A\\%}~x$'),
+]
+
+
+@pytest.mark.parametrize(('wrapper', 'body'), list(itertools.product(WRAPPERS, BODIES)))
+def test_every_wrapper_rewrites_every_body_shape(wrapper, body):
+    opening, closing = wrapper
+    source, expected = body
+    assert monospace_math.rewrap_monospace_math(opening + source + closing) == expected
+
+
+@pytest.mark.parametrize('wrapper', WRAPPERS)
+@pytest.mark.parametrize(
+    'body', ['plain', 'D', 'a_b $x$', '\\textbf{A} $x$', 'x $$y$$']
+)
+def test_every_wrapper_bails_on_every_bad_body(wrapper, body):
+    opening, closing = wrapper
+    tex = opening + body + closing
+    assert monospace_math.rewrap_monospace_math(tex) == tex
+
+
+@pytest.mark.parametrize('count', [1, 2, 5])
+def test_many_groups_in_one_block_are_all_rewritten(count):
+    tex = ' '.join(['\\texttt{A $x$}'] * count)
+    expected = ' '.join(['$\\texttt{A}~x$'] * count)
+    assert monospace_math.rewrap_monospace_math(tex) == expected
+
+
+@pytest.mark.parametrize(
+    'delimiter', ['|', '+', '!', '/', '"', "'", '#', '%', '=', '?']
+)
+def test_verb_is_skipped_whatever_its_delimiter(delimiter):
+    tex = f'\\verb{delimiter}\\texttt{{q $z$}}{delimiter} e \\texttt{{A $x$}}'
+    out = monospace_math.rewrap_monospace_math(tex)
+    assert out == f'\\verb{delimiter}\\texttt{{q $z$}}{delimiter} e $\\texttt{{A}}~x$'

--- a/tests/rbx/box/statements/testdata/markdown_export/texttt_math.md
+++ b/tests/rbx/box/statements/testdata/markdown_export/texttt_math.md
@@ -1,0 +1,9 @@
+Cada amigo enviou uma das seguintes respostas:
+
+- $\texttt{A}~a_i~t_i$: aceitou, chega em $a_i$.
+
+- `D`: recusou.
+
+- $\texttt{T}~x_i$: condicional.
+
+- `A $a_i$` e **`A`**` `$x$ ficam como estão.

--- a/tests/rbx/box/statements/testdata/markdown_export/texttt_math.tex
+++ b/tests/rbx/box/statements/testdata/markdown_export/texttt_math.tex
@@ -1,0 +1,7 @@
+Cada amigo enviou uma das seguintes respostas:
+\begin{itemize}
+    \item \texttt{A $a_i$ $t_i$}: aceitou, chega em $a_i$.
+    \item \texttt{D}: recusou.
+    \item {\tt T $x_i$}: condicional.
+    \item \verb|A $a_i$| e \texttt{\textbf{A} $x$} ficam como estão.
+\end{itemize}


### PR DESCRIPTION
## The defect

`\texttt{A $a_i$ $t_i$}` renders as **`Aa_it_i`** in a MOJ HTML statement — fields glued together, math not monospace.

pandoc's LaTeX reader maps `\texttt{...}` to a **`Code` inline**, and a pandoc `Code` holds a *string*: it cannot contain another inline. Given math inside the group, pandoc has no node to build and splits it into siblings instead:

```
\texttt{A $a_i$ $t_i$}  ->  Code "A ", Math a_i, Code " ", Math t_i
```

which reaches MOJ as

```html
<code>A</code><math…>a_i</math><code></code><math…>t_i</math>
```

The `Code " "` separators collapse to an empty `<code></code>`, and the math loses its monospace. The PDF build is fine — LaTeX has no such restriction — so this only ever shows up on the MOJ side.

## The fix

`rewrap_monospace_math` rewrites such a group into a single math span, on the TeX, before pandoc runs:

```
\texttt{A $a_i$ $t_i$}  ->  $\texttt{A}~a_i~t_i$
{\tt T $x_i$}           ->  $\texttt{T}~x_i$
```

pandoc reads that as one `Math` inline and emits one MathML node — `𝙰` as `<mtext mathvariant="monospace">`, real `<mspace>` between the fields.

**Why not on the AST.** By then the `Code` a `\texttt` left is indistinguishable from the one a `\verb` left (same empty attr triple), and `\verb` content is literal — a `$` there is a dollar sign. Rewrapping it would be a corruption, not a fix. The group boundary is also already gone, so re-merging would be heuristic. On the TeX both facts are available.

## Scope

Only the monospace wrappers are affected. I probed pandoc's AST for every command in `PolygonTeXConfig`:

- **Rewritten:** `\texttt{...}`, `{\tt ...}`, `{\ttfamily ...}` (both spellings reach pandoc — `convert_to_polygon_tex` does not fold the switches into `\texttt`).
- **Left alone, already correct:** `\textbf`→Strong, `\textit`/`\emph`→Emph, `\underline`→Underline, `\sout`→Strikeout, `\textsc`→SmallCaps, `\textsubscript`→Subscript, `\textsuperscript`→Superscript, size switches→Span, `\href`→Link. These are container nodes and nest `Math` fine.
- **Skipped wholesale:** `\verb`, `verbatim`, `lstlisting`.

Conservative by construction — a group with nested markup, display math, unsafe bare characters (`_`, `^`, `%`, braces) or an unbalanced delimiter is returned untouched. Rendering one imperfectly is a much smaller failure than mangling it.

Applied in `tex_to_markdown` only, **not** in `convert_to_polygon_tex`: Polygon renders real LaTeX and handles the original correctly, so this is a pandoc fix on the pandoc path. The pdflatex build is untouched.

## Tests

- New golden pair `testdata/markdown_export/texttt_math.{tex,md}`, covering the fixed cases and the verb/nested-markup bail-outs.
- Unit tests over `rewrap_monospace_math`: 6 rewrite cases, 11 leave-untouched cases, plus an end-to-end assertion that no split code span survives.
- No existing golden contained `texttt`+math, so **nothing had to be regenerated**.

`tests/rbx/box/statements/` (396 passed) and `tests/rbx/box/packaging/moj` (202 passed) are green on pandoc 3.7.0.2, the version the goldens record.

## Follow-ups in this PR

**Extracted to `rbx/box/statements/monospace_math.py`.** `markdown_export.py` is about pandoc; the rewrite is a self-contained TeX transform that merely has to run before pandoc. It is now a leaf module — pure text in, text out, no rbx imports — so it tests without pandoc or a package on disk, and any other consumer handing TeX to pandoc can reuse it.

**Exhaustive suite** in `tests/.../test_monospace_math.py` (319 cases): a rewrite table and a bail-out table, a wrapper × body-shape cross product so no spelling hides behind another, `\verb` across ten delimiters, and four invariants asserted over *every* corpus entry — idempotence, `$`-balance preservation, brace-balance preservation, and surrounding prose left untouched.

**Those invariants found a real bug.** An unclosed monospace group duplicated the text before it: `antes \texttt{A $x$` came back as `antes antes \texttt{A $x$`. On the bail-out path `i` was never rewound to the match start, so the already-emitted prefix was emitted a second time by the tail append. Fixed, with the case pinned in the corpus.

**Considered and rejected: building this on TexSoup** (documented in the module docstring, since it will be asked again). `find_all('texttt')` descends into `\verb|...|` — though not into `verbatim` — so a tree version silently rewrites literal text; `.contents` drops the adjacency the transform runs on (`\texttt{100\% $n$}` is indistinguishable from `100 \%`, yielding `\texttt{100}~\texttt{\%}`); and `{\tt ...}` is not a node at all, but a switch scoped by its enclosing group. The `\verb` test case is now a live guard against that refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9yozrawJLcAjZnfj2bpAN
