### PR TITLE
test(e2e): stop the interactive ML fixture from racing the time limit

### DIFF
--- a/rbx/testdata/problems/interactive/sols/af_ml.cpp
+++ b/rbx/testdata/problems/interactive/sols/af_ml.cpp
@@ -48,14 +48,18 @@ bool read() {
 
 void solve() {
   lf = 1, rg = n;
-  vector<int> was;
+  // Blocks of memory kept alive to grow the RSS of this solution. They are
+  // filled in bulk rather than by a loop of rand() calls: the memory limit
+  // is enforced by sampling RSS and CPU time, and if this solution burned CPU
+  // while allocating it could cross the time limit first and be reported as
+  // TLE instead of ML on a loaded machine. See issue #807.
+  vector<vector<char>> blocks;
   int it = 0;
   while (lf != rg) {
     it++;
     int mid = (lf + rg + 1) / 2;
     if (it > 5)
-      for (int i = 0; i < 10000000; i++)
-        was.pb(rand());
+      blocks.pb(vector<char>(40 * 1024 * 1024, 1));
     cout << mid << endl;
     fflush(stdout);
     string s;

--- a/tests/e2e/testdata/interactive/e2e.rbx.yml
+++ b/tests/e2e/testdata/interactive/e2e.rbx.yml
@@ -18,3 +18,11 @@ scenarios:
             sols/ac.java: ac
             sols/ac.kt: ac
             sols/af_wa.cpp: wa
+            # Pins the memory-limit fixture per test: the bigger tests run
+            # enough binary-search steps for `af_ml.cpp` to allocate past the
+            # 256 MiB limit, the smaller ones do not. Asserting it here keeps
+            # the ML/TLE race of issue #807 from silently coming back.
+            sols/af_ml.cpp:
+              tests/3: ml
+              tests/4: ml
+              tests/5: ml

--- a/tests/e2e/testdata/interactive/sols/af_ml.cpp
+++ b/tests/e2e/testdata/interactive/sols/af_ml.cpp
@@ -48,14 +48,18 @@ bool read() {
 
 void solve() {
   lf = 1, rg = n;
-  vector<int> was;
+  // Blocks of memory kept alive to grow the RSS of this solution. They are
+  // filled in bulk rather than by a loop of rand() calls: the memory limit
+  // is enforced by sampling RSS and CPU time, and if this solution burned CPU
+  // while allocating it could cross the time limit first and be reported as
+  // TLE instead of ML on a loaded machine. See issue #807.
+  vector<vector<char>> blocks;
   int it = 0;
   while (lf != rg) {
     it++;
     int mid = (lf + rg + 1) / 2;
     if (it > 5)
-      for (int i = 0; i < 10000000; i++)
-        was.pb(rand());
+      blocks.pb(vector<char>(40 * 1024 * 1024, 1));
     cout << mid << endl;
     fflush(stdout);
     string s;


### PR DESCRIPTION
Fixes the flaky `tests/e2e/testdata/interactive` scenario reported in #807, where `sols/af_ml.cpp` intermittently came back `TIME_LIMIT_EXCEEDED` instead of the declared `ML`.

## Cause

The fixture grew its RSS with a loop of ten million `rand()` calls per binary-search step. That is genuinely CPU-expensive, so it burned close to the fixture's 1000 ms time limit at roughly the same moment the vector crossed the 256 MiB memory limit.

Memory limits are enforced by sampling (`Program._handle_alarm` polls RSS every 100 ms and CPU time every 300 ms), and `StupidSandbox._get_exit_status` ranks `TO` above `ML`. So whichever threshold the sampler observed first decided the verdict, and on a contended runner that tipped toward CPU.

## Fix

Allocate in bulk blocks (40 MiB per step, kept alive) instead of pushing `rand()` values one at a time. Reaching 360 MiB now costs ~40 ms of CPU rather than ~1 s, so the memory threshold is crossed first with a 25x margin. The scenario shape is preserved: the small tests still finish, the three biggest still hit ML.

The scenario now also pins `sols/af_ml.cpp` per test (`tests/3`, `tests/4`, `tests/5` -> `ml`) so a regression fails with a named verdict mismatch instead of only through the exit code.

`rbx/testdata/problems/interactive/sols/af_ml.cpp` — the package the e2e fixture is a copy of — gets the same change so the two do not drift.

## Verification

- `uv run pytest -m 'e2e and not docker and not pdflatex' -k interactive` — 2 passed (macOS).
- Negative control: flipping `tests/3` to `ac` fails with `expected ACCEPTED, got MLE (memory-limit-exceeded)`, confirming the new assertion bites.
- `uv run pytest tests/rbx/box/runners/test_capabilities.py` — 14 passed (other consumer of the source package).

## Not addressed

The issue's separate observation stands: `_handle_alarm` can kill for CPU and still evaluate the memory check in the same tick, and `_get_exit_status` gives TLE precedence for a program over both limits. Whether ML should win there is a product question, left out of this fixture fix.

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S5ZgSrnrcbsMXy6T3M2oN