### PR TITLE
fix(polygon): upload empty tests with a placeholder input

### DIFF
--- a/rbx/box/packaging/polygon/upload.py
+++ b/rbx/box/packaging/polygon/upload.py
@@ -44,6 +44,14 @@ ALL_PARAMS_CHOICES = list(ParamChoices.__args__)
 MAX_WORKERS = 4
 _RAW_TEST_SIZE_LIMIT = 1024 * 1024
 
+# Polygon's `problem.saveTest` rejects an empty test input outright -- and so does
+# any input that is only whitespace, since it strips before checking ("testInput:
+# Test input can't be empty."). There is no API knob to lift that, so a package
+# with a legitimately empty test can only be uploaded by putting *something* in
+# the file. We substitute this placeholder and warn loudly, because the tests
+# Polygon ends up storing are no longer byte-identical to the local ones.
+EMPTY_TEST_PLACEHOLDER = 'NO INPUT\n'
+
 
 def _format_request_failed_comment(comment: str) -> str:
     """Prepare a Polygon FAILED ``comment`` for safe Rich rendering.
@@ -344,6 +352,36 @@ def _get_test_params_for_statement(
     return res
 
 
+def _substitute_empty_test_input(
+    content: str, label: str, substituted: List[str]
+) -> str:
+    """Return ``content``, or the placeholder if Polygon would reject it as empty.
+
+    Appends ``label`` to ``substituted`` whenever a substitution happens, so the
+    caller can warn about every affected test at once.
+    """
+    if content.strip():
+        return content
+    substituted.append(label)
+    return EMPTY_TEST_PLACEHOLDER
+
+
+def _warn_about_substituted_empty_tests(substituted: List[str]):
+    if not substituted:
+        return
+    console.console.print(
+        f'[warning]Polygon does not accept empty test inputs, so '
+        f'{len(substituted)} test(s) were uploaded with the placeholder input '
+        f'[item]{EMPTY_TEST_PLACEHOLDER.strip()}[/item] instead:[/warning]'
+    )
+    for label in substituted:
+        console.console.print(f'[warning]  - {label}[/warning]')
+    console.console.print(
+        '[warning]Make sure your validator accepts this placeholder, and that any '
+        'affected sample renders acceptably in the statement.[/warning]'
+    )
+
+
 def _get_freemarker_for_calls(calls: List[GeneratorCall], next_index: int = 1) -> str:
     return (
         '\n'.join(
@@ -434,6 +472,7 @@ def _upload_testcases(
         next_index = 1
         task_id = progress.add_task('Uploading testcases...', total=len(entries))
         calls = []
+        substituted: List[str] = []
         for entry in entries:
             if entry.metadata.generator_call is not None:
                 # Generated testcases are handled later.
@@ -458,6 +497,9 @@ def _upload_testcases(
                 content = entry.metadata.copied_from.inputPath.read_text()
             if content is None:
                 continue
+            content = _substitute_empty_test_input(
+                content, entry.short_repr(), substituted
+            )
             saved = _save_skip_coinciding_testcases(
                 problem,
                 testset='tests',
@@ -489,6 +531,8 @@ def _upload_testcases(
                 raise
         progress.update(task_id, completed=len(entries))
 
+    _warn_about_substituted_empty_tests(substituted)
+
 
 def _upload_testcases_raw(
     problem: api.Problem,
@@ -509,10 +553,13 @@ def _upload_testcases_raw(
     with rich.progress.Progress(speed_estimate_period=5) as progress:
         next_index = 1
         task_id = progress.add_task('Uploading raw testcases...', total=len(entries))
+        substituted: List[str] = []
         for entry in entries:
             path = _resolve_raw_test_input_path(entry)
             assert path is not None  # validated above
-            content = path.read_text()
+            content = _substitute_empty_test_input(
+                path.read_text(), entry.short_repr(), substituted
+            )
             saved = _save_skip_coinciding_testcases(
                 problem,
                 testset='tests',
@@ -527,6 +574,8 @@ def _upload_testcases_raw(
             if saved:
                 next_index += 1
         progress.update(task_id, completed=len(entries))
+
+    _warn_about_substituted_empty_tests(substituted)
 
 
 def _upload_solutions(problem: api.Problem, ns: flattening.FlatNamespace):

--- a/tests/rbx/box/packaging/test_polygon_upload_empty_tests.py
+++ b/tests/rbx/box/packaging/test_polygon_upload_empty_tests.py
@@ -1,0 +1,82 @@
+"""Polygon rejects empty test inputs.
+
+``problem.saveTest`` answers ``testInput: Test input can't be empty.`` for an
+empty input -- and also for one that is only whitespace, since it strips before
+checking. A package with a legitimately empty test could therefore not be
+uploaded at all. The uploader substitutes a placeholder input and warns about
+every test it touched.
+"""
+
+from unittest import mock
+
+from rbx.box.packaging.polygon import upload
+
+
+def _bare_checker(testing_pkg) -> None:
+    testing_pkg.add_file('check.cpp').write_text('#include "testlib.h"\nint main(){}\n')
+    testing_pkg.set_checker('check.cpp')
+
+
+def test_empty_content_is_replaced_by_placeholder():
+    substituted = []
+
+    assert (
+        upload._substitute_empty_test_input('', 'main/0', substituted)  # noqa: SLF001
+        == upload.EMPTY_TEST_PLACEHOLDER
+    )
+    assert substituted == ['main/0']
+
+
+def test_whitespace_only_content_is_replaced_by_placeholder():
+    # Polygon strips before checking, so '\n' is just as empty as ''.
+    substituted = []
+
+    assert (
+        upload._substitute_empty_test_input(' \n\t\n', 'main/1', substituted)  # noqa: SLF001
+        == upload.EMPTY_TEST_PLACEHOLDER
+    )
+    assert substituted == ['main/1']
+
+
+def test_non_empty_content_is_passed_through_untouched():
+    substituted = []
+
+    assert (
+        upload._substitute_empty_test_input('1 2\n', 'main/0', substituted) == '1 2\n'  # noqa: SLF001
+    )
+    assert substituted == []
+
+
+def test_upload_testcases_sends_placeholder_for_empty_manual_test(testing_pkg):
+    _bare_checker(testing_pkg)
+    testing_pkg.add_file('tests/000.in').write_text('')
+    testing_pkg.add_file('tests/001.in').write_text('42\n')
+    testing_pkg.add_testgroup_with_manual_testcases(
+        'main',
+        testcases=[{'inputPath': 'tests/000.in'}, {'inputPath': 'tests/001.in'}],
+    )
+    testing_pkg.save()
+
+    problem = mock.Mock(name='RecordingProblem')
+
+    ns = upload._build_upload_namespace()  # noqa: SLF001
+    upload._upload_testcases(problem, ns)  # noqa: SLF001
+
+    inputs = [call.kwargs['test_input'] for call in problem.save_test.call_args_list]
+    assert inputs == [upload.EMPTY_TEST_PLACEHOLDER, '42\n']
+
+
+def test_upload_testcases_raw_sends_placeholder_for_empty_manual_test(testing_pkg):
+    _bare_checker(testing_pkg)
+    testing_pkg.add_file('tests/000.in').write_text('')
+    testing_pkg.add_testgroup_with_manual_testcases(
+        'main', testcases=[{'inputPath': 'tests/000.in'}]
+    )
+    testing_pkg.save()
+
+    problem = mock.Mock(name='RecordingProblem')
+
+    upload._upload_testcases_raw(problem)  # noqa: SLF001
+
+    inputs = [call.kwargs['test_input'] for call in problem.save_test.call_args_list]
+    assert inputs == [upload.EMPTY_TEST_PLACEHOLDER]


### PR DESCRIPTION
## Problem

Polygon's `problem.saveTest` refuses an empty test input, and it strips before checking, so whitespace-only inputs are refused too:

```
testInput: Test input can't be empty.
```

Verified live against the Polygon API for `''`, `'\n'`, `' '` and `' \n'` — all rejected; `'NO INPUT\n'` is accepted. There is no package-upload or per-test flag that lifts this, so a package with a legitimately empty test could not be uploaded at all.

## Change

- Add `EMPTY_TEST_PLACEHOLDER = 'NO INPUT\n'` and `_substitute_empty_test_input`, which swaps in the placeholder for any empty-or-whitespace-only input and records the tests it touched.
- Wire it into both manual-test paths: `_upload_testcases` and `_upload_testcases_raw`. Script-generated tests are unaffected.
- After the upload, warn once listing every substituted test, since what Polygon stores is no longer byte-identical to the local tests.

## Caveats (surfaced in the warning)

- The problem's validator must accept `NO INPUT`, or the package build fails there instead.
- If an empty test is a **sample**, the statement renders `NO INPUT` as the sample input. Overriding `test_input_for_statements=''` does not help — Polygon treats an empty override as unset and falls back to the test input.

## Testing

`tests/rbx/box/packaging/test_polygon_upload_empty_tests.py` — 5 new tests covering the helper (empty / whitespace-only / passthrough) and both upload paths end-to-end against a mock Polygon problem. The 25 existing polygon-upload tests still pass; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLcqA7BtfegSAgy2Br2sYb