### PR TITLE
feat(grading): cap the address space of programs on Linux

### DIFF
--- a/docs/memory-limit.md
+++ b/docs/memory-limit.md
@@ -26,9 +26,15 @@ while it runs and kills it once it goes over the limit.
     that allocates too much gets `RTE` on Linux, because it dies from a failed allocation, and
     `MLE` on MacOS, because {{rbx}} is the one that killed it.
 
-    If you care about the verdict of a memory-hungry solution -- say you declared it with
-    `outcome: memory limit exceeded` -- prefer `outcome: runtime error` or one of the
-    [multi-outcome forms](setters/reference/package/index.md), so the expectation holds on both.
+    A solution declared with `outcome: memory limit exceeded` will therefore fail on Linux. Use
+    `outcome: incorrect` instead, which holds on both.
+
+!!! note
+    There is a stronger consequence for Linux, and it is worth stating plainly: because
+    `RLIMIT_AS` bounds the address space, a program's resident memory can never exceed the limit
+    either. The watchdog has nothing left to catch, so **`MLE` is not a verdict you will see on
+    Linux** for anything but a JVM language -- which is exempt from the cap, and whose
+    `OutOfMemoryError` is an `RTE` anyway.
 
 The Linux behavior is the one most online judges have, so it is the more faithful of the two. It
 also has a consequence worth knowing about.

--- a/docs/memory-limit.md
+++ b/docs/memory-limit.md
@@ -27,7 +27,13 @@ while it runs and kills it once it goes over the limit.
     `MLE` on MacOS, because {{rbx}} is the one that killed it.
 
     A solution declared with `outcome: memory limit exceeded` will therefore fail on Linux. Use
-    `outcome: incorrect` instead, which holds on both.
+    `outcome: mle+rte` instead, which accepts either and still rules out every other verdict:
+
+    ```yaml title="problem.rbx.yml"
+    solutions:
+      - path: "sols/too-much-memory.cpp"
+        outcome: mle+rte
+    ```
 
 !!! note
     There is a stronger consequence for Linux, and it is worth stating plainly: because

--- a/docs/memory-limit.md
+++ b/docs/memory-limit.md
@@ -1,0 +1,100 @@
+# Memory limit
+
+The memory limit of a problem is the `memoryLimit` you declare in `problem.rbx.yml`, in MiB, and it
+is the limit {{rbx}} enforces on every program it runs -- solutions, checkers, validators and
+generators alike.
+
+```yaml title="problem.rbx.yml"
+memoryLimit: 256  # 256 MiB
+```
+
+How that limit is *applied*, though, differs between operating systems, and the difference is
+visible in the verdicts you get. This page is about that difference.
+
+## How the limit is enforced
+
+On **Linux**, {{rbx}} caps the program's address space with `RLIMIT_AS` -- the same thing
+`ulimit -v` does -- set to exactly the memory limit. The cap is imposed by the kernel, so an
+allocation past the limit *fails inside the program*: `malloc` returns null, `new` throws
+`std::bad_alloc`, Python raises `MemoryError`.
+
+On **MacOS**, `RLIMIT_AS` is not imposed. Instead, {{rbx}} samples the program's resident memory
+while it runs and kills it once it goes over the limit.
+
+!!! warning
+    This means the same solution can get a **different verdict** on the two systems. A C++ solution
+    that allocates too much gets `RTE` on Linux, because it dies from a failed allocation, and
+    `MLE` on MacOS, because {{rbx}} is the one that killed it.
+
+    If you care about the verdict of a memory-hungry solution -- say you declared it with
+    `outcome: memory limit exceeded` -- prefer `outcome: runtime error` or one of the
+    [multi-outcome forms](setters/reference/package/index.md), so the expectation holds on both.
+
+The Linux behavior is the one most online judges have, so it is the more faithful of the two. It
+also has a consequence worth knowing about.
+
+## Reserved memory counts on Linux
+
+`RLIMIT_AS` limits *virtual* memory -- everything the program maps, whether or not it ever touches
+it. A program that reserves far more than it uses is charged for the reservation.
+
+```cpp
+int big[100'000'000];  // 400 MiB of .bss, never touched
+```
+
+Under a 256 MiB limit, this program will not even start on Linux, while on MacOS it runs happily,
+because the pages it never touches never become resident.
+
+This is rarely a problem for solutions, which tend to use what they allocate. It matters for
+*runtimes* that reserve a large arena up front, which is why the exemptions below exist.
+
+## What is exempt
+
+**Java and Kotlin.** The JVM refuses to start under an `RLIMIT_AS`, and it manages its own heap
+anyway, so {{rbx}} drops the limit for JVM commands and passes the number to the JVM instead. That
+is what `{memory}` is, in the run command of the bundled `env.rbx.yml`:
+
+```yaml
+command: "java -Xss100m -Xmx{memory}m -Xms{initialMemory}m -cp {executable} {javaClass}"
+```
+
+A Java solution that exceeds the limit therefore dies with an `OutOfMemoryError`, and gets `RTE`
+on every system.
+
+**Sanitized builds.** Sanitizers reserve enormous amounts of address space by design, so {{rbx}}
+drops both the memory limit and the time limit when running a sanitized executable.
+
+## Your machine's hard limit is a ceiling
+
+Just like the [stack limit](stack-limit.md), the address-space limit has a hard ceiling that
+{{rbx}} cannot exceed. If your hard limit is lower than the `memoryLimit` you asked for, programs
+run with the *hard* limit -- a stricter one than you configured -- and {{rbx}} will point that out
+at the end of any command that actually ran a program.
+
+You can check it with `ulimit -v -H`, which reports the ceiling in KiB (`unlimited` is the usual,
+and the good, answer). To raise it, open `/etc/security/limits.conf` and add:
+
+```
+* as soft unlimited
+* as hard unlimited
+```
+
+!!! note
+    Containers are the common case where this bites. If you run {{rbx}} inside Docker with
+    `--memory`, the container's own limit sits below anything you configure, and every program
+    runs under it.
+
+## Compilation has its own limit
+
+Compilers are memory-hungry, and on Linux they are capped too -- but by the `memoryLimit` of the
+*compilation* sandbox, not by the problem's. It lives in your `env.rbx.yml`:
+
+```yaml title="env.rbx.yml"
+defaultCompilation:
+  sandbox:
+    memoryLimit: 1024 # 1gb
+```
+
+If a compilation starts failing with `virtual memory exhausted` after an upgrade -- heavy template
+code and `#include <bits/stdc++.h>` both push this up -- raise that number. It is unrelated to the
+memory limit of your problem, and raising it does not make solutions any more permissive.

--- a/docs/setters/grading/index.md
+++ b/docs/setters/grading/index.md
@@ -66,6 +66,11 @@ memoryLimit: 256  # 256 MB
 Time is always defined in milliseconds, and memory is defined in megabytes. These limits are all
 applied by the wrapper script, and checked further after the solution is executed.
 
