### PR TITLE
feat(grading): warn when a configured stack limit cannot be honored

### DIFF
--- a/docs/plans/2026-08-29-stack-limit-warning-design.md
+++ b/docs/plans/2026-08-29-stack-limit-warning-design.md
@@ -1,0 +1,112 @@
+# Warn when a configured `stackLimit` cannot be honored
+
+Design for [#800](https://github.com/rsalesc/rbx/issues/800). Follow-up to #799, which wired
+`EnvironmentSandbox.stackLimit` through to `RLIMIT_STACK` on Linux.
+
+## Problem
+
+`get_preexec_fn` (`rbx/grading/judge/program.py`) applies the stack limit inside the forked child
+and swallows failures, because an exception raised in `preexec_fn` takes the whole run down. The
+`except` is correct, but it means a setter who configures `stackLimit: 256` on a machine whose hard
+`RLIMIT_STACK` is 8 MiB silently gets 8 MiB. Solutions then fail in ways that look like genuine
+RTEs.
+
+The diagnosis has to happen in the parent, before the fork, where a message can be printed and
+attributed to the configuration that caused it.
+
+## Why the check is OS-dependent
+
+The two platforms fail differently, so one check with a platform guard will not do.
+
+- **Linux** -- `setrlimit(RLIMIT_STACK)` does run, so the inherited *soft* limit is irrelevant: we
+  raise it ourselves. Only the **hard** limit caps us, and exceeding it is the silent degradation
+  #800 describes.
+- **macOS** -- `get_preexec_fn` skips `RLIMIT_STACK` entirely, so the effective stack is whatever
+  the shell handed down. A configured `stackLimit` is inert there regardless of the numbers,
+  including the case where a deep-recursion solution that *should* be caught by the cap is not.
+
+`_check_stack_limit` (`rbx/box/code.py:298`) is macOS-only today and stays that way. It is about a
+different thing -- the *machine's* soft-vs-hard shell misconfiguration -- and it keeps its existing
+`ulimit -s` guidance. The new check is about the *package's* `env.rbx.yml`, and gets its own home.
+
+## Placement
+
+`params.stack_space` is not final at `code.py`. `_relax_limits_for_jvm` (`rbx/grading/steps.py:506`)
+nulls it for JVM commands, since an `RLIMIT_STACK` bounds only the JVM launcher's main thread. That
+runs at three sites -- `steps.py:832`, `:925`, `:969` -- all of them well after the
+`_check_stack_limit()` calls at `code.py:647` and `code.py:872`. Probing from `code.py` would warn
+about a limit that is subsequently dropped, on every Java and Kotlin run.
+
+So the probe goes in `steps.py`, immediately after the relax, folded into a single
+`_finalize_limits(command, params)` helper called from those three sites so the pair cannot drift
+apart. That is the last point at which `params.stack_space` is still the value that reaches
+`stupid_sandbox.py:128` and `ProgramParams.stack_limit`, and it is still parent-side.
+
+`steps.py` already imports from `rbx.box` (`safeeval`, `exception`), and
+`_maybe_complain_about_sanitization` (`steps.py:679`) is the precedent for a platform-conditional
+diagnostic in this file.
+
+## Surfacing
+
+The warning goes on the issue stack (`rbx/box/sanitizers/issue_stack.py`), not to the console.
+
+- `IssueAccumulator._print_report_by` already skips repeated messages within a section, so "warn
+  once per run" falls out of identical message strings -- no seen-set needed however many programs
+  are spawned.
+- `package.within_problem` prints the report once at the end of the command
+  (`rbx/box/package.py:106`), so the warning lands in the Issues rule instead of scrolling past
+  mid-build.
+
+`StackLimitNotHonoredIssue(issue_stack.Issue)`, defined beside the probe:
+
+- `get_severity()` -> `WARNING`, matching `TimingIssue` (`rbx/box/solutions.py:2325`). The run still
+  produces meaningful results, and erroring would block runs that do not involve the affected
+  language at all.
+- Section key `('stack limit',)` for both detailed and overview.
+- Overview is implemented, not just detailed: `IssueLevel.OVERVIEW` is set for contest-level runs
+  (`rbx/box/contest/contest_package.py:296`), and a machine-wide ceiling affects every problem in
+  the contest.
+
+Messages carry the numbers and a link, nothing else -- no inline `ulimit -Hs` or `limits.conf`
+recipe, since `docs/stack-limit.md` already has an *Increase the hard stack limit* section:
+
+- Linux: "`stackLimit` is set to 256 MiB, but this machine's hard stack limit is 8 MiB, so programs
+  run with 8 MiB. See https://rsalesc.github.io/rbx/stack-limit"
+- macOS: "`stackLimit` is set to 256 MiB, but it is not enforced on macOS. See
+  https://rsalesc.github.io/rbx/stack-limit"
+
+## Conditions
+
+Gated on `setter_config.judging.check_stack`, the same switch that silences the existing check.
+No-op when `params.stack_space is None` -- both because that is the documented "as large as the
+system allows" path and because it is what JVM commands look like after the relax.
+
+| Platform | Condition | Result |
+| --- | --- | --- |
+| Linux | `stack_space` set, hard limit finite and below it | warn, naming both values |
+| Linux | `stack_space` set, hard limit unlimited or above it | silent |
+| macOS | `stack_space` set | warn, "not enforced on macOS" |
+| any | `stack_space` unset | silent |
+
+## Related fix
+
+When `stackLimit` is unset, the child asks for `RLIM_INFINITY`. On a machine with a finite hard
+limit that call *fails*, and the fallback is the inherited **soft** limit -- not the hard one. So
+`EnvironmentSandbox.stackLimit`'s promise that "the stack is made as large as the system allows"
+(`rbx/box/environment.py:133`) is false on any such machine: you get the shell's 8 MiB even when the
+hard limit is far higher.
+
+`get_preexec_fn` should request `min(requested, hard)` rather than let the call fail outright. This
+ships as a separate commit; it needs no syscall moved out of the child.
+
+## Not in scope
+
+Moving the `setrlimit` calls themselves out of `preexec_fn` -- they have to run in the child. Only
+the probe moves. The child-side `except` stays exactly as it is: this is a diagnostic, not a new
+failure mode.
+
+## Docs
+
+A short cross-link from *Cap the stack of the programs rbx runs* in `docs/stack-limit.md` to the
+existing *Increase the hard stack limit* section, noting that the hard limit is a ceiling on
+`stackLimit`.

--- a/docs/plans/2026-08-29-stack-limit-warning.md
+++ b/docs/plans/2026-08-29-stack-limit-warning.md
@@ -1,0 +1,721 @@
+# Stack Limit Warning Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Warn on the issue stack, once per run, when a configured `stackLimit` cannot be honored --
+because the machine's hard `RLIMIT_STACK` is lower on Linux, or because macOS does not enforce it at
+all -- instead of degrading silently.
+
+**Architecture:** A parent-side probe in `rbx/grading/steps.py`, placed immediately after
+`_relax_limits_for_jvm` so it reads the final `params.stack_space` (JVM commands have theirs nulled
+by then). It pushes a `StackLimitNotHonoredIssue` onto the issue stack rather than printing, so the
+warning is deduped and reported once at the end of the command. Plus a separate fix to
+`get_preexec_fn` so an unset `stackLimit` clamps to the hard limit rather than failing outright.
+
+**Tech Stack:** Python 3, pytest, `unittest.mock`, `resource`, Pydantic v2 (`SandboxParams`), Rich
+(via `rbx.box.sanitizers.issue_stack`).
+
+**Design doc:** [`docs/plans/2026-08-29-stack-limit-warning-design.md`](2026-08-29-stack-limit-warning-design.md)
+
+**Issue:** [#800](https://github.com/rsalesc/rbx/issues/800)
+
+---
+
+## Background you need before starting
+
+Read these before Task 1. They are short.
+
+- `rbx/grading/steps.py:506-519` -- `_relax_limits_for_jvm`, which nulls `params.stack_space` for
+  Java/Kotlin. Called at `steps.py:832`, `:925` and `:969`. Your probe must run *after* it, or it
+  will warn about a limit that is then discarded.
+- `rbx/grading/steps.py:679-699` -- `_maybe_complain_about_sanitization`. The naming and shape
+  precedent for a platform-conditional diagnostic in this file.
+- `rbx/box/sanitizers/issue_stack.py` -- the whole file. Note that
+  `IssueAccumulator._print_report_by` skips repeated messages within a section (`seen_issues`), so
+  "warn once per run" is free as long as the message string is identical between calls. Do **not**
+  add a seen-set.
+- `rbx/box/solutions.py:2325-2342` -- `TimingIssue`, the closest existing `Issue` subclass. Copy its
+  shape.
+- `rbx/grading/judge/program.py:99-125` -- `get_preexec_fn`, for Task 5.
+
+Two things that are **not** in scope and must not change:
+
+- `rbx/box/code.py:298` `_check_stack_limit` -- the macOS shell soft-vs-hard nag. Different concern,
+  stays exactly as it is.
+- The `except (ValueError, OSError)` in `get_preexec_fn`. It stays. This work is a diagnostic, not a
+  new failure mode.
+
+---
+
+## Task 1: The `StackLimitNotHonoredIssue` class
+
+**Files:**
+- Modify: `rbx/grading/steps.py` (add after `_relax_limits_for_jvm`, around line 520)
+- Test: `tests/rbx/grading/steps_stack_limit_test.py` (create)
+
+**Step 1: Write the failing tests**
+
+Create `tests/rbx/grading/steps_stack_limit_test.py`:
+
+```python
+from rbx.grading.steps import StackLimitNotHonoredIssue
+from rbx.box.sanitizers.issue_stack import IssueSeverity
+
+
+class TestStackLimitNotHonoredIssue:
+    def test_issue_is_a_warning_not_an_error(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
+
+        assert issue.get_severity() == IssueSeverity.WARNING
+
+    def test_detailed_message_names_both_limits_and_links_the_docs(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
+
+        message = issue.get_detailed_message()
+
+        assert '256 MiB' in message
+        assert '8 MiB' in message
+        assert 'https://rsalesc.github.io/rbx/stack-limit' in message
+
+    def test_detailed_message_says_unenforced_when_there_is_no_hard_limit(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=None)
+
+        message = issue.get_detailed_message()
+
+        assert '256 MiB' in message
+        assert 'macOS' in message
+        assert 'https://rsalesc.github.io/rbx/stack-limit' in message
+
+    def test_both_reports_file_the_issue_under_the_same_section(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=None)
+
+        assert issue.get_detailed_section() == ('stack limit',)
+        assert issue.get_overview_section() == ('stack limit',)
+
+    def test_overview_message_is_present_and_links_the_docs(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
+
+        assert 'https://rsalesc.github.io/rbx/stack-limit' in issue.get_overview_message()
+
+    def test_two_issues_with_the_same_values_produce_the_same_message(self):
+        """The issue stack dedupes on the message string, so this is what makes
+        the warning print once per run rather than once per program."""
+        first = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
+        second = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
+
+        assert first.get_detailed_message() == second.get_detailed_message()
+        assert first.get_overview_message() == second.get_overview_message()
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/grading/steps_stack_limit_test.py -v`
+Expected: FAIL, `ImportError: cannot import name 'StackLimitNotHonoredIssue'`
+
+**Step 3: Write the implementation**
+
+In `rbx/grading/steps.py`, right after `_relax_limits_for_jvm` (which ends at line 519). Add the
+import `from rbx.box.sanitizers import issue_stack` to the `rbx.box` import block near line 18 --
+`steps.py` already imports `rbx.box.safeeval` and `rbx.box.exception`, so this is the same direction
+of dependency, not a new layering violation.
+
+```python
+_STACK_LIMIT_DOCS = 'https://rsalesc.github.io/rbx/stack-limit'
+
+
+class StackLimitNotHonoredIssue(issue_stack.Issue):
+    """A configured `stackLimit` that the machine will not actually apply.
+
+    `hard_limit` is the ceiling that will be used instead, in bytes, or `None`
+    when the limit is not enforced at all (macOS, where `get_preexec_fn` never
+    touches `RLIMIT_STACK`).
+    """
+
+    def __init__(self, requested_mib: int, hard_limit: Optional[int]):
+        self.requested_mib = requested_mib
+        self.hard_limit = hard_limit
+
+    def get_detailed_section(self) -> Optional[Tuple[str, ...]]:
+        return ('stack limit',)
+
+    def get_overview_section(self) -> Optional[Tuple[str, ...]]:
+        return ('stack limit',)
+
+    def get_detailed_message(self) -> str:
+        from rbx.box.formatting import get_formatted_memory
+
+        requested = get_formatted_memory(self.requested_mib * 1024 * 1024)
+        if self.hard_limit is None:
+            return (
+                f'[item]stackLimit[/item] is set to [item]{requested}[/item], but it is '
+                'not enforced on macOS: the stack of a sandboxed program is whatever '
+                f'your shell hands down. See [item]{_STACK_LIMIT_DOCS}[/item].'
+            )
+        effective = get_formatted_memory(self.hard_limit)
+        return (
+            f'[item]stackLimit[/item] is set to [item]{requested}[/item], but this '
+            f"machine's hard stack limit is [item]{effective}[/item], so programs run "
+            f'with [item]{effective}[/item]. See [item]{_STACK_LIMIT_DOCS}[/item].'
+        )
+
+    def get_overview_message(self) -> str:
+        return self.get_detailed_message()
+
+    def get_severity(self) -> issue_stack.IssueSeverity:
+        return issue_stack.IssueSeverity.WARNING
+```
+
+Note `get_formatted_memory` is imported inside the method: `rbx.box.formatting` is a heavier import
+than `steps.py` should pay for at module scope, and this path is cold.
+
+Check `Optional` and `Tuple` are already imported in `steps.py`'s `typing` import; add them if not.
+
+**Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/grading/steps_stack_limit_test.py -v`
+Expected: PASS, 6 passed
+
+**Step 5: Commit**
+
+Stage `rbx/grading/steps.py` and `tests/rbx/grading/steps_stack_limit_test.py`, then commit with
+`feat(grading): add an issue for a stack limit the machine will not honor`.
+
+---
+
+## Task 2: The probe
+
+**Files:**
+- Modify: `rbx/grading/steps.py` (add after `StackLimitNotHonoredIssue`)
+- Test: `tests/rbx/grading/steps_stack_limit_test.py`
+
+**Step 1: Write the failing tests**
+
+Append to `tests/rbx/grading/steps_stack_limit_test.py`. Add these imports at the top of the file:
+
+```python
+import contextlib
+import resource
+from unittest import mock
+
+import pytest
+
+from rbx.box.sanitizers.issue_stack import IssueAccumulator, issue_stack_var
+from rbx.grading.judge.sandbox import SandboxParams
+from rbx.grading.steps import _maybe_complain_about_stack_limit
+
+
+@contextlib.contextmanager
+def _fresh_issue_stack():
+    """Isolate the issue stack, so a test sees exactly the issues it caused."""
+    accumulator = IssueAccumulator()
+    token = issue_stack_var.set([accumulator])
+    try:
+        yield accumulator
+    finally:
+        issue_stack_var.reset(token)
+
+
+@pytest.fixture
+def stack_check_enabled():
+    """`_maybe_complain_about_stack_limit` reads the setter config; pin it on."""
+    with mock.patch('rbx.box.setter_config.get_setter_config') as mock_config:
+        mock_config.return_value.judging.check_stack = True
+        yield mock_config
+```
+
+Then the tests:
+
+```python
+class TestMaybeComplainAboutStackLimit:
+    @mock.patch('sys.platform', 'linux')
+    def test_warns_on_linux_when_the_hard_limit_is_below_the_request(
+        self, stack_check_enabled
+    ):
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert len(accumulator.issues) == 1
+        issue = accumulator.issues[0]
+        assert issue.requested_mib == 256
+        assert issue.hard_limit == 8 * 1024 * 1024
+
+    @mock.patch('sys.platform', 'linux')
+    def test_silent_on_linux_when_the_hard_limit_is_above_the_request(
+        self, stack_check_enabled
+    ):
+        params = SandboxParams(stack_space=64)
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 512 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_silent_on_linux_when_the_hard_limit_is_unlimited(
+        self, stack_check_enabled
+    ):
+        params = SandboxParams(stack_space=1024)
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(8 * 1024 * 1024, resource.RLIM_INFINITY),
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_the_soft_limit_is_irrelevant_on_linux(self, stack_check_enabled):
+        """We raise the soft limit ourselves in the child; only the hard one caps us."""
+        params = SandboxParams(stack_space=64)
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(1 * 1024 * 1024, resource.RLIM_INFINITY),
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'darwin')
+    def test_warns_on_darwin_whenever_a_limit_is_configured(self, stack_check_enabled):
+        """macOS never applies RLIMIT_STACK, so the numbers do not matter."""
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(resource.RLIM_INFINITY, resource.RLIM_INFINITY),
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert len(accumulator.issues) == 1
+        assert accumulator.issues[0].hard_limit is None
+
+    @mock.patch('sys.platform', 'linux')
+    def test_silent_when_no_limit_is_configured(self, stack_check_enabled):
+        params = SandboxParams(stack_space=None)
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_silent_when_the_check_is_disabled_in_the_setter_config(self):
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch('rbx.box.setter_config.get_setter_config') as mock_config:
+            mock_config.return_value.judging.check_stack = False
+            with mock.patch(
+                'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+            ):
+                with _fresh_issue_stack() as accumulator:
+                    _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_survives_a_getrlimit_that_raises(self, stack_check_enabled):
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch('resource.getrlimit', side_effect=OSError('nope')):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/grading/steps_stack_limit_test.py -v`
+Expected: FAIL, `ImportError: cannot import name '_maybe_complain_about_stack_limit'`
+
+**Step 3: Write the implementation**
+
+In `rbx/grading/steps.py`, right after `StackLimitNotHonoredIssue`. Check `resource` is imported at
+the top of `steps.py`; add `import resource` if not.
+
+```python
+def _maybe_complain_about_stack_limit(params: SandboxParams) -> None:
+    """Diagnose a `stackLimit` the machine will not actually apply.
+
+    `get_preexec_fn` swallows a `setrlimit` that the system refuses -- raising in
+    the forked child would take the whole run down -- so a limit above the hard
+    `RLIMIT_STACK` degrades silently to whatever the process inherited, and the
+    solutions that then blow their stack look like ordinary RTEs. Diagnose it
+    here, in the parent, where it can still be attributed to the configuration
+    that caused it.
+
+    Call this *after* `_relax_limits_for_jvm`: a JVM command has no stack limit
+    left to complain about by then.
+    """
+    if params.stack_space is None:
+        # No limit configured: the stack is made as large as the system allows,
+        # which is exactly what is documented.
+        return
+
+    from rbx.box import setter_config
+
+    if not setter_config.get_setter_config().judging.check_stack:
+        return
+
+    if sys.platform == 'darwin':
+        # `get_preexec_fn` never touches RLIMIT_STACK here, so the configured
+        # limit is inert whatever the numbers say.
+        issue_stack.add_issue(StackLimitNotHonoredIssue(params.stack_space, None))
+        return
+
+    try:
+        _, hard = resource.getrlimit(resource.RLIMIT_STACK)
+    except Exception:
+        return
+
+    if hard == resource.RLIM_INFINITY:
+        return
+    if hard >= params.stack_space * 1024 * 1024:
+        return
+
+    issue_stack.add_issue(StackLimitNotHonoredIssue(params.stack_space, hard))
+```
+
+**Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/grading/steps_stack_limit_test.py -v`
+Expected: PASS, 14 passed
+
+**Step 5: Commit**
+
+Stage the same two files, then commit with
+`feat(grading): probe the stack limit before spawning a program`.
+
+---
+
+## Task 3: Wire the probe into the three run paths
+
+The probe is dead code until it is called. It must run at every site that calls
+`_relax_limits_for_jvm`, immediately after it. Fold both into one helper so the pair cannot drift.
+
+**Files:**
+- Modify: `rbx/grading/steps.py:832`, `rbx/grading/steps.py:925`, `rbx/grading/steps.py:969` (line
+  numbers will have shifted; find them by searching for `_relax_limits_for_jvm(`)
+- Test: `tests/rbx/grading/steps_stack_limit_test.py`
+
+**Step 1: Write the failing tests**
+
+Append to `tests/rbx/grading/steps_stack_limit_test.py`. These go through `steps.run` and use the
+same fixtures as `tests/rbx/grading/steps_run_test.py` -- read
+`test_run_java_removes_memory_and_stack_constraints` there (around line 359) for the setup idiom,
+including the `sandbox`, `cleandir` and `testdata_path` fixtures and the reusable
+`steps_run_test/simple.java` and `steps_run_test/simple_output.py` testdata.
+
+```python
+class TestStackLimitProbeIsWired:
+    @mock.patch('sys.platform', 'linux')
+    async def test_a_run_with_an_unhonorable_limit_files_one_issue(
+        self,
+        sandbox,
+        cleandir,
+        testdata_path,
+        stack_check_enabled,
+    ):
+        # ... same artifacts setup as steps_run_test.py's non-JVM test ...
+        params = SandboxParams(stdout_file=pathlib.Path('output.txt'), stack_space=256)
+        command = f'{sys.executable} script.py'
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                await steps.run(command, params, sandbox, artifacts)
+
+        assert len(accumulator.issues) == 1
+
+    @mock.patch('sys.platform', 'linux')
+    async def test_a_jvm_run_files_no_issue(
+        self,
+        sandbox,
+        cleandir,
+        testdata_path,
+        stack_check_enabled,
+    ):
+        """The JVM carve-out drops the limit, so there is nothing to warn about --
+        this is the whole reason the probe cannot live in `rbx/box/code.py`."""
+        # ... same artifacts setup as steps_run_test.py's Java test ...
+        params = SandboxParams(stdout_file=pathlib.Path('output.txt'), stack_space=256)
+        command = 'java Simple'
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                await steps.run(command, params, sandbox, artifacts)
+
+        assert not accumulator.issues
+```
+
+The JVM test needs a JDK. Check how `steps_run_test.py`'s Java tests are skipped when one is absent
+and mirror that; if they are not skipped at all, leave it unmarked.
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/grading/steps_stack_limit_test.py -v -k Wired`
+Expected: FAIL on the first test -- `assert 0 == 1`, no issue filed.
+
+**Step 3: Write the implementation**
+
+Add the helper right after `_maybe_complain_about_stack_limit`:
+
+```python
+def _finalize_limits(command: str, params: SandboxParams) -> None:
+    """Settle the limits a program will actually run under, and complain if they
+    are not the ones that were asked for.
+
+    The order matters: the JVM carve-out drops the stack limit, and a limit that
+    was dropped is not one worth warning about.
+    """
+    _relax_limits_for_jvm(command, params)
+    _maybe_complain_about_stack_limit(params)
+```
+
+Then replace all three `_relax_limits_for_jvm(...)` call sites:
+
+- `steps.py:832` (in the compile loop): `_relax_limits_for_jvm(command, params)` ->
+  `_finalize_limits(command, params)`
+- `steps.py:925` (in `run`): `_relax_limits_for_jvm(command, params)` ->
+  `_finalize_limits(command, params)`
+- `steps.py:969` (in the coordinated/communication run):
+  `_relax_limits_for_jvm(solution.command, solution_params)` ->
+  `_finalize_limits(solution.command, solution_params)`
+
+Verify no other caller remains with `grep -n '_relax_limits_for_jvm(' rbx/grading/steps.py`.
+Expected: exactly two hits -- the `def` and the call inside `_finalize_limits`.
+
+**Step 4: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/rbx/grading/steps_stack_limit_test.py -v
+uv run pytest tests/rbx/grading/steps_run_test.py tests/rbx/grading/steps_compile_test.py tests/rbx/grading/steps_run_coordinated_test.py -v
+```
+
+Expected: all PASS. The existing JVM carve-out tests in `steps_run_test.py` must still pass
+untouched -- they are what pins the ordering inside `_finalize_limits`.
+
+**Step 5: Commit**
+
+Stage the same two files, then commit with
+`feat(grading): warn when a configured stack limit cannot be honored`.
+
+---
+
+## Task 4: Docs
+
+**Files:**
+- Modify: `docs/stack-limit.md` (the *Cap the stack of the programs rbx runs* section, at the end)
+
+**Step 1: Write the docs**
+
+Read [`docs/plans/docs-writing-style-guide.md`](docs-writing-style-guide.md) first. The page already
+has an *Increase the hard stack limit* section earlier on, so this is a cross-link, not a new
+recipe -- do not repeat the `limits.conf` instructions.
+
+After the existing `!!! warning` about macOS and before the `!!! note` about the JVM, add:
+
+```markdown
+Your machine's hard limit is a ceiling on `stackLimit`. If you ask for 256 MiB on a machine whose
+hard limit is 8 MiB, programs get 8 MiB, and {{rbx}} says so once at the end of the run. See
+[Increase the hard stack limit](#increase-the-hard-stack-limit) for how to raise it.
+```
+
+**Step 2: Verify the docs build and the anchor resolves**
+
+Run: `uv run mkdocs build`
+Expected: builds. There are around nine pre-existing unrelated warnings on this project; ignore
+those, but check that none of them is a broken link to `#increase-the-hard-stack-limit`. Do not use
+`--strict`.
+
+**Step 3: Commit**
+
+Stage `docs/stack-limit.md` and commit with
+`docs: note that the hard limit is a ceiling on stackLimit`.
+
+---
+
+## Task 5: Clamp an unset stack limit to the hard limit
+
+Separable from the warning, and separately committed. When `stackLimit` is unset, `get_preexec_fn`
+asks for `RLIM_INFINITY`; on a machine with a finite hard limit that call **fails**, and the
+fallback is the inherited *soft* limit -- not the hard one. So `EnvironmentSandbox.stackLimit`'s
+promise that "the stack is made as large as the system allows"
+(`rbx/box/environment.py:133`) is false on any such machine: you get the shell's 8 MiB even when the
+hard limit is far higher. Clamping the request fixes it without moving any syscall out of the child.
+
+**Files:**
+- Modify: `rbx/grading/judge/program.py:99-125` (`get_preexec_fn`)
+- Test: `tests/rbx/grading/judge/test_program.py`
+
+**Step 1: Write the failing tests**
+
+Add to the same class that holds `test_preexec_fn_applies_stack_limit_on_linux`
+(`tests/rbx/grading/judge/test_program.py:604`), following its idiom exactly:
+
+```python
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_preexec_fn_clamps_an_unset_stack_limit_to_the_hard_limit(
+        self, mock_setrlimit, _
+    ):
+        """Asking for RLIM_INFINITY under a finite hard limit fails outright and
+        leaves the inherited soft limit in place, which is far smaller than what
+        the system allows."""
+        import resource as resource_module
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(8 * 1024 * 1024, 512 * 1024 * 1024),
+        ):
+            get_preexec_fn(ProgramParams())()
+
+        stack_calls = [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_STACK
+        ]
+        assert len(stack_calls) == 1
+        assert stack_calls[0][0][1] == (512 * 1024 * 1024, 512 * 1024 * 1024)
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_preexec_fn_clamps_a_configured_stack_limit_to_the_hard_limit(
+        self, mock_setrlimit, _
+    ):
+        import resource as resource_module
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(8 * 1024 * 1024, 64 * 1024 * 1024),
+        ):
+            get_preexec_fn(ProgramParams(stack_limit=256))()
+
+        stack_calls = [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_STACK
+        ]
+        assert len(stack_calls) == 1
+        assert stack_calls[0][0][1] == (64 * 1024 * 1024, 64 * 1024 * 1024)
+```
+
+Note the existing `test_preexec_fn_applies_stack_limit_on_linux` does not mock `getrlimit`, so it
+reads the real hard limit. On a CI machine with an unlimited hard limit it keeps passing unchanged;
+on a machine whose hard limit is below 64 MiB it would now fail. Add a `getrlimit` mock returning
+`(8 * 1024 * 1024, resource_module.RLIM_INFINITY)` to that test so it pins the behaviour it means to
+pin regardless of the host. Do the same for the existing unset-limit assertion at
+`test_program.py:585-599` if it asserts `RLIM_INFINITY` is requested -- with a mocked unlimited hard
+limit, that assertion stays true.
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/rbx/grading/judge/test_program.py -v -k stack`
+Expected: the two new tests FAIL -- the requested value is `RLIM_INFINITY` and `256 MiB`
+respectively, not the clamped one.
+
+**Step 3: Write the implementation**
+
+In `get_preexec_fn`, replace the `sys.platform != 'darwin'` block:
+
+```python
+        # Darwin is left alone: it refuses most RLIMIT_STACK changes, so the
+        # stack there is whatever the host shell hands down (which is what
+        # `rbx`'s stack limit check nags about).
+        if sys.platform != 'darwin':
+            stack_limit = (
+                params.stack_limit * 1024 * 1024
+                if params.stack_limit is not None
+                else resource.RLIM_INFINITY
+            )
+            # Clamp to the hard limit rather than let the call fail: a refused
+            # `setrlimit` leaves the *inherited soft* limit in place, which is
+            # usually far below what the system would actually allow.
+            try:
+                _, hard = resource.getrlimit(resource.RLIMIT_STACK)
+                if hard != resource.RLIM_INFINITY and (
+                    stack_limit == resource.RLIM_INFINITY or stack_limit > hard
+                ):
+                    stack_limit = hard
+            except (ValueError, OSError):
+                pass
+            try:
+                resource.setrlimit(resource.RLIMIT_STACK, (stack_limit, stack_limit))
+            except (ValueError, OSError):
+                # Asking for more than the hard limit allows; fall back to
+                # whatever the process already inherited.
+                pass
+```
+
+The second `try`/`except` stays. It is the backstop for anything the clamp did not anticipate, and
+removing it would let an exception in the forked child take the whole run down.
+
+**Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/rbx/grading/judge/test_program.py -v`
+Expected: all PASS, including `test_preexec_fn_survives_a_stack_limit_the_system_refuses`.
+
+**Step 5: Commit**
+
+Stage `rbx/grading/judge/program.py` and `tests/rbx/grading/judge/test_program.py`, then commit with
+`fix(grading): clamp the stack limit to the hard limit instead of failing`.
+
+---
+
+## Task 6: Verify nothing else regressed
+
+**Step 1: Run the touched suites**
+
+```bash
+uv run pytest \
+  tests/rbx/grading/steps_stack_limit_test.py \
+  tests/rbx/grading/steps_run_test.py \
+  tests/rbx/grading/steps_compile_test.py \
+  tests/rbx/grading/steps_run_coordinated_test.py \
+  tests/rbx/grading/judge/test_program.py \
+  tests/rbx/box/code_run_test.py \
+  tests/rbx/box/test_environment_sandbox.py \
+  tests/rbx/box/sanitizers/issue_stack_test.py \
+  -v
+```
+
+Expected: all PASS. `code_run_test.py`'s nine `test_stack_limit_check_*` tests cover
+`rbx/box/code.py`, which this work does not touch -- if any of them changed behaviour, something was
+edited that should not have been.
+
+Do **not** run the whole suite. It is slow and produces spurious sandbox wall-clock timeouts.
+
+**Step 2: Lint and format**
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+```
+
+Expected: clean.
+
+**Step 3: Push and open a draft PR**
+
+Push the branch and open a draft PR referencing #800. Note that `gh pr create` works, but
+`gh pr edit` and `gh pr view` fail on this repo with a classic-Projects GraphQL error -- use
+`gh api -X PATCH repos/rsalesc/rbx/pulls/N` to edit instead.

--- a/docs/stack-limit.md
+++ b/docs/stack-limit.md
@@ -103,9 +103,9 @@ languages:
     whatever your shell hands down, which is exactly what the sections above are about.
 
 Also, keep in mind your machine's hard limit is a ceiling on `stackLimit`. If you ask for 256 MiB
-on a machine whose hard limit is 8 MiB, programs get 8 MiB, and {{rbx}} will tell you so once, at
-the end of the run. See [Increase the hard stack limit](#increase-the-hard-stack-limit) for how to
-raise it.
+on a machine whose hard limit is 8 MiB, programs get 8 MiB, and {{rbx}} will point that out at the
+end of a run that actually executed something. See
+[Increase the hard stack limit](#increase-the-hard-stack-limit) for how to raise it.
 
 !!! note
     JVM programs -- Java and Kotlin -- are exempt. The JVM manages its own thread stacks, so

--- a/docs/stack-limit.md
+++ b/docs/stack-limit.md
@@ -102,6 +102,11 @@ languages:
     `stackLimit` is enforced on Linux only. On MacOS, the stack of a sandboxed program is
     whatever your shell hands down, which is exactly what the sections above are about.
 
+Also, keep in mind your machine's hard limit is a ceiling on `stackLimit`. If you ask for 256 MiB
+on a machine whose hard limit is 8 MiB, programs get 8 MiB, and {{rbx}} will tell you so once, at
+the end of the run. See [Increase the hard stack limit](#increase-the-hard-stack-limit) for how to
+raise it.
+
 !!! note
     JVM programs -- Java and Kotlin -- are exempt. The JVM manages its own thread stacks, so
     the limit would only bound the launcher's main thread and never the code you wrote. This

--- a/docs/stack-limit.md
+++ b/docs/stack-limit.md
@@ -104,7 +104,7 @@ languages:
 
 Also, keep in mind your machine's hard limit is a ceiling on `stackLimit`. If you ask for 256 MiB
 on a machine whose hard limit is 8 MiB, programs get 8 MiB, and {{rbx}} will point that out at the
-end of a run that actually executed something. See
+end of any command that actually ran a program (a fully cached re-run has nothing to check). See
 [Increase the hard stack limit](#increase-the-hard-stack-limit) for how to raise it.
 
 !!! note

--- a/rbx/grading/judge/program.py
+++ b/rbx/grading/judge/program.py
@@ -116,6 +116,17 @@ def get_preexec_fn(params: ProgramParams):
                 if params.stack_limit is not None
                 else resource.RLIM_INFINITY
             )
+            # Clamp to the hard limit rather than let the call fail: a refused
+            # `setrlimit` leaves the *inherited soft* limit in place, which is
+            # usually far below what the system would actually allow.
+            try:
+                _, hard = resource.getrlimit(resource.RLIMIT_STACK)
+                if hard != resource.RLIM_INFINITY and (
+                    stack_limit == resource.RLIM_INFINITY or stack_limit > hard
+                ):
+                    stack_limit = hard
+            except (ValueError, OSError):
+                pass
             try:
                 resource.setrlimit(resource.RLIMIT_STACK, (stack_limit, stack_limit))
             except (ValueError, OSError):

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -17,6 +17,7 @@ from rich.text import Text
 from rbx import utils
 from rbx.box import safeeval
 from rbx.box.exception import RbxException
+from rbx.box.sanitizers import issue_stack
 from rbx.config import get_bits_stdcpp
 from rbx.console import console
 from rbx.grading import grading_context
@@ -516,6 +517,51 @@ def _relax_limits_for_jvm(command: str, params: SandboxParams) -> None:
         return
     params.address_space = None
     params.stack_space = None
+
+
+_STACK_LIMIT_DOCS = 'https://rsalesc.github.io/rbx/stack-limit'
+
+
+class StackLimitNotHonoredIssue(issue_stack.Issue):
+    """A configured `stackLimit` that the machine will not actually apply.
+
+    `hard_limit` is the ceiling that will be used instead, in bytes, or `None`
+    when the limit is not enforced at all (macOS, where `get_preexec_fn` never
+    touches `RLIMIT_STACK`).
+    """
+
+    def __init__(self, requested_mib: int, hard_limit: Optional[int]):
+        self.requested_mib = requested_mib
+        self.hard_limit = hard_limit
+
+    def get_detailed_section(self) -> Optional[Tuple[str, ...]]:
+        return ('stack limit',)
+
+    def get_overview_section(self) -> Optional[Tuple[str, ...]]:
+        return ('stack limit',)
+
+    def get_detailed_message(self) -> str:
+        from rbx.box.formatting import get_formatted_memory
+
+        requested = get_formatted_memory(self.requested_mib * 1024 * 1024)
+        if self.hard_limit is None:
+            return (
+                f'[item]stackLimit[/item] is set to [item]{requested}[/item], but it is '
+                'not enforced on macOS: the stack of a sandboxed program is whatever '
+                f'your shell hands down. See [item]{_STACK_LIMIT_DOCS}[/item].'
+            )
+        effective = get_formatted_memory(self.hard_limit)
+        return (
+            f'[item]stackLimit[/item] is set to [item]{requested}[/item], but this '
+            f"machine's hard stack limit is [item]{effective}[/item], so programs run "
+            f'with [item]{effective}[/item]. See [item]{_STACK_LIMIT_DOCS}[/item].'
+        )
+
+    def get_overview_message(self) -> str:
+        return self.get_detailed_message()
+
+    def get_severity(self) -> issue_stack.IssueSeverity:
+        return issue_stack.IssueSeverity.WARNING
 
 
 def get_exe_from_command(command: str) -> str:

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -551,6 +551,11 @@ class StackLimitNotHonoredIssue(issue_stack.Issue):
                 'not enforced on macOS: the stack of a sandboxed program is whatever '
                 f'your shell hands down. See [item]{_STACK_LIMIT_DOCS}[/item].'
             )
+        # The claim that programs actually run *with* the hard limit depends on
+        # `get_preexec_fn` clamping the request down to it before calling
+        # `setrlimit`: without that clamp the call is refused and the child keeps
+        # the inherited soft limit, which can be lower. Do not revert one of the
+        # two without the other.
         effective = get_formatted_memory(self.hard_limit)
         return (
             f'[item]stackLimit[/item] is set to [item]{requested}[/item], but this '
@@ -565,15 +570,48 @@ class StackLimitNotHonoredIssue(issue_stack.Issue):
         return issue_stack.IssueSeverity.WARNING
 
 
+@functools.cache
+def _complain_about_stack_limit(stack_space: int) -> None:
+    """Back half of `_maybe_complain_about_stack_limit`, cached.
+
+    Cached for the same reason `_maybe_complain_about_sanitization` is: the
+    report dedupes on the message string, so filing the issue once per spawned
+    program only grows a list that nothing reads -- and a stress run spawns tens
+    of thousands. Keyed on the plain limit rather than on `SandboxParams`, which
+    is not hashable.
+    """
+    from rbx.box import setter_config
+
+    if not setter_config.get_setter_config().judging.check_stack:
+        return
+
+    if sys.platform == 'darwin':
+        # `get_preexec_fn` never touches RLIMIT_STACK here, so the configured
+        # limit is inert whatever the numbers say.
+        issue_stack.add_issue(StackLimitNotHonoredIssue(stack_space, None))
+        return
+
+    try:
+        _, hard = resource.getrlimit(resource.RLIMIT_STACK)
+    except (ValueError, OSError):
+        return
+
+    if hard == resource.RLIM_INFINITY:
+        return
+    if hard >= stack_space * 1024 * 1024:
+        return
+
+    issue_stack.add_issue(StackLimitNotHonoredIssue(stack_space, hard))
+
+
 def _maybe_complain_about_stack_limit(params: SandboxParams) -> None:
     """Diagnose a `stackLimit` the machine will not actually apply.
 
-    `get_preexec_fn` swallows a `setrlimit` that the system refuses -- raising in
-    the forked child would take the whole run down -- so a limit above the hard
-    `RLIMIT_STACK` degrades silently to whatever the process inherited, and the
-    solutions that then blow their stack look like ordinary RTEs. Diagnose it
-    here, in the parent, where it can still be attributed to the configuration
-    that caused it.
+    `get_preexec_fn` clamps a `stackLimit` above the hard `RLIMIT_STACK` down to
+    that hard limit rather than fail -- raising in the forked child would take
+    the whole run down -- so the limit degrades silently, and the solutions that
+    then blow their stack look like ordinary RTEs. Diagnose it here, in the
+    parent, where it can still be attributed to the configuration that caused it.
 
     Call this *after* `_relax_limits_for_jvm`: a JVM command has no stack limit
     left to complain about by then.
@@ -583,28 +621,16 @@ def _maybe_complain_about_stack_limit(params: SandboxParams) -> None:
         # which is exactly what is documented.
         return
 
-    from rbx.box import setter_config
+    from rbx.box import state
 
-    if not setter_config.get_setter_config().judging.check_stack:
+    if not state.STATE.run_through_cli:
+        # Same gate as `code._check_stack_limit`: outside the CLI there is no one
+        # to read the report, and reading the setter config would create
+        # `setter_config.yml` on disk -- a side effect the grading layer must not
+        # have when driven as a library, from the TUI or from tests.
         return
 
-    if sys.platform == 'darwin':
-        # `get_preexec_fn` never touches RLIMIT_STACK here, so the configured
-        # limit is inert whatever the numbers say.
-        issue_stack.add_issue(StackLimitNotHonoredIssue(params.stack_space, None))
-        return
-
-    try:
-        _, hard = resource.getrlimit(resource.RLIMIT_STACK)
-    except Exception:
-        return
-
-    if hard == resource.RLIM_INFINITY:
-        return
-    if hard >= params.stack_space * 1024 * 1024:
-        return
-
-    issue_stack.add_issue(StackLimitNotHonoredIssue(params.stack_space, hard))
+    _complain_about_stack_limit(params.stack_space)
 
 
 def _finalize_limits(command: str, params: SandboxParams) -> None:
@@ -1066,6 +1092,9 @@ async def run_coordinated(
     interactor_params = interactor.params.model_copy(deep=True)
     solution_params = solution.params.model_copy(deep=True)
 
+    # Solution only, on purpose: the interactor's limits are left exactly as
+    # given, so an interactor-only `stackLimit` is neither relaxed for the JVM nor
+    # diagnosed. `steps_run_coordinated_test.py` pins that behaviour.
     _finalize_limits(solution.command, solution_params)
 
     try:

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -3,6 +3,7 @@ import dataclasses
 import functools
 import pathlib
 import re
+import resource
 import shlex
 import shutil
 import subprocess
@@ -562,6 +563,48 @@ class StackLimitNotHonoredIssue(issue_stack.Issue):
 
     def get_severity(self) -> issue_stack.IssueSeverity:
         return issue_stack.IssueSeverity.WARNING
+
+
+def _maybe_complain_about_stack_limit(params: SandboxParams) -> None:
+    """Diagnose a `stackLimit` the machine will not actually apply.
+
+    `get_preexec_fn` swallows a `setrlimit` that the system refuses -- raising in
+    the forked child would take the whole run down -- so a limit above the hard
+    `RLIMIT_STACK` degrades silently to whatever the process inherited, and the
+    solutions that then blow their stack look like ordinary RTEs. Diagnose it
+    here, in the parent, where it can still be attributed to the configuration
+    that caused it.
+
+    Call this *after* `_relax_limits_for_jvm`: a JVM command has no stack limit
+    left to complain about by then.
+    """
+    if params.stack_space is None:
+        # No limit configured: the stack is made as large as the system allows,
+        # which is exactly what is documented.
+        return
+
+    from rbx.box import setter_config
+
+    if not setter_config.get_setter_config().judging.check_stack:
+        return
+
+    if sys.platform == 'darwin':
+        # `get_preexec_fn` never touches RLIMIT_STACK here, so the configured
+        # limit is inert whatever the numbers say.
+        issue_stack.add_issue(StackLimitNotHonoredIssue(params.stack_space, None))
+        return
+
+    try:
+        _, hard = resource.getrlimit(resource.RLIMIT_STACK)
+    except Exception:
+        return
+
+    if hard == resource.RLIM_INFINITY:
+        return
+    if hard >= params.stack_space * 1024 * 1024:
+        return
+
+    issue_stack.add_issue(StackLimitNotHonoredIssue(params.stack_space, hard))
 
 
 def get_exe_from_command(command: str) -> str:

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -520,7 +520,7 @@ def _relax_limits_for_jvm(command: str, params: SandboxParams) -> None:
     params.stack_space = None
 
 
-_STACK_LIMIT_DOCS = 'https://rsalesc.github.io/rbx/stack-limit'
+_STACK_LIMIT_DOCS = 'https://rbx.rsalesc.dev/stack-limit/'
 
 
 class StackLimitNotHonoredIssue(issue_stack.Issue):

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -579,6 +579,11 @@ def _complain_about_stack_limit(stack_space: int) -> None:
     program only grows a list that nothing reads -- and a stress run spawns tens
     of thousands. Keyed on the plain limit rather than on `SandboxParams`, which
     is not hashable.
+
+    Caching for the process is safe because the issue stack is process-global --
+    nothing in production pushes a nested accumulator -- and because `rbx each`
+    forks a process per problem, so a verdict cached here is never carried into
+    a package it was not computed for.
     """
     from rbx.box import setter_config
 
@@ -627,7 +632,8 @@ def _maybe_complain_about_stack_limit(params: SandboxParams) -> None:
         # Same gate as `code._check_stack_limit`: outside the CLI there is no one
         # to read the report, and reading the setter config would create
         # `setter_config.yml` on disk -- a side effect the grading layer must not
-        # have when driven as a library, from the TUI or from tests.
+        # have when driven as a library or from tests. `rbx ui` is an ordinary
+        # subcommand, so the TUI does set the flag and does get the warning.
         return
 
     _complain_about_stack_limit(params.stack_space)

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -607,6 +607,17 @@ def _maybe_complain_about_stack_limit(params: SandboxParams) -> None:
     issue_stack.add_issue(StackLimitNotHonoredIssue(params.stack_space, hard))
 
 
+def _finalize_limits(command: str, params: SandboxParams) -> None:
+    """Settle the limits a program will actually run under, and complain if they
+    are not the ones that were asked for.
+
+    The order matters: the JVM carve-out drops the stack limit, and a limit that
+    was dropped is not one worth warning about.
+    """
+    _relax_limits_for_jvm(command, params)
+    _maybe_complain_about_stack_limit(params)
+
+
 def get_exe_from_command(command: str) -> str:
     cmds = shlex.split(command)
     if not cmds:
@@ -918,7 +929,7 @@ async def compile(
         stderr_file = pathlib.PosixPath(f'compile-{i}.stderr')
         params.set_stdall(stdout=stdout_file, stderr=stderr_file)
 
-        _relax_limits_for_jvm(command, params)
+        _finalize_limits(command, params)
 
         try:
             sandbox_log = await asyncio.to_thread(sandbox.run, cmd, params)
@@ -1011,7 +1022,7 @@ async def run(
     cmd = _split_and_expand(command, sandbox, params)
     params = params.model_copy(deep=True)  # Copy to allow further modification.
 
-    _relax_limits_for_jvm(command, params)
+    _finalize_limits(command, params)
 
     try:
         sandbox_log = await asyncio.to_thread(sandbox.run, cmd, params)
@@ -1055,7 +1066,7 @@ async def run_coordinated(
     interactor_params = interactor.params.model_copy(deep=True)
     solution_params = solution.params.model_copy(deep=True)
 
-    _relax_limits_for_jvm(solution.command, solution_params)
+    _finalize_limits(solution.command, solution_params)
 
     try:
         solution_sandbox_log, interactor_sandbox_log = await asyncio.to_thread(

--- a/tests/rbx/grading/judge/test_program.py
+++ b/tests/rbx/grading/judge/test_program.py
@@ -569,7 +569,11 @@ class TestProgramMocks:
         params = ProgramParams(time_limit=5.0, fs_limit=1000, pgid=12345)
 
         preexec_fn = get_preexec_fn(params)
-        preexec_fn()
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(8 * 1024 * 1024, resource_module.RLIM_INFINITY),
+        ):
+            preexec_fn()
 
         # Verify setpgid was called
         mock_setpgid.assert_called_once_with(0, 12345)
@@ -606,7 +610,58 @@ class TestProgramMocks:
 
         params = ProgramParams(stack_limit=64)
 
-        get_preexec_fn(params)()
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(8 * 1024 * 1024, resource_module.RLIM_INFINITY),
+        ):
+            get_preexec_fn(params)()
+
+        stack_calls = [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_STACK
+        ]
+        assert len(stack_calls) == 1
+        assert stack_calls[0][0][1] == (64 * 1024 * 1024, 64 * 1024 * 1024)
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_preexec_fn_clamps_an_unset_stack_limit_to_the_hard_limit(
+        self, mock_setrlimit, _
+    ):
+        """Asking for RLIM_INFINITY under a finite hard limit fails outright and
+        leaves the inherited soft limit in place, which is far smaller than what
+        the system allows."""
+        import resource as resource_module
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(8 * 1024 * 1024, 512 * 1024 * 1024),
+        ):
+            get_preexec_fn(ProgramParams())()
+
+        stack_calls = [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_STACK
+        ]
+        assert len(stack_calls) == 1
+        assert stack_calls[0][0][1] == (512 * 1024 * 1024, 512 * 1024 * 1024)
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_preexec_fn_clamps_a_configured_stack_limit_to_the_hard_limit(
+        self, mock_setrlimit, _
+    ):
+        import resource as resource_module
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(8 * 1024 * 1024, 64 * 1024 * 1024),
+        ):
+            get_preexec_fn(ProgramParams(stack_limit=256))()
 
         stack_calls = [
             call

--- a/tests/rbx/grading/judge/test_program.py
+++ b/tests/rbx/grading/judge/test_program.py
@@ -652,6 +652,32 @@ class TestProgramMocks:
     @mock.patch('os.setpgid')
     @mock.patch('resource.setrlimit')
     @mock.patch('sys.platform', 'linux')
+    @mock.patch('resource.RLIM_INFINITY', -1)
+    def test_preexec_fn_clamps_an_unset_stack_limit_when_infinity_is_negative(
+        self, mock_setrlimit, _
+    ):
+        """On Linux, CPython exposes RLIM_INFINITY as -1, so the clamp cannot
+        rely on comparing the request against the hard limit: -1 is smaller than
+        any finite hard limit, and the unset request would sail through unclamped."""
+        import resource as resource_module
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(8 * 1024 * 1024, 512 * 1024 * 1024),
+        ):
+            get_preexec_fn(ProgramParams())()
+
+        stack_calls = [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_STACK
+        ]
+        assert len(stack_calls) == 1
+        assert stack_calls[0][0][1] == (512 * 1024 * 1024, 512 * 1024 * 1024)
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
     def test_preexec_fn_clamps_a_configured_stack_limit_to_the_hard_limit(
         self, mock_setrlimit, _
     ):

--- a/tests/rbx/grading/steps_stack_limit_test.py
+++ b/tests/rbx/grading/steps_stack_limit_test.py
@@ -1,0 +1,51 @@
+from rbx.box.sanitizers.issue_stack import IssueSeverity
+from rbx.grading.steps import StackLimitNotHonoredIssue
+
+
+class TestStackLimitNotHonoredIssue:
+    def test_issue_is_a_warning_not_an_error(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
+
+        assert issue.get_severity() == IssueSeverity.WARNING
+
+    def test_detailed_message_names_both_limits_and_links_the_docs(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
+
+        message = issue.get_detailed_message()
+
+        assert '256 MiB' in message
+        assert '8 MiB' in message
+        assert 'https://rsalesc.github.io/rbx/stack-limit' in message
+
+    def test_detailed_message_says_unenforced_when_there_is_no_hard_limit(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=None)
+
+        message = issue.get_detailed_message()
+
+        assert '256 MiB' in message
+        assert 'macOS' in message
+        assert 'https://rsalesc.github.io/rbx/stack-limit' in message
+
+    def test_both_reports_file_the_issue_under_the_same_section(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=None)
+
+        assert issue.get_detailed_section() == ('stack limit',)
+        assert issue.get_overview_section() == ('stack limit',)
+
+    def test_overview_message_is_present_and_links_the_docs(self):
+        issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
+
+        assert (
+            'https://rsalesc.github.io/rbx/stack-limit' in issue.get_overview_message()
+        )
+
+    def test_two_issues_with_the_same_values_produce_the_same_message(self):
+        """The issue stack dedupes on the message string, so this is what makes
+        the warning print once per run rather than once per program."""
+        first = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
+        second = StackLimitNotHonoredIssue(
+            requested_mib=256, hard_limit=8 * 1024 * 1024
+        )
+
+        assert first.get_detailed_message() == second.get_detailed_message()
+        assert first.get_overview_message() == second.get_overview_message()

--- a/tests/rbx/grading/steps_stack_limit_test.py
+++ b/tests/rbx/grading/steps_stack_limit_test.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 
+from rbx.box import state
 from rbx.box.sanitizers.issue_stack import (
     IssueAccumulator,
     IssueSeverity,
@@ -45,6 +46,26 @@ def _fake_stack_rlimit(soft: int, hard: int):
         return real_getrlimit(which)
 
     return mock.patch('resource.getrlimit', side_effect=getrlimit)
+
+
+@pytest.fixture(autouse=True)
+def clear_stack_limit_cache():
+    """`_complain_about_stack_limit` is cached, so a verdict reached under one
+    test's mocked platform/config must not carry into the next."""
+    steps._complain_about_stack_limit.cache_clear()  # noqa: SLF001
+    yield
+    steps._complain_about_stack_limit.cache_clear()  # noqa: SLF001
+
+
+@pytest.fixture
+def cli_mode():
+    """The probe only runs under the CLI; pin the flag on and put it back."""
+    original = state.STATE.run_through_cli
+    state.STATE.run_through_cli = True
+    try:
+        yield
+    finally:
+        state.STATE.run_through_cli = original
 
 
 @pytest.fixture
@@ -105,7 +126,7 @@ class TestStackLimitNotHonoredIssue:
 class TestMaybeComplainAboutStackLimit:
     @mock.patch('sys.platform', 'linux')
     def test_warns_on_linux_when_the_hard_limit_is_below_the_request(
-        self, stack_check_enabled
+        self, stack_check_enabled, cli_mode
     ):
         params = SandboxParams(stack_space=256)
 
@@ -122,7 +143,7 @@ class TestMaybeComplainAboutStackLimit:
 
     @mock.patch('sys.platform', 'linux')
     def test_silent_on_linux_when_the_hard_limit_is_above_the_request(
-        self, stack_check_enabled
+        self, stack_check_enabled, cli_mode
     ):
         params = SandboxParams(stack_space=64)
 
@@ -135,8 +156,43 @@ class TestMaybeComplainAboutStackLimit:
         assert not accumulator.issues
 
     @mock.patch('sys.platform', 'linux')
+    def test_silent_on_linux_when_the_hard_limit_exactly_meets_the_request(
+        self, stack_check_enabled, cli_mode
+    ):
+        """The boundary: a hard limit equal to the request is honored in full."""
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 256 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_silent_when_not_running_through_the_cli(self, stack_check_enabled):
+        """Outside the CLI nothing reads the report, and reading the setter config
+        would create `setter_config.yml` on disk."""
+        params = SandboxParams(stack_space=256)
+        original = state.STATE.run_through_cli
+        state.STATE.run_through_cli = False
+
+        try:
+            with mock.patch(
+                'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+            ):
+                with _fresh_issue_stack() as accumulator:
+                    _maybe_complain_about_stack_limit(params)
+        finally:
+            state.STATE.run_through_cli = original
+
+        assert not accumulator.issues
+        stack_check_enabled.assert_not_called()
+
+    @mock.patch('sys.platform', 'linux')
     def test_silent_on_linux_when_the_hard_limit_is_unlimited(
-        self, stack_check_enabled
+        self, stack_check_enabled, cli_mode
     ):
         params = SandboxParams(stack_space=1024)
 
@@ -150,7 +206,7 @@ class TestMaybeComplainAboutStackLimit:
         assert not accumulator.issues
 
     @mock.patch('sys.platform', 'linux')
-    def test_the_soft_limit_is_irrelevant_on_linux(self, stack_check_enabled):
+    def test_the_soft_limit_is_irrelevant_on_linux(self, stack_check_enabled, cli_mode):
         """We raise the soft limit ourselves in the child; only the hard one caps us."""
         params = SandboxParams(stack_space=64)
 
@@ -164,7 +220,9 @@ class TestMaybeComplainAboutStackLimit:
         assert not accumulator.issues
 
     @mock.patch('sys.platform', 'darwin')
-    def test_warns_on_darwin_whenever_a_limit_is_configured(self, stack_check_enabled):
+    def test_warns_on_darwin_whenever_a_limit_is_configured(
+        self, stack_check_enabled, cli_mode
+    ):
         """macOS never applies RLIMIT_STACK, so the numbers do not matter."""
         params = SandboxParams(stack_space=256)
 
@@ -179,7 +237,7 @@ class TestMaybeComplainAboutStackLimit:
         assert accumulator.issues[0].hard_limit is None
 
     @mock.patch('sys.platform', 'linux')
-    def test_silent_when_no_limit_is_configured(self, stack_check_enabled):
+    def test_silent_when_no_limit_is_configured(self, stack_check_enabled, cli_mode):
         params = SandboxParams(stack_space=None)
 
         with mock.patch(
@@ -191,7 +249,7 @@ class TestMaybeComplainAboutStackLimit:
         assert not accumulator.issues
 
     @mock.patch('sys.platform', 'linux')
-    def test_silent_when_the_check_is_disabled_in_the_setter_config(self):
+    def test_silent_when_the_check_is_disabled_in_the_setter_config(self, cli_mode):
         params = SandboxParams(stack_space=256)
 
         with mock.patch('rbx.box.setter_config.get_setter_config') as mock_config:
@@ -205,7 +263,24 @@ class TestMaybeComplainAboutStackLimit:
         assert not accumulator.issues
 
     @mock.patch('sys.platform', 'linux')
-    def test_survives_a_getrlimit_that_raises(self, stack_check_enabled):
+    def test_repeated_calls_file_the_issue_only_once(
+        self, stack_check_enabled, cli_mode
+    ):
+        """A stress run spawns tens of thousands of programs; the report dedupes
+        the message anyway, so only the first call should accumulate an issue."""
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                for _ in range(5):
+                    _maybe_complain_about_stack_limit(params)
+
+        assert len(accumulator.issues) == 1
+
+    @mock.patch('sys.platform', 'linux')
+    def test_survives_a_getrlimit_that_raises(self, stack_check_enabled, cli_mode):
         params = SandboxParams(stack_space=256)
 
         with mock.patch('resource.getrlimit', side_effect=OSError('nope')):
@@ -216,6 +291,11 @@ class TestMaybeComplainAboutStackLimit:
 
 
 class TestStackLimitProbeIsWired:
+    # NOTE: these two patch `sys.platform` across a real fork/exec, so on a macOS
+    # host the blast radius is wider than the intent: `get_memory_usage` and
+    # `maxrss_inherits_parent` take their Linux branches too, and the child really
+    # does attempt `setrlimit(RLIMIT_STACK)`. Nothing asserted below depends on
+    # any of that, but a new assertion here might.
     @mock.patch('sys.platform', 'linux')
     async def test_a_run_with_an_unhonorable_limit_files_one_issue(
         self,
@@ -223,6 +303,7 @@ class TestStackLimitProbeIsWired:
         cleandir: pathlib.Path,
         testdata_path: pathlib.Path,
         stack_check_enabled,
+        cli_mode,
     ):
         script_file = testdata_path / 'steps_run_test' / 'simple_output.py'
         artifacts = GradingArtifacts(root=cleandir)
@@ -254,6 +335,7 @@ class TestStackLimitProbeIsWired:
         cleandir: pathlib.Path,
         testdata_path: pathlib.Path,
         stack_check_enabled,
+        cli_mode,
     ):
         """The JVM carve-out drops the limit, so there is nothing to warn about --
         this is the whole reason the probe cannot live in `rbx/box/code.py`."""

--- a/tests/rbx/grading/steps_stack_limit_test.py
+++ b/tests/rbx/grading/steps_stack_limit_test.py
@@ -338,7 +338,12 @@ class TestStackLimitProbeIsWired:
         cli_mode,
     ):
         """The JVM carve-out drops the limit, so there is nothing to warn about --
-        this is the whole reason the probe cannot live in `rbx/box/code.py`."""
+        this is the whole reason the probe cannot live in `rbx/box/code.py`.
+
+        This pins the ordering inside `_finalize_limits`: the configured limit is
+        above the mocked hard limit, so probing before the carve-out instead of
+        after it would file an issue and fail the assertion below.
+        """
         source_file = testdata_path / 'steps_run_test' / 'simple.java'
         artifacts = GradingArtifacts(root=cleandir)
         artifacts.inputs.append(

--- a/tests/rbx/grading/steps_stack_limit_test.py
+++ b/tests/rbx/grading/steps_stack_limit_test.py
@@ -1,5 +1,38 @@
-from rbx.box.sanitizers.issue_stack import IssueSeverity
-from rbx.grading.steps import StackLimitNotHonoredIssue
+import contextlib
+import resource
+from unittest import mock
+
+import pytest
+
+from rbx.box.sanitizers.issue_stack import (
+    IssueAccumulator,
+    IssueSeverity,
+    issue_stack_var,
+)
+from rbx.grading.judge.sandbox import SandboxParams
+from rbx.grading.steps import (
+    StackLimitNotHonoredIssue,
+    _maybe_complain_about_stack_limit,
+)
+
+
+@contextlib.contextmanager
+def _fresh_issue_stack():
+    """Isolate the issue stack, so a test sees exactly the issues it caused."""
+    accumulator = IssueAccumulator()
+    token = issue_stack_var.set([accumulator])
+    try:
+        yield accumulator
+    finally:
+        issue_stack_var.reset(token)
+
+
+@pytest.fixture
+def stack_check_enabled():
+    """`_maybe_complain_about_stack_limit` reads the setter config; pin it on."""
+    with mock.patch('rbx.box.setter_config.get_setter_config') as mock_config:
+        mock_config.return_value.judging.check_stack = True
+        yield mock_config
 
 
 class TestStackLimitNotHonoredIssue:
@@ -49,3 +82,116 @@ class TestStackLimitNotHonoredIssue:
 
         assert first.get_detailed_message() == second.get_detailed_message()
         assert first.get_overview_message() == second.get_overview_message()
+
+
+class TestMaybeComplainAboutStackLimit:
+    @mock.patch('sys.platform', 'linux')
+    def test_warns_on_linux_when_the_hard_limit_is_below_the_request(
+        self, stack_check_enabled
+    ):
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert len(accumulator.issues) == 1
+        issue = accumulator.issues[0]
+        assert issue.requested_mib == 256
+        assert issue.hard_limit == 8 * 1024 * 1024
+
+    @mock.patch('sys.platform', 'linux')
+    def test_silent_on_linux_when_the_hard_limit_is_above_the_request(
+        self, stack_check_enabled
+    ):
+        params = SandboxParams(stack_space=64)
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 512 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_silent_on_linux_when_the_hard_limit_is_unlimited(
+        self, stack_check_enabled
+    ):
+        params = SandboxParams(stack_space=1024)
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(8 * 1024 * 1024, resource.RLIM_INFINITY),
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_the_soft_limit_is_irrelevant_on_linux(self, stack_check_enabled):
+        """We raise the soft limit ourselves in the child; only the hard one caps us."""
+        params = SandboxParams(stack_space=64)
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(1 * 1024 * 1024, resource.RLIM_INFINITY),
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'darwin')
+    def test_warns_on_darwin_whenever_a_limit_is_configured(self, stack_check_enabled):
+        """macOS never applies RLIMIT_STACK, so the numbers do not matter."""
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(resource.RLIM_INFINITY, resource.RLIM_INFINITY),
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert len(accumulator.issues) == 1
+        assert accumulator.issues[0].hard_limit is None
+
+    @mock.patch('sys.platform', 'linux')
+    def test_silent_when_no_limit_is_configured(self, stack_check_enabled):
+        params = SandboxParams(stack_space=None)
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_silent_when_the_check_is_disabled_in_the_setter_config(self):
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch('rbx.box.setter_config.get_setter_config') as mock_config:
+            mock_config.return_value.judging.check_stack = False
+            with mock.patch(
+                'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+            ):
+                with _fresh_issue_stack() as accumulator:
+                    _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_survives_a_getrlimit_that_raises(self, stack_check_enabled):
+        params = SandboxParams(stack_space=256)
+
+        with mock.patch('resource.getrlimit', side_effect=OSError('nope')):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues

--- a/tests/rbx/grading/steps_stack_limit_test.py
+++ b/tests/rbx/grading/steps_stack_limit_test.py
@@ -34,6 +34,19 @@ def _fresh_issue_stack():
         issue_stack_var.reset(token)
 
 
+def _fake_stack_rlimit(soft: int, hard: int):
+    """Report `(soft, hard)` for RLIMIT_STACK only, leaving every other rlimit
+    query -- including the ones the sandbox makes while spawning -- untouched."""
+    real_getrlimit = resource.getrlimit
+
+    def getrlimit(which: int):
+        if which == resource.RLIMIT_STACK:
+            return (soft, hard)
+        return real_getrlimit(which)
+
+    return mock.patch('resource.getrlimit', side_effect=getrlimit)
+
+
 @pytest.fixture
 def stack_check_enabled():
     """`_maybe_complain_about_stack_limit` reads the setter config; pin it on."""
@@ -55,7 +68,7 @@ class TestStackLimitNotHonoredIssue:
 
         assert '256 MiB' in message
         assert '8 MiB' in message
-        assert 'https://rsalesc.github.io/rbx/stack-limit' in message
+        assert 'https://rbx.rsalesc.dev/stack-limit/' in message
 
     def test_detailed_message_says_unenforced_when_there_is_no_hard_limit(self):
         issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=None)
@@ -64,7 +77,7 @@ class TestStackLimitNotHonoredIssue:
 
         assert '256 MiB' in message
         assert 'macOS' in message
-        assert 'https://rsalesc.github.io/rbx/stack-limit' in message
+        assert 'https://rbx.rsalesc.dev/stack-limit/' in message
 
     def test_both_reports_file_the_issue_under_the_same_section(self):
         issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=None)
@@ -75,9 +88,7 @@ class TestStackLimitNotHonoredIssue:
     def test_overview_message_is_present_and_links_the_docs(self):
         issue = StackLimitNotHonoredIssue(requested_mib=256, hard_limit=8 * 1024 * 1024)
 
-        assert (
-            'https://rsalesc.github.io/rbx/stack-limit' in issue.get_overview_message()
-        )
+        assert 'https://rbx.rsalesc.dev/stack-limit/' in issue.get_overview_message()
 
     def test_two_issues_with_the_same_values_produce_the_same_message(self):
         """The issue stack dedupes on the message string, so this is what makes
@@ -228,12 +239,12 @@ class TestStackLimitProbeIsWired:
         params = SandboxParams(stdout_file=pathlib.Path('output.txt'), stack_space=256)
         command = f'{sys.executable} script.py'
 
-        with mock.patch(
-            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
-        ):
+        with _fake_stack_rlimit(8 * 1024 * 1024, 8 * 1024 * 1024):
             with _fresh_issue_stack() as accumulator:
-                await steps.run(command, params, sandbox, artifacts)
+                result = await steps.run(command, params, sandbox, artifacts)
 
+        assert result is not None
+        assert result.exitcode == 0
         assert len(accumulator.issues) == 1
 
     @mock.patch('sys.platform', 'linux')
@@ -261,10 +272,9 @@ class TestStackLimitProbeIsWired:
         params = SandboxParams(stdout_file=pathlib.Path('output.txt'), stack_space=256)
         command = 'java Simple'
 
-        with mock.patch(
-            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
-        ):
+        with _fake_stack_rlimit(8 * 1024 * 1024, 8 * 1024 * 1024):
             with _fresh_issue_stack() as accumulator:
-                await steps.run(command, params, sandbox, artifacts)
+                result = await steps.run(command, params, sandbox, artifacts)
 
+        assert result is not None
         assert not accumulator.issues

--- a/tests/rbx/grading/steps_stack_limit_test.py
+++ b/tests/rbx/grading/steps_stack_limit_test.py
@@ -1,5 +1,7 @@
 import contextlib
+import pathlib
 import resource
+import sys
 from unittest import mock
 
 import pytest
@@ -9,8 +11,13 @@ from rbx.box.sanitizers.issue_stack import (
     IssueSeverity,
     issue_stack_var,
 )
-from rbx.grading.judge.sandbox import SandboxParams
+from rbx.grading import steps
+from rbx.grading.judge.sandbox import SandboxBase, SandboxParams
 from rbx.grading.steps import (
+    GradingArtifacts,
+    GradingFileInput,
+    GradingFileOutput,
+    GradingLogsHolder,
     StackLimitNotHonoredIssue,
     _maybe_complain_about_stack_limit,
 )
@@ -193,5 +200,71 @@ class TestMaybeComplainAboutStackLimit:
         with mock.patch('resource.getrlimit', side_effect=OSError('nope')):
             with _fresh_issue_stack() as accumulator:
                 _maybe_complain_about_stack_limit(params)
+
+        assert not accumulator.issues
+
+
+class TestStackLimitProbeIsWired:
+    @mock.patch('sys.platform', 'linux')
+    async def test_a_run_with_an_unhonorable_limit_files_one_issue(
+        self,
+        sandbox: SandboxBase,
+        cleandir: pathlib.Path,
+        testdata_path: pathlib.Path,
+        stack_check_enabled,
+    ):
+        script_file = testdata_path / 'steps_run_test' / 'simple_output.py'
+        artifacts = GradingArtifacts(root=cleandir)
+        artifacts.inputs.append(
+            GradingFileInput(src=script_file, dest=pathlib.Path('script.py'))
+        )
+        artifacts.outputs.append(
+            GradingFileOutput(
+                src=pathlib.Path('output.txt'), dest=pathlib.Path('output.txt')
+            )
+        )
+        artifacts.logs = GradingLogsHolder()
+
+        params = SandboxParams(stdout_file=pathlib.Path('output.txt'), stack_space=256)
+        command = f'{sys.executable} script.py'
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                await steps.run(command, params, sandbox, artifacts)
+
+        assert len(accumulator.issues) == 1
+
+    @mock.patch('sys.platform', 'linux')
+    async def test_a_jvm_run_files_no_issue(
+        self,
+        sandbox: SandboxBase,
+        cleandir: pathlib.Path,
+        testdata_path: pathlib.Path,
+        stack_check_enabled,
+    ):
+        """The JVM carve-out drops the limit, so there is nothing to warn about --
+        this is the whole reason the probe cannot live in `rbx/box/code.py`."""
+        source_file = testdata_path / 'steps_run_test' / 'simple.java'
+        artifacts = GradingArtifacts(root=cleandir)
+        artifacts.inputs.append(
+            GradingFileInput(src=source_file, dest=pathlib.Path('Simple.java'))
+        )
+        artifacts.outputs.append(
+            GradingFileOutput(
+                src=pathlib.Path('output.txt'), dest=pathlib.Path('output.txt')
+            )
+        )
+        artifacts.logs = GradingLogsHolder()
+
+        params = SandboxParams(stdout_file=pathlib.Path('output.txt'), stack_space=256)
+        command = 'java Simple'
+
+        with mock.patch(
+            'resource.getrlimit', return_value=(8 * 1024 * 1024, 8 * 1024 * 1024)
+        ):
+            with _fresh_issue_stack() as accumulator:
+                await steps.run(command, params, sandbox, artifacts)
 
         assert not accumulator.issues


### PR DESCRIPTION
Closes #800.

Follow-up to #799. Two coupled changes: a warning when a configured `stackLimit` cannot be honored, and a fix so an unset one actually means what the schema says it means.

## The warning

`get_preexec_fn` applies `stackLimit` via `setrlimit(RLIMIT_STACK)` inside the forked child and swallows failures — raising in `preexec_fn` would take the whole run down. So `stackLimit: 256` on a machine whose hard `RLIMIT_STACK` is 8 MiB silently degraded to 8 MiB, and the stack overflows that followed looked like ordinary RTEs.

The probe is parent-side, in `rbx/grading/steps.py`, and files a `StackLimitNotHonoredIssue` on the issue stack instead of printing:

- **Linux** — warns when a configured limit exceeds the hard limit, naming the requested value, the ceiling, and what programs actually get.
- **macOS** — warns whenever a limit is configured, since `get_preexec_fn` never touches `RLIMIT_STACK` there and the setting is inert regardless of the numbers.

Both messages link to https://rbx.rsalesc.dev/stack-limit/ rather than inlining a `ulimit` recipe.

### Why `steps.py` and not `code.py`

`rbx/box/code.py:298` `_check_stack_limit` looked like the natural home — it already reads `getrlimit` and runs before any program is spawned. But `stack_space` is not final there: `_relax_limits_for_jvm` nulls it for JVM commands much later, at three call sites. Probing from `code.py` would warn about a limit that is then discarded, on every Java and Kotlin run. `_finalize_limits` now pairs the carve-out with the probe so the ordering is structural rather than a comment. `_check_stack_limit` is untouched — it is about the *machine's* shell limits, a different concern.

### Why the issue stack

`IssueAccumulator._print_report_by` dedupes on the message string, so "warn once per run" needs no bookkeeping however many programs spawn, and `package.within_problem` prints the report at the end of the command instead of mid-build. Gated on the existing `judging.check_stack`, and on `run_through_cli` so the grading layer does not read (and create) `setter_config.yml` when driven as a library.

## The clamp — please read, this can move verdicts

Separately: when `stackLimit` is **unset**, the child asked for `RLIM_INFINITY`. Under a finite hard limit that call *fails*, and the child keeps the inherited **soft** limit — not the hard one. So `EnvironmentSandbox.stackLimit`'s promise that "the stack is made as large as the system allows" was false on any such machine: you got the shell's 8 MiB even when the hard limit was far higher. The request is now clamped to the hard limit.

**This is a behaviour change for packages that configure no `stackLimit` at all.** On a machine with a finite hard `RLIMIT_STACK`, deep-recursion solutions that used to RTE may now pass, and no warning fires — the probe returns early precisely because nothing was configured. That is the intended reading of the documented promise, but if a verdict moves after upgrading, this is why.

The clamp is also what makes the Linux warning's "programs run with 8 MiB" accurate: without it the `setrlimit` fails and the child keeps its inherited soft limit, which can be lower. The two changes should not be reverted independently; there is a comment in `get_detailed_message` saying so.

One subtlety worth flagging for review: on Linux `RLIM_INFINITY` is `-1`, so `stack_limit > hard` is false for an infinite request and the explicit `== RLIM_INFINITY` disjunct is load-bearing on exactly the platform this targets. `test_preexec_fn_clamps_an_unset_stack_limit_when_infinity_is_negative` pins it by patching the sentinel, because on a macOS dev box (`2**63-1`) the `>` arm masks a missing `==`.

## Known gap

On a cache hit `steps_with_caching` never reaches `steps.run`, so a fully-cached re-run prints nothing. Accepted — the warning fires on the run that computed the verdicts — and the docs say so rather than promising a warning every time.

## Tests

`tests/rbx/grading/steps_stack_limit_test.py` (new) plus additions to `tests/rbx/grading/judge/test_program.py`: 139 passed, 1 skipped across the touched grading suites; ruff clean; `mkdocs build` clean.

`tests/rbx/box/code_run_test.py::TestRunItem::test_stack_limit_check_calculates_target_correctly_with_hard_limit` fails on this branch, but fails identically on the merge base — a terminal-width wrapping assertion, unrelated.

Design and plan: `docs/plans/2026-08-29-stack-limit-warning-design.md`, `docs/plans/2026-08-29-stack-limit-warning.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aa5XjoukYpA4Zhk2s3uA8R
