### PR TITLE
fix(statements): allow building contest documents by name

### DIFF
--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -1154,7 +1154,7 @@ rbx contest statements build <NAMES> [OPTIONS]
 
 | Name | Description | Required |
 | :--- | :--- | :--- |
-| `NAMES` | Names of statements to build. | No |
+| `NAMES` | Names of statements or documents to build. | No |
 
 | Name | Type | Description | Default |
 | :--- | :--- | :--- | :--- |

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -96,9 +96,18 @@ async def _execute_build(
     )
     valid_statements = [st for st in all_statements if should_process(st)]
 
-    if not valid_statements:
+    # Documents are selectable by name just like statements, so a run that names
+    # only documents is legitimate -- bail out only when nothing at all matched.
+    valid_documents = (
+        [doc for doc in contest.expanded_documents if should_process(doc)]
+        if build_documents
+        else []
+    )
+
+    if not valid_statements and not valid_documents:
+        what = f'{kind.singular} or document' if build_documents else str(kind.singular)
         console.console.print(
-            f'[error]No {kind.singular} found according to the specified criteria.[/error]',
+            f'[error]No {what} found according to the specified criteria.[/error]',
         )
         raise typer.Exit(1)
 
@@ -135,11 +144,6 @@ async def _execute_build(
     built_statements = []
     built_documents = []
     failed_statements: List[Tuple[str, str]] = []
-    valid_documents = (
-        [doc for doc in contest.expanded_documents if should_process(doc)]
-        if build_documents
-        else []
-    )
 
     with limits_info.use_profile(profile, when=lambda: profile is not None):
         for statement in valid_statements:
@@ -253,7 +257,7 @@ async def build(
     names: Annotated[
         Optional[List[str]],
         typer.Argument(
-            help='Names of statements to build.',
+            help='Names of statements or documents to build.',
         ),
     ] = None,
     languages: Annotated[

--- a/tests/rbx/box/contest/test_contest_build_v2.py
+++ b/tests/rbx/box/contest/test_contest_build_v2.py
@@ -1,6 +1,7 @@
 import inspect
 
 import pytest
+import typer
 
 from rbx.box.contest import statements as contest_statements_cli
 from rbx.box.statements.schema import StatementType
@@ -9,10 +10,10 @@ _build_async = inspect.unwrap(contest_statements_cli.build)
 _build_tut_async = inspect.unwrap(contest_statements_cli.build_tutorials)
 
 
-async def _run(output=StatementType.TeX):
+async def _run(output=StatementType.TeX, names=None):
     await _build_async(
         verification=0,
-        names=None,
+        names=names,
         languages=None,
         validate=False,
         output=output,
@@ -71,6 +72,29 @@ async def test_documents_emitted_without_joining(cleandir_with_testdata):
     assert 'info sheet' in info
     assert 'Statements v2 Contest' in info
     assert '\\subimport' not in info
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_document_can_be_selected_by_name(cleandir_with_testdata):
+    # Naming only a document must build it, even though it matches no statement.
+    await _run(output=StatementType.TeX, names=['info-en'])
+
+    assert (cleandir_with_testdata / 'build' / 'info-en.tex').is_file()
+    assert not (cleandir_with_testdata / 'build' / 'main-en.tex').exists()
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_statement_selected_by_name_skips_documents(cleandir_with_testdata):
+    await _run(output=StatementType.TeX, names=['main-en'])
+
+    assert (cleandir_with_testdata / 'build' / 'main-en.tex').is_file()
+    assert not (cleandir_with_testdata / 'build' / 'info-en.tex').exists()
+
+
+@pytest.mark.test_pkg('contests/statements_v2')
+async def test_unknown_name_still_fails(cleandir_with_testdata):
+    with pytest.raises(typer.Exit):
+        await _run(output=StatementType.TeX, names=['nonexistent'])
 
 
 @pytest.mark.test_pkg('contests/statements_v2')


### PR DESCRIPTION
`rbx contest st b <doc-name>` always failed with `No statements found according to the specified criteria.`, even for a document that exists in `contest.rbx.yml`.

The `names` filter was already applied to documents — the bug is ordering. In `_execute_build`, the "nothing matched" check ran against statements only, and the document list was computed ~30 lines later:

```python
valid_statements = [st for st in all_statements if should_process(st)]
if not valid_statements:
    raise typer.Exit(1)   # ← bails before documents are ever considered
```

So naming a document (which matches no statement) exited 1 before anything was built.

## Fix

Compute `valid_documents` before the emptiness check and only fail when neither a statement nor a document matched. The error message now says "statement or document" when documents are in play; `rbx contest tut b` never builds documents, so its message is unchanged.

Also updated the `NAMES` argument help to mention documents (CLI + the matching row in the checked-in `docs/setters/reference/cli.md`, hand-edited rather than regenerated, since that file has drifted).

## Tests

Three new cases in `tests/rbx/box/contest/test_contest_build_v2.py`:

- naming only a document builds it and no statement
- naming only a statement builds it and no document
- an unknown name still exits 1

`test_contest_build_v2.py` (11 passed) plus the partial-build / profile / summary contest suites (13 passed). ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YKScXfcuYSr3xEM19my5K
