### PR TITLE
fix(moj): read reran testcases and tolerate CE/NT verdicts

### DIFF
--- a/docs/plans/2026-08-21-moj-probe-notes.md
+++ b/docs/plans/2026-08-21-moj-probe-notes.md
@@ -138,15 +138,69 @@ Three notes on the mapping, which is no longer one-to-one:
   `Runtime Error`; rbx does not follow, because a broken checker reported as the solution's
   runtime error is the same silent lie in a different costume. `JUDGE_FAILED` says what
   happened.
-- **`CE` and `NT` stay unmapped, for opposite reasons.** `CE` is real but run-level only
-  (§3b). `NT` ("Não executado") is `gen-report.sh` substituting for a *missing* verdict while
-  rendering HTML — it is never written to `log.verdictall`, so it cannot reach the `code`
-  position; a testcase MOJ said nothing about is already `SKIPPED`.
+- **`CE` and `NT` are handled, but not as verdicts of equal standing** — see §3f. Neither is
+  written by `run-testinput`, so neither is *expected* in the `code` position; both are
+  tolerated there rather than refused, because refusing costs a whole run and neither can
+  corrupt an estimate.
 
 `_outcome_for_moj_code` still reads any other `RE_*` as `RUNTIME_ERROR`, as a backstop for a
 sibling mojtools might grow — the prefix names the verdict, so the outcome carries no guess.
 Everything else is still refused by name. The invented spellings the earlier table warned
 about (`PE` and `JE` on their own) are now confirmed **not** to exist.
