### PR TITLE
fix(moj): map MOJ's full per-test verdict vocabulary

### DIFF
--- a/docs/plans/2026-08-21-moj-probe-notes.md
+++ b/docs/plans/2026-08-21-moj-probe-notes.md
@@ -99,6 +99,18 @@ one. Per-test `code` uses the short forms above. `MLE` / `OLE` / `PE` / `JE` wer
 provoked and remain unconfirmed — Task 6's mapping must therefore treat an unknown code as
 *unknown*, not silently coerce it.
 
+### 3c. `RE_NZEC` — observed 2026-08-29, from a user's run
+
+A real `moj testrun` came back with the per-test `code` `RE_NZEC`, and rbx refused it as an
+unknown code, failing the whole run. It is the qualified spelling of the `RE` already in the
+table: a non-zero exit code is a runtime error.
+
+`_OUTCOME_BY_MOJ_CODE` gained the entry, and `_outcome_for_moj_code` reads any `RE_*` code as
+`RUNTIME_ERROR` — the prefix names the family, so unobserved members (`RE_SIGSEGV` and the
+like) carry no guess about the outcome. Everything outside the family is still refused by
+name; the reason for refusing — a wrong outcome silently corrupting the time-limit estimate —
+does not apply to a code that already says it is a runtime error.
+
 ### 3b. `Compilation Error` — observed 2026-08-21, by accident
 
 The first end-to-end `rbx time --runner moj` submitted solutions that did not build on the
@@ -198,7 +210,8 @@ Note this is still not a terminal *failure* `status`: the run above finished `do
 
 - Whether a testrun can reach a terminal **failure** status (a compile error does not: it is
   a `done` run with a run-level verdict — see §3b).
-- The full `code` vocabulary beyond `AC` / `WA` / `RE` / `TLE`.
+- The full `code` vocabulary beyond `AC` / `WA` / `RE` / `RE_NZEC` / `TLE` — in
+  particular, which other members of the `RE_*` family MOJ emits.
 - Whether `testrun` requires a prior calibration (this problem was already calibrated).
 - Whether a submission outside `.moj-meta.json`'s `languages` is really refused.
 - Whether a `TLOVERRIDE`-only `conf` change forces recalibration.

--- a/docs/plans/2026-08-21-moj-probe-notes.md
+++ b/docs/plans/2026-08-21-moj-probe-notes.md
@@ -105,11 +105,48 @@ A real `moj testrun` came back with the per-test `code` `RE_NZEC`, and rbx refus
 unknown code, failing the whole run. It is the qualified spelling of the `RE` already in the
 table: a non-zero exit code is a runtime error.
 
-`_OUTCOME_BY_MOJ_CODE` gained the entry, and `_outcome_for_moj_code` reads any `RE_*` code as
-`RUNTIME_ERROR` — the prefix names the family, so unobserved members (`RE_SIGSEGV` and the
-like) carry no guess about the outcome. Everything outside the family is still refused by
-name; the reason for refusing — a wrong outcome silently corrupting the time-limit estimate —
-does not apply to a code that already says it is a runtime error.
+That prompted the question the probe had left open — what the *rest* of the vocabulary is —
+and it turned out not to need probing at all.
+
+### 3d. The full per-test vocabulary — from the judge's source, 2026-08-29
+
+The codes are not the server's invention: mojtools' `build-and-test.sh` writes
+`VERDICT[<file>]=<code>` into `log.verdictall`, and `calibreitor.sh`'s `sol_tests_json` — the
+same shape the judge agent's `agent_tests_json` produces, as its comment says — parses that
+file straight into `{name, code, time, tl}`. Nothing rewrites the string in between, so
+`run-testinput` **is** the vocabulary:
+
+| `code` | written when | rbx `Outcome` |
+|---|---|---|
+| `AC` | comparator exit 4 | `ACCEPTED` |
+| `AC,PE` | comparator exit 5 | `ACCEPTED` |
+| `WA` | comparator exit 6 | `WRONG_ANSWER` |
+| `MLE` | measured RSS over `MEMLIMITMB` | `MEMORY_LIMIT_EXCEEDED` |
+| `TLE` | exec time over the language's TL | `TIME_LIMIT_EXCEEDED` |
+| `RE` | bwrap exit ≥ 127 | `RUNTIME_ERROR` |
+| `RE_NZEC` | bwrap exit ≠ 0 | `RUNTIME_ERROR` |
+| `TMT` | legacy "signaled PPDI"; still ranked and named, no longer assigned | `RUNTIME_ERROR` |
+| `UE` | comparator exited something else | `JUDGE_FAILED` |
+
+Three notes on the mapping, which is no longer one-to-one:
+
+- **`AC,PE` is a pass.** MOJ scores it as correct (`[[ "$THISVERDICT" =~ "AC" ]]`), ranks it
+  with `AC` in `VERDICTORDER`, and canonicalises it to `Accepted`. rbx has no
+  presentation-error outcome; turning MOJ's pass into a failure would corrupt the estimate in
+  exactly the direction the refusal rule exists to prevent.
+- **`UE` is the comparator, not the solution.** MOJ's `VERDICTCANON` collapses it onto
+  `Runtime Error`; rbx does not follow, because a broken checker reported as the solution's
+  runtime error is the same silent lie in a different costume. `JUDGE_FAILED` says what
+  happened.
+- **`CE` and `NT` stay unmapped, for opposite reasons.** `CE` is real but run-level only
+  (§3b). `NT` ("Não executado") is `gen-report.sh` substituting for a *missing* verdict while
+  rendering HTML — it is never written to `log.verdictall`, so it cannot reach the `code`
+  position; a testcase MOJ said nothing about is already `SKIPPED`.
+
+`_outcome_for_moj_code` still reads any other `RE_*` as `RUNTIME_ERROR`, as a backstop for a
+sibling mojtools might grow — the prefix names the verdict, so the outcome carries no guess.
+Everything else is still refused by name. The invented spellings the earlier table warned
+about (`PE` and `JE` on their own) are now confirmed **not** to exist.
 
 ### 3b. `Compilation Error` — observed 2026-08-21, by accident
 
@@ -210,8 +247,8 @@ Note this is still not a terminal *failure* `status`: the run above finished `do
 
 - Whether a testrun can reach a terminal **failure** status (a compile error does not: it is
   a `done` run with a run-level verdict — see §3b).
