### PR TITLE
feat(moj): refuse packages whose secret tests mojtools would leak

### DIFF
--- a/rbx/box/packaging/moj/CLAUDE.md
+++ b/rbx/box/packaging/moj/CLAUDE.md
@@ -274,6 +274,14 @@ an empty list means no examples and no leak. With samples, tier 2 already picks
 exactly the right tests, and a `samples` file would be a second source of truth to
 drift out of sync with `naming.testcase_name`.
 
+There is a second leak on the same theme: `build-and-test.sh` echoes the raw input of
+a failing test back to the submitter when `$INPUT` contains `sample` or `example` --
+an unanchored substring match against the **full path**, package directory included.
+A group named `examples` or a problem named `sample-tree` therefore leaks every
+secret test it touches (upstream bug; see issue #804). `package()` refuses such a
+package up front via `naming.check_secret_test_path`, rather than renaming tests
+behind the author's back.
+
 Tier 1 is an undocumented branch of `gen-problem-json.sh` -- mojtools' README only
 ever documents examples as `tests/input/sample*` -- so it is worth re-checking against
 upstream when the packager is next revised.

--- a/rbx/box/packaging/moj/naming.py
+++ b/rbx/box/packaging/moj/naming.py
@@ -17,6 +17,13 @@ SAMPLES_GLOB = 'sample*'
 # statement presents them in.
 TESTSET_PREFIX = 't'
 
+# `build-and-test.sh` echoes the raw input of a failing test back to the submitter
+# when `$INPUT` contains `sample` or `example`. That is meant as a courtesy for the
+# public samples, but the match is an unanchored, case-sensitive substring test
+# against the *full path* -- package directory included -- so a group named
+# `examples` or a problem named `sample-tree` leaks every secret test it touches.
+LEAKY_SUBSTRINGS = ('sample', 'example')
+
 
 class MojNamingError(RbxException):
     """A package cannot be expressed in MOJ's naming or scoring conventions."""
@@ -81,3 +88,19 @@ def build_score_file(groups: Sequence[ScoreGroup]) -> str:
             )
         lines.append(f'{group.glob} - {int(group.weight)} pontos')
     return '\n'.join(lines) + '\n'
+
+
+def check_secret_test_path(basename: str, name: str) -> None:
+    """Refuse a secret test whose path would make MOJ echo its raw input.
+
+    See `LEAKY_SUBSTRINGS`. Only non-sample tests are checked: a sample matching is
+    the intended behavior, and its input is public anyway.
+    """
+    path = f'{basename}/tests/input/{name}'
+    for needle in LEAKY_SUBSTRINGS:
+        if needle in path:
+            raise MojNamingError(
+                f'MOJ would show the raw input of secret test {path!r} to '
+                f'submitters, because its path contains {needle!r}. Rename the '
+                f'group or the problem.'
+            )

--- a/rbx/box/packaging/moj/packager.py
+++ b/rbx/box/packaging/moj/packager.py
@@ -1102,6 +1102,17 @@ class MojPackager(BasePackager):
             )
         return named
 
+    def _check_tests_do_not_leak(self) -> None:
+        """Refuse a package whose secret tests MOJ would echo back to submitters.
+
+        See `naming.LEAKY_SUBSTRINGS`.
+        """
+        basename = self.package_basename()
+        for entry, name in self.testcase_names():
+            if entry.is_sample():
+                continue
+            naming.check_secret_test_path(basename, name)
+
     def _write_tests(self, into_path: pathlib.Path) -> List[str]:
         """Write `tests/input` and `tests/output`; return the group names that got
         at least one test, in encounter order."""
@@ -1425,6 +1436,7 @@ class MojPackager(BasePackager):
     ) -> pathlib.Path:
         into_path.mkdir(parents=True, exist_ok=True)
 
+        self._check_tests_do_not_leak()
         self._write_metadata(into_path)
         self._write_conf(into_path)
         seen_groups = self._write_tests(into_path)

--- a/tests/rbx/box/packaging/moj/test_naming.py
+++ b/tests/rbx/box/packaging/moj/test_naming.py
@@ -88,3 +88,22 @@ def test_distinct_groups_never_share_a_prefix():
     a = naming.testcase_name('ab', group_index=1, index=1, is_sample=False)
     assert not fnmatch.fnmatch(a, naming.group_glob('a', 2))
     assert not fnmatch.fnmatch(a, naming.SAMPLES_GLOB)
+
+
+def test_secret_test_path_rejects_leaky_group_name():
+    # build-and-test.sh echoes the raw input of a failing test whose path matches.
+    name = naming.testcase_name('examples', group_index=1, index=1, is_sample=False)
+    with pytest.raises(naming.MojNamingError) as exc:
+        naming.check_secret_test_path('a-problem', name)
+    assert 'example' in str(exc.value)
+
+
+def test_secret_test_path_rejects_leaky_package_name():
+    name = naming.testcase_name('easy', group_index=1, index=1, is_sample=False)
+    with pytest.raises(naming.MojNamingError):
+        naming.check_secret_test_path('a-sample-tree', name)
+
+
+def test_secret_test_path_accepts_ordinary_names():
+    name = naming.testcase_name('easy', group_index=1, index=1, is_sample=False)
+    naming.check_secret_test_path('a-problem', name)


### PR DESCRIPTION
Closes #804.

`mojtools`' `build-and-test.sh` echoes the raw input of a failing test back to the submitter when `$INPUT` contains `sample` or `example`. The match is unanchored and runs against the **full path**, package directory included — so a group named `examples`/`counterexample`, or a problem short-named `sample-tree`, leaks every secret test it touches.

This implements option 2 from the issue: validate at package time rather than sanitizing names behind the author's back.

- `naming.check_secret_test_path(basename, name)` builds the emitted path (`<package basename>/tests/input/<name>`) and raises `MojNamingError` when it contains a leaky substring. Case-sensitive, mirroring the bash `=~`.
- `MojPackager._check_tests_do_not_leak()` runs first in `package()`, skipping samples (their input is public by design).
- The message is one line plus the fix:

  ```
  MOJ would show the raw input of secret test 'a-sample-tree/tests/input/t01_easy_001'
  to submitters, because its path contains 'sample'. Rename the group or the problem.
  ```

- Three unit tests, plus a short note in `rbx/box/packaging/moj/CLAUDE.md` beside the existing sample-leak section.

Upstream (option 1) is still worth doing; this is the local guardrail in the meantime.

## Testing

`uv run pytest tests/rbx/box/packaging/moj/test_naming.py tests/rbx/box/packaging/moj/test_packager.py` — 70 passed. ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fekxht7Chs2u17m1J6WNy