+
+### 3e. A testcase can appear **twice**, and the last one is the answer — 2026-08-31
+
+Read off mojtools while chasing [#824](https://github.com/rsalesc/rbx/issues/824), and it is
+not an anomaly: it is what the judge does on every TLE.
+
+`build-and-test.sh` runs the testset in parallel (`NPROC` jobs), then walks it a second time
+and reruns any testcase that came back `TLE` — *"Rerun: because got TLE while running
+parallel tests"* — because a timeout measured while N tests shared the machine is not a
+timeout. Each call of `run-testinput` **appends** its own line:
+
+```sh
+echo "VERDICT[$FILE]=$VERDICT" >> $workdirbase/log.verdictall
+```
+
+and `sol_tests_json` walks that file line by line into the `{name, code, time, tl}` array.
+So a reran testcase arrives **twice** in `tests`: first the contended measurement, then the
+one the judge kept. (It gives up after one rerun — a second `TLE` sets `TLERERUN=n` — so a
+name appears at most twice, though nothing here depends on that.)
+
+**The last entry wins**, and that is the judge's own rule rather than a tiebreak rbx
+invented: `build-and-test.sh` re-`source`s `log.verdictall` after the rerun and reads the
+testcase's verdict straight back out of the bash array, which is last-assignment-wins.
+
+`TestrunStatus.by_name` used to *refuse* a repeated name — it read a duplicate as the kind of
+misattribution that pairing-by-name exists to prevent — and so failed the whole run with
+"the judge reported more than one test named `…`" on a testrun MOJ considers perfectly
+ordinary. It now keeps the last entry. Reading the first would have been worse than the
+refusal: it feeds the estimate a time the judge itself discarded.
+
+### 3f. `CE` and `NT` in the `code` position — tolerated, 2026-08-31
+
+Neither is written by `run-testinput`, so §3d's argument stands: they are not expected
+per-test. But `gen-report.sh` shows both are real spellings in mojtools' vocabulary
+(`VERDICTFULLNAME` carries `[CE]="Compilation Error"` and `[NT]="Não executado"`, and the
+report's verdict histogram iterates `AC "AC,PE" WA TLE RE RE_NZEC TMT UE NT`), and the judge
+*agent*'s `agent_tests_json` — which `sol_tests_json` only claims to mirror — is server-side
+and cannot be read from here. So "cannot reach the `code` position" was an inference about
+code rbx has never seen.
+
+The cost of that inference being wrong is a **whole failed run**, and the cost of tolerating
+the two codes is nothing, because neither can put a wrong number into an estimate:
+
+- **`CE` → `COMPILATION_ERROR`.** It is what the code says. A run-level compile error still
+  takes §7b's `ran_nothing` path, which is the one that explains itself properly.
+- **`NT` → dropped, not mapped** (`_UNEXECUTED_MOJ_CODES`). It names the *absence* of a
+  verdict — `gen-report.sh` substitutes it for an input file with no `log.verdictall` entry,
+  which is a testset cut short — so every `Outcome` would be a claim about the solution that
+  nothing measured. Dropping it puts the testcase back on the path of one MOJ never
+  mentioned: `SKIPPED`, no timing, and counted in the "reported no result for N of M"
+  warning.
+
+Unknown codes are still refused by name. This widens what rbx reads; it does not weaken the
+rule that a code it cannot read stops the run.
 
 ### 3b. `Compilation Error` — observed 2026-08-21, by accident
 
@@ -161,8 +215,8 @@ judge, and every testrun came back:
 So `Compilation Error` joins the confirmed `verdict_canon` vocabulary — **as a run-level
 verdict, never as a per-test `code`**. There is no per-test anything: a submission that does
 not compile never reaches the testset, so the `tests` array is empty and `CE` was *not*
-observed in the `code` position. `_OUTCOME_BY_MOJ_CODE` therefore still has no `CE` entry,
-and should not grow one on this evidence.
+observed in the `code` position. `_OUTCOME_BY_MOJ_CODE` did not grow a `CE` entry on this
+evidence — it grew one later, on the different argument in §3f.
 
 What rbx said about it was `MOJ reported no result for 6 of 6 testcases ... Those testcases
 are left unmeasured` — true, useless, and pointing at the wrong thing entirely. See section

--- a/docs/plans/2026-08-21-moj-probe-notes.md
+++ b/docs/plans/2026-08-21-moj-probe-notes.md
@@ -202,6 +202,71 @@ the two codes is nothing, because neither can put a wrong number into an estimat
 Unknown codes are still refused by name. This widens what rbx reads; it does not weaken the
 rule that a code it cannot read stops the run.
 
+### 3g. `Unknown ERROR` on a run whose testcases all look fine — 2026-08-31
+
+Reported from a real run: a testrun whose per-test codes were only `AC` and `TLE` came back
+with a **run-level** verdict of `Unknown ERROR`. Traced through mojtools and the CD-MOJ
+server (`cd-moj/cdmoj`, which is open source), and it has exactly one source.
+
+**The server never produces it.** `judged.sh:390` merges the worker's payload wholesale and
+the read handler is a bare `jq -c '{success:true} + .'` (`api/v1/handlers/problems/test-run.sh:110`),
+so `verdict`, `verdict_canon`, `correct`, `total_tests` and `tests[]` are all the worker's
+own words. The only verdict the server ever *synthesizes* is the literal `Judge Error` — and
+not even that for a testrun, because the `_testrun` divert (`judged.sh:418`) runs before that
+fallback. A payload with no verdict therefore yields **no `verdict` key**, never `UE`.
+
+So it always comes from `build-and-test.sh`'s second-to-last decision:
+
+```sh
+[[ "$SMALLRESP" =~ "AC" ]] && (( RESPERRO > 0 )) && SMALLRESP=UE
+```
+
+`SMALLRESP` is the worst verdict across the testcases that *reported* one; `RESPERRO` counts
+inputs that reported none (`RESP="INPUT NOT TESTED"`, line ~514). The line reads: **every
+testcase I have a verdict for passed, and at least one produced no verdict at all** — a
+statement about the judging run, not about the submission.
+
+**How the testset comes up short**, and why a `TLE` can be sitting in `tests` while this
+fires:
+
+1. A testcase returns non-zero during the parallel dispatch (`3` = TLE, `6` = WA, `≥126` = RE)
+   and the loop breaks at line ~475 — `(( RET != 0 )) && [[ "$RUNALL" != "y" ]] && break`.
+   Every remaining input is then never executed. **`RUNALL` is the 4th argv of
+   `build-and-test.sh`, not a package setting**, and it defaults to `no`; it appears as `y`
+   only in the server's dev-only gateway (`server/judge-gw/judge.sh:106`), so what the
+   production agent passes cannot be determined from open source. This break is independent
+   of the `STOPWHEN_*` bits — which is worth knowing, because `STOPWHEN_TLE=n` alone does not
+   keep a run going.
+2. Each unexecuted input hits line ~514 in the second loop, so `RESPERRO > 0`.
+3. If the testcase that broke the loop was a **`TLE` that passed on its `TLERERUN` rerun**
+   (§3e), lines ~516-525 overwrite its verdict with `AC`. Now every *tested* verdict is `AC`,
+   `SMALLRESP` stays `AC`, and line ~568 flips it to `UE`.
+
+That is the reported shape: the discarded `TLE` is still in `tests`, nothing in the array
+looks wrong, and the run as a whole is `Unknown ERROR`.
+
+**The signature**, for reading one of these off a real response:
+
+- `verdict` = `Unknown ERROR,<n>p`, and `verdict_canon` = **`Runtime Error`** —
+  `VERDICTCANON[UE]`, naming a failure of the solution that did not happen. This is the one
+  place `canonical_verdict`'s preference for the canon spelling inverts, and why
+  `_note_on_run_verdict` reads the raw `verdict`.
+- `correct < total_tests`: `TOTALTESTS` counts every input file (line ~403) while `CORRECT`
+  counts only tested ones. The cheapest discriminator available.
+- `tests[]` truncated to the inputs actually dispatched.
+
+rbx now appends the judge's own words to the "reported no result for N of M testcases"
+warning when the run-level verdict is this one, and stays quiet for the rest of the
+vocabulary — a `Wrong Answer` at run level only repeats what the per-test codes already said.
+
+**Still unread:** the agent's `agent_tests_json`, which builds `tests[]`. It lives in a
+separate, non-public repo (`judge/agent/moj-agent.sh`, per `server/judge-gw/PULL.md:51`).
+`calibreitor.sh`'s `sol_tests_json` says it is the same format, and *it* walks
+`log.verdictall` line by line — which is what §3e's duplicate rests on. Two consumers that
+dedupe instead, by sourcing the file into a bash array, are `gen-report.sh:35-36` and
+`build-and-test.sh:484-485`; so `report.html` shows one row per testcase while a line-walking
+`tests[]` would show two. That difference is the check to run against a real reran testrun.
+
 ### 3b. `Compilation Error` — observed 2026-08-21, by accident
 
 The first end-to-end `rbx time --runner moj` submitted solutions that did not build on the
@@ -300,7 +365,14 @@ Note this is still not a terminal *failure* `status`: the run above finished `do
 ## Still open
 
 - Whether a testrun can reach a terminal **failure** status (a compile error does not: it is
-  a `done` run with a run-level verdict — see §3b).
+  a `done` run with a run-level verdict — see §3b). Partly answered by the server source: a
+  worker payload without a verdict leaves the register with no `verdict` key rather than a
+  failure status, and the server's own `Judge Error` fallback is skipped for testruns (§3g).
+- Whether the production judge agent passes `RUNALL=y` to `build-and-test.sh`, which decides
+  whether a single failing testcase truncates the whole testset (§3g). Not in any public
+  repo; it needs a testrun against a problem with more testcases than the judge has cores.
+- Whether the agent's `agent_tests_json` duplicates a reran testcase the way
+  `sol_tests_json` does (§3e, §3g).
 - ~~The full `code` vocabulary~~ — closed 2026-08-29 by reading mojtools' `run-testinput`;
   see §3d.
 - Whether `testrun` requires a prior calibration (this problem was already calibrated).

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -333,13 +333,28 @@ replaced a `ctx.progress.update(...)` that nobody ever saw: every caller exits i
 flight may share a machine and inflate each other, and the park is shared with everyone
 else. A 429 is waited out rather than failed -- it cannot be cleared, since `moj` has no
 way to cancel a testrun. The poll is bounded, like `prepare`'s. `_outcome_for_moj_code` maps MOJ's whole per-test vocabulary,
-read off mojtools' `run-testinput` (`AC`/`AC,PE`/`WA`/`MLE`/`TLE`/`RE`/`RE_NZEC`/`TMT`/`UE`, plus any
+read off mojtools' `run-testinput` (`AC`/`AC,PE`/`WA`/`MLE`/`TLE`/`RE`/`RE_NZEC`/`TMT`/`UE`/`CE`, plus any
 other `RE_*` read as a runtime error by its prefix) and **refuses an unrecognised one by name** rather
 than guessing -- a wrong verdict silently corrupts the time limit being estimated. `AC,PE` is a *pass*
 (MOJ scores it as correct) and `UE` is the comparator failing, so it becomes `JUDGE_FAILED` rather than
-the solution's runtime error. A testcase MOJ did not
+the solution's runtime error. `NT` ("nao executado") is the one code with no `Outcome`: it names the
+*absence* of a verdict, so it is dropped (`_UNEXECUTED_MOJ_CODES`) onto the same path as a testcase MOJ
+never mentioned. A testcase MOJ did not
 report on becomes `SKIPPED` with no timing (never a zero), and only the `.eval` is written,
 never an empty `.out`.
+
+**A name can repeat, and the last one wins.** mojtools reruns a testcase that came back `TLE` under
+parallel load and *appends* a second `VERDICT[<name>]=` line, so the judge can report the same testcase
+twice -- the discarded contended measurement, then the one it kept. `TestrunStatus.by_name` takes the
+last, which is what `build-and-test.sh` itself reads back; refusing the pair (which it used to do)
+failed a whole run over a testrun MOJ considers ordinary.
+
+**A truncated run can come back `Unknown ERROR`, which is not about the solution.** mojtools flips the
+run-level verdict to `UE` when every testcase that produced a verdict passed *and* at least one produced
+none -- the judge saying it cannot account for the testset. Its canon spelling is `Runtime Error`, naming
+a failure that did not happen, so `_note_on_run_verdict` reads the raw `verdict` and appends the judge's
+own words to the "reported no result for N of M testcases" warning. See
+`docs/plans/2026-08-21-moj-probe-notes.md` §3e-§3g for the mechanism and its signature.
 
 **Finished testruns are cached, so re-running `rbx time` costs no judge time.** The key
 (`_cache_key`) is the probe package's `_directory_fingerprint` -- which already contains

--- a/rbx/box/runners/moj/cli.py
+++ b/rbx/box/runners/moj/cli.py
@@ -29,7 +29,6 @@ an `OPEN:` comment naming what the probe has to settle.
 """
 
 import asyncio
-import collections
 import json
 import os
 import pathlib
@@ -173,10 +172,11 @@ _NO_SESSION_RE = re.compile(r'\blogin\b.*\bprimeiro\b', re.IGNORECASE)
 class TestrunTest(BaseModel):
     """One test of one testrun.
 
-    `code` stays a plain string. OPEN (probe): its vocabulary. Inventing a
-    code -> `Outcome` mapping here would bake a guess into the layer everything
-    else reads; the mapping belongs to the runner, where an unknown code can be
-    surfaced instead of silently becoming a verdict.
+    `code` stays a plain string. Inventing a code -> `Outcome` mapping here would
+    bake a guess into the layer everything else reads; the mapping belongs to the
+    runner, where an unknown code can be surfaced instead of silently becoming a
+    verdict. mojtools' vocabulary is enumerated there, in
+    `_OUTCOME_BY_MOJ_CODE`.
     """
 
     model_config = ConfigDict(extra='ignore')
@@ -259,10 +259,11 @@ class TestrunStatus(BaseModel):
         reports tests alongside a zero (or absent) `total_tests` is read by what
         it actually returned rather than by its bookkeeping.
 
-        Deliberately structural rather than a `verdict_canon` denylist: the
-        verdict vocabulary is only half observed -- five values so far -- and
-        `_OUTCOME_BY_MOJ_CODE` already refuses to guess at the other half.
-        `verdict_canon` is what *names* the cause once this has detected it.
+        Deliberately structural rather than a `verdict_canon` denylist: run-level
+        verdicts are a *scored* vocabulary (`Wrong Answer,88p`) whose spellings
+        the server is free to grow, and `_OUTCOME_BY_MOJ_CODE` already refuses to
+        guess at anything it cannot read. `verdict_canon` is what *names* the
+        cause once this has detected it.
         """
         return self.done and not self.tests and not self.total_tests
 
@@ -284,30 +285,30 @@ class TestrunStatus(BaseModel):
 
     @property
     def by_name(self) -> Dict[str, TestrunTest]:
-        """The tests keyed by MOJ's name for them.
+        """The tests keyed by MOJ's name for them, last entry winning.
 
         Pairing rbx's testcases to these by *name* rather than by position is what
         keeps a change in the packager's naming from silently misattributing a
-        timing to the wrong testcase. Duplicate names would defeat exactly that --
-        a dict comprehension drops one of them just as silently -- so they are an
-        error rather than a last-one-wins.
+        timing to the wrong testcase.
+
+        **A name can legitimately repeat, and the last one is the answer.**
+        mojtools' `build-and-test.sh` reruns a testcase that came back `TLE`
+        ("Rerun: because got TLE while running parallel tests"), because a TLE
+        measured while N tests shared the machine is not a TLE. Each run of
+        `run-testinput` *appends* a `VERDICT[<name>]=<code>` line to
+        `log.verdictall`, and `sol_tests_json` walks that file line by line into
+        the `{name, code, time, tl}` array this parses -- so a reran testcase
+        arrives twice, its first entry the discarded parallel measurement.
+
+        Last-one-wins is not a tiebreak invented here: `build-and-test.sh` itself
+        re-`source`s `log.verdictall` after the rerun and reads the testcase's
+        verdict straight back out of the array, which is bash's own
+        last-assignment-wins. Reading the *first* entry would hand rbx the
+        contended time the judge threw away, and refusing the pair outright --
+        which is what this used to do -- failed the whole run over a testrun the
+        judge considers perfectly ordinary.
         """
-        by_name = {test.name: test for test in self.tests}
-        if len(by_name) != len(self.tests):
-            repeated = sorted(
-                name
-                for name, count in collections.Counter(
-                    test.name for test in self.tests
-                ).items()
-                if count > 1
-            )
-            raise MojCliError(
-                f'The judge reported more than one test named '
-                f'{", ".join(f"`{name}`" for name in repeated)} in the same '
-                f"testrun. rbx pairs its testcases to MOJ's by name, and cannot "
-                f'tell repeated names apart.'
-            )
-        return by_name
+        return {test.name: test for test in self.tests}
 
 
 class MojCheck(BaseModel):

--- a/rbx/box/runners/moj/runner.py
+++ b/rbx/box/runners/moj/runner.py
@@ -18,6 +18,7 @@ import dataclasses
 import hashlib
 import json
 import pathlib
+import re
 import tempfile
 from typing import (
     TYPE_CHECKING,
@@ -224,6 +225,52 @@ _OUTCOME_BY_MOJ_CODE: Dict[str, Outcome] = {
 # `NT` means, and it keeps a non-measurement out of the time-limit estimate.
 _UNEXECUTED_MOJ_CODES = frozenset({'NT'})
 
+# What mojtools calls a run it cannot account for -- `VERDICTFULLNAME[UE]`, the
+# run-level verdict `build-and-test.sh` reaches on its second-to-last line:
+#
+#     [[ "$SMALLRESP" =~ "AC" ]] && (( RESPERRO > 0 )) && SMALLRESP=UE
+#
+# It says: *every testcase that produced a verdict passed, and at least one
+# produced none*. That is a statement about the judging run, not about the
+# submission -- and it is the run-level verdict a truncated testset lands on
+# whenever the testcase that truncated it was a `TLE` that passed on its rerun,
+# which is the one shape where nothing in `tests` looks wrong at all.
+#
+# Matched on the two words: the run-level verdict carries a score suffix
+# (`Unknown ERROR,88p`), and the capitalisation is mojtools' own.
+#
+# Read off `verdict` and never `verdict_canon`, which is the one place
+# `canonical_verdict`'s usual preference inverts: `VERDICTCANON[UE]` collapses
+# this onto `Runtime Error`, naming a failure of the solution that did not
+# happen. See `_note_on_run_verdict`.
+_UNKNOWN_ERROR_VERDICT_RE = re.compile(r'\bunknown\s+error\b', re.IGNORECASE)
+
+
+def _note_on_run_verdict(verdict: Optional[str]) -> Optional[str]:
+    """What a run-level verdict adds to "some testcases went unmeasured".
+
+    Only `Unknown ERROR` has anything to add, and it has a lot: it is the judge
+    saying it does not know why the testset came up short, and a setter reading
+    the missing-testcase warning on its own has no way to tell that from a judge
+    that simply stopped early on purpose. The rest of the vocabulary (`Wrong
+    Answer`, `Time Limit Exceeded`, ...) already agrees with the verdicts in
+    `tests`, so repeating it would be noise.
+
+    `None` when there is nothing worth saying, which includes a run with no
+    run-level verdict at all.
+    """
+    if not verdict or not _UNKNOWN_ERROR_VERDICT_RE.search(verdict):
+        return None
+    return (
+        f'MOJ called the run as a whole `{verdict}`, which is the judge saying '
+        f'it cannot account for those testcases -- not a verdict about this '
+        f'solution. mojtools reports it when every testcase that produced a '
+        f'verdict passed and at least one produced none, which is what a testset '
+        f'cut short looks like when the testcase that cut it short passed on its '
+        f'rerun. The judge run is what to look at, not the solution.'
+    )
+
+
 # `RE_NZEC` is the only qualified runtime error mojtools writes today, and it is in
 # the table above. The prefix is honoured anyway, as a backstop for a judge that
 # grows a sibling (`RE_SIGSEGV` and the like): `RE_` names the family, so reading a
@@ -279,6 +326,10 @@ class _TestrunResult:
     expected: int
     # The names rbx asked about and MOJ said nothing about.
     missing: List[str]
+    # What the judge called the run as a whole, raw -- score suffix and all. Kept
+    # only to be *said*, and only when the testset came up short: see
+    # `_note_on_run_verdict` for why `verdict` and not `canonical_verdict`.
+    verdict: Optional[str] = None
     # Set the first time the missing ones are reported, so N deferreds over one
     # testrun produce one warning rather than N.
     warned: bool = False
@@ -948,7 +999,11 @@ class MojRunner:
         # of 72 against a problem that had them enabled.
         missing = [name for name in expected_names if name not in tests]
         return _TestrunResult(
-            run=run, tests=tests, expected=len(expected_names), missing=missing
+            run=run,
+            tests=tests,
+            expected=len(expected_names),
+            missing=missing,
+            verdict=status.verdict,
         )
 
     def _solution_content(self, solution: 'SolutionSkeleton') -> bytes:
@@ -1206,13 +1261,19 @@ class MojRunner:
         # deferreds cannot both pass the check.
         if result.missing and not result.warned:
             result.warned = True
-            console.console.print(
+            lines = [
                 f'[warning]MOJ reported no result for {len(result.missing)} of '
                 f'{result.expected} testcases of [item]{solution.path}[/item] '
-                f'(testrun [item]{result.run}[/item]).[/warning]\n'
-                f'[warning]Those testcases are left unmeasured; the time limit is '
-                f'estimated from the rest.[/warning]'
-            )
+                f'(testrun [item]{result.run}[/item]).[/warning]',
+                '[warning]Those testcases are left unmeasured; the time limit is '
+                'estimated from the rest.[/warning]',
+            ]
+            # Appended rather than replacing the count: the count is what the
+            # estimate lost, and the verdict is why. A setter needs both.
+            note = _note_on_run_verdict(result.verdict)
+            if note is not None:
+                lines.append(f'[warning]{note}[/warning]')
+            console.console.print('\n'.join(lines))
 
         # The slot is deliberately **not** cleared here. Clearing it was meant to
         # keep a stale `running` chip from sitting beside a finished verdict, but

--- a/rbx/box/runners/moj/runner.py
+++ b/rbx/box/runners/moj/runner.py
@@ -177,13 +177,16 @@ QUEUE_FULL_ATTEMPTS = 40
 #   reported as a solution's runtime error is exactly the silent lie this table
 #   guards against.
 #
-# Deliberately absent: `CE`, which is real but run-level only -- a submission that
-# does not compile never enters the testset, so `tests` comes back empty and
-# `ran_nothing` handles it (probe notes, section 3b) -- and `NT` ("Nao executado"),
-# which `gen-report.sh` substitutes for a *missing* verdict when rendering HTML and
-# which is therefore never written to `log.verdictall` in the first place. A
-# testcase MOJ said nothing about is already handled, as `SKIPPED`, by
-# `_evaluation_for`.
+# - `CE` is real but, on `run-testinput`'s side, run-level only: a submission that
+#   does not compile never enters the testset, so `tests` comes back empty and
+#   `ran_nothing` handles it (probe notes, section 3b). It is mapped anyway, at no
+#   risk -- `COMPILATION_ERROR` is what the code says, and one that only ever
+#   arrives run-level costs a table row to tolerate and a whole failed run to
+#   refuse.
+#
+# `NT` ("Nao executado") is the one code in mojtools' vocabulary with no `Outcome`,
+# and lives in `_UNEXECUTED_MOJ_CODES` instead of here: it does not name a verdict,
+# it names the *absence* of one.
 #
 # An unrecognised code is refused by name (see `MojRunner._submit_and_poll`)
 # rather than mapped: this table feeds a *time limit*, and a wrong verdict there is
@@ -200,7 +203,26 @@ _OUTCOME_BY_MOJ_CODE: Dict[str, Outcome] = {
     'RE_NZEC': Outcome.RUNTIME_ERROR,
     'TMT': Outcome.RUNTIME_ERROR,
     'UE': Outcome.JUDGE_FAILED,
+    'CE': Outcome.COMPILATION_ERROR,
 }
+
+# Codes that say a testcase produced no result at all, rather than naming one.
+#
+# `NT` ("Nao executado") is what mojtools writes for a testcase with no verdict:
+# `gen-report.sh` substitutes it when `log.verdictall` has no entry for an input
+# file, which happens whenever the testset was cut short -- a `STOPWHEN_*` problem
+# that stopped early, or a run the judge abandoned. Whether the judge agent's
+# `agent_tests_json` puts it in the `tests` array the way `gen-report.sh` puts it
+# in the HTML is not something rbx can read off the source it has, so this exists
+# to be *tolerant*: if one arrives, it costs one testcase's measurement rather than
+# the whole run.
+#
+# Dropped rather than mapped, because every `Outcome` would be a claim about the
+# solution that nothing measured. Dropping puts the testcase back on the same path
+# as one MOJ never mentioned: `SKIPPED`, no timing, and counted in the "reported no
+# result for N of M" warning `_evaluation_from_job` prints. That is exactly what an
+# `NT` means, and it keeps a non-measurement out of the time-limit estimate.
+_UNEXECUTED_MOJ_CODES = frozenset({'NT'})
 
 # `RE_NZEC` is the only qualified runtime error mojtools writes today, and it is in
 # the table above. The prefix is honoured anyway, as a backstop for a judge that
@@ -867,9 +889,21 @@ class MojRunner:
         if status.ran_nothing:
             raise _run_never_started(solution, run, status)
 
-        # `by_name` refuses duplicate names rather than letting a dict
-        # comprehension drop one of them.
+        # Last entry wins on a repeated name: that is a testcase mojtools reran
+        # after a TLE measured under parallel load, and the rerun is the number
+        # the judge itself keeps. See `TestrunStatus.by_name`.
         tests = status.by_name
+
+        # Before the codes are checked, because an `NT` is not a code to check:
+        # the judge is saying it never ran this testcase. Removing it here is what
+        # sends it down `_evaluation_for`'s `test is None` path -- `SKIPPED`, no
+        # timing -- and gets it counted in the warning that says how many
+        # testcases came back without a result. See `_UNEXECUTED_MOJ_CODES`.
+        tests = {
+            name: test
+            for name, test in tests.items()
+            if test.code not in _UNEXECUTED_MOJ_CODES
+        }
 
         # Every code is checked here, once, before any evaluation is built -- and
         # the failure lands on *every* deferred of this solution, because they all
@@ -884,7 +918,10 @@ class MojRunner:
         )
         if unknown:
             listed = ', '.join(f'`{code}`' for code in unknown)
-            known = ', '.join(f'`{code}`' for code in _OUTCOME_BY_MOJ_CODE)
+            known = ', '.join(
+                f'`{code}`'
+                for code in (*_OUTCOME_BY_MOJ_CODE, *sorted(_UNEXECUTED_MOJ_CODES))
+            )
             raise MojRunnerError(
                 f'MOJ reported the verdict code(s) {listed} for `{solution.path}` '
                 f'in testrun `{run}`, and rbx does not know what they mean.\n'
@@ -893,6 +930,8 @@ class MojRunner:
                 f'mapped to the wrong outcome would silently corrupt the time '
                 f'limit this run is estimating, with nothing in the report to say '
                 f'so.\n'
+                f'See what the judge actually reported with `moj testrun-status '
+                f'{run}`.\n'
                 f'If the code is legitimate, add it to `_OUTCOME_BY_MOJ_CODE` in '
                 f'`rbx/box/runners/moj/runner.py`.'
             )

--- a/tests/rbx/box/runners/moj/test_cli.py
+++ b/tests/rbx/box/runners/moj/test_cli.py
@@ -371,13 +371,16 @@ async def test_a_done_testrun_exposes_its_tests_by_name(
     assert status.by_name['sample001'].time == 0.11
 
 
-async def test_two_tests_sharing_a_name_are_an_error_not_a_last_one_wins(
+async def test_a_rerun_testcase_is_read_from_its_last_entry(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Name pairing is what prevents misattributing a timing.
+    """mojtools reruns a TLE measured under parallel load, and reports both.
 
-    Dropping one of two same-named tests would misattribute one just as silently
-    as pairing by position would.
+    `run-testinput` appends a `VERDICT[<name>]=` line per run, so the reran
+    testcase arrives twice: first the contended measurement the judge threw away,
+    then the one it kept. Reading the first would hand rbx a TLE the judge does
+    not believe in -- and refusing the pair, which is what this used to do, failed
+    the whole run over a testrun MOJ considers ordinary.
     """
     _fake_moj(
         monkeypatch,
@@ -385,8 +388,8 @@ async def test_two_tests_sharing_a_name_are_an_error_not_a_last_one_wins(
             {
                 'status': 'done',
                 'tests': [
-                    {'name': 'sample001', 'code': 'AC', 'time': 0.11},
                     {'name': 'sample001', 'code': 'TLE', 'time': 2.0},
+                    {'name': 'sample001', 'code': 'AC', 'time': 0.11},
                 ],
             }
         ),
@@ -394,10 +397,10 @@ async def test_two_tests_sharing_a_name_are_an_error_not_a_last_one_wins(
 
     status = await cli.testrun_status('4711')
 
-    with pytest.raises(MojCliError) as exc_info:
-        assert status.by_name
-
-    assert '`sample001`' in str(exc_info.value)
+    assert status.by_name['sample001'].code == 'AC'
+    assert status.by_name['sample001'].time == 0.11
+    # One testcase, however many times the judge measured it.
+    assert len(status.by_name) == 1
 
 
 async def test_a_test_without_a_measurement_reads_as_unmeasured(

--- a/tests/rbx/box/runners/moj/test_run_solution.py
+++ b/tests/rbx/box/runners/moj/test_run_solution.py
@@ -325,6 +325,10 @@ async def test_subgroups_of_one_group_are_paired_apart(
         ('UE', Outcome.JUDGE_FAILED),
         # Unobserved sibling of the `RE_*` family, read by its prefix.
         ('RE_SIGSEGV', Outcome.RUNTIME_ERROR),
+        # Run-level on `run-testinput`'s side -- a submission that does not build
+        # never enters the testset -- but mapped rather than refused, so a judge
+        # that reports it per-test costs a verdict rather than the whole run.
+        ('CE', Outcome.COMPILATION_ERROR),
     ],
 )
 async def test_every_moj_code_maps_to_the_matching_outcome(
@@ -392,6 +396,85 @@ async def test_an_unknown_code_fails_loudly_and_names_it(
     assert 'RE_NZEC' in message
     # Plain text: `main.py` bare-prints `str(e)`.
     assert '[item]' not in message and '[error]' not in message
+
+
+async def test_a_testcase_rerun_after_a_tle_is_read_from_its_last_entry(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The whole run used to fail on a testrun MOJ considers ordinary.
+
+    mojtools reruns a testcase that came back TLE while the park was running tests
+    in parallel, and each run appends its own `VERDICT[<name>]=` line -- so the
+    array carries the testcase twice. The rerun is the measurement the judge keeps
+    (it re-`source`s the file and reads the name straight back out), and it is the
+    one the time-limit estimate has to be built on: the first entry is a time
+    measured under contention that the judge itself threw away.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+    fake.results['sol.cpp'] = [
+        _test(SAMPLE_NAMES[0], 'TLE', 3.9),
+        _test(SAMPLE_NAMES[1], 'AC', 0.2),
+        # The rerun, appended by mojtools after the parallel pass.
+        _test(SAMPLE_NAMES[0], 'AC', 0.3),
+    ]
+
+    evals = await _run(runner, ctx)
+
+    assert evals[0].result.outcome == Outcome.ACCEPTED
+    assert evals[0].log.time == 0.3
+    assert evals[1].result.outcome == Outcome.ACCEPTED
+
+
+async def test_a_rerun_that_is_still_a_tle_stays_a_tle(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """Last-one-wins is not "prefer the better verdict".
+
+    mojtools gives up after one rerun (`TLERERUN=n`), and a testcase that timed
+    out on its own is a real TLE. Taking the last entry has to keep it, or the
+    rerun would become a way to launder every timeout into a pass.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+    fake.results['sol.cpp'] = [
+        _test(SAMPLE_NAMES[0], 'AC', 0.1),
+        _test(SAMPLE_NAMES[1], 'TLE', 3.9),
+        _test(SAMPLE_NAMES[1], 'TLE', 4.1),
+    ]
+
+    evals = await _run(runner, ctx)
+
+    assert evals[1].result.outcome == Outcome.TIME_LIMIT_EXCEEDED
+    assert evals[1].log.time == 4.1
+
+
+async def test_a_testcase_the_judge_did_not_execute_is_skipped_not_refused(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """`NT` ("Nao executado") names the absence of a verdict, not a verdict.
+
+    It is what mojtools writes for a testcase with no entry in `log.verdictall` --
+    a testset cut short. Refusing the run over it would fail a solution for a
+    testcase nobody claims to have run; mapping it to any `Outcome` would state a
+    result nothing measured. It reads as the testcase MOJ never mentioned.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+    fake.results['sol.cpp'] = [
+        _test(SAMPLE_NAMES[0], 'AC', 0.1),
+        _test(SAMPLE_NAMES[1], 'NT', None),
+    ]
+
+    evals = await _run(runner, ctx)
+
+    assert evals[0].result.outcome == Outcome.ACCEPTED
+    assert evals[1].result.outcome == Outcome.SKIPPED
+    # And nothing it did not measure reaches the estimate.
+    assert evals[1].log.time is None
 
 
 async def test_an_unknown_code_fails_every_testcase_of_that_solution(

--- a/tests/rbx/box/runners/moj/test_run_solution.py
+++ b/tests/rbx/box/runners/moj/test_run_solution.py
@@ -477,6 +477,70 @@ async def test_a_testcase_the_judge_did_not_execute_is_skipped_not_refused(
     assert evals[1].log.time is None
 
 
+async def test_a_truncated_run_says_the_judge_called_it_unknown_error(
+    testing_pkg, tmp_path, monkeypatch, capsys
+):
+    """The missing-testcase count says what was lost; the verdict says why.
+
+    `Unknown ERROR` is mojtools' run-level verdict for "every testcase that
+    produced a verdict passed, and at least one produced none" -- the judge saying
+    it cannot account for the testset. It is what a run cut short lands on when
+    the testcase that cut it short passed on its rerun, which is the one shape
+    where nothing in `tests` looks wrong at all. Without it the setter reads "no
+    result for 1 of 2" and cannot tell that from a judge that stopped on purpose.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+    fake.statuses['sol.cpp'] = cli.TestrunStatus(
+        status='done',
+        verdict='Unknown ERROR,50p',
+        # The canon spelling MOJ pairs with it, and the reason the raw `verdict`
+        # is what gets reported: `VERDICTCANON[UE]` names a failure of the
+        # solution that did not happen.
+        verdict_canon='Runtime Error',
+        correct=1,
+        total_tests=2,
+        tests=[_test(SAMPLE_NAMES[0], 'AC', 0.1)],
+    )
+
+    await _run(runner, ctx)
+
+    out = _ANSI.sub('', capsys.readouterr().out)
+    assert 'no result for 1 of 2' in out
+    assert 'Unknown ERROR,50p' in out
+    assert 'cannot account for' in out
+    # The canon spelling is exactly what must not be repeated at the setter.
+    assert 'Runtime Error' not in out
+
+
+async def test_an_ordinary_run_level_verdict_is_not_repeated(
+    testing_pkg, tmp_path, monkeypatch, capsys
+):
+    """`Wrong Answer` already agrees with the codes in `tests`; saying it is noise.
+
+    Only the judge's own "I do not know" adds anything the per-test verdicts have
+    not already said.
+    """
+    runner, fake, ctx = await _prepared(
+        testing_pkg, tmp_path, monkeypatch, groups=['samples']
+    )
+    fake.statuses['sol.cpp'] = cli.TestrunStatus(
+        status='done',
+        verdict='Wrong Answer,0p',
+        verdict_canon='Wrong Answer',
+        correct=0,
+        total_tests=2,
+        tests=[_test(SAMPLE_NAMES[0], 'WA', 0.1)],
+    )
+
+    await _run(runner, ctx)
+
+    out = _ANSI.sub('', capsys.readouterr().out)
+    assert 'no result for 1 of 2' in out
+    assert 'cannot account for' not in out
+
+
 async def test_an_unknown_code_fails_every_testcase_of_that_solution(
     testing_pkg, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Closes #824.

Two things go wrong when a MOJ testrun comes back, both found by reading [`cd-moj/mojtools`](https://github.com/cd-moj/mojtools) rather than by guessing at spellings.

### A reran testcase appears twice, and rbx refused the run

`build-and-test.sh` runs the testset in parallel and then **reruns any testcase that came back `TLE`** ("Rerun: because got TLE while running parallel tests"), because a timeout measured while N tests shared the machine is not a timeout. Every call of `run-testinput` *appends* its own `VERDICT[<name>]=<code>` line to `log.verdictall`, and `sol_tests_json` walks that file line by line into the `{name, code, time, tl}` array — so the reran testcase arrives twice.

`TestrunStatus.by_name` read a repeated name as the misattribution that pairing-by-name exists to prevent, and failed the whole run. It now keeps the **last** entry, which is not a tiebreak invented here: `build-and-test.sh` re-`source`s `log.verdictall` after the rerun and reads the verdict straight back out of the bash array. Taking the first would have been worse than the refusal — it feeds the time-limit estimate a time the judge itself discarded.

### `CE` and `NT` are real codes rbx refused by name

Both are in mojtools' vocabulary (`gen-report.sh`'s `VERDICTFULLNAME`, and its verdict histogram iterates `AC "AC,PE" WA TLE RE RE_NZEC TMT UE NT`). rbx had deliberately left them out on the reasoning that `run-testinput` never writes them per-test — but that is an inference about the judge *agent*'s `agent_tests_json`, which is server-side and cannot be read from here. Being wrong costs a whole failed run; tolerating them costs nothing, because neither can put a wrong number into an estimate:

- `CE` → `COMPILATION_ERROR`. A run-level compile error still takes the `ran_nothing` path that explains itself properly.
- `NT` ("não executado") → **dropped, not mapped**. It names the *absence* of a verdict, so every `Outcome` would be a claim nothing measured. Dropping it puts the testcase on the existing path for one MOJ never mentioned: `SKIPPED`, no timing, counted in the "reported no result for N of M" warning.

Unknown codes are still refused by name — this widens what rbx reads, it does not weaken the rule.

### Tests

`tests/rbx/box/runners/moj` — 178 pass. New coverage: a rerun read from its last entry, a rerun that is *still* a TLE staying a TLE (last-wins is not "prefer the better verdict"), `NT` degrading to `SKIPPED` rather than failing, and `CE` in the code-mapping parametrisation.

Findings are recorded in `docs/plans/2026-08-21-moj-probe-notes.md` §3e/§3f, which previously said `CE`/`NT` should *not* be mapped; that section now carries the argument for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jFFXbajyRUfWLWgVP3eUP

---

### Follow-up: a run the judge called `Unknown ERROR`

A second report: a testrun whose per-test codes were only `AC` and `TLE` came back with a run-level verdict of `Unknown ERROR`. Traced through mojtools *and* the CD-MOJ server (`cd-moj/cdmoj`, open source).

**The server never produces it.** `judged.sh:390` merges the worker's payload wholesale and the read handler is a bare `jq -c '{success:true} + .'`, so every field is the worker's own words. The only verdict the server synthesizes is the literal `Judge Error`, and for a testrun the `_testrun` divert (`judged.sh:418`) runs *before* even that fallback — a payload with no verdict leaves the register with no `verdict` key, never `UE`.

So it always comes from `build-and-test.sh`:

```sh
[[ "$SMALLRESP" =~ "AC" ]] && (( RESPERRO > 0 )) && SMALLRESP=UE
```

i.e. **every testcase that produced a verdict passed, and at least one produced none** — a statement about the judging run, not the submission. It coexists with a `TLE` in `tests` because: a non-zero test breaks the dispatch loop at line 475 (`(( RET != 0 )) && [[ "$RUNALL" != "y" ]] && break`), the remaining inputs are never executed and so report nothing, and if the testcase that broke the loop was a TLE that **passed on its rerun**, every tested verdict is `AC` and line 568 fires.

Note `RUNALL` is the 4th argv of `build-and-test.sh`, not a package setting, and defaults to `no` — so this truncation is independent of the `STOPWHEN_*` bits, and `STOPWHEN_TLE=n` alone does not keep a run going. What the production agent passes is not determinable from open source.

rbx now appends the judge's own words to the "reported no result for N of M testcases" warning when the run-level verdict is this one, and stays quiet for the rest of the vocabulary. It reads the raw `verdict` and **not** `verdict_canon` — `VERDICTCANON[UE]` collapses this onto `Runtime Error`, naming a failure of the solution that did not happen, and that is the field `canonical_verdict` normally prefers.

Signature, for reading one off a real response: `verdict = "Unknown ERROR,<n>p"`, `verdict_canon = "Runtime Error"`, `correct < total_tests`, `tests[]` truncated. Recorded in `docs/plans/2026-08-21-moj-probe-notes.md` §3g.