-- The full `code` vocabulary beyond `AC` / `WA` / `RE` / `RE_NZEC` / `TLE` — in
-  particular, which other members of the `RE_*` family MOJ emits.
+- ~~The full `code` vocabulary~~ — closed 2026-08-29 by reading mojtools' `run-testinput`;
+  see §3d.
 - Whether `testrun` requires a prior calibration (this problem was already calibrated).
 - Whether a submission outside `.moj-meta.json`'s `languages` is really refused.
 - Whether a `TLOVERRIDE`-only `conf` change forces recalibration.

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -332,10 +332,12 @@ replaced a `ctx.progress.update(...)` that nobody ever saw: every caller exits i
 (three, observed) and answers 429 past that, `moj testrun` cannot pick a judge so two in
 flight may share a machine and inflate each other, and the park is shared with everyone
 else. A 429 is waited out rather than failed -- it cannot be cleared, since `moj` has no
-way to cancel a testrun. The poll is bounded, like `prepare`'s. `_outcome_for_moj_code` maps only the codes actually seen
-(`AC`/`WA`/`RE`/`RE_NZEC`/`TLE`, plus any `RE_*` read as a runtime error by its prefix) and
-**refuses an unrecognised one by name** rather than guessing --
-a wrong verdict silently corrupts the time limit being estimated. A testcase MOJ did not
+way to cancel a testrun. The poll is bounded, like `prepare`'s. `_outcome_for_moj_code` maps MOJ's whole per-test vocabulary,
+read off mojtools' `run-testinput` (`AC`/`AC,PE`/`WA`/`MLE`/`TLE`/`RE`/`RE_NZEC`/`TMT`/`UE`, plus any
+other `RE_*` read as a runtime error by its prefix) and **refuses an unrecognised one by name** rather
+than guessing -- a wrong verdict silently corrupts the time limit being estimated. `AC,PE` is a *pass*
+(MOJ scores it as correct) and `UE` is the comparator failing, so it becomes `JUDGE_FAILED` rather than
+the solution's runtime error. A testcase MOJ did not
 report on becomes `SKIPPED` with no timing (never a zero), and only the `.eval` is written,
 never an empty `.out`.
 

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -332,8 +332,9 @@ replaced a `ctx.progress.update(...)` that nobody ever saw: every caller exits i
 (three, observed) and answers 429 past that, `moj testrun` cannot pick a judge so two in
 flight may share a machine and inflate each other, and the park is shared with everyone
 else. A 429 is waited out rather than failed -- it cannot be cleared, since `moj` has no
