### PR TITLE
feat(time): carry -b and --keep-checker-stderr into rbx time and rbx preship

### DIFF
--- a/docs/setters/profiling/estimating.md
+++ b/docs/setters/profiling/estimating.md
@@ -198,6 +198,13 @@ and check every solution against it. It takes the rest of `rbx time`'s flags —
 `--runs`, `--profile`, `--runner`, `--skip-slow`, `--fail-fast`, `--share` — but not the ones
 `--auto` settles (`--strategy`, `--integrate`).
 
+Both commands also take the `rbx run` flags about how a run is reported, and apply them to every
+stage: `-b` for a [judging-time benchmark](../running/index.md#benchmarking-the-judging-time),
+and [`--keep-checker-stderr`](../running/index.md#reading-what-the-checker-said). Neither takes
+`--sanitized` (sanitizers inflate every timing the estimate rests on), `--verification-level`
+(pinned, so the estimation cap is never doubled), or a solution filter (both run the whole
+package by definition).
+
 ## Sharing the report
 
 ```bash

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -163,6 +163,7 @@ rbx time [OPTIONS]
 
 | Name | Type | Description | Default |
 | :--- | :--- | :--- | :--- |
+| `--benchmark`, `-b` | INTEGER | Benchmark level: 0 (off), 1 (benchmark the solution run). | `0` |
 | `--check` | BOOLEAN | Whether to not build outputs for tests and run checker. | `True` |
 | `--validate` | BOOLEAN | Whether to not validate outputs for tests. | `True` |
 | `--detailed`, `-d` | BOOLEAN | Whether to print a detailed view of the tests using tables. | `False` |
@@ -177,6 +178,7 @@ rbx time [OPTIONS]
 | `--dry` | BOOLEAN | Run the whole estimation but write nothing to the disk: the limits profile is printed instead of saved. | `False` |
 | `--run-all` | BOOLEAN | After the estimation, also run every solution it did not need -- the ones expected to be wrong, and any slow one that was never checked -- against the estimated time limit. | `False` |
 | `--fail-fast`, `--ff` | BOOLEAN | Whether to stop running a solution as soon as it gets a non-accepted verdict. Applies only to the solutions run after the estimation, and is only meant for quick experimentation, as the remaining tests are reported as failed. | `False` |
+| `--keep-checker-stderr` | BOOLEAN | Also keep each testcase's full checker stderr, as a `.checker.err` file next to its output. Only the checker's last line reaches the verdict, so this is how to read whatever it printed before that. | `False` |
 
 
 ---
@@ -192,6 +194,7 @@ rbx preship [OPTIONS]
 
 | Name | Type | Description | Default |
 | :--- | :--- | :--- | :--- |
+| `--benchmark`, `-b` | INTEGER | Benchmark level: 0 (off), 1 (benchmark the solution run). | `0` |
 | `--check` | BOOLEAN | Whether to not build outputs for tests and run checker. | `True` |
 | `--validate` | BOOLEAN | Whether to not validate outputs for tests. | `True` |
 | `--detailed`, `-d` | BOOLEAN | Whether to print a detailed view of the tests using tables. | `False` |
@@ -202,6 +205,7 @@ rbx preship [OPTIONS]
 | `--skip-slow` | BOOLEAN | Skip checking the estimated limit against the solutions expected to be too slow. The limit is written with its upper bound unchecked. | `False` |
 | `--dry` | BOOLEAN | Run the whole estimation but write nothing to the disk: the limits profile is printed instead of saved. | `False` |
 | `--fail-fast`, `--ff` | BOOLEAN | Whether to stop running a solution as soon as it gets a non-accepted verdict. Applies only to the solutions run after the estimation, and is only meant for quick experimentation, as the remaining tests are reported as failed. | `False` |
+| `--keep-checker-stderr` | BOOLEAN | Also keep each testcase's full checker stderr, as a `.checker.err` file next to its output. Only the checker's last line reaches the verdict, so this is how to read whatever it printed before that. | `False` |
 
 
 ---

--- a/rbx/box/cli/commands/time_cmd.py
+++ b/rbx/box/cli/commands/time_cmd.py
@@ -12,6 +12,7 @@ import typer
 
 from rbx import annotations, console
 from rbx.box import (
+    benchmark,
     environment,
     limits_info,
     package,
@@ -98,6 +99,15 @@ _Dry = Annotated[
         'profile is printed instead of saved.',
     ),
 ]
+_KeepCheckerStderr = Annotated[
+    bool,
+    typer.Option(
+        '--keep-checker-stderr',
+        help="Also keep each testcase's full checker stderr, as a `.checker.err` file "
+        "next to its output. Only the checker's last line reaches the verdict, so "
+        'this is how to read whatever it printed before that.',
+    ),
+]
 _FailFast = Annotated[
     bool,
     typer.Option(
@@ -127,6 +137,8 @@ async def _estimate(
     dry: bool,
     run_all: bool,
     fail_fast: bool,
+    benchmark_level: int,
+    keep_checker_stderr: bool,
 ) -> None:
     """The body of `rbx time`, shared with `rbx preship`.
 
@@ -135,6 +147,11 @@ async def _estimate(
     with a mode flag: what distinguishes them is which options they *offer*, and
     that is a property of the signature.
     """
+    # Parsed before anything is built, for the same reason `rbx run` parses it
+    # there: a level rbx cannot report on is a mistake in the command line, and a
+    # mistake should cost the setter an error rather than a whole estimation.
+    level = benchmark.parse_level(benchmark_level)
+
     if share is not None and share not in ('png', 'text'):
         console.console.print(
             f'[error]Invalid --share format: {share!r} (use png or text).[/error]'
@@ -258,6 +275,8 @@ async def _estimate(
         dry=dry,
         run_all=run_all,
         fail_fast=fail_fast,
+        benchmark_level=level,
+        keep_checker_stderr=keep_checker_stderr,
     )
     if estimated is None:
         # Every failure of the estimation -- an unsatisfiable range, a solution
@@ -276,6 +295,12 @@ async def _estimate(
 @package.within_problem
 @syncer.sync
 async def time(
+    # Ahead of every parameter carrying a Python-level default, for the same
+    # reason as in `rbx run`: `BenchmarkParam` supplies its default through
+    # `default_factory` and so has none of its own, and tidying it further down
+    # the list is a `SyntaxError` raised when this module is imported. It is an
+    # option either way, so its position says nothing about the command line.
+    benchmark_level: benchmark.BenchmarkParam,
     check: _Check = True,
     validate: _Validate = True,
     detailed: _Detailed = False,
@@ -319,6 +344,7 @@ async def time(
         ),
     ] = False,
     fail_fast: _FailFast = False,
+    keep_checker_stderr: _KeepCheckerStderr = False,
 ):
     await _estimate(
         check=check,
@@ -335,6 +361,8 @@ async def time(
         dry=dry,
         run_all=run_all,
         fail_fast=fail_fast,
+        benchmark_level=benchmark_level,
+        keep_checker_stderr=keep_checker_stderr,
     )
 
 
@@ -347,6 +375,9 @@ async def time(
 @package.within_problem
 @syncer.sync
 async def preship(
+    # First for the same reason as in `rbx time` above: it carries no default of
+    # its own.
+    benchmark_level: benchmark.BenchmarkParam,
     check: _Check = True,
     validate: _Validate = True,
     detailed: _Detailed = False,
@@ -357,11 +388,20 @@ async def preship(
     skip_slow: _SkipSlow = False,
     dry: _Dry = False,
     fail_fast: _FailFast = False,
+    keep_checker_stderr: _KeepCheckerStderr = False,
 ):
     # `rbx time --auto --run-all` under a name that says what it is for. The
     # three options it does not offer are the ones `--auto` and `--run-all`
     # settle: `--strategy` (auto forces `estimate`), `--auto` itself, and
     # `--integrate`, which writes the package instead of estimating anything.
+    #
+    # It offers the `rbx run` flags that are about how a run is *reported* and
+    # what it leaves behind -- `-b`, `--keep-checker-stderr`, `--detailed`,
+    # `--share`, `--fail-fast` -- and none of the ones that would change what is
+    # measured or which solutions run. `--sanitized` inflates every timing the
+    # estimate rests on; `--verification-level` is pinned at ALL_SOLUTIONS so
+    # `isDoubleTL` stays off; and a solution filter would leave the solutions it
+    # skipped looking checked. See `test_timing_run_flags_omitted.py`.
     await _estimate(
         check=check,
         validate=validate,
@@ -377,4 +417,6 @@ async def preship(
         dry=dry,
         run_all=True,
         fail_fast=fail_fast,
+        benchmark_level=benchmark_level,
+        keep_checker_stderr=keep_checker_stderr,
     )

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -315,6 +315,14 @@ SPEC = {
             'panel': 'Testing',
             'params': [
                 {
+                    'help': 'Benchmark level: 0 (off), 1 (benchmark the solution run).',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--benchmark', '-b'],
+                    'takes_value': True,
+                    'value': {'completer': 'benchmark_level', 'kind': 'completer'},
+                },
+                {
                     'help': 'Whether to not build outputs for tests and run checker.',
                     'kind': 'option',
                     'multiple': False,
@@ -439,6 +447,17 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': "Also keep each testcase's full checker stderr, as a "
+                    "`.checker.err` file next to its output. Only the checker's "
+                    'last line reaches the verdict, so this is how to read whatever '
+                    'it printed before that.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--keep-checker-stderr'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,
@@ -454,6 +473,14 @@ SPEC = {
             'name': 'preship',
             'panel': 'Testing',
             'params': [
+                {
+                    'help': 'Benchmark level: 0 (off), 1 (benchmark the solution run).',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--benchmark', '-b'],
+                    'takes_value': True,
+                    'value': {'completer': 'benchmark_level', 'kind': 'completer'},
+                },
                 {
                     'help': 'Whether to not build outputs for tests and run checker.',
                     'kind': 'option',
@@ -540,6 +567,17 @@ SPEC = {
                     'kind': 'option',
                     'multiple': False,
                     'names': ['--fail-fast', '--ff'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': "Also keep each testcase's full checker stderr, as a "
+                    "`.checker.err` file next to its output. Only the checker's "
+                    'last line reaches the verdict, so this is how to read whatever '
+                    'it printed before that.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--keep-checker-stderr'],
                     'takes_value': False,
                     'value': {'kind': 'none'},
                 },

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 
 from rbx import console, utils
 from rbx.box import (
+    benchmark,
     environment,
     limits_info,
     package,
@@ -1153,6 +1154,8 @@ async def _run_for_inference(
     runs: int,
     formula: Optional[str],
     runner: Optional['SolutionRunner'] = None,
+    benchmark_level: benchmark.BenchmarkLevel = benchmark.BenchmarkLevel.NONE,
+    keep_checker_stderr: bool = False,
 ) -> Optional[_InferenceRun]:
     """Run the solutions the time limit is inferred from, report them, and say
     what their verdicts mean. ``None`` when the estimate must not proceed."""
@@ -1194,6 +1197,7 @@ async def _run_for_inference(
             # validation one, or from a plain `rbx run`.
             purpose=RunPurpose.ESTIMATION,
             nruns=runs,
+            keep_checker_stderr=keep_checker_stderr,
             # An accepted solution killed at the cap fails the estimate outright,
             # so its remaining tests only cost wall clock.
             abort_on=lambda ctx: ctx.evaluation.result.outcome.is_slow(),
@@ -1211,6 +1215,7 @@ async def _run_for_inference(
             detailed=detailed,
             skip_printing_limits=True,
             gating_solutions={str(solution.path) for solution in lower_solutions},
+            benchmark_level=benchmark_level,
         )
 
         diagnosis = await _diagnose_inference_run(result)
@@ -1404,6 +1409,8 @@ async def _validate_upper_bound(
     runs: int,
     runner: Optional['SolutionRunner'] = None,
     ran: Optional[Set[str]] = None,
+    benchmark_level: benchmark.BenchmarkLevel = benchmark.BenchmarkLevel.NONE,
+    keep_checker_stderr: bool = False,
 ) -> _ValidationOutcome:
     """Run each slow solution at the limit this estimate demands of it, and say
     whether it is genuinely too slow.
@@ -1453,6 +1460,7 @@ async def _validate_upper_bound(
             # runs instead of overwriting each other.
             purpose=RunPurpose.VALIDATION,
             nruns=runs,
+            keep_checker_stderr=keep_checker_stderr,
             # One timeout settles the question, so the remaining testcases only
             # cost wall clock.
             abort_on=lambda ctx: ctx.evaluation.result.outcome.is_slow(),
@@ -1470,6 +1478,7 @@ async def _validate_upper_bound(
             detailed=detailed,
             skip_printing_limits=True,
             gating_solutions=set(tracked_solutions),
+            benchmark_level=benchmark_level,
         )
 
         failed, unmeasured = await _record_validation_run(
@@ -1528,6 +1537,8 @@ async def _estimate_and_validate(
     runs: int,
     runner: Optional['SolutionRunner'] = None,
     ran: Optional[Set[str]] = None,
+    benchmark_level: benchmark.BenchmarkLevel = benchmark.BenchmarkLevel.NONE,
+    keep_checker_stderr: bool = False,
 ) -> Optional[TimingProfile]:
     """Estimate a limit and check it against the solutions expected to be too
     slow, letting the setter re-decide until the two agree.
@@ -1572,6 +1583,8 @@ async def _estimate_and_validate(
             runs=runs,
             runner=runner,
             ran=ran,
+            benchmark_level=benchmark_level,
+            keep_checker_stderr=keep_checker_stderr,
         )
         _report_validation_outcome(outcome, profile)
         if outcome.ok:
@@ -1607,6 +1620,8 @@ async def _run_remaining(
     runs: int,
     fail_fast: bool = False,
     runner: Optional['SolutionRunner'] = None,
+    benchmark_level: benchmark.BenchmarkLevel = benchmark.BenchmarkLevel.NONE,
+    keep_checker_stderr: bool = False,
 ) -> bool:
     """Run whatever the estimate did not, at the limit the estimate produced.
 
@@ -1665,6 +1680,7 @@ async def _run_remaining(
             # `MojRunner` stages this on the same remote problem `rbx run` uses.
             purpose=RunPurpose.RUN,
             nruns=runs,
+            keep_checker_stderr=keep_checker_stderr,
             # `--fail-fast` is the only reason to stop early here. The two phases
             # above abort on a timeout because a timeout answers their question;
             # this one has no question of its own, so it runs everything unless
@@ -1687,6 +1703,7 @@ async def _run_remaining(
             # the testcases that never ran, so every extreme in the summary
             # would rest on a lower bound. Same rule as `rbx run --fail-fast`.
             timing=not fail_fast,
+            benchmark_level=benchmark_level,
         )
         if fail_fast:
             console.console.print()
@@ -1721,6 +1738,8 @@ async def compute_time_limits(
     dry: bool = False,
     run_all: bool = False,
     fail_fast: bool = False,
+    benchmark_level: benchmark.BenchmarkLevel = benchmark.BenchmarkLevel.NONE,
+    keep_checker_stderr: bool = False,
 ):
     if package.get_main_solution() is None:
         # An error, not a warning: with no accepted solution nothing bounds the
@@ -1738,7 +1757,13 @@ async def compute_time_limits(
     }
 
     run = await _run_for_inference(
-        check=check, detailed=detailed, runs=runs, formula=formula, runner=runner
+        check=check,
+        detailed=detailed,
+        runs=runs,
+        formula=formula,
+        runner=runner,
+        benchmark_level=benchmark_level,
+        keep_checker_stderr=keep_checker_stderr,
     )
     if run is None:
         return None
@@ -1764,6 +1789,8 @@ async def compute_time_limits(
         runs=runs,
         runner=runner,
         ran=ran,
+        benchmark_level=benchmark_level,
+        keep_checker_stderr=keep_checker_stderr,
     )
     if estimated_tl is None:
         return None
@@ -1795,6 +1822,10 @@ async def compute_time_limits(
             _INFERENCE_VERIFICATION,
             detailed=detailed,
             skip_printing_limits=True,
+            # Benchmarked too, for the same reason `rbx run --share` benchmarks
+            # its copy: a shared report silently missing a block the setter asked
+            # for reads as a run that had nothing to report.
+            benchmark_level=benchmark_level,
         )
         rec.print()
         rec.print(
@@ -1810,6 +1841,8 @@ async def compute_time_limits(
         runs=runs,
         fail_fast=fail_fast,
         runner=runner,
+        benchmark_level=benchmark_level,
+        keep_checker_stderr=keep_checker_stderr,
     ):
         # Raised rather than folded into the `None` the estimation returns: that
         # `None` means no limit was produced and nothing was written, and this is

--- a/tests/e2e/testdata/keep-checker-stderr/e2e.rbx.yml
+++ b/tests/e2e/testdata/keep-checker-stderr/e2e.rbx.yml
@@ -25,3 +25,26 @@ scenarios:
           solutions:
             sols/main.cpp: ac
             sols/wrong.cpp: wa
+
+  # `rbx preship` carries both `rbx run` reporting flags. Each stage stages its
+  # run under the same `.rbx/runs` directory, so what is on disk afterwards is
+  # the last stage's -- this pins that the flags survive the whole command, and
+  # `test_timing_run_flags.py` pins that each of the three stages gets them.
+  - name: preship-carries-the-run-reporting-flags
+    steps:
+      - cmd: preship -b1 --keep-checker-stderr
+        expect:
+          files_exist:
+            - "**/*.checker.err"
+          stdout_contains:
+            - 'Benchmark: slowest test'
+            - 'Total judging:'
+
+  - name: preship-benchmarks-nothing-by-default
+    steps:
+      - cmd: preship
+        expect:
+          files_absent:
+            - "**/*.checker.err"
+          stdout_not_contains:
+            - 'Benchmark: slowest test'

--- a/tests/rbx/box/test_timing_run_flags.py
+++ b/tests/rbx/box/test_timing_run_flags.py
@@ -1,0 +1,247 @@
+"""`-b` and `--keep-checker-stderr` reach every run `rbx time` performs.
+
+Both are `rbx run` flags about *how a run is reported and what it leaves behind*
+rather than about what is measured, so they carry over unchanged -- and they
+carry over to all three phases, not only to the one `--run-all` adds: a setter
+asking what the package costs to judge means the whole package, and a checker's
+stderr is worth keeping wherever the checker ran.
+
+The `rbx run` flags that deliberately do *not* carry over are pinned in
+`test_timing_run_flags_omitted.py`.
+"""
+
+import asyncio
+import pathlib
+from typing import List
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box import benchmark, cli, timing, timing_validation
+from rbx.box.schema import ExpectedOutcome, Solution, TimingMultipliers
+from rbx.box.testing import testing_package
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _skip_preset_check():
+    with mock.patch('rbx.box.presets.check_active_preset_compatibility'):
+        yield
+
+
+async def _build_ok(*args, **kwargs):
+    return True
+
+
+def _invoke(runner: CliRunner, args: List[str]):
+    seen = {}
+
+    async def compute_time_limits(check, detailed, runs=0, **kwargs):
+        seen.update(kwargs, check=check, detailed=detailed, runs=runs)
+        return timing.TimingProfile(timeLimit=1000)
+
+    with (
+        mock.patch('rbx.box.builder.build', _build_ok),
+        mock.patch('rbx.box.timing.compute_time_limits', compute_time_limits),
+    ):
+        result = runner.invoke(cli.app, args)
+    return result, seen
+
+
+# How the flags reach `compute_time_limits`.
+
+
+def test_the_benchmark_level_is_off_by_default(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['preship'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['benchmark_level'] is benchmark.BenchmarkLevel.NONE
+    assert seen['keep_checker_stderr'] is False
+
+
+def test_preship_takes_the_benchmark_flag(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['preship', '-b', '1'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['benchmark_level'] is benchmark.BenchmarkLevel.SOLUTIONS
+
+
+def test_time_takes_the_benchmark_flag(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['time', '--auto', '--benchmark', '1'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['benchmark_level'] is benchmark.BenchmarkLevel.SOLUTIONS
+
+
+def test_an_unimplemented_benchmark_level_is_refused(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    # Same rule as `rbx run`: silently treating `-b2` as `-b1` would hand back a
+    # report quietly missing half of what was asked for.
+    result, _ = _invoke(runner, ['preship', '-b', '2'])
+
+    assert result.exit_code != 0
+    assert 'not implemented yet' in result.output
+
+
+def test_preship_takes_keep_checker_stderr(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['preship', '--keep-checker-stderr'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['keep_checker_stderr'] is True
+
+
+def test_time_takes_keep_checker_stderr(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    result, seen = _invoke(runner, ['time', '--auto', '--keep-checker-stderr'])
+
+    assert result.exit_code == 0, result.output
+    assert seen['keep_checker_stderr'] is True
+
+
+# How they reach each of the three phases.
+
+
+def _solution(
+    name: str,
+    language: str = 'cpp',
+    outcome: ExpectedOutcome = ExpectedOutcome.WRONG_ANSWER,
+) -> Solution:
+    return Solution(path=pathlib.Path(name), language=language, outcome=outcome)
+
+
+def _profile() -> timing.TimingProfile:
+    return timing.TimingProfile(
+        timeLimit=1000,
+        multipliers=TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
+    )
+
+
+class _Phase:
+    def __init__(self, run_solutions, print_run_report):
+        self.run_solutions = run_solutions
+        self.print_run_report = print_run_report
+
+    @property
+    def kept_checker_stderr(self):
+        return self.run_solutions.call_args.kwargs['keep_checker_stderr']
+
+    @property
+    def benchmark_level(self):
+        return self.print_run_report.call_args.kwargs['benchmark_level']
+
+
+def _phase_mocks(solutions: List[Solution], report_ok: bool = True):
+    result = mock.Mock()
+    result.skeleton.solutions = list(solutions)
+    result.close = mock.AsyncMock()
+    return result, (
+        mock.patch('rbx.box.package.get_solutions', return_value=solutions),
+        mock.patch('rbx.box.timing.run_solutions', return_value=result),
+        mock.patch('rbx.box.timing.print_run_report', return_value=report_ok),
+        mock.patch('rbx.box.timing.consume_and_key_evaluation_items', return_value={}),
+        mock.patch(
+            'rbx.box.timing.find_language_name', side_effect=lambda sol: sol.language
+        ),
+    )
+
+
+async def _run_phase(coro_factory, solutions: List[Solution]) -> _Phase:
+    result, patches = _phase_mocks(solutions)
+    with (
+        patches[0],
+        patches[1] as mock_run_solutions,
+        patches[2] as mock_print_run_report,
+        patches[3],
+        patches[4],
+    ):
+        await coro_factory()
+    del result
+    return _Phase(mock_run_solutions, mock_print_run_report)
+
+
+async def test_the_remaining_run_carries_both_flags():
+    solutions = [_solution('sols/wa.cpp')]
+
+    phase = await _run_phase(
+        lambda: timing._run_remaining(  # noqa: SLF001
+            _profile(),
+            set(),
+            check=False,
+            detailed=False,
+            runs=0,
+            benchmark_level=benchmark.BenchmarkLevel.SOLUTIONS,
+            keep_checker_stderr=True,
+        ),
+        solutions,
+    )
+
+    assert phase.kept_checker_stderr is True
+    assert phase.benchmark_level is benchmark.BenchmarkLevel.SOLUTIONS
+
+
+async def test_the_upper_bound_check_carries_both_flags():
+    slow = _solution('sols/slow.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED)
+
+    phase = await _run_phase(
+        lambda: timing._validate_upper_bound(  # noqa: SLF001
+            _profile(),
+            [slow],
+            timing_validation.SlowKnowledge(),
+            check=False,
+            detailed=False,
+            runs=0,
+            benchmark_level=benchmark.BenchmarkLevel.SOLUTIONS,
+            keep_checker_stderr=True,
+        ),
+        [slow],
+    )
+
+    assert phase.kept_checker_stderr is True
+    assert phase.benchmark_level is benchmark.BenchmarkLevel.SOLUTIONS
+
+
+async def test_the_estimation_run_carries_both_flags():
+    accepted = _solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED)
+
+    with (
+        mock.patch('rbx.box.timing.get_inference_solutions', return_value=[accepted]),
+        mock.patch(
+            'rbx.box.timing._diagnose_inference_run', mock.AsyncMock(return_value=None)
+        ),
+        mock.patch('rbx.box.timing._report_inference_diagnosis', return_value=True),
+        mock.patch('rbx.box.timing._resolve_inference_strategy') as strategy,
+    ):
+        strategy.return_value.inferenceTimeout = 10_000
+        phase = await _run_phase(
+            lambda: timing._run_for_inference(  # noqa: SLF001
+                check=False,
+                detailed=False,
+                runs=0,
+                formula=None,
+                benchmark_level=benchmark.BenchmarkLevel.SOLUTIONS,
+                keep_checker_stderr=True,
+            ),
+            [accepted],
+        )
+
+    assert phase.kept_checker_stderr is True
+    assert phase.benchmark_level is benchmark.BenchmarkLevel.SOLUTIONS

--- a/tests/rbx/box/test_timing_run_flags_omitted.py
+++ b/tests/rbx/box/test_timing_run_flags_omitted.py
@@ -1,0 +1,69 @@
+"""The `rbx run` flags `rbx time` and `rbx preship` deliberately do not offer.
+
+Each of these would either corrupt the measurement the command exists to make or
+contradict what the command promises to run, so their absence is a decision
+rather than an oversight. Pinned here so adding one is a deliberate act.
+"""
+
+import asyncio
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from rbx.box import cli
+from rbx.box.testing import testing_package
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _skip_preset_check():
+    with mock.patch('rbx.box.presets.check_active_preset_compatibility'):
+        yield
+
+
+@pytest.mark.parametrize(
+    ('flag', 'why'),
+    [
+        # Sanitizers inflate a solution's runtime severalfold, so a limit
+        # estimated under them is a limit for a binary nobody will ship.
+        ('--sanitized', 'would corrupt every timing the estimate rests on'),
+        # The estimation pins ALL_SOLUTIONS so `isDoubleTL` stays off; FULL would
+        # double the very cap the accepted solutions are measured under.
+        ('--verification-level', 'is pinned by the estimation'),
+        # `rbx preship` promises to run every solution. A filter would leave the
+        # ones it skipped looking checked.
+        ('--outcome', 'would contradict "every solution runs"'),
+        ('--tag', 'would contradict "every solution runs"'),
+        ('--choice', 'would contradict "every solution runs"'),
+    ],
+)
+def test_preship_does_not_offer(
+    runner: CliRunner,
+    testing_pkg: testing_package.TestingPackage,
+    flag: str,
+    why: str,
+):
+    result = runner.invoke(cli.app, ['preship', flag, 'x'])
+
+    assert result.exit_code != 0, f'{flag} {why}, but was accepted'
+    assert 'No such option' in result.output
+
+
+def test_preship_takes_no_solution_arguments(
+    runner: CliRunner, testing_pkg: testing_package.TestingPackage
+):
+    # `rbx run` takes solution paths positionally; `rbx preship` runs the whole
+    # package, so a stray path is a mistake worth reporting rather than a filter.
+    result = runner.invoke(cli.app, ['preship', 'sols/main.cpp'])
+
+    assert result.exit_code != 0
+    assert 'unexpected extra argument' in result.output.lower()


### PR DESCRIPTION
Follow-up to #813. `rbx preship` and `rbx time` now take the `rbx run` flags that were missing.

## Added

| Flag | Why it carries over |
| :--- | :--- |
| `-b` / `--benchmark` | Judging cost is a property of the package, not of one command. Applies to **all three phases**, plus the `--share` copy — for the same reason `rbx run --share` benchmarks its copy: a shared report silently missing a block the setter asked for reads as a run that had nothing to report. |
| `--keep-checker-stderr` | A checker's stderr is worth keeping wherever the checker ran, and all three phases run it. |

Both are flags about how a run is *reported* and what it leaves behind, not about what is measured, so they carry over unchanged. `-b2` is refused with the same message `rbx run` gives.

## Deliberately not added

Pinned by `tests/rbx/box/test_timing_run_flags_omitted.py`, so adding one later is a deliberate act rather than a slip:

- **`--sanitized` / `-s`** — sanitizers inflate a solution's runtime severalfold, so a limit estimated under them is a limit for a binary nobody will ship.
- **`--verification-level` / `-v`** — the estimation pins `ALL_SOLUTIONS` precisely so `isDoubleTL` stays off; `FULL` would double the very cap the accepted solutions are measured under.
- **Solution filters** — positional paths, `--outcome`/`-o`, `--tag`, `--choice`/`-c`. `rbx preship` promises to run every solution; a filter would leave the ones it skipped looking checked.

## Note on the signature

`BenchmarkParam` supplies its default through `default_factory` and so carries no Python-level default, which means it has to lead both command signatures — tidying it further down is a `SyntaxError` at import. `rbx run` has the same constraint and the same comment; since command modules are imported lazily, getting it wrong would let `rbx --help` keep working while `rbx time` alone blew up.

## Testing

- `test_timing_run_flags.py` — the flags reach `compute_time_limits`, and each of the three phases receives them.
- `test_timing_run_flags_omitted.py` — the five flags above are refused.
- `tests/e2e/testdata/keep-checker-stderr/e2e.rbx.yml` — two scenarios driving `rbx preship -b1 --keep-checker-stderr` for real, and one pinning that neither happens by default.

1272 unit tests and 10 e2e scenarios green; completion spec regenerated; `cli.md` rows hand-inserted (that file has drifted from its generator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKeJKoEDk5EXt9YfEoKFmF
