### PR TITLE
feat(time): run the remaining solutions with --run-all, and add rbx preship

### DIFF
--- a/docs/setters/profiling/estimating.md
+++ b/docs/setters/profiling/estimating.md
@@ -187,10 +187,10 @@ verdict. It applies to this stage only, it is for quick experimentation, and the
 its timing summary under it — a solution that stopped early was not timed on the testcases that
 never ran.
 
-### `rbx check`
+### `rbx preship`
 
 ```bash
-rbx check      # alias: rbx ck
+rbx preship
 ```
 
 `rbx time --auto --run-all` under a name that says what it is for: estimate the limit, check it,

--- a/docs/setters/profiling/estimating.md
+++ b/docs/setters/profiling/estimating.md
@@ -20,6 +20,9 @@ A run moves through four stages, and the middle two are where your attention is 
 4. **Checking.** Each solution you declared too slow is run against the limit, to confirm it
    really is. See [Checking the upper bound](#checking-the-upper-bound).
 
+A fifth stage runs the solutions none of these needed, but only if you
+[ask for it](#checking-the-rest-of-the-package).
+
 The solutions declared too slow are not timed in stage 1. Nobody needs to know *how* slow they
 are, only that they are slow enough, which stage 4 settles far more cheaply.
 
@@ -163,6 +166,37 @@ That makes it the flag to reach for when the question is whether the estimation 
 a ratio you just changed, a solution you just declared too slow, a remote judge you are trying
 for the first time — rather than what limit to commit to. It applies to every strategy, and to
 `--integrate` as well, which leaves `problem.rbx.yml` untouched under it.
+
+## Checking the rest of the package
+
+The four stages above run only the solutions the limit depends on: the accepted ones, and the
+slow ones the check had to ask about. Everything else — the solutions you expect to be wrong,
+and any slow one the check could skip — has no verdict at all when the run ends.
+
+```bash
+rbx time --run-all
+```
+
+A fifth stage then runs exactly those, at the limit that was just written, and the command
+fails if any of them does not behave as `problem.rbx.yml` says it does. The solutions that
+already ran are not run again: an accepted one was measured under a far looser cap, and a slow
+one timed out at a bound above the limit, so both answers already hold.
+
+Add `--fail-fast` (or `--ff`) to stop each of those solutions at its first non-accepted
+verdict. It applies to this stage only, it is for quick experimentation, and the report drops
+its timing summary under it — a solution that stopped early was not timed on the testcases that
+never ran.
+
+### `rbx check`
+
+```bash
+rbx check      # alias: rbx ck
+```
+
+`rbx time --auto --run-all` under a name that says what it is for: estimate the limit, check it,
+and check every solution against it. It takes the rest of `rbx time`'s flags — `--dry`,
+`--runs`, `--profile`, `--runner`, `--skip-slow`, `--fail-fast`, `--share` — but not the ones
+`--auto` settles (`--strategy`, `--integrate`).
 
 ## Sharing the report
 

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -175,6 +175,33 @@ rbx time [OPTIONS]
 | `--share` | TEXT | Capture the time report (run report + limits table) and copy it to the clipboard. Pass a format: --share png or --share text. | - |
 | `--skip-slow` | BOOLEAN | Skip checking the estimated limit against the solutions expected to be too slow. The limit is written with its upper bound unchecked. | `False` |
 | `--dry` | BOOLEAN | Run the whole estimation but write nothing to the disk: the limits profile is printed instead of saved. | `False` |
+| `--run-all` | BOOLEAN | After the estimation, also run every solution it did not need -- the ones expected to be wrong, and any slow one that was never checked -- against the estimated time limit. | `False` |
+| `--fail-fast`, `--ff` | BOOLEAN | Whether to stop running a solution as soon as it gets a non-accepted verdict. Applies only to the solutions run after the estimation, and is only meant for quick experimentation, as the remaining tests are reported as failed. | `False` |
+
+
+---
+
+## check (ck)
+
+Estimate a time limit and check the whole package against it: every solution is run, and every one of them has to behave as problem.rbx.yml says it does.
+
+**Usage:**
+```bash
+rbx check [OPTIONS]
+```
+
+| Name | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `--check` | BOOLEAN | Whether to not build outputs for tests and run checker. | `True` |
+| `--validate` | BOOLEAN | Whether to not validate outputs for tests. | `True` |
+| `--detailed`, `-d` | BOOLEAN | Whether to print a detailed view of the tests using tables. | `False` |
+| `--runs`, `-r` | INTEGER | Number of runs to perform for each solution. Zero means the config default. | `0` |
+| `--profile`, `-p` | TEXT | Profile to use for time limit estimation. | `local` |
+| `--runner` | TEXT | Where to run the solutions being timed (local, moj). | `local` |
+| `--share` | TEXT | Capture the time report (run report + limits table) and copy it to the clipboard. Pass a format: --share png or --share text. | - |
+| `--skip-slow` | BOOLEAN | Skip checking the estimated limit against the solutions expected to be too slow. The limit is written with its upper bound unchecked. | `False` |
+| `--dry` | BOOLEAN | Run the whole estimation but write nothing to the disk: the limits profile is printed instead of saved. | `False` |
+| `--fail-fast`, `--ff` | BOOLEAN | Whether to stop running a solution as soon as it gets a non-accepted verdict. Applies only to the solutions run after the estimation, and is only meant for quick experimentation, as the remaining tests are reported as failed. | `False` |
 
 
 ---

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -181,13 +181,13 @@ rbx time [OPTIONS]
 
 ---
 
-## check (ck)
+## preship
 
 Estimate a time limit and check the whole package against it: every solution is run, and every one of them has to behave as problem.rbx.yml says it does.
 
 **Usage:**
 ```bash
-rbx check [OPTIONS]
+rbx preship [OPTIONS]
 ```
 
 | Name | Type | Description | Default |

--- a/rbx/box/cli/__init__.py
+++ b/rbx/box/cli/__init__.py
@@ -74,6 +74,16 @@ _COMMANDS = [
         rich_help_panel='Testing',
     ),
     LazyCommand(
+        'check, ck',
+        'rbx.box.cli.commands.time_cmd:app',
+        help=(
+            'Estimate a time limit and check the whole package against it: every '
+            'solution is run, and every one of them has to behave as '
+            'problem.rbx.yml says it does.'
+        ),
+        rich_help_panel='Testing',
+    ),
+    LazyCommand(
         'irun, ir',
         'rbx.box.cli.commands.run:app',
         help='Build and run solution(s) by passing testcases in the CLI.',

--- a/rbx/box/cli/__init__.py
+++ b/rbx/box/cli/__init__.py
@@ -74,7 +74,7 @@ _COMMANDS = [
         rich_help_panel='Testing',
     ),
     LazyCommand(
-        'check, ck',
+        'preship',
         'rbx.box.cli.commands.time_cmd:app',
         help=(
             'Estimate a time limit and check the whole package against it: every '

--- a/rbx/box/cli/commands/time_cmd.py
+++ b/rbx/box/cli/commands/time_cmd.py
@@ -1,11 +1,11 @@
-"""`rbx time`.
+"""`rbx time` and `rbx check`.
 
 Registered lazily from `rbx.box.cli.ENTRIES`, so this module is imported
 only when one of its commands is invoked. A command added here needs a row
 there too.
 """
 
-from typing import Optional
+from typing import Annotated, Optional
 
 import syncer
 import typer
@@ -23,62 +23,46 @@ from rbx.box.runners import registry as runners_registry
 
 app = typer.Typer(cls=annotations.AliasGroup)
 
-
-@app.command(
-    'time, t',
-    rich_help_panel='Testing',
-    help='Estimate a time limit for the problem using the timings of its solutions and the estimation strategy configured in the environment.',
-)
-@package.within_problem
-@syncer.sync
-async def time(
-    check: bool = typer.Option(
-        True,
-        help='Whether to not build outputs for tests and run checker.',
-    ),
-    validate: bool = typer.Option(
-        True,
-        help='Whether to not validate outputs for tests.',
-    ),
-    detailed: bool = typer.Option(
-        False,
+# The options `rbx time` and `rbx check` share. Declared once, as annotated
+# types, because the two commands differ only in which of them they *offer*:
+# spelling each option twice would leave two help strings to keep in step, and
+# the completion spec is generated from them.
+_Check = Annotated[
+    bool,
+    typer.Option(help='Whether to not build outputs for tests and run checker.'),
+]
+_Validate = Annotated[
+    bool,
+    typer.Option(help='Whether to not validate outputs for tests.'),
+]
+_Detailed = Annotated[
+    bool,
+    typer.Option(
         '--detailed',
         '-d',
         help='Whether to print a detailed view of the tests using tables.',
     ),
-    strategy: Optional[str] = typer.Option(
-        None,
-        '--strategy',
-        '-s',
-        help='Strategy to use for time limit estimation (estimate, inherit, estimate_custom, custom).',
-    ),
-    auto: bool = typer.Option(
-        False,
-        '--auto',
-        '-a',
-        help='Whether to automatically estimate the time limit.',
-    ),
-    runs: int = typer.Option(
-        0,
+]
+_Runs = Annotated[
+    int,
+    typer.Option(
         '--runs',
         '-r',
         help='Number of runs to perform for each solution. Zero means the config default.',
     ),
-    profile: str = typer.Option(
-        'local',
+]
+_Profile = Annotated[
+    str,
+    typer.Option(
         '--profile',
         '-p',
         help='Profile to use for time limit estimation.',
         autocompletion=annotations._adapt('profile'),  # noqa: SLF001
     ),
-    integrate: bool = typer.Option(
-        False,
-        '--integrate',
-        '-i',
-        help='Integrate the given limits profile into the package.',
-    ),
-    runner: str = typer.Option(
-        runners_registry.DEFAULT_RUNNER,
+]
+_Runner = Annotated[
+    str,
+    typer.Option(
         '--runner',
         # Built from the table, never spelled out: this string is baked into
         # the committed completion spec, so a hard-coded list would be a second
@@ -89,25 +73,68 @@ async def time(
         ),
         autocompletion=annotations._adapt('runner'),  # noqa: SLF001
     ),
-    share: Optional[str] = typer.Option(
-        None,
+]
+_Share = Annotated[
+    Optional[str],
+    typer.Option(
         '--share',
         help='Capture the time report (run report + limits table) and copy it '
         'to the clipboard. Pass a format: --share png or --share text.',
     ),
-    skip_slow: bool = typer.Option(
-        False,
+]
+_SkipSlow = Annotated[
+    bool,
+    typer.Option(
         '--skip-slow',
         help='Skip checking the estimated limit against the solutions expected to '
         'be too slow. The limit is written with its upper bound unchecked.',
     ),
-    dry: bool = typer.Option(
-        False,
+]
+_Dry = Annotated[
+    bool,
+    typer.Option(
         '--dry',
         help='Run the whole estimation but write nothing to the disk: the limits '
         'profile is printed instead of saved.',
     ),
-):
+]
+_FailFast = Annotated[
+    bool,
+    typer.Option(
+        '--fail-fast',
+        '--ff',
+        help='Whether to stop running a solution as soon as it gets a non-accepted '
+        'verdict. Applies only to the solutions run after the estimation, and is '
+        'only meant for quick experimentation, as the remaining tests are reported '
+        'as failed.',
+    ),
+]
+
+
+async def _estimate(
+    *,
+    check: bool,
+    validate: bool,
+    detailed: bool,
+    strategy: Optional[str],
+    auto: bool,
+    runs: int,
+    profile: str,
+    integrate: bool,
+    runner: str,
+    share: Optional[str],
+    skip_slow: bool,
+    dry: bool,
+    run_all: bool,
+    fail_fast: bool,
+) -> None:
+    """The body of `rbx time`, shared with `rbx check`.
+
+    `rbx check` is the same command with `--auto` and `--run-all` fixed on, so
+    the two are one implementation and two signatures rather than one signature
+    with a mode flag: what distinguishes them is which options they *offer*, and
+    that is a property of the signature.
+    """
     if share is not None and share not in ('png', 'text'):
         console.console.print(
             f'[error]Invalid --share format: {share!r} (use png or text).[/error]'
@@ -229,6 +256,8 @@ async def time(
         skip_slow=skip_slow,
         runner=solution_runner,
         dry=dry,
+        run_all=run_all,
+        fail_fast=fail_fast,
     )
     if estimated is None:
         # Every failure of the estimation -- an unsatisfiable range, a solution
@@ -237,3 +266,115 @@ async def time(
         # limit it did not produce. The reasons were printed where they were
         # found; this only turns them into an exit code a pipeline can see.
         raise typer.Exit(1)
+
+
+@app.command(
+    'time, t',
+    rich_help_panel='Testing',
+    help='Estimate a time limit for the problem using the timings of its solutions and the estimation strategy configured in the environment.',
+)
+@package.within_problem
+@syncer.sync
+async def time(
+    check: _Check = True,
+    validate: _Validate = True,
+    detailed: _Detailed = False,
+    strategy: Annotated[
+        Optional[str],
+        typer.Option(
+            '--strategy',
+            '-s',
+            help='Strategy to use for time limit estimation (estimate, inherit, estimate_custom, custom).',
+        ),
+    ] = None,
+    auto: Annotated[
+        bool,
+        typer.Option(
+            '--auto',
+            '-a',
+            help='Whether to automatically estimate the time limit.',
+        ),
+    ] = False,
+    runs: _Runs = 0,
+    profile: _Profile = 'local',
+    integrate: Annotated[
+        bool,
+        typer.Option(
+            '--integrate',
+            '-i',
+            help='Integrate the given limits profile into the package.',
+        ),
+    ] = False,
+    runner: _Runner = runners_registry.DEFAULT_RUNNER,
+    share: _Share = None,
+    skip_slow: _SkipSlow = False,
+    dry: _Dry = False,
+    run_all: Annotated[
+        bool,
+        typer.Option(
+            '--run-all',
+            help='After the estimation, also run every solution it did not need -- the '
+            'ones expected to be wrong, and any slow one that was never checked -- '
+            'against the estimated time limit.',
+        ),
+    ] = False,
+    fail_fast: _FailFast = False,
+):
+    await _estimate(
+        check=check,
+        validate=validate,
+        detailed=detailed,
+        strategy=strategy,
+        auto=auto,
+        runs=runs,
+        profile=profile,
+        integrate=integrate,
+        runner=runner,
+        share=share,
+        skip_slow=skip_slow,
+        dry=dry,
+        run_all=run_all,
+        fail_fast=fail_fast,
+    )
+
+
+@app.command(
+    'check, ck',
+    rich_help_panel='Testing',
+    help='Estimate a time limit and check the whole package against it: every solution '
+    'is run, and every one of them has to behave as problem.rbx.yml says it does.',
+)
+@package.within_problem
+@syncer.sync
+async def check_package(
+    check: _Check = True,
+    validate: _Validate = True,
+    detailed: _Detailed = False,
+    runs: _Runs = 0,
+    profile: _Profile = 'local',
+    runner: _Runner = runners_registry.DEFAULT_RUNNER,
+    share: _Share = None,
+    skip_slow: _SkipSlow = False,
+    dry: _Dry = False,
+    fail_fast: _FailFast = False,
+):
+    # `rbx time --auto --run-all` under a name that says what it is for. The
+    # three options it does not offer are the ones `--auto` and `--run-all`
+    # settle: `--strategy` (auto forces `estimate`), `--auto` itself, and
+    # `--integrate`, which writes the package instead of estimating anything.
+    await _estimate(
+        check=check,
+        validate=validate,
+        detailed=detailed,
+        strategy=None,
+        auto=True,
+        runs=runs,
+        profile=profile,
+        integrate=False,
+        runner=runner,
+        share=share,
+        skip_slow=skip_slow,
+        dry=dry,
+        run_all=True,
+        fail_fast=fail_fast,
+    )

--- a/rbx/box/cli/commands/time_cmd.py
+++ b/rbx/box/cli/commands/time_cmd.py
@@ -1,4 +1,4 @@
-"""`rbx time` and `rbx check`.
+"""`rbx time` and `rbx preship`.
 
 Registered lazily from `rbx.box.cli.ENTRIES`, so this module is imported
 only when one of its commands is invoked. A command added here needs a row
@@ -23,7 +23,7 @@ from rbx.box.runners import registry as runners_registry
 
 app = typer.Typer(cls=annotations.AliasGroup)
 
-# The options `rbx time` and `rbx check` share. Declared once, as annotated
+# The options `rbx time` and `rbx preship` share. Declared once, as annotated
 # types, because the two commands differ only in which of them they *offer*:
 # spelling each option twice would leave two help strings to keep in step, and
 # the completion spec is generated from them.
@@ -128,9 +128,9 @@ async def _estimate(
     run_all: bool,
     fail_fast: bool,
 ) -> None:
-    """The body of `rbx time`, shared with `rbx check`.
+    """The body of `rbx time`, shared with `rbx preship`.
 
-    `rbx check` is the same command with `--auto` and `--run-all` fixed on, so
+    `rbx preship` is the same command with `--auto` and `--run-all` fixed on, so
     the two are one implementation and two signatures rather than one signature
     with a mode flag: what distinguishes them is which options they *offer*, and
     that is a property of the signature.
@@ -339,14 +339,14 @@ async def time(
 
 
 @app.command(
-    'check, ck',
+    'preship',
     rich_help_panel='Testing',
     help='Estimate a time limit and check the whole package against it: every solution '
     'is run, and every one of them has to behave as problem.rbx.yml says it does.',
 )
 @package.within_problem
 @syncer.sync
-async def check_package(
+async def preship(
     check: _Check = True,
     validate: _Validate = True,
     detailed: _Detailed = False,

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -418,6 +418,132 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': 'After the estimation, also run every solution it did not need '
+                    '-- the ones expected to be wrong, and any slow one that was '
+                    'never checked -- against the estimated time limit.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--run-all'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Whether to stop running a solution as soon as it gets a '
+                    'non-accepted verdict. Applies only to the solutions run after '
+                    'the estimation, and is only meant for quick experimentation, '
+                    'as the remaining tests are reported as failed.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--fail-fast', '--ff'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Show this message and exit.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--help'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+            ],
+        },
+        {
+            'help': 'Estimate a time limit and check the whole...',
+            'is_group': False,
+            'name': 'check, ck',
+            'panel': 'Testing',
+            'params': [
+                {
+                    'help': 'Whether to not build outputs for tests and run checker.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--check', '--no-check'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Whether to not validate outputs for tests.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--validate', '--no-validate'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Whether to print a detailed view of the tests using tables.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--detailed', '-d'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Number of runs to perform for each solution. Zero means the '
+                    'config default.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--runs', '-r'],
+                    'takes_value': True,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Profile to use for time limit estimation.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--profile', '-p'],
+                    'takes_value': True,
+                    'value': {'completer': 'profile', 'kind': 'completer'},
+                },
+                {
+                    'help': 'Where to run the solutions being timed (local, moj).',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--runner'],
+                    'takes_value': True,
+                    'value': {'completer': 'runner', 'kind': 'completer'},
+                },
+                {
+                    'help': 'Capture the time report (run report + limits table) and copy '
+                    'it to the clipboard. Pass a format: --share png or --share '
+                    'text.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--share'],
+                    'takes_value': True,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Skip checking the estimated limit against the solutions '
+                    'expected to be too slow. The limit is written with its upper '
+                    'bound unchecked.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--skip-slow'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Run the whole estimation but write nothing to the disk: the '
+                    'limits profile is printed instead of saved.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--dry'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Whether to stop running a solution as soon as it gets a '
+                    'non-accepted verdict. Applies only to the solutions run after '
+                    'the estimation, and is only meant for quick experimentation, '
+                    'as the remaining tests are reported as failed.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--fail-fast', '--ff'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -451,7 +451,7 @@ SPEC = {
         {
             'help': 'Estimate a time limit and check the whole...',
             'is_group': False,
-            'name': 'check, ck',
+            'name': 'preship',
             'panel': 'Testing',
             'params': [
                 {

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -34,6 +34,7 @@ from rbx.box.schema import InferenceRole, Solution
 from rbx.box.solutions import (
     RunSolutionResult,
     consume_and_key_evaluation_items,
+    fail_fast_abort_predicate,
     get_inference_solutions,
     inference_role_of,
     print_run_report,
@@ -1402,6 +1403,7 @@ async def _validate_upper_bound(
     detailed: bool,
     runs: int,
     runner: Optional['SolutionRunner'] = None,
+    ran: Optional[Set[str]] = None,
 ) -> _ValidationOutcome:
     """Run each slow solution at the limit this estimate demands of it, and say
     whether it is genuinely too slow.
@@ -1409,6 +1411,12 @@ async def _validate_upper_bound(
     Only the solutions whose answer is not already known are run: ``knowledge``
     carries what earlier iterations established, and a lower limit never needs
     re-asking.
+
+    ``ran``, when given, collects the solutions this phase actually executed.
+    `--run-all` runs the complement of that set, and it has to be *recorded*
+    rather than derived: which slow solutions this phase skips depends on
+    ``knowledge``, on ``--skip-slow`` and on whether the estimate is bounded from
+    above at all, none of which is visible in `problem.rbx.yml`.
     """
     if not upper_solutions:
         return _ValidationOutcome()
@@ -1423,6 +1431,8 @@ async def _validate_upper_bound(
         return _classify_slow_solutions(profile, upper_solutions, knowledge, [])
 
     tracked_solutions = OrderedSet(str(solution.path) for solution in to_run)
+    if ran is not None:
+        ran.update(tracked_solutions)
     languages = {find_language_name(solution) for solution in to_run}
     with utils.StatusProgress('Checking solutions expected to be too slow...') as s:
         result = await run_solutions(
@@ -1517,6 +1527,7 @@ async def _estimate_and_validate(
     detailed: bool,
     runs: int,
     runner: Optional['SolutionRunner'] = None,
+    ran: Optional[Set[str]] = None,
 ) -> Optional[TimingProfile]:
     """Estimate a limit and check it against the solutions expected to be too
     slow, letting the setter re-decide until the two agree.
@@ -1560,6 +1571,7 @@ async def _estimate_and_validate(
             detailed=detailed,
             runs=runs,
             runner=runner,
+            ran=ran,
         )
         _report_validation_outcome(outcome, profile)
         if outcome.ok:
@@ -1587,6 +1599,115 @@ async def _estimate_and_validate(
         )
 
 
+async def _run_remaining(
+    profile: TimingProfile,
+    already_run: Set[str],
+    check: bool,
+    detailed: bool,
+    runs: int,
+    fail_fast: bool = False,
+    runner: Optional['SolutionRunner'] = None,
+) -> bool:
+    """Run whatever the estimate did not, at the limit the estimate produced.
+
+    The two phases before this one run only what bounds the limit: the accepted
+    solutions, and the slow ones the check actually had to ask about. Everything
+    else -- a `wrong-answer`, an `rte`, an `accepted-or-tle`, anything carrying
+    `inference: false`, and every slow solution `--skip-slow` or `SlowKnowledge`
+    let it skip -- has no verdict yet. This runs exactly those, which is what
+    turns `rbx time` into a full check of the problem rather than of its limit
+    alone.
+
+    Deliberately *not* re-run: the solutions that did run. Their verdicts under
+    this limit already follow from the phases that ran them -- an accepted
+    solution was checked under a far looser cap, and a slow one that timed out
+    at `ceil(TL x timeLimitToTle) >= TL` times out here a fortiori -- and the
+    time limit is part of the sandbox cache key, so re-running them would cost a
+    full second pass to learn nothing.
+    """
+    remaining = [
+        solution
+        for solution in package.get_solutions()
+        if str(solution.path) not in already_run
+    ]
+    if not remaining:
+        console.console.print(
+            '[status]Every solution already ran while the time limit was being '
+            'estimated. Nothing left to run.[/status]'
+        )
+        return True
+
+    # Every language present is named, never only the ones with an entry of
+    # their own: `resolve_timelimit_override` reads an unmentioned language off
+    # the limits profile *on disk*, which is the limit this estimate replaces.
+    limits: Dict[str, int] = {}
+    for solution in remaining:
+        lang = find_language_name(solution)
+        limits[lang] = profile.timeLimitPerLanguage.get(lang, profile.timeLimit)
+
+    tracked_solutions = OrderedSet(str(solution.path) for solution in remaining)
+    with utils.StatusProgress('Running remaining solutions...') as s:
+        result = await run_solutions(
+            progress=s,
+            # The backend the limit was estimated on. A solution judged against
+            # this limit somewhere else is judged against a different machine.
+            runner=runner,
+            tracked_solutions=tracked_solutions,
+            check=check,
+            # ALL_SOLUTIONS keeps `isDoubleTL` off, as in both phases above: the
+            # override carries the estimated limit exactly, and doubling it here
+            # would judge every remaining solution against a limit the setter is
+            # not about to ship.
+            verification=_INFERENCE_VERIFICATION,
+            timelimit_override=limits,
+            # A plain run, and said so: these solutions are not being measured
+            # for anything, they are being judged against the limit that was.
+            # `MojRunner` stages this on the same remote problem `rbx run` uses.
+            purpose=RunPurpose.RUN,
+            nruns=runs,
+            # `--fail-fast` is the only reason to stop early here. The two phases
+            # above abort on a timeout because a timeout answers their question;
+            # this one has no question of its own, so it runs everything unless
+            # the setter asked it not to.
+            abort_on=fail_fast_abort_predicate if fail_fast else None,
+        )
+
+    try:
+        console.console.print()
+        console.console.rule(
+            '[status]Run report (remaining solutions)[/status]', style='status'
+        )
+        ok = await print_run_report(
+            result,
+            console.console,
+            _INFERENCE_VERIFICATION,
+            detailed=detailed,
+            skip_printing_limits=True,
+            # A solution that stopped at its first bad verdict was not timed on
+            # the testcases that never ran, so every extreme in the summary
+            # would rest on a lower bound. Same rule as `rbx run --fail-fast`.
+            timing=not fail_fast,
+        )
+        if fail_fast:
+            console.console.print()
+            console.console.print(
+                '[warning]The [item]--fail-fast / --ff[/item] flag should only be '
+                'used for quick experimentation, and should not be trusted for '
+                'full validation of the problem.[/warning]'
+            )
+            console.console.print(
+                '[warning]The timing summary was omitted: a solution that stopped '
+                'early is only timed on the testcases that ran.[/warning]'
+            )
+        return ok
+    finally:
+        # Same reasoning as both phases above: the report is what consumes this
+        # batch, so once it has returned the backend holds nothing anybody wants
+        # -- and if it raised, the batch belongs to a run that ended early,
+        # which is precisely what this `finally` is here for.
+        await result.close()
+
+
 async def compute_time_limits(
     check: bool,
     detailed: bool,
@@ -1598,6 +1719,8 @@ async def compute_time_limits(
     skip_slow: bool = False,
     runner: Optional['SolutionRunner'] = None,
     dry: bool = False,
+    run_all: bool = False,
+    fail_fast: bool = False,
 ):
     if package.get_main_solution() is None:
         # An error, not a warning: with no accepted solution nothing bounds the
@@ -1606,6 +1729,13 @@ async def compute_time_limits(
             '[error]No main solution found, so cannot estimate a time limit.[/error]'
         )
         return None
+
+    # Seeded with what phase 1 is about to run -- every solution that bounds the
+    # limit from below -- and added to by phase 2 as it decides which slow ones
+    # it actually has to ask about. `--run-all` runs the complement.
+    ran: Set[str] = {
+        str(solution.path) for solution in get_inference_solutions(InferenceRole.LOWER)
+    }
 
     run = await _run_for_inference(
         check=check, detailed=detailed, runs=runs, formula=formula, runner=runner
@@ -1633,6 +1763,7 @@ async def compute_time_limits(
         detailed=detailed,
         runs=runs,
         runner=runner,
+        ran=ran,
     )
     if estimated_tl is None:
         return None
@@ -1670,6 +1801,27 @@ async def compute_time_limits(
             limits_info.build_limits_table(limits, title=f'Time limits ({profile})')
         )
         sharing.capture_and_share(rec, fmt=share, title='rbx time report')
+
+    if run_all and not await _run_remaining(
+        estimated_tl,
+        ran,
+        check=check,
+        detailed=detailed,
+        runs=runs,
+        fail_fast=fail_fast,
+        runner=runner,
+    ):
+        # Raised rather than folded into the `None` the estimation returns: that
+        # `None` means no limit was produced and nothing was written, and this is
+        # the opposite case -- the limit is estimated, checked and saved, and a
+        # solution unrelated to it does not do what the package says it does. The
+        # exit code is the same, so a pipeline still stops; the message is not,
+        # so a setter reading it knows the profile on disk is good.
+        console.console.print(
+            '[error]The time limit was estimated and written, but some solution '
+            'did not behave as the package expects it to.[/error]'
+        )
+        raise typer.Exit(1)
 
     return estimated_tl
 

--- a/tests/e2e/testdata/mixed-solutions/e2e.rbx.yml
+++ b/tests/e2e/testdata/mixed-solutions/e2e.rbx.yml
@@ -59,3 +59,34 @@ scenarios:
               samples: wa
               main/0: wa
             sols/tle.cpp: tle
+
+  - name: check-runs-what-the-estimate-did-not
+    description: >
+      `rbx check` is `rbx time --auto --run-all`: it estimates the limit off
+      sols/main.cpp, checks it against sols/tle.cpp, and then runs sols/wa.cpp
+      -- the only solution neither phase had a reason to touch -- against the
+      limit it just wrote. The accepted and the slow solution are not run a
+      third time: their verdicts under this limit already follow from the
+      phases that ran them.
+    steps:
+      - cmd: check
+        expect:
+          stdout_contains:
+            - 'Run report (for time estimation)'
+            - 'Run report (upper-bound validation)'
+            - 'Run report (remaining solutions)'
+          files_exist:
+            - '.limits/local.yml'
+          file_contains:
+            # The extra phase runs exactly one solution, so it is `.rbx/runs/0`
+            # of its own batch: sols/wa.cpp, wrong as the package says it is.
+            .rbx/runs/0/samples/1-gen-000.eval: 'outcome: wrong-answer'
+
+  - name: time-does-not-run-the-rest-by-default
+    description: >
+      Without --run-all there is no third phase, so sols/wa.cpp is never run.
+    steps:
+      - cmd: time --auto
+        expect:
+          stdout_not_contains:
+            - 'Run report (remaining solutions)'

--- a/tests/e2e/testdata/mixed-solutions/e2e.rbx.yml
+++ b/tests/e2e/testdata/mixed-solutions/e2e.rbx.yml
@@ -60,16 +60,16 @@ scenarios:
               main/0: wa
             sols/tle.cpp: tle
 
-  - name: check-runs-what-the-estimate-did-not
+  - name: preship-runs-what-the-estimate-did-not
     description: >
-      `rbx check` is `rbx time --auto --run-all`: it estimates the limit off
+      `rbx preship` is `rbx time --auto --run-all`: it estimates the limit off
       sols/main.cpp, checks it against sols/tle.cpp, and then runs sols/wa.cpp
       -- the only solution neither phase had a reason to touch -- against the
       limit it just wrote. The accepted and the slow solution are not run a
       third time: their verdicts under this limit already follow from the
       phases that ran them.
     steps:
-      - cmd: check
+      - cmd: preship
         expect:
           stdout_contains:
             - 'Run report (for time estimation)'

--- a/tests/rbx/box/test_timing_run_all.py
+++ b/tests/rbx/box/test_timing_run_all.py
@@ -1,0 +1,289 @@
+"""`rbx time --run-all` runs, at the estimated limit, whatever the estimate did not.
+
+The estimation phase runs the solutions that bound the limit from below and the
+validation phase runs the ones that bound it from above -- so between them they
+leave every other solution unrun, and the slow ones they were able to skip.
+This phase picks those up, which is what makes `rbx time --run-all` a full
+verification of the problem rather than only of its limit.
+"""
+
+import pathlib
+from typing import Dict, List, Optional
+from unittest import mock
+
+from rbx.box import timing, timing_validation
+from rbx.box.runners.base import RunPurpose
+from rbx.box.schema import ExpectedOutcome, Solution, TimingMultipliers
+from rbx.box.solutions import fail_fast_abort_predicate
+
+
+def _solution(
+    name: str,
+    language: str = 'cpp',
+    outcome: ExpectedOutcome = ExpectedOutcome.WRONG_ANSWER,
+) -> Solution:
+    return Solution(path=pathlib.Path(name), language=language, outcome=outcome)
+
+
+def _profile(
+    time_limit: int = 1000,
+    per_language: Optional[Dict[str, int]] = None,
+) -> timing.TimingProfile:
+    return timing.TimingProfile(
+        timeLimit=time_limit,
+        timeLimitPerLanguage=per_language or {},
+        multipliers=TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
+    )
+
+
+class _Run:
+    """One mocked run of the remaining solutions."""
+
+    def __init__(self):
+        self.run_solutions = None
+        self.print_run_report = None
+        self.ok = None
+
+    @property
+    def tracked(self) -> List[str]:
+        return list(self.run_solutions.call_args.kwargs['tracked_solutions'])
+
+    @property
+    def kwargs(self):
+        return self.run_solutions.call_args.kwargs
+
+    @property
+    def report_kwargs(self):
+        return self.print_run_report.call_args.kwargs
+
+    @property
+    def ran(self) -> bool:
+        return self.run_solutions.called
+
+
+async def _run_remaining(
+    solutions: List[Solution],
+    already_run: List[str],
+    profile: Optional[timing.TimingProfile] = None,
+    report_ok: bool = True,
+    **kwargs,
+) -> _Run:
+    run = _Run()
+    result = mock.Mock()
+    result.skeleton.solutions = list(solutions)
+    result.close = mock.AsyncMock()
+    with (
+        mock.patch('rbx.box.package.get_solutions', return_value=solutions),
+        mock.patch(
+            'rbx.box.timing.run_solutions', return_value=result
+        ) as mock_run_solutions,
+        mock.patch(
+            'rbx.box.timing.print_run_report', return_value=report_ok
+        ) as mock_print_run_report,
+        mock.patch(
+            'rbx.box.timing.find_language_name', side_effect=lambda sol: sol.language
+        ),
+    ):
+        run.run_solutions = mock_run_solutions
+        run.print_run_report = mock_print_run_report
+        run.ok = await timing._run_remaining(  # noqa: SLF001
+            profile if profile is not None else _profile(),
+            set(already_run),
+            check=False,
+            detailed=False,
+            runs=0,
+            **kwargs,
+        )
+    return run
+
+
+async def test_only_the_solutions_that_did_not_run_are_run():
+    solutions = [
+        _solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED),
+        _solution('sols/slow.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED),
+        _solution('sols/wa.cpp'),
+    ]
+
+    run = await _run_remaining(solutions, already_run=['sols/ac.cpp'])
+
+    assert run.tracked == ['sols/slow.cpp', 'sols/wa.cpp']
+
+
+async def test_a_slow_solution_the_validation_skipped_is_picked_up():
+    # `--skip-slow`, a missing `timeLimitToTle` or a question `SlowKnowledge`
+    # already answered all leave a slow solution unrun. It is a solution like
+    # any other here.
+    solutions = [
+        _solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED),
+        _solution('sols/slow.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED),
+    ]
+
+    run = await _run_remaining(solutions, already_run=['sols/ac.cpp'])
+
+    assert run.tracked == ['sols/slow.cpp']
+
+
+async def test_nothing_runs_when_every_solution_already_ran():
+    solutions = [_solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED)]
+
+    run = await _run_remaining(solutions, already_run=['sols/ac.cpp'])
+
+    assert not run.ran
+    assert run.ok
+
+
+async def test_each_language_runs_at_its_own_estimated_limit():
+    solutions = [
+        _solution('sols/wa.cpp', language='cpp'),
+        _solution('sols/wa.java', language='java'),
+    ]
+
+    run = await _run_remaining(
+        solutions,
+        already_run=[],
+        profile=_profile(time_limit=1000, per_language={'java': 3000}),
+    )
+
+    assert run.kwargs['timelimit_override'] == {'cpp': 1000, 'java': 3000}
+
+
+async def test_a_language_without_its_own_limit_runs_at_the_base_limit():
+    # The override is a mapping, and `resolve_timelimit_override` falls back to
+    # the *profile on disk* for a language it does not mention -- which is the
+    # limit this estimate is replacing. Every language present must be named.
+    solutions = [_solution('sols/wa.cpp', language='cpp')]
+
+    run = await _run_remaining(
+        solutions, already_run=[], profile=_profile(time_limit=1234)
+    )
+
+    assert run.kwargs['timelimit_override'] == {'cpp': 1234}
+
+
+async def test_it_is_a_plain_run():
+    solutions = [_solution('sols/wa.cpp')]
+
+    run = await _run_remaining(solutions, already_run=[])
+
+    assert run.kwargs['purpose'] is RunPurpose.RUN
+
+
+async def test_without_fail_fast_the_run_stops_on_nothing():
+    solutions = [_solution('sols/wa.cpp')]
+
+    run = await _run_remaining(solutions, already_run=[])
+
+    assert run.kwargs['abort_on'] is None
+    assert run.report_kwargs['timing'] is True
+
+
+async def test_fail_fast_stops_a_solution_at_its_first_bad_verdict():
+    solutions = [_solution('sols/wa.cpp')]
+
+    run = await _run_remaining(solutions, already_run=[], fail_fast=True)
+
+    assert run.kwargs['abort_on'] is fail_fast_abort_predicate
+
+
+async def test_fail_fast_drops_the_timing_summary():
+    # A solution that stopped early was not timed on the testcases that never
+    # ran, so every extreme in the summary would be a lower bound.
+    solutions = [_solution('sols/wa.cpp')]
+
+    run = await _run_remaining(solutions, already_run=[], fail_fast=True)
+
+    assert run.report_kwargs['timing'] is False
+
+
+async def test_a_solution_that_misbehaves_fails_the_phase():
+    solutions = [_solution('sols/wa.cpp')]
+
+    run = await _run_remaining(solutions, already_run=[], report_ok=False)
+
+    assert not run.ok
+
+
+async def test_the_batch_is_closed_even_when_the_run_fails():
+    solutions = [_solution('sols/wa.cpp')]
+    result = mock.Mock()
+    result.skeleton.solutions = list(solutions)
+    result.close = mock.AsyncMock()
+
+    with (
+        mock.patch('rbx.box.package.get_solutions', return_value=solutions),
+        mock.patch('rbx.box.timing.run_solutions', return_value=result),
+        mock.patch('rbx.box.timing.print_run_report', side_effect=RuntimeError('boom')),
+        mock.patch(
+            'rbx.box.timing.find_language_name', side_effect=lambda sol: sol.language
+        ),
+    ):
+        try:
+            await timing._run_remaining(  # noqa: SLF001
+                _profile(), set(), check=False, detailed=False, runs=0
+            )
+        except RuntimeError:
+            pass
+
+    result.close.assert_awaited()
+
+
+# The ledger: which solutions the estimate actually executed. `--run-all` runs
+# the complement of it, so it has to be recorded where the runs happen rather
+# than guessed back from the roles -- the validation phase skips slow solutions
+# for several reasons, and none of them is visible in `problem.rbx.yml`.
+
+
+async def test_the_validation_phase_records_what_it_ran():
+    slow = _solution('sols/slow.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED)
+    ledger = set()
+    result = mock.Mock()
+    result.skeleton.solutions = [slow]
+    result.close = mock.AsyncMock()
+
+    with (
+        mock.patch('rbx.box.timing.run_solutions', return_value=result),
+        mock.patch('rbx.box.timing.print_run_report', return_value=True),
+        mock.patch('rbx.box.timing.consume_and_key_evaluation_items', return_value={}),
+        mock.patch(
+            'rbx.box.timing.find_language_name', side_effect=lambda sol: sol.language
+        ),
+    ):
+        await timing._validate_upper_bound(  # noqa: SLF001
+            _profile(),
+            [slow],
+            timing_validation.SlowKnowledge(),
+            check=False,
+            detailed=False,
+            runs=0,
+            ran=ledger,
+        )
+
+    assert ledger == {'sols/slow.cpp'}
+
+
+async def test_a_slow_solution_the_validation_never_ran_stays_off_the_ledger():
+    # Its answer was already known, so `SlowKnowledge` skipped it -- and that is
+    # exactly the case `--run-all` exists to pick up.
+    slow = _solution('sols/slow.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED)
+    knowledge = timing_validation.SlowKnowledge()
+    knowledge.record_timeout('sols/slow.cpp', 10_000)
+    ledger = set()
+
+    with (
+        mock.patch('rbx.box.timing.run_solutions') as mock_run_solutions,
+        mock.patch(
+            'rbx.box.timing.find_language_name', side_effect=lambda sol: sol.language
+        ),
+    ):
+        await timing._validate_upper_bound(  # noqa: SLF001
+            _profile(),
+            [slow],
+            knowledge,
+            check=False,
+            detailed=False,
+            runs=0,
+            ran=ledger,
+        )
+
+    assert not mock_run_solutions.called
+    assert ledger == set()

--- a/tests/rbx/box/test_timing_run_all_cli.py
+++ b/tests/rbx/box/test_timing_run_all_cli.py
@@ -1,6 +1,6 @@
-"""How `--run-all`, `--fail-fast` and `rbx check` reach the extra run.
+"""How `--run-all`, `--fail-fast` and `rbx preship` reach the extra run.
 
-`rbx check` is `rbx time --auto --run-all` under another name, so what it has to
+`rbx preship` is `rbx time --auto --run-all` under another name, so what it has to
 guarantee is that it lands on the same code path with those two switched on.
 """
 
@@ -88,21 +88,21 @@ def test_the_short_alias_of_fail_fast_works(
     assert seen['fail_fast'] is True
 
 
-def test_check_is_an_automatic_run_all(
+def test_preship_is_an_automatic_run_all(
     runner: CliRunner, testing_pkg: testing_package.TestingPackage
 ):
-    result, seen = _invoke(runner, ['check'])
+    result, seen = _invoke(runner, ['preship'])
 
     assert result.exit_code == 0, result.output
     assert seen['run_all'] is True
     assert seen['auto'] is True
 
 
-def test_check_takes_the_remaining_flags(
+def test_preship_takes_the_remaining_flags(
     runner: CliRunner, testing_pkg: testing_package.TestingPackage
 ):
     result, seen = _invoke(
-        runner, ['check', '--dry', '--skip-slow', '--fail-fast', '-r', '3']
+        runner, ['preship', '--dry', '--skip-slow', '--fail-fast', '-r', '3']
     )
 
     assert result.exit_code == 0, result.output

--- a/tests/rbx/box/test_timing_run_all_cli.py
+++ b/tests/rbx/box/test_timing_run_all_cli.py
@@ -1,0 +1,190 @@
+"""How `--run-all`, `--fail-fast` and `rbx check` reach the extra run.
+
+`rbx check` is `rbx time --auto --run-all` under another name, so what it has to
+guarantee is that it lands on the same code path with those two switched on.
+"""
+
+import asyncio
+import pathlib
+from typing import List, Optional
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box import cli, timing
+from rbx.box.schema import ExpectedOutcome, Solution
+from rbx.box.testing import testing_package
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _skip_preset_check():
+    with mock.patch('rbx.box.presets.check_active_preset_compatibility'):
+        yield
+
+
+async def _build_ok(*args, **kwargs):
+    return True
+
+
+def _invoke(runner: CliRunner, args: List[str]):
+    seen = {}
+
+    async def compute_time_limits(check, detailed, runs=0, **kwargs):
+        seen.update(kwargs, check=check, detailed=detailed, runs=runs)
+        return timing.TimingProfile(timeLimit=1000)
+
+    with (
+        mock.patch('rbx.box.builder.build', _build_ok),
+        mock.patch('rbx.box.timing.compute_time_limits', compute_time_limits),
+    ):
+        result = runner.invoke(cli.app, args)
+    return result, seen
+
+
+def test_the_extra_run_is_off_by_default(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['time', '--auto'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['run_all'] is False
+    assert seen['fail_fast'] is False
+
+
+def test_run_all_asks_for_the_extra_run(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['time', '--auto', '--run-all'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['run_all'] is True
+
+
+def test_fail_fast_reaches_the_extra_run(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['time', '--auto', '--run-all', '--fail-fast'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['fail_fast'] is True
+
+
+def test_the_short_alias_of_fail_fast_works(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['time', '--auto', '--run-all', '--ff'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['fail_fast'] is True
+
+
+def test_check_is_an_automatic_run_all(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['check'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['run_all'] is True
+    assert seen['auto'] is True
+
+
+def test_check_takes_the_remaining_flags(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(
+        runner, ['check', '--dry', '--skip-slow', '--fail-fast', '-r', '3']
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen['dry'] is True
+    assert seen['skip_slow'] is True
+    assert seen['fail_fast'] is True
+    assert seen['runs'] == 3
+
+
+# What `compute_time_limits` does with the flag.
+
+
+def _solution(name: str, outcome: ExpectedOutcome) -> Solution:
+    return Solution(path=pathlib.Path(name), language='cpp', outcome=outcome)
+
+
+async def _compute(
+    tmp_path: pathlib.Path,
+    run_all: bool,
+    lower: Optional[List[Solution]] = None,
+    remaining_ok: bool = True,
+    **kwargs,
+):
+    lower = lower or [_solution('sols/ac.cpp', ExpectedOutcome.ACCEPTED)]
+    run_remaining = mock.AsyncMock(return_value=remaining_ok)
+
+    async def _estimate_and_validate(*_, **__):
+        return timing.TimingProfile(timeLimit=1000)
+
+    with (
+        mock.patch('rbx.box.package.get_main_solution', return_value=lower[0]),
+        mock.patch(
+            'rbx.box.timing._run_for_inference',
+            mock.AsyncMock(return_value=mock.Mock(result=mock.Mock())),
+        ),
+        mock.patch(
+            'rbx.box.timing.build_estimation_context',
+            mock.AsyncMock(return_value=mock.Mock()),
+        ),
+        mock.patch('rbx.box.timing._estimate_and_validate', _estimate_and_validate),
+        mock.patch('rbx.box.timing.get_inference_solutions', return_value=lower),
+        mock.patch('rbx.box.timing._run_remaining', run_remaining),
+        mock.patch(
+            'rbx.box.package.get_limits_file', return_value=tmp_path / 'local.yml'
+        ),
+        mock.patch('rbx.box.limits_info.render_limits_table'),
+    ):
+        profile = await timing.compute_time_limits(
+            check=False, detailed=False, run_all=run_all, **kwargs
+        )
+    return profile, run_remaining
+
+
+async def test_the_extra_run_only_happens_when_asked(tmp_path: pathlib.Path):
+    _, run_remaining = await _compute(tmp_path, run_all=False)
+
+    assert not run_remaining.called
+
+
+async def test_the_solutions_the_estimate_ran_are_not_run_again(
+    tmp_path: pathlib.Path,
+):
+    lower = [_solution('sols/ac.cpp', ExpectedOutcome.ACCEPTED)]
+
+    _, run_remaining = await _compute(tmp_path, run_all=True, lower=lower)
+
+    assert run_remaining.called
+    already_run = run_remaining.call_args.args[1]
+    assert 'sols/ac.cpp' in already_run
+
+
+async def test_a_failing_extra_run_fails_the_command(tmp_path: pathlib.Path):
+    import typer
+
+    with pytest.raises(typer.Exit) as exc:
+        await _compute(tmp_path, run_all=True, remaining_ok=False)
+
+    assert exc.value.exit_code == 1
+
+
+async def test_a_passing_extra_run_still_returns_the_profile(tmp_path: pathlib.Path):
+    profile, _ = await _compute(tmp_path, run_all=True)
+
+    assert profile is not None
+    assert profile.timeLimit == 1000


### PR DESCRIPTION
`rbx time` runs only the solutions that *bound* the limit: the accepted ones (phase 1) and the slow ones the upper-bound check actually has to ask about (phase 2). Everything else — the solutions expected to be wrong, and any slow one `--skip-slow` or `SlowKnowledge` let it skip — ends the command with no verdict at all.

## `--run-all`

Adds a third phase that runs exactly those, at the limit that was just written, and fails the command if any of them does not behave as `problem.rbx.yml` says it does.

Which solutions those are comes from a **ledger of what actually executed**, not from the inference roles. That distinction is load-bearing: which slow solutions phase 2 skips depends on `SlowKnowledge`, on `--skip-slow`, and on whether the environment configures `timeLimitToTle` at all — none of which is visible in the YAML. The ledger is seeded with the LOWER solutions and updated by `_validate_upper_bound` as it decides what to run.

The solutions that already ran are deliberately **not** re-run. Their verdicts under this limit already follow from the phases that ran them — an accepted solution was checked under a far looser cap, and a slow one that timed out at `ceil(TL × timeLimitToTle) >= TL` times out here a fortiori — and the time limit is part of the sandbox cache key, so a second pass would cost a full run to learn nothing.

Other details:

- Every language present is named in the `timelimit_override` mapping, never only those with a `timeLimitPerLanguage` entry: `resolve_timelimit_override` reads an unmentioned language off the limits profile *on disk*, which is the limit this estimate replaces.
- `purpose=RunPurpose.RUN`, so `MojRunner` stages it on the same remote problem `rbx run` uses rather than provisioning a fourth.
- `verification=ALL_SOLUTIONS`, as in both phases above, so `isDoubleTL` stays off and the override carries the estimated limit exactly.
- On failure the command exits 1 with a message distinct from an estimation failure — the profile *was* written and is good; a solution is not.

## `--fail-fast` / `--ff`

Applies to the new phase only. Reuses `fail_fast_abort_predicate` and drops the timing summary, with the same warning `rbx run --fail-fast` prints — a solution that stopped early was not timed on the testcases that never ran.

## `rbx preship`

`rbx time --auto --run-all` under a name that says what it is for. It offers every flag the two do not settle (`--dry`, `--runs`, `--profile`, `--runner`, `--skip-slow`, `--fail-fast`, `--share`, `--check`, `--validate`, `--detailed`) but not `--strategy`, `--auto` or `--integrate`.

Both commands share one implementation and a set of `Annotated` option types, so there is a single copy of each help string — which is what the generated completion spec and the CLI reference are built from.

## Testing

- `tests/rbx/box/test_timing_run_all.py` — the phase itself: which solutions it runs, the per-language limits, the purpose, the abort predicate, the report's `timing` flag, batch teardown, and the ledger.
- `tests/rbx/box/test_timing_run_all_cli.py` — flag plumbing and what `compute_time_limits` does with it.
- `tests/e2e/testdata/mixed-solutions/e2e.rbx.yml` — two scenarios driving the real command: `rbx preship` produces all three run reports and runs `sols/wa.cpp` (the only solution neither phase touched) against the written limit; plain `rbx time --auto` produces no third report.

All green, plus the existing timing, lazy-CLI and completion suites. Completion spec regenerated; docs updated in `estimating.md` and hand-inserted into `cli.md` (that file has drifted from its generator, so regenerating it would have brought 900 lines of unrelated churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKeJKoEDk5EXt9YfEoKFmF