-way to cancel a testrun. The poll is bounded, like `prepare`'s. `_OUTCOME_BY_MOJ_CODE` maps only the four codes the probe actually saw
-(`AC`/`WA`/`RE`/`TLE`) and **refuses an unrecognised one by name** rather than guessing --
+way to cancel a testrun. The poll is bounded, like `prepare`'s. `_outcome_for_moj_code` maps only the codes actually seen
+(`AC`/`WA`/`RE`/`RE_NZEC`/`TLE`, plus any `RE_*` read as a runtime error by its prefix) and
+**refuses an unrecognised one by name** rather than guessing --
 a wrong verdict silently corrupts the time limit being estimated. A testcase MOJ did not
 report on becomes `SKIPPED` with no timing (never a zero), and only the `.eval` is written,
 never an empty `.out`.

--- a/rbx/box/runners/moj/runner.py
+++ b/rbx/box/runners/moj/runner.py
@@ -162,8 +162,40 @@ _OUTCOME_BY_MOJ_CODE: Dict[str, Outcome] = {
     'AC': Outcome.ACCEPTED,
     'WA': Outcome.WRONG_ANSWER,
     'RE': Outcome.RUNTIME_ERROR,
+    'RE_NZEC': Outcome.RUNTIME_ERROR,
     'TLE': Outcome.TIME_LIMIT_EXCEEDED,
 }
+
+# The one family MOJ spells out rather than abbreviating: a plain `RE` is not the
+# only runtime error it reports, and `RE_NZEC` -- observed 2026-08-29 from a real
+# testrun, which `rbx time --runner moj` refused as unknown -- is the qualified
+# form of exactly the code already in the table above. Others of the shape
+# (`RE_SIGSEGV` and friends) are unobserved, but the prefix says what they are:
+# `RE_` is the runtime-error family, and every member of it maps to the outcome
+# `RE` already maps to.
+#
+# This is the only inference `_outcome_for_moj_code` makes, and it is bounded on
+# purpose. The reason unknown codes are refused is that a *wrong* outcome silently
+# corrupts the time-limit estimate -- an unmapped slow solution changes the number
+# rbx writes with nothing in the report to say so. Reading `RE_*` as a runtime
+# error cannot be wrong in that way: the prefix already names the verdict, so the
+# outcome carries no guess. A code outside this family still has no reading, and
+# is still refused by name.
+_RUNTIME_ERROR_CODE_PREFIX = 'RE_'
+
+
+def _outcome_for_moj_code(code: str) -> Optional[Outcome]:
+    """The rbx `Outcome` for one MOJ per-test `code`, or `None` if there is none.
+
+    `None` is what `_result_from_status` turns into a refusal that names the code,
+    so an unreadable code stops the run instead of becoming a verdict.
+    """
+    if code in _OUTCOME_BY_MOJ_CODE:
+        return _OUTCOME_BY_MOJ_CODE[code]
+    if code.startswith(_RUNTIME_ERROR_CODE_PREFIX):
+        return Outcome.RUNTIME_ERROR
+    return None
+
 
 # What goes in `TestcaseLog.exitstatus` for a testcase MOJ ran.
 #
@@ -819,7 +851,7 @@ class MojRunner:
             {
                 test.code
                 for test in tests.values()
-                if test.code not in _OUTCOME_BY_MOJ_CODE
+                if _outcome_for_moj_code(test.code) is None
             }
         )
         if unknown:
@@ -827,8 +859,9 @@ class MojRunner:
             raise MojRunnerError(
                 f'MOJ reported the verdict code(s) {listed} for `{solution.path}` '
                 f'in testrun `{run}`, and rbx does not know what they mean.\n'
-                f'Refusing to guess: only `AC`, `WA`, `RE` and `TLE` have ever '
-                f'been seen from a real testrun (see '
+                f'Refusing to guess: only `AC`, `WA`, `RE`, `RE_NZEC` and `TLE` '
+                f'have ever been seen from a real testrun -- plus anything in the '
+                f'`RE_*` runtime-error family, which is read by its prefix (see '
                 f'`docs/plans/2026-08-21-moj-probe-notes.md`), and a code mapped '
                 f'to the wrong outcome would silently corrupt the time limit this '
                 f'run is estimating, with nothing in the report to say so.\n'
@@ -1622,8 +1655,12 @@ def _evaluation_for(
             memory=None,
         )
     else:
+        # Never `None` here: `_result_from_status` refused the whole run before any
+        # evaluation was built if a single code was unreadable.
+        outcome = _outcome_for_moj_code(test.code)
+        assert outcome is not None
         result = CheckerResult(
-            outcome=_OUTCOME_BY_MOJ_CODE[test.code],
+            outcome=outcome,
             # MOJ judges with the packaged checker and hands back a code, never
             # the checker's own words (`reports_checker_messages=False`). Saying
             # where the verdict came from is the useful thing left to say, and it

--- a/rbx/box/runners/moj/runner.py
+++ b/rbx/box/runners/moj/runner.py
@@ -148,39 +148,67 @@ QUEUE_FULL_ATTEMPTS = 40
 # MOJ's per-test `code`, as it lands in `TestrunTest.code`, mapped onto rbx's
 # `Outcome`. Adding a code is one line here and nothing else.
 #
-# **Observed** -- provoked against the live judge and read off the response
-# (`docs/plans/2026-08-21-moj-probe-notes.md`, section 3): all four below. There
-# are no *inferred* entries in this table on purpose. `MLE`, `OLE`, `PE`, `CE` and
-# `JE` are codes MOJ plausibly emits -- it enforces `MEMLIMITMB`, and its checker
-# bridge has a judge-error path -- but plausibly is not observed, and their exact
-# spellings are guesses. An unrecognised code is therefore refused by name (see
-# `MojRunner._submit_and_poll`) rather than mapped: this table feeds a *time
-# limit*, and a wrong verdict there is silent. A solution mis-mapped to ACCEPTED contributes its
-# time to the estimate as if it had passed; one mis-mapped to TIME_LIMIT_EXCEEDED
-# drops out of it. Neither leaves a trace in the report the setter reads.
+# **This is the judge's whole per-test vocabulary**, read off `run-testinput` in
+# mojtools' `build-and-test.sh` (the only writer of `log.verdictall`) and reaching
+# rbx verbatim: `calibreitor.sh`'s `sol_tests_json` -- and the judge agent's
+# `agent_tests_json`, which it says it mirrors -- parse `VERDICT[<file>]=<code>`
+# straight out of that file into `{name, code, time, tl}`. Nothing rewrites the
+# string on the way. `AC` / `WA` / `RE` / `TLE` were also provoked against the live
+# judge (`docs/plans/2026-08-21-moj-probe-notes.md`, section 3) and `RE_NZEC` came
+# off a real user run; the rest are here on the judge's source rather than on an
+# observation, which is a stronger warrant than a guess at a spelling -- the
+# earlier version of this table had invented `PE` and `JE`, and MOJ emits neither.
+#
+# The mappings that are not one-to-one, and why:
+#
+# - `AC,PE` is an *accepted* run in MOJ's own accounting -- it scores as correct
+#   (`[[ "$THISVERDICT" =~ "AC" ]]`), ranks with `AC` in `VERDICTORDER`, and
+#   canonicalises to `Accepted`. rbx has no presentation-error outcome, and
+#   inventing a failure where the judge counted a pass would corrupt the estimate
+#   in the direction this table exists to avoid. The raw code still reaches the
+#   report through the evaluation's message.
+# - `RE_NZEC` ("non-zero return") and `TMT` ("signaled PPDI") are runtime errors
+#   under different names; MOJ's own `VERDICTCANON` collapses both onto
+#   `Runtime Error`.
+# - `UE` ("Unknown ERROR") is what `run-testinput` writes when the *comparator*
+#   exits with something other than accept/PE/WA. That is the checker
+#   misbehaving, not the solution, so it maps to `JUDGE_FAILED` rather than
+#   following `VERDICTCANON`'s collapse onto `Runtime Error`: a broken checker
+#   reported as a solution's runtime error is exactly the silent lie this table
+#   guards against.
+#
+# Deliberately absent: `CE`, which is real but run-level only -- a submission that
+# does not compile never enters the testset, so `tests` comes back empty and
+# `ran_nothing` handles it (probe notes, section 3b) -- and `NT` ("Nao executado"),
+# which `gen-report.sh` substitutes for a *missing* verdict when rendering HTML and
+# which is therefore never written to `log.verdictall` in the first place. A
+# testcase MOJ said nothing about is already handled, as `SKIPPED`, by
+# `_evaluation_for`.
+#
+# An unrecognised code is refused by name (see `MojRunner._submit_and_poll`)
+# rather than mapped: this table feeds a *time limit*, and a wrong verdict there is
+# silent. A solution mis-mapped to ACCEPTED contributes its time to the estimate as
+# if it had passed; one mis-mapped to TIME_LIMIT_EXCEEDED drops out of it. Neither
+# leaves a trace in the report the setter reads.
 _OUTCOME_BY_MOJ_CODE: Dict[str, Outcome] = {
     'AC': Outcome.ACCEPTED,
+    'AC,PE': Outcome.ACCEPTED,
     'WA': Outcome.WRONG_ANSWER,
+    'MLE': Outcome.MEMORY_LIMIT_EXCEEDED,
+    'TLE': Outcome.TIME_LIMIT_EXCEEDED,
     'RE': Outcome.RUNTIME_ERROR,
     'RE_NZEC': Outcome.RUNTIME_ERROR,
-    'TLE': Outcome.TIME_LIMIT_EXCEEDED,
+    'TMT': Outcome.RUNTIME_ERROR,
+    'UE': Outcome.JUDGE_FAILED,
 }
 
-# The one family MOJ spells out rather than abbreviating: a plain `RE` is not the
-# only runtime error it reports, and `RE_NZEC` -- observed 2026-08-29 from a real
-# testrun, which `rbx time --runner moj` refused as unknown -- is the qualified
-# form of exactly the code already in the table above. Others of the shape
-# (`RE_SIGSEGV` and friends) are unobserved, but the prefix says what they are:
-# `RE_` is the runtime-error family, and every member of it maps to the outcome
-# `RE` already maps to.
-#
-# This is the only inference `_outcome_for_moj_code` makes, and it is bounded on
-# purpose. The reason unknown codes are refused is that a *wrong* outcome silently
-# corrupts the time-limit estimate -- an unmapped slow solution changes the number
-# rbx writes with nothing in the report to say so. Reading `RE_*` as a runtime
-# error cannot be wrong in that way: the prefix already names the verdict, so the
-# outcome carries no guess. A code outside this family still has no reading, and
-# is still refused by name.
+# `RE_NZEC` is the only qualified runtime error mojtools writes today, and it is in
+# the table above. The prefix is honoured anyway, as a backstop for a judge that
+# grows a sibling (`RE_SIGSEGV` and the like): `RE_` names the family, so reading a
+# member of it as `RUNTIME_ERROR` cannot produce the silent wrong verdict that
+# refusing unknown codes exists to prevent. It is the only inference
+# `_outcome_for_moj_code` makes; anything outside the family is still refused by
+# name.
 _RUNTIME_ERROR_CODE_PREFIX = 'RE_'
 
 
@@ -856,15 +884,15 @@ class MojRunner:
         )
         if unknown:
             listed = ', '.join(f'`{code}`' for code in unknown)
+            known = ', '.join(f'`{code}`' for code in _OUTCOME_BY_MOJ_CODE)
             raise MojRunnerError(
                 f'MOJ reported the verdict code(s) {listed} for `{solution.path}` '
                 f'in testrun `{run}`, and rbx does not know what they mean.\n'
-                f'Refusing to guess: only `AC`, `WA`, `RE`, `RE_NZEC` and `TLE` '
-                f'have ever been seen from a real testrun -- plus anything in the '
-                f'`RE_*` runtime-error family, which is read by its prefix (see '
-                f'`docs/plans/2026-08-21-moj-probe-notes.md`), and a code mapped '
-                f'to the wrong outcome would silently corrupt the time limit this '
-                f'run is estimating, with nothing in the report to say so.\n'
+                f'Refusing to guess: {known} are the codes mojtools writes, plus '
+                f'anything else in the `RE_*` runtime-error family, and a code '
+                f'mapped to the wrong outcome would silently corrupt the time '
+                f'limit this run is estimating, with nothing in the report to say '
+                f'so.\n'
                 f'If the code is legitimate, add it to `_OUTCOME_BY_MOJ_CODE` in '
                 f'`rbx/box/runners/moj/runner.py`.'
             )

--- a/tests/rbx/box/runners/moj/test_cache.py
+++ b/tests/rbx/box/runners/moj/test_cache.py
@@ -342,7 +342,7 @@ async def test_a_verdict_rbx_could_not_read_is_never_cached(
     ctx = _context(tmp_path, entries=build_entries(tmp_path, ['samples']))
     fake.results['sol.cpp'] = [
         _test(SAMPLE_NAMES[0], 'AC', 0.1),
-        _test(SAMPLE_NAMES[1], 'MLE', 0.2),
+        _test(SAMPLE_NAMES[1], 'PE', 0.2),
     ]
 
     with pytest.raises(MojRunnerError):

--- a/tests/rbx/box/runners/moj/test_run_solution.py
+++ b/tests/rbx/box/runners/moj/test_run_solution.py
@@ -324,6 +324,33 @@ async def test_every_observed_code_maps_to_the_matching_outcome(
     ]
 
 
+async def test_a_qualified_runtime_error_code_maps_to_runtime_error(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """`RE_NZEC` is the qualified spelling of `RE`, observed from a real testrun.
+
+    It used to be refused as unknown, which failed the whole run over a verdict
+    whose own name says what it is. Any `RE_*` reads the same way -- the prefix
+    names the family, so the outcome carries no guess.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+    fake.results['sol.cpp'] = [
+        _test(SAMPLE_NAMES[0], 'RE_NZEC', 0.1),
+        _test(SAMPLE_NAMES[1], 'RE_SIGSEGV', 0.2),
+    ]
+
+    evals = await _run(runner, ctx)
+
+    assert [e.result.outcome for e in evals] == [
+        Outcome.RUNTIME_ERROR,
+        Outcome.RUNTIME_ERROR,
+    ]
+    # The code the judge sent is what gets reported, not the family it fell into.
+    assert 'RE_NZEC' in evals[0].result.message
+
+
 async def test_a_tle_keeps_the_time_it_really_took(testing_pkg, tmp_path, monkeypatch):
     """MOJ reports a TLE's real time, not the limit: 2.81s against a 0.614s `tl`.
 

--- a/tests/rbx/box/runners/moj/test_run_solution.py
+++ b/tests/rbx/box/runners/moj/test_run_solution.py
@@ -304,51 +304,46 @@ async def test_subgroups_of_one_group_are_paired_apart(
     assert len(paths) == 4
 
 
-async def test_every_observed_code_maps_to_the_matching_outcome(
-    testing_pkg, tmp_path, monkeypatch
+@pytest.mark.parametrize(
+    ('code', 'outcome'),
+    [
+        # mojtools' `run-testinput` writes exactly these, and nothing rewrites the
+        # string between `log.verdictall` and `TestrunTest.code`.
+        ('AC', Outcome.ACCEPTED),
+        # Accepted in MOJ's own accounting: it scores as correct and canonicalises
+        # to `Accepted`, so it must not arrive as a failure.
+        ('AC,PE', Outcome.ACCEPTED),
+        ('WA', Outcome.WRONG_ANSWER),
+        ('MLE', Outcome.MEMORY_LIMIT_EXCEEDED),
+        ('TLE', Outcome.TIME_LIMIT_EXCEEDED),
+        ('RE', Outcome.RUNTIME_ERROR),
+        # Used to be refused as unknown, which failed a whole run over a verdict
+        # whose own name says what it is.
+        ('RE_NZEC', Outcome.RUNTIME_ERROR),
+        ('TMT', Outcome.RUNTIME_ERROR),
+        # The *comparator* misbehaved, which is not the solution's runtime error.
+        ('UE', Outcome.JUDGE_FAILED),
+        # Unobserved sibling of the `RE_*` family, read by its prefix.
+        ('RE_SIGSEGV', Outcome.RUNTIME_ERROR),
+    ],
+)
+async def test_every_moj_code_maps_to_the_matching_outcome(
+    code, outcome, testing_pkg, tmp_path, monkeypatch
 ):
-    """`AC` / `WA` / `RE` / `TLE` are the four codes a real testrun has produced."""
-    runner, fake, ctx = await _prepared(testing_pkg, tmp_path, monkeypatch)
-    names = [*SAMPLE_NAMES, *MAIN_NAMES]
-    fake.results['sol.cpp'] = [
-        _test(name, code, 0.5) for name, code in zip(names, ['AC', 'WA', 'RE', 'TLE'])
-    ]
-
-    evals = await _run(runner, ctx)
-
-    assert [e.result.outcome for e in evals] == [
-        Outcome.ACCEPTED,
-        Outcome.WRONG_ANSWER,
-        Outcome.RUNTIME_ERROR,
-        Outcome.TIME_LIMIT_EXCEEDED,
-    ]
-
-
-async def test_a_qualified_runtime_error_code_maps_to_runtime_error(
-    testing_pkg, tmp_path, monkeypatch
-):
-    """`RE_NZEC` is the qualified spelling of `RE`, observed from a real testrun.
-
-    It used to be refused as unknown, which failed the whole run over a verdict
-    whose own name says what it is. Any `RE_*` reads the same way -- the prefix
-    names the family, so the outcome carries no guess.
-    """
+    """MOJ's whole per-test vocabulary, one code at a time."""
     runner, fake, ctx = await _prepared(
         testing_pkg, tmp_path, monkeypatch, groups=['samples']
     )
     fake.results['sol.cpp'] = [
-        _test(SAMPLE_NAMES[0], 'RE_NZEC', 0.1),
-        _test(SAMPLE_NAMES[1], 'RE_SIGSEGV', 0.2),
+        _test(SAMPLE_NAMES[0], code, 0.1),
+        _test(SAMPLE_NAMES[1], 'AC', 0.2),
     ]
 
     evals = await _run(runner, ctx)
 
-    assert [e.result.outcome for e in evals] == [
-        Outcome.RUNTIME_ERROR,
-        Outcome.RUNTIME_ERROR,
-    ]
-    # The code the judge sent is what gets reported, not the family it fell into.
-    assert 'RE_NZEC' in evals[0].result.message
+    assert evals[0].result.outcome == outcome
+    # The code the judge sent is what gets reported, not the outcome it became.
+    assert code in evals[0].result.message
 
 
 async def test_a_tle_keeps_the_time_it_really_took(testing_pkg, tmp_path, monkeypatch):
@@ -373,7 +368,7 @@ async def test_a_tle_keeps_the_time_it_really_took(testing_pkg, tmp_path, monkey
 async def test_an_unknown_code_fails_loudly_and_names_it(
     testing_pkg, tmp_path, monkeypatch
 ):
-    """`MLE`/`OLE`/`PE`/`CE`/`JE` were never provoked, so they are not mapped.
+    """`OLE`/`PE`/`JE` are spellings MOJ does not write, so they have no reading.
 
     A code guessed into a plausible `Outcome` corrupts the time-limit estimate
     with nothing in the report to say so -- an unmapped slow solution silently
@@ -385,15 +380,16 @@ async def test_an_unknown_code_fails_loudly_and_names_it(
     )
     fake.results['sol.cpp'] = [
         _test(SAMPLE_NAMES[0], 'AC', 0.1),
-        _test(SAMPLE_NAMES[1], 'MLE', 0.2),
+        _test(SAMPLE_NAMES[1], 'PE', 0.2),
     ]
 
     with pytest.raises(MojRunnerError) as exc:
         await _run(runner, ctx)
 
     message = str(exc.value)
-    assert 'MLE' in message
-    assert '2026-08-21-moj-probe-notes' in message
+    assert 'PE' in message
+    # The codes rbx *does* know are listed, so the fix is visible from the error.
+    assert 'RE_NZEC' in message
     # Plain text: `main.py` bare-prints `str(e)`.
     assert '[item]' not in message and '[error]' not in message
 
@@ -942,7 +938,7 @@ async def test_a_solution_nobody_waits_for_does_not_haunt_the_run_later(
         _test(SAMPLE_NAMES[1], 'AC', 0.2),
     ]
     # The abandoned one fails, which is the case that leaves a trace.
-    fake.results['other.cpp'] = [_test(SAMPLE_NAMES[0], 'MLE', 0.1)]
+    fake.results['other.cpp'] = [_test(SAMPLE_NAMES[0], 'PE', 0.1)]
 
     first = runner.run_solution(ctx.skeleton.solutions[0], ctx.skeleton.entries, ctx)
     abandoned = runner.run_solution(
@@ -980,7 +976,7 @@ async def test_an_abandoned_failure_is_not_reported_out_of_the_garbage_collector
         groups=['samples'],
         solutions=[('sol.cpp', ExpectedOutcome.ACCEPTED)],
     )
-    fake.results['sol.cpp'] = [_test(SAMPLE_NAMES[0], 'MLE', 0.1)]
+    fake.results['sol.cpp'] = [_test(SAMPLE_NAMES[0], 'PE', 0.1)]
 
     loop = asyncio.get_running_loop()
     reported: List[dict] = []


### PR DESCRIPTION
MOJ returns per-test verdict codes rbx did not know how to read, and an unrecognised code fails the whole testrun by design — so `rbx time --runner moj` aborted on `RE_NZEC`, the judge's spelling for "non-zero return".

Rather than patch that one code, this maps MOJ's **whole** per-test vocabulary, taken from the judge's source instead of from guesses. mojtools' `build-and-test.sh` (`run-testinput`) is the only writer of `log.verdictall`, and `calibreitor.sh`'s `sol_tests_json` — the same shape the judge agent's `agent_tests_json` produces, as its own comment says — parses `VERDICT[<file>]=<code>` straight out of that file into `{name, code, time, tl}`. Nothing rewrites the string in between, so `run-testinput` *is* the vocabulary. rbx knew five of its nine codes.

| `code` | written when | rbx `Outcome` | |
|---|---|---|---|
| `AC` | comparator exit 4 | `ACCEPTED` | already mapped |
| `AC,PE` | comparator exit 5 | `ACCEPTED` | **new** |
| `WA` | comparator exit 6 | `WRONG_ANSWER` | already mapped |
| `MLE` | measured RSS over `MEMLIMITMB` | `MEMORY_LIMIT_EXCEEDED` | **new** |
| `TLE` | exec time over the language's TL | `TIME_LIMIT_EXCEEDED` | already mapped |
| `RE` | bwrap exit ≥ 127 | `RUNTIME_ERROR` | already mapped |
| `RE_NZEC` | bwrap exit ≠ 0 | `RUNTIME_ERROR` | **new** — the reported bug |
| `TMT` | legacy "signaled PPDI"; still ranked and named, no longer assigned | `RUNTIME_ERROR` | **new** |
| `UE` | comparator exited something else | `JUDGE_FAILED` | **new** |

Two mappings are deliberately not one-to-one:

- **`AC,PE` is a pass.** MOJ scores it as correct (`[[ "$THISVERDICT" =~ "AC" ]]`), ranks it with `AC` in `VERDICTORDER`, and canonicalises it to `Accepted`. rbx has no presentation-error outcome, and turning MOJ's pass into a failure would corrupt the time-limit estimate in exactly the direction the refuse-unknown-codes rule exists to prevent.
- **`UE` is the comparator, not the solution.** MOJ's own `VERDICTCANON` collapses it onto `Runtime Error`; rbx does not follow, because a broken checker reported as the solution's runtime error is the same silent lie in a different costume. `JUDGE_FAILED` says what actually happened.

Left unmapped on purpose, for opposite reasons: `CE` is real but **run-level only** — a submission that does not compile never enters the testset, so `tests` comes back empty and `ran_nothing` already handles it — and `NT` ("Não executado") is what `gen-report.sh` substitutes for a *missing* verdict while rendering HTML, so it is never written to `log.verdictall` and cannot reach the `code` position at all. A testcase MOJ said nothing about is already `SKIPPED`.

`_outcome_for_moj_code` also reads any other `RE_*` code as `RUNTIME_ERROR`, as a backstop should mojtools grow a sibling: the prefix names the verdict, so the outcome carries no guess. Everything outside that family is still refused by name, and the refusal message now lists the codes rbx knows from the table rather than a hardcoded four.

Incidentally confirmed: `PE` and `JE` on their own, which the old comment guessed MOJ "plausibly emits", do not exist.

## Tests

- The mapping test is now parametrized over all nine codes plus an unobserved `RE_*` sibling, asserting both the outcome and that the raw code still reaches the evaluation's message.
- Three tests that used `MLE` purely as "a code rbx refuses" now use `PE`, a spelling MOJ really does not write — including the cache test pinning that an unreadable verdict is never cached.
- `uv run pytest tests/rbx/box/runners/moj tests/rbx/box/packaging` → 592 passed, 6 skipped. `ruff check` / `format` clean.

## Docs

`docs/plans/2026-08-21-moj-probe-notes.md` gains §3c (the `RE_NZEC` sighting) and §3d (the full vocabulary table and its provenance), and closes the "full `code` vocabulary" item that section left open. `rbx/box/CLAUDE.md` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vnEBbwTt6EzPUX69t9BNs