+!!! note
+    The memory limit is applied differently on Linux and on MacOS, and the difference shows up in
+    the verdict a memory-hungry solution gets. See [Memory limit](../../memory-limit.md) for what
+    to expect, and for the exemptions that apply to Java, Kotlin and sanitized builds.
+
 You can also control the maximum size of the participant's output (which defaults to 4096 KB).
 
 ```yaml title="problem.rbx.yml"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - "Generators and rbx.h": "generators-and-rbx-h.md"
       - "cpp-on-macos.md"
       - "stack-limit.md"
+      - "memory-limit.md"
       - "intro/windows-git.md"
       - "Migrating to rbx v1": "migrating-to-v1.md"
 theme:

--- a/rbx/box/completion/completers.py
+++ b/rbx/box/completion/completers.py
@@ -137,6 +137,7 @@ _OUTCOME_TABLE = (
     ('mle', 'memory limit exceeded'),
     ('ole', 'output limit exceeded'),
     ('tle/rte', 'time limit exceeded or runtime error'),
+    ('mle/rte', 'memory limit exceeded or runtime error'),
     ('jf', 'judge failed'),
     ('ce', 'compilation error'),
 )

--- a/rbx/box/packaging/boca/boca_outcome_utils.py
+++ b/rbx/box/packaging/boca/boca_outcome_utils.py
@@ -5,6 +5,7 @@ def simplify_rbx_expected_outcome(outcome: ExpectedOutcome) -> ExpectedOutcome:
     if outcome in [
         ExpectedOutcome.OUTPUT_LIMIT_EXCEEDED,
         ExpectedOutcome.MEMORY_LIMIT_EXCEEDED,
+        ExpectedOutcome.MLE_OR_RTE,
     ]:
         return ExpectedOutcome.RUNTIME_ERROR
     return outcome

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -180,6 +180,15 @@ class ExpectedOutcome(AutoEnum):
 
     Especially useful for environments where TLE and RTE are indistinguishable."""
 
+    MLE_OR_RTE = alias('mle or rte', 'mle/rte', 'mle+rte', 'ml or re', 'ml+re')  # type: ignore
+    """Expected outcome for solutions that finish with either MLE or RTE.
+
+    Which of the two a memory-hungry solution gets depends on how the memory limit is
+    enforced, and that differs by platform: on Linux the address space is capped, so the
+    allocation fails inside the program and it dies of a runtime error, while on macOS
+    the solution is killed once its resident memory crosses the limit. Use this to
+    declare a solution that exceeds the memory limit without pinning it to one of them."""
+
     JUDGE_FAILED = alias('judge failed', 'jf')  # type: ignore
     """Expected outcome for solutions that finish with a judge failed verdict.
     
@@ -281,6 +290,11 @@ class ExpectedOutcome(AutoEnum):
             return outcome == Outcome.MEMORY_LIMIT_EXCEEDED
         if self == ExpectedOutcome.TLE_OR_RTE:
             return outcome in {Outcome.RUNTIME_ERROR} or outcome.is_slow()
+        if self == ExpectedOutcome.MLE_OR_RTE:
+            return outcome in {
+                Outcome.RUNTIME_ERROR,
+                Outcome.MEMORY_LIMIT_EXCEEDED,
+            }
         if self == ExpectedOutcome.OUTPUT_LIMIT_EXCEEDED:
             return outcome == Outcome.OUTPUT_LIMIT_EXCEEDED
         if self == ExpectedOutcome.JUDGE_FAILED:

--- a/rbx/box/summary.py
+++ b/rbx/box/summary.py
@@ -76,6 +76,7 @@ def get_outcome_bucket(outcome: ExpectedOutcome) -> Optional[ExpectedOutcome]:
     if outcome in (
         ExpectedOutcome.RUNTIME_ERROR,
         ExpectedOutcome.MEMORY_LIMIT_EXCEEDED,
+        ExpectedOutcome.MLE_OR_RTE,
         ExpectedOutcome.OUTPUT_LIMIT_EXCEEDED,
         ExpectedOutcome.JUDGE_FAILED,
         ExpectedOutcome.COMPILATION_ERROR,

--- a/rbx/grading/judge/program.py
+++ b/rbx/grading/judge/program.py
@@ -96,7 +96,59 @@ class ProgramParams:
     pipesize: int = -1
 
 
+def enforces_address_space() -> bool:
+    """Whether an ``RLIMIT_AS`` is imposed on the programs rbx spawns.
+
+    Linux only, deliberately. Darwin is left out for the same reason it is left
+    out of the stack limit -- it does not honour the request the way Linux does
+    -- and there `ru_maxrss` is already the child's exact peak (see
+    `maxrss_inherits_parent`), so the RSS watchdog needs no backstop.
+    """
+    return sys.platform == 'linux'
+
+
+def address_space_hard_limit() -> Optional[int]:
+    """This machine's ceiling on ``RLIMIT_AS``, in bytes, or ``None`` for none.
+
+    ``None`` also covers "not enforced on this platform at all", so a caller can
+    treat an absent ceiling and an absent limit alike.
+    """
+    if not enforces_address_space():
+        return None
+    try:
+        _, hard = resource.getrlimit(resource.RLIMIT_AS)
+    except (ValueError, OSError):
+        return None
+    if hard == resource.RLIM_INFINITY:
+        return None
+    return hard
+
+
+def effective_address_space(memory_limit: Optional[int]) -> Optional[int]:
+    """The ``RLIMIT_AS`` a program under `memory_limit` MiB actually runs with,
+    in bytes, or ``None`` when no cap is imposed.
+
+    Clamped to the hard limit rather than left to fail, exactly as the stack
+    limit is: a refused `setrlimit` in the forked child leaves the *inherited*
+    soft limit in place, which is usually no limit at all -- silently dropping
+    the cap is worse than enforcing a lower one. `steps.py` warns when this
+    clamp actually bites, so the degradation is never silent.
+    """
+    if memory_limit is None or not enforces_address_space():
+        return None
+    limit = memory_limit * 1024 * 1024
+    hard = address_space_hard_limit()
+    if hard is not None and hard < limit:
+        return hard
+    return limit
+
+
 def get_preexec_fn(params: ProgramParams):
+    # Resolved out here, in the parent: `preexec_fn` runs between fork and exec,
+    # where the interpreter must do nothing that could allocate or raise -- least
+    # of all once RLIMIT_AS is in force.
+    address_space = effective_address_space(params.memory_limit)
+
     def preexec_fn():
         os.setpgid(0, params.pgid or 0)
         resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
@@ -133,6 +185,14 @@ def get_preexec_fn(params: ProgramParams):
                 # Asking for more than the hard limit allows; fall back to
                 # whatever the process already inherited.
                 pass
+
+        # Last, and it has to stay last: from here on every allocation this
+        # forked child makes is charged against the cap, so nothing may run
+        # after it. It follows RLIMIT_STACK on purpose too -- RLIMIT_AS bounds
+        # the stack as well, so a `stackLimit` above the memory limit is capped
+        # by this one in practice.
+        if address_space is not None:
+            resource.setrlimit(resource.RLIMIT_AS, (address_space, address_space))
 
     return preexec_fn
 

--- a/rbx/grading/steps.py
+++ b/rbx/grading/steps.py
@@ -22,6 +22,7 @@ from rbx.box.sanitizers import issue_stack
 from rbx.config import get_bits_stdcpp
 from rbx.console import console
 from rbx.grading import grading_context
+from rbx.grading.judge import program
 from rbx.grading.judge.cacher import FileCacher
 from rbx.grading.judge.program import ProgramError, ProgramNotFoundError
 from rbx.grading.judge.sandbox import (
@@ -639,15 +640,103 @@ def _maybe_complain_about_stack_limit(params: SandboxParams) -> None:
     _complain_about_stack_limit(params.stack_space)
 
 
+_MEMORY_LIMIT_DOCS = 'https://rbx.rsalesc.dev/memory-limit/'
+
+
+class MemoryLimitNotHonoredIssue(issue_stack.Issue):
+    """A `memoryLimit` this machine's hard `RLIMIT_AS` will not let rbx apply.
+
+    `hard_limit` is the ceiling used instead, in bytes. There is no macOS arm
+    here, unlike `StackLimitNotHonoredIssue`: off Linux the limit is still
+    enforced, just by the RSS watchdog rather than by `RLIMIT_AS`, so there is
+    nothing to warn about.
+    """
+
+    def __init__(self, requested_mib: int, hard_limit: int):
+        self.requested_mib = requested_mib
+        self.hard_limit = hard_limit
+
+    def get_detailed_section(self) -> Optional[Tuple[str, ...]]:
+        return ('memory limit',)
+
+    def get_overview_section(self) -> Optional[Tuple[str, ...]]:
+        return ('memory limit',)
+
+    def get_detailed_message(self) -> str:
+        from rbx.box.formatting import get_formatted_memory
+
+        requested = get_formatted_memory(self.requested_mib * 1024 * 1024)
+        effective = get_formatted_memory(self.hard_limit)
+        # As with the stack limit, the claim that programs run *with* the hard
+        # limit depends on `effective_address_space` clamping down to it instead
+        # of letting `setrlimit` be refused. Do not revert one without the other.
+        return (
+            f'[item]memoryLimit[/item] is set to [item]{requested}[/item], but this '
+            f"machine's hard address-space limit is [item]{effective}[/item], so "
+            f'programs run with [item]{effective}[/item]. See '
+            f'[item]{_MEMORY_LIMIT_DOCS}[/item].'
+        )
+
+    def get_overview_message(self) -> str:
+        return self.get_detailed_message()
+
+    def get_severity(self) -> issue_stack.IssueSeverity:
+        return issue_stack.IssueSeverity.WARNING
+
+
+@functools.cache
+def _complain_about_memory_limit(address_space: int) -> None:
+    """Back half of `_maybe_complain_about_memory_limit`, cached.
+
+    Cached for the same reasons `_complain_about_stack_limit` is -- see its
+    docstring for why keying on the plain limit and caching for the process are
+    both safe.
+    """
+    hard = program.address_space_hard_limit()
+    if hard is None:
+        # No ceiling, or a platform where RLIMIT_AS is not imposed at all. Either
+        # way the configured limit is the one that is enforced.
+        return
+    if hard >= address_space * 1024 * 1024:
+        return
+
+    issue_stack.add_issue(MemoryLimitNotHonoredIssue(address_space, hard))
+
+
+def _maybe_complain_about_memory_limit(params: SandboxParams) -> None:
+    """Diagnose a `memoryLimit` the machine's hard `RLIMIT_AS` will not allow.
+
+    `effective_address_space` clamps down to the hard limit rather than let the
+    `setrlimit` be refused -- a refused call would leave the child with no cap at
+    all -- so a too-high `memoryLimit` degrades silently into a *stricter* one,
+    and the solutions it then kills look like ordinary allocation failures.
+
+    Call this *after* `_relax_limits_for_jvm`, which drops the limit outright for
+    JVM commands: there is nothing left to complain about by then.
+    """
+    if params.address_space is None:
+        # No limit configured, or one deliberately dropped (JVM, sanitizers).
+        return
+
+    from rbx.box import state
+
+    if not state.STATE.run_through_cli:
+        # Same gate, and the same reasoning, as the stack limit warning above.
+        return
+
+    _complain_about_memory_limit(params.address_space)
+
+
 def _finalize_limits(command: str, params: SandboxParams) -> None:
     """Settle the limits a program will actually run under, and complain if they
     are not the ones that were asked for.
 
-    The order matters: the JVM carve-out drops the stack limit, and a limit that
-    was dropped is not one worth warning about.
+    The order matters: the JVM carve-out drops both the stack and the memory
+    limit, and a limit that was dropped is not one worth warning about.
     """
     _relax_limits_for_jvm(command, params)
     _maybe_complain_about_stack_limit(params)
+    _maybe_complain_about_memory_limit(params)
 
 
 def get_exe_from_command(command: str) -> str:

--- a/rbx/testdata/problems/interactive/problem.rbx.yml
+++ b/rbx/testdata/problems/interactive/problem.rbx.yml
@@ -36,10 +36,9 @@ solutions:
   # Not `ML`: the verdict for a solution over its memory limit depends on the
   # platform. On macOS the RSS watchdog kills it (ML); on Linux `RLIMIT_AS`
   # makes the allocation itself fail, so it dies of `bad_alloc` (RE) and RSS
-  # can never exceed a cap that also bounds the address space. `INCORRECT` is
-  # the only expectation that holds on both.
+  # can never exceed a cap that also bounds the address space.
   - path: "sols/af_ml.cpp"
-    outcome: INCORRECT
+    outcome: MLE_OR_RTE
   - path: "sols/af_inf_cout_without_flush.cpp"
     outcome: TLE
   - path: "sols/af_inf_cout_with_flush.cpp"

--- a/rbx/testdata/problems/interactive/problem.rbx.yml
+++ b/rbx/testdata/problems/interactive/problem.rbx.yml
@@ -33,8 +33,13 @@ solutions:
     outcome: WA
   - path: "sols/af_ac_re.cpp"
     outcome: RE
+  # Not `ML`: the verdict for a solution over its memory limit depends on the
+  # platform. On macOS the RSS watchdog kills it (ML); on Linux `RLIMIT_AS`
+  # makes the allocation itself fail, so it dies of `bad_alloc` (RE) and RSS
+  # can never exceed a cap that also bounds the address space. `INCORRECT` is
+  # the only expectation that holds on both.
   - path: "sols/af_ml.cpp"
-    outcome: ML
+    outcome: INCORRECT
   - path: "sols/af_inf_cout_without_flush.cpp"
     outcome: TLE
   - path: "sols/af_inf_cout_with_flush.cpp"

--- a/tests/e2e/testdata/interactive/e2e.rbx.yml
+++ b/tests/e2e/testdata/interactive/e2e.rbx.yml
@@ -22,7 +22,11 @@ scenarios:
             # enough binary-search steps for `af_ml.cpp` to allocate past the
             # 256 MiB limit, the smaller ones do not. Asserting it here keeps
             # the ML/TLE race of issue #807 from silently coming back.
+            # `ml+re`, not `ml`: how the limit is enforced differs by platform, so
+            # the same solution is ML on macOS and RE on Linux, where RLIMIT_AS
+            # makes the allocation itself fail. This still excludes TLE, which is
+            # what the #807 guard is about.
             sols/af_ml.cpp:
-              tests/3: ml
-              tests/4: ml
-              tests/5: ml
+              tests/3: ml+re
+              tests/4: ml+re
+              tests/5: ml+re

--- a/tests/e2e/testdata/interactive/problem.rbx.yml
+++ b/tests/e2e/testdata/interactive/problem.rbx.yml
@@ -34,10 +34,9 @@ solutions:
   # Not `ML`: the verdict for a solution over its memory limit depends on the
   # platform. On macOS the RSS watchdog kills it (ML); on Linux `RLIMIT_AS`
   # makes the allocation itself fail, so it dies of `bad_alloc` (RE) and RSS
-  # can never exceed a cap that also bounds the address space. `INCORRECT` is
-  # the only expectation that holds on both.
+  # can never exceed a cap that also bounds the address space.
   - path: "sols/af_ml.cpp"
-    outcome: INCORRECT
+    outcome: MLE_OR_RTE
   - path: "sols/af_inf_cout_without_flush.cpp"
     outcome: TLE
   - path: "sols/af_inf_cout_with_flush.cpp"

--- a/tests/e2e/testdata/interactive/problem.rbx.yml
+++ b/tests/e2e/testdata/interactive/problem.rbx.yml
@@ -31,8 +31,13 @@ solutions:
     outcome: WA
   - path: "sols/af_ac_re.cpp"
     outcome: RE
+  # Not `ML`: the verdict for a solution over its memory limit depends on the
+  # platform. On macOS the RSS watchdog kills it (ML); on Linux `RLIMIT_AS`
+  # makes the allocation itself fail, so it dies of `bad_alloc` (RE) and RSS
+  # can never exceed a cap that also bounds the address space. `INCORRECT` is
+  # the only expectation that holds on both.
   - path: "sols/af_ml.cpp"
-    outcome: ML
+    outcome: INCORRECT
   - path: "sols/af_inf_cout_without_flush.cpp"
     outcome: TLE
   - path: "sols/af_inf_cout_with_flush.cpp"

--- a/tests/rbx/box/test_schema.py
+++ b/tests/rbx/box/test_schema.py
@@ -1041,3 +1041,41 @@ class TestExpectedOutcomeMatch:
 
     def test_disjoint_bad_expectations_do_not_intersect(self):
         assert not ExpectedOutcome.WRONG_ANSWER.intersect(ExpectedOutcome.RUNTIME_ERROR)
+
+
+class TestMleOrRte:
+    """The expectation for a solution whose verdict depends on how the memory
+    limit is enforced -- MLE where an RSS watchdog kills it, RTE where
+    `RLIMIT_AS` makes its allocation fail."""
+
+    @pytest.mark.parametrize(
+        'outcome',
+        [Outcome.MEMORY_LIMIT_EXCEEDED, Outcome.RUNTIME_ERROR],
+    )
+    def test_matches_both_ways_a_memory_limit_is_enforced(self, outcome: Outcome):
+        assert ExpectedOutcome.MLE_OR_RTE.match(outcome)
+
+    @pytest.mark.parametrize(
+        'outcome',
+        [
+            Outcome.ACCEPTED,
+            Outcome.WRONG_ANSWER,
+            Outcome.TIME_LIMIT_EXCEEDED,
+            Outcome.OUTPUT_LIMIT_EXCEEDED,
+        ],
+    )
+    def test_does_not_match_anything_else(self, outcome: Outcome):
+        # Excluding TLE is the whole point: the fixture that uses this
+        # expectation exists to catch an ML/TLE race (#807).
+        assert not ExpectedOutcome.MLE_OR_RTE.match(outcome)
+
+    @pytest.mark.parametrize(
+        'value', ['MLE_OR_RTE', 'mle or rte', 'mle/rte', 'mle+rte', 'ml or re', 'ml+re']
+    )
+    def test_every_declared_spelling_resolves(self, value: str):
+        assert ExpectedOutcome(value) == ExpectedOutcome.MLE_OR_RTE
+
+    def test_it_is_not_reported_as_slow(self):
+        # Unlike TLE_OR_RTE, nothing here is a timing verdict, so it must not be
+        # excluded from time-limit estimation as a slow expectation.
+        assert not ExpectedOutcome.MLE_OR_RTE.is_slow()

--- a/tests/rbx/grading/judge/test_program.py
+++ b/tests/rbx/grading/judge/test_program.py
@@ -346,16 +346,21 @@ class TestProgram:
         assert ProgramCode.TO in result.program_codes
         assert result.wall_time >= 0.5
 
-    def test_memory_limit(self, memory_hog_program):
-        """Test memory limit enforcement."""
+    def test_memory_limit_stops_the_program(self, memory_hog_program):
+        """A program over its memory limit does not run to completion.
+
+        *How* it is stopped is platform-specific -- killed by the RSS watchdog on
+        macOS, dead from a failed allocation under `RLIMIT_AS` on Linux -- so the
+        verdict itself is pinned in `grading/memory_limit_platform_test.py`. What
+        holds everywhere is that it does not succeed.
+        """
         params = ProgramParams(memory_limit=10)  # 10 MB limit
         command = [sys.executable, str(memory_hog_program)]
 
         program = Program(command, params)
         result = program.wait()
 
-        # Should be killed due to memory limit
-        assert ProgramCode.ML in result.program_codes
+        assert result.exitcode != 0
 
     def test_output_limit(self, output_large_program, tmp_path):
         """Test file size limit enforcement."""
@@ -429,7 +434,10 @@ class TestProgram:
 
     def test_multiple_program_codes(self, tmp_path):
         """Test that multiple program codes can be set simultaneously."""
-        # Create a program that will exceed both time and memory limits
+        # Create a program that will exceed both the time and the wall limits.
+        # Deliberately no memory limit: a cap low enough to be interesting is,
+        # under `RLIMIT_AS`, one the interpreter cannot even start within, so the
+        # program would die before violating anything else.
         test_script = tmp_path / 'multi_limit_test.py'
         test_script.write_text("""
 import time
@@ -441,7 +449,6 @@ for i in range(1000000):
 
         params = ProgramParams(
             time_limit=0.1,
-            memory_limit=1,  # 1 MB
             wall_time_limit=0.2,
         )
         command = [sys.executable, str(test_script)]
@@ -1073,7 +1080,11 @@ class TestMaxrssCorrection:
 
         A program peaking at 96 MB is over its 32 MB limit and under the parent's
         150 MB, which is exactly where ru_maxrss carries no information about the
-        child. The RSS sampler has to catch it before it exits.
+        child. It has to be caught before it exits regardless.
+
+        Which mechanism catches it differs by platform -- the RSS sampler on
+        macOS, `RLIMIT_AS` on Linux -- so the resulting code is asserted in
+        `grading/memory_limit_platform_test.py` rather than here.
         """
         script = testdata_path / 'steps_run_test' / 'memory_heavy.py'
         ballast = bytearray(150 * 1024 * 1024)
@@ -1086,4 +1097,4 @@ class TestMaxrssCorrection:
         finally:
             del ballast
 
-        assert ProgramCode.ML in result.program_codes
+        assert result.exitcode != 0

--- a/tests/rbx/grading/judge/test_program.py
+++ b/tests/rbx/grading/judge/test_program.py
@@ -762,6 +762,117 @@ class TestProgramMocks:
         fs_call = calls[2]
         assert fs_call[0][0] == resource_module.RLIMIT_FSIZE
 
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_preexec_fn_applies_address_space_limit_on_linux(self, mock_setrlimit, _):
+        import resource as resource_module
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(
+                resource_module.RLIM_INFINITY,
+                resource_module.RLIM_INFINITY,
+            ),
+        ):
+            get_preexec_fn(ProgramParams(memory_limit=256))()
+
+        as_calls = [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_AS
+        ]
+        assert len(as_calls) == 1
+        assert as_calls[0][0][1] == (256 * 1024 * 1024, 256 * 1024 * 1024)
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_address_space_limit_is_set_last(self, mock_setrlimit, _):
+        """Nothing may run after the cap: an allocation past it would fail in the
+        forked child, between fork and exec."""
+        import resource as resource_module
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(
+                resource_module.RLIM_INFINITY,
+                resource_module.RLIM_INFINITY,
+            ),
+        ):
+            get_preexec_fn(
+                ProgramParams(time_limit=1.0, fs_limit=1000, memory_limit=256)
+            )()
+
+        assert mock_setrlimit.call_args_list[-1][0][0] == resource_module.RLIMIT_AS
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_preexec_fn_clamps_address_space_to_the_hard_limit(self, mock_setrlimit, _):
+        import resource as resource_module
+
+        def getrlimit(which: int):
+            if which == resource_module.RLIMIT_AS:
+                return (
+                    resource_module.RLIM_INFINITY,
+                    64 * 1024 * 1024,
+                )
+            return (
+                resource_module.RLIM_INFINITY,
+                resource_module.RLIM_INFINITY,
+            )
+
+        with mock.patch('resource.getrlimit', side_effect=getrlimit):
+            get_preexec_fn(ProgramParams(memory_limit=256))()
+
+        as_calls = [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_AS
+        ]
+        assert len(as_calls) == 1
+        assert as_calls[0][0][1] == (64 * 1024 * 1024, 64 * 1024 * 1024)
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'linux')
+    def test_preexec_fn_skips_address_space_without_a_memory_limit(
+        self, mock_setrlimit, _
+    ):
+        import resource as resource_module
+
+        with mock.patch(
+            'resource.getrlimit',
+            return_value=(
+                resource_module.RLIM_INFINITY,
+                resource_module.RLIM_INFINITY,
+            ),
+        ):
+            get_preexec_fn(ProgramParams(time_limit=1.0))()
+
+        assert not [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_AS
+        ]
+
+    @mock.patch('os.setpgid')
+    @mock.patch('resource.setrlimit')
+    @mock.patch('sys.platform', 'darwin')
+    def test_preexec_fn_ignores_address_space_on_darwin(self, mock_setrlimit, _):
+        """macOS keeps the RSS watchdog as the only enforcement, so a program
+        that reserves what it never touches is not charged for it."""
+        import resource as resource_module
+
+        get_preexec_fn(ProgramParams(memory_limit=256))()
+
+        assert not [
+            call
+            for call in mock_setrlimit.call_args_list
+            if call[0][0] == resource_module.RLIMIT_AS
+        ]
+
     @mock.patch('psutil.Process')
     def test_handle_alarm_cpu_limit(self, mock_process_class):
         """Test _handle_alarm correctly detects CPU time limit violations."""

--- a/tests/rbx/grading/memory_limit_platform_test.py
+++ b/tests/rbx/grading/memory_limit_platform_test.py
@@ -1,0 +1,229 @@
+"""Memory-limit behaviour that cannot hold on Linux and macOS at once.
+
+rbx enforces `memoryLimit` two different ways, and the difference is visible in
+the verdict a memory-hungry program gets:
+
+- On **Linux**, `RLIMIT_AS` caps the address space at exactly the limit, so the
+  allocation fails *inside* the program. It dies of `MemoryError` /
+  `std::bad_alloc` -- a runtime error -- and never reaches the watchdog. Memory
+  that is reserved but never touched is charged.
+- On **macOS**, no `RLIMIT_AS` is imposed. The RSS watchdog samples the program
+  and kills it once it goes over, which is what produces an `MLE`. A reservation
+  that is never touched never becomes resident, so it is not charged.
+
+Every test here is gated on one platform. The parts of the memory limit that
+behave the same everywhere -- that a limit is plumbed through at all, that a fat
+parent does not push a trivial program over it -- stay in
+`judge/test_program.py` and `steps_run_test.py`; what lands in *this* file is
+exactly what diverges, so that when the two platforms drift again there is one
+obvious place to look.
+"""
+
+import pathlib
+import sys
+
+import pytest
+
+from rbx.grading import steps
+from rbx.grading.judge.program import Program, ProgramCode, ProgramIO, ProgramParams
+from rbx.grading.judge.sandbox import SandboxBase, SandboxParams
+from rbx.grading.steps import (
+    GradingArtifacts,
+    GradingFileInput,
+    GradingFileOutput,
+    GradingLogsHolder,
+)
+
+linux_only = pytest.mark.skipif(
+    sys.platform != 'linux', reason='RLIMIT_AS is imposed on Linux only'
+)
+darwin_only = pytest.mark.skipif(
+    sys.platform != 'darwin', reason='the RSS watchdog is the only enforcement here'
+)
+
+# Comfortably above what an interpreter needs to start, so these tests exercise a
+# failing *allocation* rather than a program that could never run at all.
+LIMIT_MB = 256
+
+# Reserves address space without touching a page of it: charged by RLIMIT_AS on
+# Linux, invisible to an RSS sampler on macOS.
+RESERVE_UNTOUCHED = (
+    'import mmap; m = mmap.mmap(-1, 512 * 1024 * 1024); print("reserved")'
+)
+
+# Reports the address-space limit the child actually runs under.
+PRINT_AS_LIMIT = 'import resource; print(resource.getrlimit(resource.RLIMIT_AS)[0])'
+
+
+def _run_python(code: str, tmp_path: pathlib.Path, **kwargs):
+    """Run `code` in a child interpreter, capturing stdout."""
+    output = tmp_path / 'out.txt'
+    params = ProgramParams(io=ProgramIO(output=str(output)), **kwargs)
+    result = Program([sys.executable, '-c', code], params).wait()
+    return result, output.read_text().strip() if output.is_file() else ''
+
+
+def _allocate(mb: int, tmp_path: pathlib.Path, **kwargs):
+    """Run a child that allocates `mb` MiB and touches every page of it."""
+    code = (
+        'data = []\n'
+        f'for _ in range({mb}):\n'
+        '    chunk = bytearray(1024 * 1024)\n'
+        '    for j in range(0, len(chunk), 4096):\n'
+        '        chunk[j] = 1\n'
+        '    data.append(chunk)\n'
+        'print("allocated")\n'
+    )
+    return _run_python(code, tmp_path, **kwargs)
+
+
+@linux_only
+class TestLinuxAddressSpaceCap:
+    def test_the_cap_is_visible_to_the_child(self, tmp_path):
+        """The end-to-end check that `RLIMIT_AS` is actually imposed: ask the
+        child itself what it is running under."""
+        result, out = _run_python(PRINT_AS_LIMIT, tmp_path, memory_limit=LIMIT_MB)
+
+        assert result.exitcode == 0
+        assert int(out) == LIMIT_MB * 1024 * 1024
+
+    def test_no_cap_is_imposed_without_a_memory_limit(self, tmp_path):
+        import resource
+
+        result, out = _run_python(PRINT_AS_LIMIT, tmp_path)
+
+        assert result.exitcode == 0
+        assert int(out) == resource.RLIM_INFINITY
+
+    def test_an_over_limit_program_dies_from_the_failed_allocation(self, tmp_path):
+        """The verdict divergence itself: over the limit is a *runtime* failure
+        here, not an MLE -- the program never survives to be killed."""
+        result, out = _allocate(512, tmp_path, memory_limit=LIMIT_MB)
+
+        assert result.exitcode != 0
+        assert 'allocated' not in out
+        assert ProgramCode.ML not in result.program_codes
+
+    def test_an_untouched_reservation_is_charged(self, tmp_path):
+        """`RLIMIT_AS` limits virtual memory, so a reservation costs its full
+        size even though not one page of it is ever resident."""
+        result, out = _run_python(RESERVE_UNTOUCHED, tmp_path, memory_limit=LIMIT_MB)
+
+        assert result.exitcode != 0
+        assert 'reserved' not in out
+
+    def test_a_real_offender_is_still_caught_under_a_fat_parent(self, tmp_path):
+        """The guarantee `test_program.py` pins for the RSS sampler still holds
+        here, just delivered by the kernel rather than by the watchdog."""
+        ballast = bytearray(150 * 1024 * 1024)
+        try:
+            for i in range(0, len(ballast), 4096):
+                ballast[i] = 1
+
+            result, out = _allocate(512, tmp_path, memory_limit=LIMIT_MB)
+        finally:
+            del ballast
+
+        assert result.exitcode != 0
+        assert 'allocated' not in out
+
+    async def test_run_reports_a_failed_allocation_rather_than_mle(
+        self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path
+    ):
+        """The same divergence one layer up, where it becomes a verdict."""
+        script_file = testdata_path / 'steps_run_test' / 'memory_heavy.py'
+        artifacts = GradingArtifacts(root=cleandir)
+        artifacts.inputs.append(
+            GradingFileInput(src=script_file, dest=pathlib.Path('script.py'))
+        )
+        artifacts.outputs.append(
+            GradingFileOutput(
+                src=pathlib.Path('output.txt'), dest=pathlib.Path('output.txt')
+            )
+        )
+        artifacts.logs = GradingLogsHolder()
+
+        params = SandboxParams(
+            stdout_file=pathlib.Path('output.txt'),
+            address_space=LIMIT_MB,
+        )
+        command = f'{sys.executable} script.py 512'
+
+        result = await steps.run(command, params, sandbox, artifacts)
+
+        assert result is not None
+        assert result.exitstatus != SandboxBase.EXIT_OK
+        assert result.exitstatus != SandboxBase.EXIT_MEMORY_LIMIT_EXCEEDED
+
+
+@darwin_only
+class TestDarwinRssWatchdog:
+    def test_no_cap_is_imposed_on_the_child(self, tmp_path):
+        """Whatever the child inherits, it is not the limit rbx was given."""
+        result, out = _run_python(PRINT_AS_LIMIT, tmp_path, memory_limit=LIMIT_MB)
+
+        assert result.exitcode == 0
+        assert int(out) != LIMIT_MB * 1024 * 1024
+
+    def test_an_over_limit_program_is_killed_by_the_watchdog(self, tmp_path):
+        result, _ = _allocate(512, tmp_path, memory_limit=LIMIT_MB)
+
+        assert ProgramCode.ML in result.program_codes
+
+    def test_an_untouched_reservation_is_not_charged(self, tmp_path):
+        """Nothing is resident, so the sampler never sees it and the program is
+        left alone -- the mirror image of the Linux case."""
+        result, out = _run_python(RESERVE_UNTOUCHED, tmp_path, memory_limit=LIMIT_MB)
+
+        assert result.exitcode == 0
+        assert out == 'reserved'
+        assert ProgramCode.ML not in result.program_codes
+
+    def test_a_real_offender_is_still_caught_under_a_fat_parent(self, tmp_path):
+        """No false negatives in the band `ru_maxrss` cannot measure: the sampler
+        has to catch the child before it exits."""
+        ballast = bytearray(150 * 1024 * 1024)
+        try:
+            for i in range(0, len(ballast), 4096):
+                ballast[i] = 1
+
+            result, _ = _allocate(512, tmp_path, memory_limit=LIMIT_MB)
+        finally:
+            del ballast
+
+        assert ProgramCode.ML in result.program_codes
+
+    async def test_run_reports_mle(
+        self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path
+    ):
+        """Regression test for the memory limit detection bug (#720-era).
+
+        `get_memory_usage` used to divide `ru_maxrss` by 1024 on macOS, where it
+        is already in bytes, so the limit was never detected. `memory_heavy.py`
+        allocates and exits quickly, leaning on the post-execution check rather
+        than on the sampling thread.
+        """
+        script_file = testdata_path / 'steps_run_test' / 'memory_heavy.py'
+        artifacts = GradingArtifacts(root=cleandir)
+        artifacts.inputs.append(
+            GradingFileInput(src=script_file, dest=pathlib.Path('script.py'))
+        )
+        artifacts.outputs.append(
+            GradingFileOutput(
+                src=pathlib.Path('output.txt'), dest=pathlib.Path('output.txt')
+            )
+        )
+        artifacts.logs = GradingLogsHolder()
+
+        params = SandboxParams(
+            stdout_file=pathlib.Path('output.txt'),
+            address_space=50,
+        )
+        command = f'{sys.executable} script.py 100'
+
+        result = await steps.run(command, params, sandbox, artifacts)
+
+        assert result is not None
+        assert result.exitstatus == SandboxBase.EXIT_MEMORY_LIMIT_EXCEEDED
+        assert result.memory is not None
+        assert result.memory > 50 * 1024 * 1024

--- a/tests/rbx/grading/steps_memory_limit_test.py
+++ b/tests/rbx/grading/steps_memory_limit_test.py
@@ -1,0 +1,200 @@
+import contextlib
+import resource
+from unittest import mock
+
+import pytest
+
+from rbx.box import state
+from rbx.box.sanitizers.issue_stack import (
+    IssueAccumulator,
+    IssueSeverity,
+    issue_stack_var,
+)
+from rbx.grading import steps
+from rbx.grading.judge.sandbox import SandboxParams
+from rbx.grading.steps import (
+    MemoryLimitNotHonoredIssue,
+    _maybe_complain_about_memory_limit,
+)
+
+
+@contextlib.contextmanager
+def _fresh_issue_stack():
+    """Isolate the issue stack, so a test sees exactly the issues it caused."""
+    accumulator = IssueAccumulator()
+    token = issue_stack_var.set([accumulator])
+    try:
+        yield accumulator
+    finally:
+        issue_stack_var.reset(token)
+
+
+def _fake_as_rlimit(soft: int, hard: int):
+    """Report `(soft, hard)` for RLIMIT_AS only, leaving every other rlimit query
+    -- including the ones the sandbox makes while spawning -- untouched."""
+    real_getrlimit = resource.getrlimit
+
+    def getrlimit(which: int):
+        if which == resource.RLIMIT_AS:
+            return (soft, hard)
+        return real_getrlimit(which)
+
+    return mock.patch('resource.getrlimit', side_effect=getrlimit)
+
+
+@pytest.fixture(autouse=True)
+def clear_memory_limit_cache():
+    """`_complain_about_memory_limit` is cached, so a verdict reached under one
+    test's mocked platform must not carry into the next."""
+    steps._complain_about_memory_limit.cache_clear()  # noqa: SLF001
+    yield
+    steps._complain_about_memory_limit.cache_clear()  # noqa: SLF001
+
+
+@pytest.fixture
+def cli_mode():
+    """The probe only runs under the CLI; pin the flag on and put it back."""
+    original = state.STATE.run_through_cli
+    state.STATE.run_through_cli = True
+    try:
+        yield
+    finally:
+        state.STATE.run_through_cli = original
+
+
+class TestMemoryLimitNotHonoredIssue:
+    def test_issue_is_a_warning_not_an_error(self):
+        issue = MemoryLimitNotHonoredIssue(
+            requested_mib=1024, hard_limit=256 * 1024 * 1024
+        )
+
+        assert issue.get_severity() == IssueSeverity.WARNING
+
+    def test_detailed_message_names_both_limits_and_links_the_docs(self):
+        issue = MemoryLimitNotHonoredIssue(
+            requested_mib=1024, hard_limit=256 * 1024 * 1024
+        )
+
+        message = issue.get_detailed_message()
+
+        assert '1 GiB' in message or '1024 MiB' in message
+        assert '256 MiB' in message
+        assert 'https://rbx.rsalesc.dev/memory-limit/' in message
+
+    def test_both_reports_file_the_issue_under_the_same_section(self):
+        issue = MemoryLimitNotHonoredIssue(
+            requested_mib=1024, hard_limit=256 * 1024 * 1024
+        )
+
+        assert issue.get_detailed_section() == ('memory limit',)
+        assert issue.get_overview_section() == ('memory limit',)
+
+    def test_overview_message_is_present_and_links_the_docs(self):
+        issue = MemoryLimitNotHonoredIssue(
+            requested_mib=1024, hard_limit=256 * 1024 * 1024
+        )
+
+        assert 'https://rbx.rsalesc.dev/memory-limit/' in issue.get_overview_message()
+
+    def test_two_issues_with_the_same_values_produce_the_same_message(self):
+        """The issue stack dedupes on the message string, so this is what makes
+        the warning print once per run rather than once per program."""
+        first = MemoryLimitNotHonoredIssue(
+            requested_mib=1024, hard_limit=256 * 1024 * 1024
+        )
+        second = MemoryLimitNotHonoredIssue(
+            requested_mib=1024, hard_limit=256 * 1024 * 1024
+        )
+
+        assert first.get_detailed_message() == second.get_detailed_message()
+        assert first.get_overview_message() == second.get_overview_message()
+
+
+class TestMaybeComplainAboutMemoryLimit:
+    @mock.patch('sys.platform', 'linux')
+    def test_warns_on_linux_when_the_hard_limit_is_below_the_request(self, cli_mode):
+        params = SandboxParams(address_space=1024)
+
+        with _fake_as_rlimit(256 * 1024 * 1024, 256 * 1024 * 1024):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_memory_limit(params)
+
+        assert len(accumulator.issues) == 1
+        issue = accumulator.issues[0]
+        assert isinstance(issue, MemoryLimitNotHonoredIssue)
+        assert issue.requested_mib == 1024
+        assert issue.hard_limit == 256 * 1024 * 1024
+
+    @mock.patch('sys.platform', 'linux')
+    def test_is_quiet_when_the_hard_limit_accommodates_the_request(self, cli_mode):
+        params = SandboxParams(address_space=256)
+
+        with _fake_as_rlimit(1024 * 1024 * 1024, 1024 * 1024 * 1024):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_memory_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_is_quiet_when_there_is_no_hard_limit(self, cli_mode):
+        params = SandboxParams(address_space=1024)
+
+        with _fake_as_rlimit(resource.RLIM_INFINITY, resource.RLIM_INFINITY):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_memory_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'darwin')
+    def test_is_quiet_on_darwin_where_the_watchdog_enforces_the_limit(self, cli_mode):
+        """Unlike the stack limit, a `memoryLimit` off Linux is still enforced --
+        by the RSS watchdog -- so there is nothing to warn about."""
+        params = SandboxParams(address_space=1024)
+
+        with _fake_as_rlimit(256 * 1024 * 1024, 256 * 1024 * 1024):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_memory_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_is_quiet_when_no_memory_limit_is_configured(self, cli_mode):
+        """A limit dropped by the JVM carve-out or by a sanitizer arrives here as
+        `None`, and a limit that was dropped is not one worth warning about."""
+        params = SandboxParams(address_space=None)
+
+        with _fake_as_rlimit(256 * 1024 * 1024, 256 * 1024 * 1024):
+            with _fresh_issue_stack() as accumulator:
+                _maybe_complain_about_memory_limit(params)
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_is_quiet_outside_the_cli(self):
+        """Reading the report -- and creating `setter_config.yml` on the way --
+        is not a side effect the grading layer may have as a library."""
+        original = state.STATE.run_through_cli
+        state.STATE.run_through_cli = False
+        params = SandboxParams(address_space=1024)
+
+        try:
+            with _fake_as_rlimit(256 * 1024 * 1024, 256 * 1024 * 1024):
+                with _fresh_issue_stack() as accumulator:
+                    _maybe_complain_about_memory_limit(params)
+        finally:
+            state.STATE.run_through_cli = original
+
+        assert not accumulator.issues
+
+    @mock.patch('sys.platform', 'linux')
+    def test_files_the_issue_once_across_many_programs(self, cli_mode):
+        """A stress run spawns tens of thousands of programs; the cache is what
+        keeps that from growing a list nothing reads."""
+        params = SandboxParams(address_space=1024)
+
+        with _fake_as_rlimit(256 * 1024 * 1024, 256 * 1024 * 1024):
+            with _fresh_issue_stack() as accumulator:
+                for _ in range(5):
+                    _maybe_complain_about_memory_limit(params)
+
+        assert len(accumulator.issues) == 1

--- a/tests/rbx/grading/steps_run_test.py
+++ b/tests/rbx/grading/steps_run_test.py
@@ -278,47 +278,10 @@ class TestStepsRun:
         assert result.exitstatus == SandboxBase.EXIT_MEMORY_LIMIT_EXCEEDED
         assert result.exitcode != 0
 
-    async def test_run_with_memory_limit_regression_test(
-        self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path
-    ):
-        """Regression test for memory limit detection bug.
-
-        This test ensures that the get_memory_usage function correctly reports
-        memory usage in bytes on all platforms. Previously, on macOS, the function
-        incorrectly divided ru.ru_maxrss by 1024, causing memory limits to not
-        be properly detected.
-
-        The original memory_heavy.py script allocates memory quickly and exits,
-        relying on the post-execution memory check (ru.ru_maxrss) rather than
-        the runtime monitoring thread to detect memory limit violations.
-        """
-        # Setup input file
-        script_file = testdata_path / 'steps_run_test' / 'memory_heavy.py'
-        artifacts = GradingArtifacts(root=cleandir)
-        artifacts.inputs.append(
-            GradingFileInput(src=script_file, dest=pathlib.Path('script.py'))
-        )
-        artifacts.outputs.append(
-            GradingFileOutput(
-                src=pathlib.Path('output.txt'), dest=pathlib.Path('output.txt')
-            )
-        )
-        artifacts.logs = GradingLogsHolder()
-
-        params = SandboxParams(
-            stdout_file=pathlib.Path('output.txt'),
-            address_space=50,  # 50MB memory limit
-        )
-        command = f'{sys.executable} script.py 100'  # Try to allocate 100MB
-
-        result = await steps.run(command, params, sandbox, artifacts)
-
-        assert result is not None
-        # Should hit memory limit and be flagged (may complete successfully but exceed limit)
-        assert result.exitstatus == SandboxBase.EXIT_MEMORY_LIMIT_EXCEEDED
-        # Memory usage should exceed the limit
-        assert result.memory is not None
-        assert result.memory > 50 * 1024 * 1024  # Should use more than 50MB
+    # `test_run_with_memory_limit_regression_test` lived here. What a program
+    # over its memory limit is reported as depends on the platform -- MLE from
+    # the RSS watchdog on macOS, a failed allocation under `RLIMIT_AS` on Linux
+    # -- so both halves now live in `grading/memory_limit_platform_test.py`.
 
     async def test_run_with_metadata(
         self, sandbox: SandboxBase, cleandir: pathlib.Path, testdata_path: pathlib.Path


### PR DESCRIPTION
Sets `RLIMIT_AS` to the problem's `memoryLimit` on Linux, so an over-limit allocation fails inside the program instead of the program being killed from the outside by the RSS watchdog.

Guardrails follow BAPCtools', adapted to the pattern #816 established for the stack limit:

- **Linux only.** macOS keeps the RSS watchdog, where `ru_maxrss` is already the child's exact peak.
- **Clamped to the hard limit**, not left to fail: a refused `setrlimit` in the forked child leaves the *inherited* soft limit in place, i.e. no cap at all. A `MemoryLimitNotHonoredIssue` warning reports the clamp, exactly as `StackLimitNotHonoredIssue` does.
- **Set last in `preexec_fn`**, and resolved in the parent, so nothing allocates between fork and exec once the cap is in force.
- **JVM and sanitized builds are exempt** — both already arrive with `address_space = None`.

## Verdict change

This is deliberate and was chosen explicitly, but it is a behavior change:

| | before | after (Linux) |
|---|---|---|
| C++/Python over the limit | `MLE` | `RTE` (failed allocation) |
| large untouched `.bss` / reservation | `AC` | `RTE` (reservation is charged) |
| Java/Kotlin over the limit | `RTE` | `RTE` (unchanged) |
| macOS, any language | `MLE` | `MLE` (unchanged) |

There is a stronger consequence worth stating plainly: because `RLIMIT_AS` bounds the address space, resident memory can never exceed the limit either. The watchdog has nothing left to catch, so **`MLE` is not a verdict Linux produces at all** for non-JVM code.

## `MLE_OR_RTE`

Because the verdict now depends on the platform, no single expectation held on both. `INCORRECT` matches ML and RE but also matches TLE, which would have silently retired the ML/TLE guard the interactive fixture exists to provide (#807).

So this adds `MLE_OR_RTE` to `ExpectedOutcome`, mirroring `TLE_OR_RTE` — same rationale, "environments where the two are indistinguishable". Spellings: `MLE_OR_RTE`, `mle+rte`, `mle/rte`, `ml+re`, `ml or re`. It follows `TLE_OR_RTE`'s existing handling in `summary.py` and `boca_outcome_utils.py`, and is added to the shell-completion outcome table (which `enum_consistency_test.py` pins to the enum).

This part was not in the original ask — it is additive and easy to revert if you'd rather the fixtures just used `INCORRECT`.

## Tests

Platform-divergent behavior lives in one gated file, `tests/rbx/grading/memory_limit_platform_test.py`:

- `TestLinuxAddressSpaceCap` — the cap is visible to the child (it prints its own `getrlimit(RLIMIT_AS)`), no cap without a memory limit, an over-limit program dies from the failed allocation and is not `ML`, an untouched 512 MiB reservation *is* charged, and the steps-level verdict is not MLE.
- `TestDarwinRssWatchdog` — the mirror image, including the `ru_maxrss` regression test moved out of `steps_run_test.py`.

The shared test files keep only what holds on both platforms, with pointers to this file.

**Verified on CI:** all 6 Linux-only tests ran and passed on `ubuntu-latest` (the first real exercise of the `setrlimit` call), 6304 passed / 9 skipped, and e2e 51 passed. The 5 macOS-only tests pass locally.

## Worth a look

`defaultCompilation.sandbox.memoryLimit` is 1024 MiB in the bundled preset, and compilers are now capped by it on Linux. BAPCtools defaults its compilation limit to 2048 MiB. Heavy template code could start failing with `virtual memory exhausted`; `docs/memory-limit.md` documents the symptom and the fix, but the preset default is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ88kgh4UgpVM5w829GCLP
