### PR TITLE
feat(time): judge the remaining solutions at 2*TL, like rbx run

### DIFF
--- a/docs/setters/profiling/estimating.md
+++ b/docs/setters/profiling/estimating.md
@@ -182,6 +182,13 @@ fails if any of them does not behave as `problem.rbx.yml` says it does. The solu
 already ran are not run again: an accepted one was measured under a far looser cap, and a slow
 one timed out at a bound above the limit, so both answers already hold.
 
+This stage judges rather than measures, so it runs them exactly as
+[`rbx run`](../running/index.md) would: with twice the time limit, and with the warning that
+appears when a TLE solution passes within `2*TL`. The verdicts are the ones the limit itself
+produces — anything past `1*TL` is still a TLE — so the extra headroom only buys the report
+those warnings. The four stages before it never double anything: their caps are what the
+estimate is measured against, and a doubled cap is a corrupted measurement.
+
 Add `--fail-fast` (or `--ff`) to stop each of those solutions at its first non-accepted
 verdict. It applies to this stage only, it is for quick experimentation, and the report drops
 its timing summary under it — a solution that stopped early was not timed on the testcases that
@@ -202,7 +209,7 @@ Both commands also take the `rbx run` flags about how a run is reported, and app
 stage: `-b` for a [judging-time benchmark](../running/index.md#benchmarking-the-judging-time),
 and [`--keep-checker-stderr`](../running/index.md#reading-what-the-checker-said). Neither takes
 `--sanitized` (sanitizers inflate every timing the estimate rests on), `--verification-level`
-(pinned, so the estimation cap is never doubled), or a solution filter (both run the whole
+(each stage is pinned to the level its job calls for), or a solution filter (both run the whole
 package by definition).
 
 ## Sharing the report

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -71,8 +71,11 @@ class MissingLowerBoundError(RbxException):
         self.msg.append(message)
 
 
-# Solutions are verified during estimation, but never at FULL -- which is the
-# only level that turns `isDoubleTL` on (see `limits_info._get_limits_from_profile`).
+# The level of the phases that *measure*: never FULL, which is the only level
+# that turns `isDoubleTL` on (see `limits_info._get_limits_from_profile`), and a
+# doubled cap is a corrupted measurement. `_run_remaining_solutions` measures
+# nothing and runs at FULL instead, like `rbx run`; the reasoning is written out
+# at that call site.
 _INFERENCE_VERIFICATION = VerificationLevel.ALL_SOLUTIONS
 
 _NO_LOWER_BOUND_MESSAGE = (
@@ -1639,6 +1642,11 @@ async def _run_remaining(
     at `ceil(TL x timeLimitToTle) >= TL` times out here a fortiori -- and the
     time limit is part of the sandbox cache key, so re-running them would cost a
     full second pass to learn nothing.
+
+    One consequence of that, worth saying out loud now that this phase runs at
+    FULL: the 2x-TL diagnostics cover the solutions this phase runs, and only
+    those. A slow solution the upper-bound check already settled is not reported
+    as fitting in 2x TL -- that check asked a stricter question and answered it.
     """
     remaining = [
         solution
@@ -1669,11 +1677,27 @@ async def _run_remaining(
             runner=runner,
             tracked_solutions=tracked_solutions,
             check=check,
-            # ALL_SOLUTIONS keeps `isDoubleTL` off, as in both phases above: the
-            # override carries the estimated limit exactly, and doubling it here
-            # would judge every remaining solution against a limit the setter is
-            # not about to ship.
-            verification=_INFERENCE_VERIFICATION,
+            # FULL, which is what `rbx run` defaults to -- and unlike both
+            # phases above, this one measures nothing, so `isDoubleTL` is safe
+            # to turn on. It does not judge the solutions against 2x the limit:
+            # `_get_execution_config` doubles the *sandbox* limit only, leaving
+            # `problemLimits.time` at the estimate, and that is the value
+            # `checkers._process_run_log` stamps TLE from. Every verdict is the
+            # one a 1x run would have produced; what the headroom buys is the
+            # diagnostics a setter about to ship wants and `ALL_SOLUTIONS` cannot
+            # produce -- a solution declared `tle` that actually fits in 2x TL,
+            # and the verdicts a soft TLE hid (see `runUnderDoubleTl` and
+            # `unexpectedNoTleVerdicts` in `solutions.py`). None of them feed the
+            # pass/fail status, so this run's exit code keeps meaning what it
+            # meant. The bill is wall clock: a solution that times out here is
+            # killed at 2x TL, exactly as it is under `rbx run`.
+            #
+            # The two phases above stay at `_INFERENCE_VERIFICATION` because
+            # they measure: doubling phase one's cap doubles the
+            # `inferenceTimeout` its accepted solutions are measured against,
+            # and doubling phase two's doubles the `TL x timeLimitToTle` it
+            # probes at, whose measured time decides `violates_upper_bound`.
+            verification=VerificationLevel.FULL,
             timelimit_override=limits,
             # A plain run, and said so: these solutions are not being measured
             # for anything, they are being judged against the limit that was.
@@ -1696,9 +1720,16 @@ async def _run_remaining(
         ok = await print_run_report(
             result,
             console.console,
-            _INFERENCE_VERIFICATION,
+            # The level the run above actually used. Passing the inference one
+            # would report a run that did not happen: this argument is read both
+            # for the `>TL ms` formatting and for the double-TL verdict logic.
+            VerificationLevel.FULL,
             detailed=detailed,
-            skip_printing_limits=True,
+            # Printed here, unlike in the two phases above, whose caps are
+            # internal to the estimation. This phase judges against the limit
+            # the setter is about to ship, so the limits table -- and with it the
+            # `Running with 2*TL` warning -- is what says at what.
+            skip_printing_limits=False,
             # A solution that stopped at its first bad verdict was not timed on
             # the testcases that never ran, so every extreme in the summary
             # would rest on a lower bound. Same rule as `rbx run --fail-fast`.

--- a/tests/e2e/testdata/mixed-solutions/e2e.rbx.yml
+++ b/tests/e2e/testdata/mixed-solutions/e2e.rbx.yml
@@ -75,6 +75,11 @@ scenarios:
             - 'Run report (for time estimation)'
             - 'Run report (upper-bound validation)'
             - 'Run report (remaining solutions)'
+            # The remaining-solutions phase judges rather than measures, so it
+            # runs like `rbx run` -- at 2*TL, and printing the limits it judged
+            # against. Neither estimation phase prints a limits table, so this
+            # line can only come from that one.
+            - 'Running with 2*TL'
           files_exist:
             - '.limits/local.yml'
           file_contains:

--- a/tests/rbx/box/test_timing_run_flags_omitted.py
+++ b/tests/rbx/box/test_timing_run_flags_omitted.py
@@ -36,8 +36,10 @@ def _skip_preset_check():
         # Sanitizers inflate a solution's runtime severalfold, so a limit
         # estimated under them is a limit for a binary nobody will ship.
         ('--sanitized', 'would corrupt every timing the estimate rests on'),
-        # The estimation pins ALL_SOLUTIONS so `isDoubleTL` stays off; FULL would
-        # double the very cap the accepted solutions are measured under.
+        # Every phase's level is pinned: the two that measure run at
+        # ALL_SOLUTIONS so `isDoubleTL` stays off -- FULL would double the very
+        # cap they measure under -- and the remaining-solutions phase runs at
+        # FULL, like `rbx run`. See `test_timing_verification_level.py`.
         ('--verification-level', 'is pinned by the estimation'),
         # `rbx preship` promises to run every solution. A filter would leave the
         # ones it skipped looking checked.

--- a/tests/rbx/box/test_timing_verification_level.py
+++ b/tests/rbx/box/test_timing_verification_level.py
@@ -1,0 +1,189 @@
+"""The verification level each `rbx time` phase runs at.
+
+Two of the three phases measure, and the level they run at is part of what they
+measure: FULL is the only level that turns `isDoubleTL` on, and a doubled cap is
+a doubled `inferenceTimeout` in the estimation phase and a doubled probe limit in
+the upper-bound check. The remaining-solutions phase measures nothing -- it
+judges, against the limit the other two produced -- so it runs at FULL, like
+`rbx run`, and gets the 2x-TL diagnostics `rbx run` reports.
+
+Pinned here because the difference between the phases is deliberate and invisible
+from the call sites alone.
+"""
+
+import pathlib
+from typing import List
+from unittest import mock
+
+from rbx.box import benchmark, timing, timing_validation
+from rbx.box.environment import VerificationLevel
+from rbx.box.schema import ExpectedOutcome, Solution, TimingMultipliers
+from rbx.box.tasks import get_limits_for_language
+
+
+def _solution(
+    name: str,
+    language: str = 'cpp',
+    outcome: ExpectedOutcome = ExpectedOutcome.WRONG_ANSWER,
+) -> Solution:
+    return Solution(path=pathlib.Path(name), language=language, outcome=outcome)
+
+
+def _profile() -> timing.TimingProfile:
+    return timing.TimingProfile(
+        timeLimit=1000,
+        multipliers=TimingMultipliers(acToTimeLimit=2.0, timeLimitToTle=1.5),
+    )
+
+
+class _Phase:
+    """What a phase asked of `run_solutions` and of the report."""
+
+    def __init__(self, run_solutions, print_run_report):
+        self.run_solutions = run_solutions
+        self.print_run_report = print_run_report
+
+    @property
+    def ran_at(self) -> VerificationLevel:
+        return self.run_solutions.call_args.kwargs['verification']
+
+    @property
+    def reported_at(self) -> VerificationLevel:
+        # Third positional of `print_run_report`.
+        return self.print_run_report.call_args.args[2]
+
+    @property
+    def skipped_printing_limits(self) -> bool:
+        return self.print_run_report.call_args.kwargs['skip_printing_limits']
+
+
+async def _run_phase(coro_factory, solutions: List[Solution]) -> _Phase:
+    result = mock.Mock()
+    result.skeleton.solutions = list(solutions)
+    result.close = mock.AsyncMock()
+    with (
+        mock.patch('rbx.box.package.get_solutions', return_value=solutions),
+        mock.patch(
+            'rbx.box.timing.run_solutions', return_value=result
+        ) as mock_run_solutions,
+        mock.patch(
+            'rbx.box.timing.print_run_report', return_value=True
+        ) as mock_print_run_report,
+        mock.patch('rbx.box.timing.consume_and_key_evaluation_items', return_value={}),
+        mock.patch(
+            'rbx.box.timing.find_language_name', side_effect=lambda sol: sol.language
+        ),
+    ):
+        await coro_factory()
+    return _Phase(mock_run_solutions, mock_print_run_report)
+
+
+async def _remaining_phase() -> _Phase:
+    return await _run_phase(
+        lambda: timing._run_remaining(  # noqa: SLF001
+            _profile(),
+            set(),
+            check=False,
+            detailed=False,
+            runs=0,
+            benchmark_level=benchmark.BenchmarkLevel.NONE,
+        ),
+        [_solution('sols/wa.cpp')],
+    )
+
+
+async def test_the_remaining_run_runs_at_full():
+    # The solutions the estimate never needed -- every `wrong-answer`, every
+    # `rte`, every slow one `--skip-slow` let through -- are judged here exactly
+    # as `rbx run` would judge them.
+    phase = await _remaining_phase()
+
+    assert phase.ran_at is VerificationLevel.FULL
+
+
+async def test_the_remaining_run_is_reported_at_the_level_it_ran_at():
+    # The report reads this both for the `>TL ms` formatting and for the
+    # double-TL verdict logic, so reporting a level the run did not use would
+    # describe a run that did not happen.
+    phase = await _remaining_phase()
+
+    assert phase.reported_at is VerificationLevel.FULL
+
+
+async def test_the_remaining_run_prints_the_limits_it_judged_against():
+    # Unlike the two phases above, whose caps are internal to the estimation,
+    # this one judges against the limit the setter is about to ship -- so the
+    # limits table, and with it the `Running with 2*TL` warning, is printed.
+    phase = await _remaining_phase()
+
+    assert phase.skipped_printing_limits is False
+
+
+async def test_the_upper_bound_check_stays_below_full():
+    # It probes at `TL x timeLimitToTle` and feeds the measured time into
+    # `violates_upper_bound`. Doubling that cap changes what it concludes.
+    slow = _solution('sols/slow.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED)
+
+    phase = await _run_phase(
+        lambda: timing._validate_upper_bound(  # noqa: SLF001
+            _profile(),
+            [slow],
+            timing_validation.SlowKnowledge(),
+            check=False,
+            detailed=False,
+            runs=0,
+            benchmark_level=benchmark.BenchmarkLevel.NONE,
+        ),
+        [slow],
+    )
+
+    assert phase.ran_at is timing._INFERENCE_VERIFICATION  # noqa: SLF001
+    assert phase.ran_at.value < VerificationLevel.FULL.value
+
+
+async def test_the_estimation_run_stays_below_full():
+    # Its cap is the `inferenceTimeout` the accepted solutions are measured
+    # against. Doubling it doubles the very bound the measurement rests on.
+    accepted = _solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED)
+
+    with (
+        mock.patch('rbx.box.timing.get_inference_solutions', return_value=[accepted]),
+        mock.patch(
+            'rbx.box.timing._diagnose_inference_run', mock.AsyncMock(return_value=None)
+        ),
+        mock.patch('rbx.box.timing._report_inference_diagnosis', return_value=True),
+        mock.patch('rbx.box.timing._resolve_inference_strategy') as strategy,
+    ):
+        strategy.return_value.inferenceTimeout = 10_000
+        phase = await _run_phase(
+            lambda: timing._run_for_inference(  # noqa: SLF001
+                check=False,
+                detailed=False,
+                runs=0,
+                formula=None,
+                benchmark_level=benchmark.BenchmarkLevel.NONE,
+            ),
+            [accepted],
+        )
+
+    assert phase.ran_at is timing._INFERENCE_VERIFICATION  # noqa: SLF001
+    assert phase.ran_at.value < VerificationLevel.FULL.value
+
+
+def test_full_is_what_turns_double_tl_on(testing_pkg):
+    # What the levels above actually buy, stated once so the assertions on them
+    # are readable: only FULL doubles the sandbox limit.
+    assert (
+        get_limits_for_language(
+            'cpp', VerificationLevel.FULL, timelimit_override=None
+        ).isDoubleTL
+        is True
+    )
+    assert (
+        get_limits_for_language(
+            'cpp',
+            timing._INFERENCE_VERIFICATION,  # noqa: SLF001
+            timelimit_override=None,
+        ).isDoubleTL
+        is False
+    )


### PR DESCRIPTION
The last phase of `rbx time --run-all` / `rbx preship` — the one that runs the solutions the estimate never needed — ran at `ALL_SOLUTIONS`, the level the two estimation phases are pinned to. `FULL` is the only level that turns `isDoubleTL` on, so `preship` judged every `wrong-answer`, `rte`, `accepted-or-tle` and `--skip-slow` solution without any of the 2×TL diagnostics `rbx run` gives: no warning when a solution declared `tle` actually fits in 2×TL, and no verdict recovered from under a soft TLE.

### Why the phase can double when the other two cannot

The comment on that call site claimed doubling would "judge every remaining solution against a limit the setter is not about to ship". That is not what the mechanism does. `tasks._get_execution_config` doubles the **sandbox** limit only and leaves `problemLimits.time` at the estimate, and `problemLimits.time` is what `checkers._process_run_log` stamps TLE from. Anything past 1×TL is still a TLE. So every verdict is the one a 1×TL run produces, and the headroom only buys the report `runUnderDoubleTl`, `doubleTlVerdicts` and `unexpectedNoTleVerdicts` — none of which feed `SolutionOutcomeStatus`, so `preship`'s exit code keeps meaning exactly what it meant.

The other two phases stay at `_INFERENCE_VERIFICATION` because they *measure*: doubling phase one's cap doubles the `inferenceTimeout` its accepted solutions are measured against, and doubling phase two's doubles the `TL × timeLimitToTle` it probes at, whose measured time decides `violates_upper_bound`. The constant's comment now says that is what it means.

The cost is wall clock: a solution that times out in this phase is killed at 2×TL rather than 1×TL — the same bill `rbx run` already pays.

### Also

- The phase stops passing `skip_printing_limits`, so its report shows the per-language limits it judged against and the `Running with 2*TL` warning. The two estimation phases still suppress theirs, since their caps are internal to the estimate.
- `print_run_report` gets the level the run actually used; it reads that both for the `>TL ms` formatting and for the double-TL verdict logic, so passing the old one would have described a run that did not happen.

### Scope

Deliberately unchanged: which solutions run, how they are selected, and the flags `rbx time`/`preship` refuse (`--sanitized`, `--verification-level`, solution filters). `--runs` was already equivalent to `rbx run`'s default — `nruns=0` resolves to the same setter config.

### Tests

- `tests/rbx/box/test_timing_verification_level.py` (new): pins each phase's level, the level the remaining-solutions report is rendered at, and that it prints its limits. Verified to fail against the old code (3 of 6).
- `tests/e2e/testdata/mixed-solutions/e2e.rbx.yml`: the `preship` scenario now asserts `Running with 2*TL` in the output. Neither estimation phase prints a limits table, so the line can only come from the remaining-solutions phase — an end-to-end proof the doubling is really on.
- Docs updated in `docs/setters/profiling/estimating.md`, including the `--verification-level` line, which said the level was pinned "so the estimation cap is never doubled".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RB1DFbNw2a4UtzA3p8Qbi
