### PR TITLE
feat(timing): checksum what a time limit was estimated from

### DIFF
--- a/docs/plans/2026-08-31-estimation-checksum-design.md
+++ b/docs/plans/2026-08-31-estimation-checksum-design.md
@@ -117,6 +117,16 @@ satisfy the tests segment reports a match that describes nothing the caller is d
 | `rbx run` | after `builder.build` | Same reason. Checking at the flag would compare against whatever manifest an earlier build left behind — stale exactly when the testset is what changed. |
 | `rbx irun` | after the profile is set, `light_only` | It never builds a testset, so nothing in `build/` is evidence about this run. |
 | `rbx time` | ahead of the `--integrate` branch | `integrate` copies the saved limit into `problem.rbx.yml` without re-estimating, so a stale number is about to become the package's own. Elsewhere the command replaces the estimate anyway. |
+| `rbx st b` / `rbx tut b` | `execute_build`, `light_only` | The rendered statement carries the profile's time limit, so a stale estimate is printed into a PDF rather than merely used for a run. |
+| `rbx contest st b` / `tut b` | the per-problem eligibility loop, `light_only` | Same, per problem. Reported once, naming the stale problems, rather than repeating the warning a dozen times. |
+
+The statement paths are `light_only` for a reason that is not "nothing is built yet": a
+statement build only ever builds `samples`, which the manifest records as partial, so the tests
+segment is never available there. What `light_only` rules out is reading a manifest some
+*earlier* full build left behind and reporting a match about tests this build never touched.
+
+Packaging builds statements too, but through `execute_build_on_statements` rather than
+`execute_build`, so the packaging path warns exactly once.
 
 `rbx run` keys on `limits_info.get_active_profile()` rather than on its own `--profile`
 value, so the root-level `rbx -p boca run` is checked exactly like `rbx run -p boca`.
@@ -142,16 +152,11 @@ never checked.
 * `rbx/box/builder.py` — plumbs them, and the determinism and partial flags, into the
   manifest.
 * `rbx/box/packaging/packager.py`, `rbx/box/cli/commands/run.py`,
-  `rbx/box/cli/commands/time_cmd.py` — the three consumers.
+  `rbx/box/cli/commands/time_cmd.py`, `rbx/box/statements/build_statements.py`,
+  `rbx/box/contest/statements.py` — the consumers.
 * `docs/setters/profiling/profiles.md` — "When an estimate goes stale".
 
 The manifest becomes load-bearing for rbx itself here, for the first time: it was written
 purely for external readers (the VS Code extension). That is the deliberate cost of making the
 tests segment free at check time. `write_manifest_or_warn` still downgrades every failure to a
 warning — a missing manifest costs the checksum its heavy level and nothing else.
-
-## Known gap
-
-`rbx statements build -p <profile>` renders the profile's time limit into the statement and
-does not check the checksum. The packaging path already warns before it builds statements, so
-the common route is covered; a standalone statement build is not.

--- a/docs/plans/2026-08-31-estimation-checksum-design.md
+++ b/docs/plans/2026-08-31-estimation-checksum-design.md
@@ -1,0 +1,138 @@
+# Checksumming what a time limit was estimated from
+
+Closes [#823](https://github.com/rsalesc/rbx/issues/823).
+
+## The problem
+
+`.limits/<profile>.yml` records the time limit `rbx time` computed. It records nothing about
+what that number was computed *from*. Edit the accepted solution, add a slow one, rewrite a
+generator, and the limit stays where it is, indistinguishable from one measured five minutes
+ago. The setter has no way to tell a current estimate from a stale one, and neither does a
+teammate who just cloned the repo.
+
+## The shape of the answer
+
+A checksum of the inputs that can move an estimate, written into the profile beside the limit,
+and recomputed by the commands that consume it.
+
+Two levels, because the inputs are not equally available:
+
+* **Light** — the solutions alone. Always computable, from `problem.rbx.yml` and the sources.
+* **Heavy** — light, plus the interactor and a digest of every built test input. Needs a
+  finished build to read them from.
+
+A consumer computes whichever level it can and compares only the segments both sides carry, so
+a heavy record checked on a clean checkout still gets its solutions compared.
+
+## What goes in
+
+### Solutions
+
+Every solution carrying an **inference role** — `LOWER` or `UPPER`, as
+`solutions.inference_role_of` decides — labelled by that role. A `lower` solution sets the base
+estimate and an `upper` one validates the bound; everything else (`inference: false`,
+`accepted-or-tle`) is measured for the report and never feeds the number.
+
+Deriving the set this way, rather than storing the roster of paths that actually ran, is what
+lets the estimator and the checker agree without extra state: both ask the package the same
+question. It also means `--run-all` does not change the checksum, which is correct — the extra
+solutions it runs are reported, not estimated from.
+
+Per solution: the package-relative path, the role, the language, and the digest of the whole
+transitive source closure via `dependencies.graph.expand`. The closure matters: a C++ solution
+whose hot loop lives in an included header changes its timing without a byte of the solution
+itself moving.
+
+### Interactor
+
+Its source and closure, when the package has one. Timing on an interactive problem depends on
+it directly. In the heavy level only.
+
+### Tests
+
+The digest of every built test input, keyed by group and index. These already exist: generation
+computes them to detect duplicates and non-determinism, and used to throw them away. They are
+now persisted into `build/testset.yml` and read back, so the check costs nothing at consumption
+time.
+
+Digests of the built inputs, deliberately, rather than a hash of the testplan declarations. The
+inputs are the ground truth the declarations were only trying to produce — a generator rewrite
+that happens to emit identical bytes is genuinely not a change worth warning about.
+
+### Not the checker
+
+Checker time is not part of a solution's measured runtime, so a checker change cannot make a
+limit stale.
+
+## The encoding
+
+One string, segmented:
+
+```
+v1.h.9f3a1c22.4b7e0d81.c1a8f930
+│  │ solutions  interactor  tests
+│  └ level: `l` or `h`
+└ format version
+```
+
+Light is `v1.l.9f3a1c22`. One field to store and one to compare, but the segment that differs
+names the bucket that moved — which is the whole reason for structuring it rather than rolling
+everything into a single opaque hash.
+
+The version prefix is what lets the recipe change later. An unknown version compares as "cannot
+tell", never as a mismatch, so a new rbx does not greet an old package with a warning about a
+format it does not speak. The same rule covers an unparseable string: the field is
+hand-editable YAML, and a garbled one should cost a missing warning, never a failed build.
+
+`-` stands in for a segment whose subject the package does not have, so positions stay fixed
+and a package that later gains an interactor reads as a change rather than as a different
+format.
+
+## When the heavy level is refused
+
+`_tests_segment` returns nothing — silently downgrading to light — on any of:
+
+* **No manifest, or one from a different manifest version.** Nothing to read.
+* **A build that did not check determinism.** `generators.generate_testcases` only verifies
+  generator determinism at `VerificationLevel.VALIDATE` or above, where a generator emitting
+  different bytes on two runs fails the build outright. Below that, an unseeded generator would
+  mismatch on every single build and turn the warning into noise nobody reads.
+* **A build restricted to a subset of the groups.** `--samples-only` leaves a manifest
+  describing one group; comparing it against an estimate taken over the whole testset would
+  flag every such build.
+
+## Consumers
+
+| Command | Where | Why there |
+| --- | --- | --- |
+| `rbx package build` | after `builder.verify`, in `run_packager` | The heavy level reads the manifest, and only the build that just ran leaves one describing the tests actually being packaged. |
+| `rbx run -p <profile>` | `_set_timing_profile` | Naming a profile is asking to be judged by its limits. Nothing is built yet, so this is usually a light check. |
+| `rbx time` | beside the "Current limits" table | Informational: the command exists to replace the estimate, so staleness is context, not a warning to act on. |
+
+All three go through `warn_if_stale`, so the message is identical everywhere. It is a warning
+in every case — never an error, and never a reason to refuse a package. Only the setter can say
+whether an edited solution was one whose timing mattered.
+
+Writers other than an estimation write no checksum at all: `inherit_time_limits` and
+`set_time_limit` construct a fresh `LimitsProfile`, so an inherited or hand-set limit is simply
+never checked.
+
+## Changes
+
+* `rbx/box/estimation_checksum.py` — new. Computation, encoding, comparison, the warning.
+* `rbx/box/schema.py` — `LimitsProfile.estimationChecksum`, in the presentation-only group
+  beside `groups` and `baseEstimate`.
+* `rbx/box/timing.py` — `TimingProfile.estimationChecksum`, carried by `to_limits()` and
+  stamped in `compute_time_limits` once the estimation has settled.
+* `rbx/box/testset_manifest.py` — `TestsetTest.input_digest`, `TestsetManifest.deterministic`,
+  a `read_manifest` reader, `MANIFEST_VERSION` 1 → 2.
+* `rbx/box/generators.py` — `generate_testcases` returns the input digests it already computed.
+* `rbx/box/builder.py` — plumbs them, and the determinism flag, into the manifest.
+* `rbx/box/packaging/packager.py`, `rbx/box/cli/commands/run.py`,
+  `rbx/box/cli/commands/time_cmd.py` — the three consumers.
+* `docs/setters/profiling/profiles.md` — "When an estimate goes stale".
+
+The manifest becomes load-bearing for rbx itself here, for the first time: it was written
+purely for external readers (the VS Code extension). That is the deliberate cost of making the
+tests segment free at check time. `write_manifest_or_warn` still downgrades every failure to a
+warning — a missing manifest costs the checksum its heavy level and nothing else.

--- a/docs/plans/2026-08-31-estimation-checksum-design.md
+++ b/docs/plans/2026-08-31-estimation-checksum-design.md
@@ -99,17 +99,29 @@ format.
   mismatch on every single build and turn the warning into noise nobody reads.
 * **A build restricted to a subset of the groups.** `--samples-only` leaves a manifest
   describing one group; comparing it against an estimate taken over the whole testset would
-  flag every such build.
+  flag every such build. The manifest records this as an explicit `partial` flag rather than
+  having the reader infer it by comparing built groups against declared ones — a declared
+  group can legitimately produce no tests (a `testcaseGlob` matching nothing), and inferring
+  would read that as a partial build forever, silently disabling the heavy level for the whole
+  package.
+
+A caller may also ask for `light_only` explicitly. That is for the case where it is *not*
+about to build: whatever `build/` holds then describes some earlier run, and letting it
+satisfy the tests segment reports a match that describes nothing the caller is doing.
 
 ## Consumers
 
 | Command | Where | Why there |
 | --- | --- | --- |
 | `rbx package build` | after `builder.verify`, in `run_packager` | The heavy level reads the manifest, and only the build that just ran leaves one describing the tests actually being packaged. |
-| `rbx run -p <profile>` | `_set_timing_profile` | Naming a profile is asking to be judged by its limits. Nothing is built yet, so this is usually a light check. |
-| `rbx time` | beside the "Current limits" table | Informational: the command exists to replace the estimate, so staleness is context, not a warning to act on. |
+| `rbx run` | after `builder.build` | Same reason. Checking at the flag would compare against whatever manifest an earlier build left behind — stale exactly when the testset is what changed. |
+| `rbx irun` | after the profile is set, `light_only` | It never builds a testset, so nothing in `build/` is evidence about this run. |
+| `rbx time` | ahead of the `--integrate` branch | `integrate` copies the saved limit into `problem.rbx.yml` without re-estimating, so a stale number is about to become the package's own. Elsewhere the command replaces the estimate anyway. |
 
-All three go through `warn_if_stale`, so the message is identical everywhere. It is a warning
+`rbx run` keys on `limits_info.get_active_profile()` rather than on its own `--profile`
+value, so the root-level `rbx -p boca run` is checked exactly like `rbx run -p boca`.
+
+They all go through `warn_if_stale`, so the message is identical everywhere. It is a warning
 in every case — never an error, and never a reason to refuse a package. Only the setter can say
 whether an edited solution was one whose timing mattered.
 
@@ -124,10 +136,11 @@ never checked.
   beside `groups` and `baseEstimate`.
 * `rbx/box/timing.py` — `TimingProfile.estimationChecksum`, carried by `to_limits()` and
   stamped in `compute_time_limits` once the estimation has settled.
-* `rbx/box/testset_manifest.py` — `TestsetTest.input_digest`, `TestsetManifest.deterministic`,
-  a `read_manifest` reader, `MANIFEST_VERSION` 1 → 2.
+* `rbx/box/testset_manifest.py` — `TestsetTest.input_digest`, `TestsetManifest.deterministic`
+  and `.partial`, a `read_manifest` reader, `MANIFEST_VERSION` 1 → 2.
 * `rbx/box/generators.py` — `generate_testcases` returns the input digests it already computed.
-* `rbx/box/builder.py` — plumbs them, and the determinism flag, into the manifest.
+* `rbx/box/builder.py` — plumbs them, and the determinism and partial flags, into the
+  manifest.
 * `rbx/box/packaging/packager.py`, `rbx/box/cli/commands/run.py`,
   `rbx/box/cli/commands/time_cmd.py` — the three consumers.
 * `docs/setters/profiling/profiles.md` — "When an estimate goes stale".
@@ -136,3 +149,9 @@ The manifest becomes load-bearing for rbx itself here, for the first time: it wa
 purely for external readers (the VS Code extension). That is the deliberate cost of making the
 tests segment free at check time. `write_manifest_or_warn` still downgrades every failure to a
 warning — a missing manifest costs the checksum its heavy level and nothing else.
+
+## Known gap
+
+`rbx statements build -p <profile>` renders the profile's time limit into the statement and
+does not check the checksum. The packaging path already warns before it builds statements, so
+the common route is covered; a standalone statement build is not.

--- a/docs/plans/2026-08-31-estimation-checksum-design.md
+++ b/docs/plans/2026-08-31-estimation-checksum-design.md
@@ -128,8 +128,13 @@ segment is never available there. What `light_only` rules out is reading a manif
 Packaging builds statements too, but through `execute_build_on_statements` rather than
 `execute_build`, so the packaging path warns exactly once.
 
-`rbx run` keys on `limits_info.get_active_profile()` rather than on its own `--profile`
-value, so the root-level `rbx -p boca run` is checked exactly like `rbx run -p boca`.
+`rbx run` keys on `limits_info.get_run_profile()` — the profile the run is *actually* judged
+against. Not its own `--profile` value, so the root-level `rbx -p boca run` is checked exactly
+like `rbx run -p boca`; and not `get_active_profile()`, which is None for a plain `rbx run`
+even though such a run resolves its limits from `local`. Since `rbx time` writes `local` by
+default, keying on the active profile skipped the commonest workflow there is: estimate, edit
+a solution, run. `tasks.get_limits_for_language` goes through the same helper, so the profile
+the run is judged by and the profile the check inspects cannot drift apart.
 
 They all go through `warn_if_stale`, so the message is identical everywhere. It is a warning
 in every case — never an error, and never a reason to refuse a package. Only the setter can say

--- a/docs/setters/profiling/profiles.md
+++ b/docs/setters/profiling/profiles.md
@@ -133,11 +133,10 @@ rbx package boca
 
 ## When an estimate goes stale
 
-An estimate is only as good as what it was measured against. Rewrite the accepted solution,
-add a slow one, change a generator — and the number in the profile stays where it is, looking
-as authoritative as the day it was measured.
+An estimate is only as good as what it was measured against. Rewrite a solution, add a slow
+one, change a generator, and the number in the profile stays as it was.
 
-So {{rbx}} records what it measured, alongside the number:
+So {{rbx}} records what it measured, next to the number:
 
 ```yaml title=".limits/boca.yml"
 timeLimit: 1400
@@ -147,7 +146,7 @@ estimationChecksum: 'v1.h.9f3a1c22.4b7e0d81.c1a8f930'
 That string is a checksum of the solutions the estimate was derived from — the accepted ones
 that set the limit and the slow ones that validated it — plus, when the tests had been built,
 the interactor and the test inputs themselves. `rbx run -p`, `rbx package` and `rbx time`
-recompute it and tell you when it no longer matches:
+recompute it and warn you when it no longer matches:
 
 ```
 The time limit saved in profile boca is stale: the solutions it was estimated from
@@ -155,14 +154,7 @@ have changed since it was estimated.
 Re-run `rbx time -p boca` to refresh it.
 ```
 
-It is a warning and never an error. Only you can say whether a solution you just edited was
-one whose timing mattered; {{rbx}} only says that the question is now open.
-
-Two things it deliberately stays quiet about. A profile whose limit you set by hand or
-inherited from the package carries no checksum at all — nothing was estimated, so there is
-nothing to go stale. And a package whose tests are not currently built is checked on its
-solutions alone: on a fresh clone, before any build, an edited generator goes unnoticed until
-you build.
+It is a warning, not an error: whether the change mattered to the timing is your call.
 
 ## Inheriting from the package
 

--- a/docs/setters/profiling/profiles.md
+++ b/docs/setters/profiling/profiles.md
@@ -145,8 +145,9 @@ estimationChecksum: 'v1.h.9f3a1c22.4b7e0d81.c1a8f930'
 
 That string is a checksum of the solutions the estimate was derived from — the accepted ones
 that set the limit and the slow ones that validated it — plus, when the tests had been built,
-the interactor and the test inputs themselves. `rbx run -p`, `rbx package` and `rbx time`
-recompute it and warn you when it no longer matches:
+the interactor and the test inputs themselves. The commands that use a profile — `rbx run -p`,
+`rbx package`, `rbx st b -p`, `rbx time` — recompute it and warn you when it no longer
+matches:
 
 ```
 The time limit saved in profile boca is stale: the solutions it was estimated from

--- a/docs/setters/profiling/profiles.md
+++ b/docs/setters/profiling/profiles.md
@@ -131,6 +131,39 @@ rbx package boca
     names the command that would create it, rather than shipping a package with limits
     measured for something else.
 
+## When an estimate goes stale
+
+An estimate is only as good as what it was measured against. Rewrite the accepted solution,
+add a slow one, change a generator — and the number in the profile stays where it is, looking
+as authoritative as the day it was measured.
+
+So {{rbx}} records what it measured, alongside the number:
+
+```yaml title=".limits/boca.yml"
+timeLimit: 1400
+estimationChecksum: 'v1.h.9f3a1c22.4b7e0d81.c1a8f930'
+```
+
+That string is a checksum of the solutions the estimate was derived from — the accepted ones
+that set the limit and the slow ones that validated it — plus, when the tests had been built,
+the interactor and the test inputs themselves. `rbx run -p`, `rbx package` and `rbx time`
+recompute it and tell you when it no longer matches:
+
+```
+The time limit saved in profile boca is stale: the solutions it was estimated from
+have changed since it was estimated.
+Re-run `rbx time -p boca` to refresh it.
+```
+
+It is a warning and never an error. Only you can say whether a solution you just edited was
+one whose timing mattered; {{rbx}} only says that the question is now open.
+
+Two things it deliberately stays quiet about. A profile whose limit you set by hand or
+inherited from the package carries no checksum at all — nothing was estimated, so there is
+nothing to go stale. And a package whose tests are not currently built is checked on its
+solutions alone: on a fresh clone, before any build, an edited generator goes unnoticed until
+you build.
+
 ## Inheriting from the package
 
 Some targets do not need limits of their own — they should use whatever `problem.rbx.yml` says.

--- a/rbx/box/builder.py
+++ b/rbx/box/builder.py
@@ -55,7 +55,7 @@ async def build(
         'Built [item]{processed}[/item] testcases...',
         keep=True,
     ) as s:
-        await generate_testcases(
+        input_digests = await generate_testcases(
             s, groups=groups, verification=VerificationLevel(verification)
         )
 
@@ -140,7 +140,16 @@ async def build(
     # Last, on purpose: a reader that sees the manifest may assume everything it
     # names -- inputs, outputs, visualizations -- has already landed, which is
     # what lets its watcher be a single glob instead of a settling heuristic.
-    write_manifest_or_warn(entries, input_validation_infos)
+    write_manifest_or_warn(
+        entries,
+        input_validation_infos,
+        input_digests,
+        # Only a build that checked determinism can promise that regenerating
+        # produces the same bytes, which is what makes the recorded digests a
+        # property of the testset rather than of this one run.
+        deterministic=VerificationLevel(verification).value
+        >= VerificationLevel.VALIDATE.value,
+    )
 
     return True
 

--- a/rbx/box/builder.py
+++ b/rbx/box/builder.py
@@ -149,6 +149,10 @@ async def build(
         # property of the testset rather than of this one run.
         deterministic=VerificationLevel(verification).value
         >= VerificationLevel.VALIDATE.value,
+        # A subset build describes a testset nobody estimated against, and the
+        # manifest has to say so: its own group list cannot be used to work this
+        # out, since a declared group may simply have produced no tests.
+        partial=groups is not None,
     )
 
     return True

--- a/rbx/box/cli/commands/run.py
+++ b/rbx/box/cli/commands/run.py
@@ -17,6 +17,7 @@ from rbx.annotations import PackagePath
 from rbx.box import (
     benchmark,
     environment,
+    estimation_checksum,
     generators,
     limits_info,
     package,
@@ -56,6 +57,12 @@ def _set_timing_profile(profile: Optional[str]) -> None:
 
     limits_info.get_limits_profile(profile, fallback_to_package_profile=False)
     limits_info.profile_var.set(profile)
+    # Naming a profile is asking to be judged by its limits, so it is also the
+    # moment to say that those limits predate the solutions being run. The check
+    # is at whatever level the build dir currently supports -- `rbx run` has not
+    # built anything yet here, so on a clean checkout it compares the solutions
+    # and stays quiet about the tests.
+    estimation_checksum.warn_if_stale(profile)
 
 
 @app.command(

--- a/rbx/box/cli/commands/run.py
+++ b/rbx/box/cli/commands/run.py
@@ -234,12 +234,17 @@ async def run(
     ):
         raise typer.Exit(1)
 
-    # After the build, and keyed on the *active* profile rather than on this
-    # command's own flag, so `rbx -p boca run` is checked exactly like
-    # `rbx run -p boca`. Before the build it would have compared against whatever
-    # manifest an earlier build happened to leave in `build/` -- which is a stale
-    # answer precisely when the testset is what changed.
-    estimation_checksum.warn_if_stale(limits_info.get_active_profile())
+    # After the build, and keyed on the profile the run is actually judged
+    # against -- not on this command's own flag, so `rbx -p boca run` is checked
+    # like `rbx run -p boca`, and not on `get_active_profile()`, which is None for
+    # a plain `rbx run` even though that run resolves its limits from `local`.
+    # `rbx time` writes `local` by default, so keying on the active profile
+    # skipped the check for the commonest workflow there is.
+    #
+    # Before the build it would have compared against whatever manifest an
+    # earlier build happened to leave in `build/` -- a stale answer precisely
+    # when the testset is what changed.
+    estimation_checksum.warn_if_stale(limits_info.get_run_profile())
 
     if verification <= VerificationLevel.VALIDATE.value:
         console.console.print(
@@ -487,7 +492,7 @@ async def irun(
     # `rbx irun` never builds a testset, so whatever sits in `build/` says
     # nothing about this run: the check is deliberately held to its light level
     # rather than reading a manifest an unrelated build left behind.
-    estimation_checksum.warn_if_stale(limits_info.get_active_profile(), light_only=True)
+    estimation_checksum.warn_if_stale(limits_info.get_run_profile(), light_only=True)
 
     if not print:
         console.console.print(

--- a/rbx/box/cli/commands/run.py
+++ b/rbx/box/cli/commands/run.py
@@ -57,12 +57,6 @@ def _set_timing_profile(profile: Optional[str]) -> None:
 
     limits_info.get_limits_profile(profile, fallback_to_package_profile=False)
     limits_info.profile_var.set(profile)
-    # Naming a profile is asking to be judged by its limits, so it is also the
-    # moment to say that those limits predate the solutions being run. The check
-    # is at whatever level the build dir currently supports -- `rbx run` has not
-    # built anything yet here, so on a clean checkout it compares the solutions
-    # and stays quiet about the tests.
-    estimation_checksum.warn_if_stale(profile)
 
 
 @app.command(
@@ -239,6 +233,13 @@ async def run(
         verification=verification, output=check, validate=validate, is_run=True
     ):
         raise typer.Exit(1)
+
+    # After the build, and keyed on the *active* profile rather than on this
+    # command's own flag, so `rbx -p boca run` is checked exactly like
+    # `rbx run -p boca`. Before the build it would have compared against whatever
+    # manifest an earlier build happened to leave in `build/` -- which is a stale
+    # answer precisely when the testset is what changed.
+    estimation_checksum.warn_if_stale(limits_info.get_active_profile())
 
     if verification <= VerificationLevel.VALIDATE.value:
         console.console.print(
@@ -483,6 +484,10 @@ async def irun(
     level = benchmark.parse_level(benchmark_level)
 
     _set_timing_profile(profile)
+    # `rbx irun` never builds a testset, so whatever sits in `build/` says
+    # nothing about this run: the check is deliberately held to its light level
+    # rather than reading a manifest an unrelated build left behind.
+    estimation_checksum.warn_if_stale(limits_info.get_active_profile(), light_only=True)
 
     if not print:
         console.console.print(

--- a/rbx/box/cli/commands/time_cmd.py
+++ b/rbx/box/cli/commands/time_cmd.py
@@ -14,6 +14,7 @@ from rbx import annotations, console
 from rbx.box import (
     benchmark,
     environment,
+    estimation_checksum,
     limits_info,
     package,
     timing,
@@ -176,6 +177,10 @@ async def _estimate(
     limits_info.render_limits_table(
         current_profile, title=f'Current limits ({profile})'
     )
+    # Informational here, unlike in `rbx run` and `rbx package build`: the whole
+    # command exists to replace this estimate, so saying it is stale is context
+    # for the run about to happen, not a warning to act on.
+    estimation_checksum.warn_if_stale(profile)
     console.console.print()
     if integrate:
         timing.integrate(profile, dry=dry)

--- a/rbx/box/cli/commands/time_cmd.py
+++ b/rbx/box/cli/commands/time_cmd.py
@@ -177,9 +177,11 @@ async def _estimate(
     limits_info.render_limits_table(
         current_profile, title=f'Current limits ({profile})'
     )
-    # Informational here, unlike in `rbx run` and `rbx package build`: the whole
-    # command exists to replace this estimate, so saying it is stale is context
-    # for the run about to happen, not a warning to act on.
+    # Ahead of the `--integrate` branch below, which is the one path here where
+    # this is a warning to act on rather than context: `integrate` copies the
+    # saved limit into `problem.rbx.yml` without re-estimating anything, so a
+    # stale number is about to become the package's own. On every other path the
+    # command is about to replace the estimate anyway.
     estimation_checksum.warn_if_stale(profile)
     console.console.print()
     if integrate:

--- a/rbx/box/contest/statements.py
+++ b/rbx/box/contest/statements.py
@@ -4,7 +4,13 @@ import syncer
 import typer
 
 from rbx import annotations, console
-from rbx.box import cd, environment, limits_info, package_utils
+from rbx.box import (
+    cd,
+    environment,
+    estimation_checksum,
+    limits_info,
+    package_utils,
+)
 from rbx.box.contest.build_contest_statements import (
     StatementBuildIssue,
     StatementFailedIssue,
@@ -78,6 +84,26 @@ async def _execute_build(
                 f'[error]No problems in this contest define the timing profile [item]{profile}[/item].[/error]'
             )
             raise typer.Exit(1)
+
+        # Collected and reported once, naming the problems, rather than warned
+        # per problem: a contest has a dozen of these, and the same three-line
+        # warning repeated a dozen times buries the build log it precedes.
+        stale = []
+        for problem in eligible_problems:
+            with cd.new_package_cd(problem.get_path()):
+                package_utils.clear_package_cache()
+                if estimation_checksum.check_profile(profile, light_only=True):
+                    stale.append(problem.short_name)
+        if stale:
+            console.console.print(
+                f'[warning]The time limit saved in profile [item]{profile}[/item] is '
+                f'stale for [item]{", ".join(stale)}[/item]: the solutions it was '
+                f'estimated from have changed since it was estimated.[/warning]'
+            )
+            console.console.print(
+                f'[warning]Re-run [item]rbx time -p {profile}[/item] in those '
+                f'problems to refresh it.[/warning]'
+            )
 
     candidate_languages = set(languages or [])
     candidate_names = set(names or [])

--- a/rbx/box/estimation_checksum.py
+++ b/rbx/box/estimation_checksum.py
@@ -30,7 +30,7 @@ import dataclasses
 import enum
 import io
 import pathlib
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from pydantic import BaseModel
 
@@ -200,8 +200,14 @@ def _tests_segment() -> Optional[str]:
     * a build that did not prove its generators deterministic (`-v0`), since an
       unseeded generator would otherwise mismatch on every single build and turn
       the warning into noise;
-    * a build restricted to a subset of the groups, whose manifest describes a
-      testset that is not the one an estimate ran against.
+    * a build restricted to a subset of the groups (`--samples-only`), whose
+      manifest describes a testset that is not the one an estimate ran against.
+
+    That last one is read off the flag the build recorded, not inferred by
+    comparing the manifest's groups against the declared ones. A group can be
+    declared and still legitimately produce no tests -- a `testcaseGlob` matching
+    nothing -- and inferring would read that as a partial build forever, silently
+    disabling the heavy level for the whole package.
     """
     # Local import: the manifest module imports half of box, and this module is
     # imported from the CLI's hot paths.
@@ -212,12 +218,7 @@ def _tests_segment() -> Optional[str]:
         return None
     if manifest.version != testset_manifest.MANIFEST_VERSION:
         return None
-    if not manifest.deterministic:
-        return None
-
-    pkg = package.find_problem_package_or_die()
-    built_groups = {group.name for group in manifest.groups}
-    if {group.name for group in pkg.testcases} - built_groups:
+    if not manifest.deterministic or manifest.partial:
         return None
 
     tests = []
@@ -278,14 +279,20 @@ class EstimationChecksum:
         return None
 
 
-def compute() -> EstimationChecksum:
+def compute(light_only: bool = False) -> EstimationChecksum:
     """The checksum of the package as it stands right now.
 
     Heavy whenever the built tests can be trusted, light otherwise. Callers do
-    not choose the level: the package does.
+    not normally choose the level -- the package does.
+
+    `light_only` is for the one case where they must: a caller that is *not*
+    about to build cannot treat whatever `build/` happens to hold as evidence
+    about the run it is starting. A leftover manifest from an earlier build would
+    otherwise satisfy the tests segment and report a match that describes nothing
+    this run will do.
     """
     solutions = _solutions_segment()
-    tests = _tests_segment()
+    tests = None if light_only else _tests_segment()
     if tests is None:
         return EstimationChecksum(
             version=CHECKSUM_VERSION, level=_LIGHT, solutions=solutions
@@ -300,7 +307,9 @@ def compute() -> EstimationChecksum:
 
 
 def compare(
-    recorded: str, current: Optional[EstimationChecksum] = None
+    recorded: str,
+    current: Optional[EstimationChecksum] = None,
+    light_only: bool = False,
 ) -> Optional[ChecksumBucket]:
     """The first bucket where `recorded` and the package disagree.
 
@@ -314,7 +323,7 @@ def compare(
     if parsed is None or parsed.version != CHECKSUM_VERSION:
         return None
     if current is None:
-        current = compute()
+        current = compute(light_only=light_only)
     if parsed.solutions != current.solutions:
         return ChecksumBucket.SOLUTIONS
     if not parsed.is_heavy or not current.is_heavy:
@@ -329,7 +338,7 @@ def compare(
     return None
 
 
-def check_profile(profile: str) -> Optional[ChecksumBucket]:
+def check_profile(profile: str, light_only: bool = False) -> Optional[ChecksumBucket]:
     """Compare the checksum saved in `profile` against the package.
 
     None whenever there is nothing to say -- no such profile, a profile that was
@@ -340,13 +349,21 @@ def check_profile(profile: str) -> Optional[ChecksumBucket]:
     saved = limits_info.get_saved_limits_profile(profile)
     if saved is None or saved.estimationChecksum is None:
         return None
-    return compare(saved.estimationChecksum)
+    return compare(saved.estimationChecksum, light_only=light_only)
 
 
-def warn_if_stale(profile: str) -> Optional[ChecksumBucket]:
-    """Print the staleness warning for `profile`, if it has one coming."""
+def warn_if_stale(
+    profile: Optional[str], light_only: bool = False
+) -> Optional[ChecksumBucket]:
+    """Print the staleness warning for `profile`, if it has one coming.
+
+    Accepts None -- "no profile is active" -- so a caller can hand over whatever
+    `limits_info.get_active_profile()` returned without branching on it.
+    """
+    if profile is None:
+        return None
     try:
-        bucket = check_profile(profile)
+        bucket = check_profile(profile, light_only=light_only)
     except Exception as e:
         # Never let a checksum take down a build. The estimate might be stale;
         # the package is still fine.
@@ -365,15 +382,3 @@ def warn_if_stale(profile: str) -> Optional[ChecksumBucket]:
         f'[warning]Re-run [item]rbx time -p {profile}[/item] to refresh it.[/warning]'
     )
     return bucket
-
-
-def describe(profile: str) -> Dict[str, str]:
-    """Human-readable status of a profile's checksum, for `rbx time` to show."""
-    from rbx.box import limits_info
-
-    saved = limits_info.get_saved_limits_profile(profile)
-    if saved is None or saved.estimationChecksum is None:
-        return {}
-    bucket = compare(saved.estimationChecksum)
-    status = 'up to date' if bucket is None else f'stale ({bucket.value} changed)'
-    return {'checksum': saved.estimationChecksum, 'status': status}

--- a/rbx/box/estimation_checksum.py
+++ b/rbx/box/estimation_checksum.py
@@ -1,0 +1,379 @@
+"""What a saved time limit was estimated against, folded into one string.
+
+A `.limits/<profile>.yml` records the time limit `rbx time` computed, but not
+what it computed it *from*. Edit a solution, add a slow one, regenerate the
+tests, and the number stays there looking authoritative. This module produces a
+checksum of the inputs that can move an estimate, so the profile can say when it
+predates them.
+
+The checksum is a single dotted string, and deliberately so: one field to store,
+one field to compare, but segmented so a mismatch still names *which* bucket
+moved rather than only that something did.
+
+    v1.h.9f3a1c22.4b7e0d81.c1a8f930
+    │  │ solutions  interactor  tests
+    │  └ level: `l` (light) or `h` (heavy)
+    └ format version
+
+The **light** level covers the solutions alone, and is always computable. The
+**heavy** level adds the interactor and a digest of every built test input, and
+needs a finished build to read them from -- so a checker asks for whatever it can
+compute and compares only the segments both sides carry. A heavy record checked
+against a light recomputation still compares its solutions.
+
+The version prefix is what lets the recipe below change later: an unknown version
+compares as "cannot tell", not as a mismatch, so a new rbx never greets an old
+package with a warning about a checksum it simply does not speak.
+"""
+
+import dataclasses
+import enum
+import io
+import pathlib
+from typing import Dict, List, Optional, Tuple
+
+from pydantic import BaseModel
+
+from rbx import console, utils
+from rbx.box import package
+from rbx.box.dependencies import graph
+from rbx.box.schema import CodeItem
+from rbx.grading.judge.digester import Digester, digest_cooperatively
+
+CHECKSUM_VERSION = 'v1'
+
+# Enough to make an accidental collision irrelevant -- this gates a warning, not
+# a cache -- while keeping the whole string short enough to read in a diff.
+_SEGMENT_LENGTH = 8
+
+_LIGHT = 'l'
+_HEAVY = 'h'
+
+# Stands in for a segment whose subject the package does not have (a problem with
+# no interactor), so segment *positions* stay fixed and a package that gains an
+# interactor reads as a change rather than as a different format.
+_ABSENT = '-'
+
+# What a digest says about a file that is not there. Distinct from any real
+# digest, so a deleted dependency moves the checksum.
+_MISSING = 'missing'
+
+
+class ChecksumBucket(enum.Enum):
+    """The part of the package a mismatch points at."""
+
+    SOLUTIONS = 'solutions'
+    INTERACTOR = 'interactor'
+    TESTS = 'tests'
+
+
+_BUCKET_DESCRIPTION = {
+    ChecksumBucket.SOLUTIONS: 'the solutions it was estimated from have changed',
+    ChecksumBucket.INTERACTOR: 'the interactor has changed',
+    ChecksumBucket.TESTS: 'the tests have changed',
+}
+
+
+class _CodeFingerprint(BaseModel):
+    """One code item, with everything about it that can move a measured time."""
+
+    path: str
+    language: Optional[str] = None
+    # The root's own digest plus its transitive source closure, package-relative
+    # and in deterministic order. A C++ solution whose hot loop lives in an
+    # included header changes timing without its own bytes moving at all.
+    files: List[Tuple[str, str]] = []
+
+
+class _SolutionFingerprint(BaseModel):
+    code: _CodeFingerprint
+    # `lower` or `upper` -- which bound the solution contributes to. A solution
+    # promoted from lower to upper changes what the estimate means even when not
+    # one byte of it changed.
+    role: str
+
+
+class _SolutionsSegment(BaseModel):
+    solutions: List[_SolutionFingerprint]
+
+
+class _InteractorSegment(BaseModel):
+    interactor: _CodeFingerprint
+
+
+class _TestsSegment(BaseModel):
+    # (group, index, input digest), sorted.
+    tests: List[Tuple[str, int, str]]
+
+
+def _digest_model(model: BaseModel) -> str:
+    """Hash a pydantic model by its canonical JSON dump.
+
+    The same trick `grading.caching` uses to key a cache entry on its inputs: the
+    dump is stable for a fixed model definition, and adding a field to one of the
+    models above changes every checksum -- which is exactly why the string above
+    carries a version.
+    """
+    payload = model.model_dump_json().encode()
+    return digest_cooperatively(io.BytesIO(payload))[:_SEGMENT_LENGTH]
+
+
+def _digest_path(path: pathlib.Path) -> str:
+    if not path.is_file():
+        return _MISSING
+    digester = Digester()
+    with path.open('rb') as f:
+        digester.update(f.read())
+    return digester.digest()
+
+
+def _closure_of(code: CodeItem) -> List[pathlib.Path]:
+    """`code`'s own path plus everything it transitively pulls in.
+
+    `graph.expand` returns None whenever it cannot answer -- no scanner for the
+    language, a source outside the package root -- and a checksum over the root
+    alone is the honest answer there, not a failure.
+    """
+    paths = [code.path]
+    try:
+        expanded = graph.expand(code)
+    except Exception:
+        # A checksum is a convenience; a package that cannot be scanned must
+        # still be packageable.
+        expanded = None
+    if expanded is not None:
+        paths.extend(expanded.files())
+    for extra in (code.compilationFiles or []) + (code.executionFiles or []):
+        paths.append(pathlib.Path(extra))
+    # Deduplicated and ordered, so the same package always hashes the same way
+    # regardless of how the scanner happened to walk it.
+    return sorted(set(paths))
+
+
+def _fingerprint_code(code: CodeItem) -> _CodeFingerprint:
+    return _CodeFingerprint(
+        path=code.path.as_posix(),
+        language=code.language,
+        files=[(path.as_posix(), _digest_path(path)) for path in _closure_of(code)],
+    )
+
+
+def _solutions_segment() -> str:
+    """Hash every solution that can move the estimate.
+
+    Only solutions carrying an inference role are included. A `lower` solution
+    sets the base estimate and an `upper` one validates the bound; everything
+    else -- `inference: false`, `accepted-or-tle` -- is measured for the report
+    and never feeds the number. Deriving the set from the package this way is
+    what lets the estimator and the checker agree without the profile having to
+    store a roster of paths.
+    """
+    from rbx.box.solutions import inference_role_of
+
+    fingerprints = []
+    for solution in package.get_solutions():
+        role = inference_role_of(solution)
+        if role is None:
+            continue
+        fingerprints.append(
+            _SolutionFingerprint(code=_fingerprint_code(solution), role=role.value)
+        )
+    fingerprints.sort(key=lambda fingerprint: fingerprint.code.path)
+    return _digest_model(_SolutionsSegment(solutions=fingerprints))
+
+
+def _interactor_segment() -> str:
+    pkg = package.find_problem_package_or_die()
+    if pkg.interactor is None:
+        return _ABSENT
+    return _digest_model(
+        _InteractorSegment(interactor=_fingerprint_code(pkg.interactor))
+    )
+
+
+def _tests_segment() -> Optional[str]:
+    """Hash the built test inputs, or None when they cannot be trusted.
+
+    None -- which downgrades the whole checksum to light -- on any of:
+
+    * no manifest, or one written by a different manifest version;
+    * a build that did not prove its generators deterministic (`-v0`), since an
+      unseeded generator would otherwise mismatch on every single build and turn
+      the warning into noise;
+    * a build restricted to a subset of the groups, whose manifest describes a
+      testset that is not the one an estimate ran against.
+    """
+    # Local import: the manifest module imports half of box, and this module is
+    # imported from the CLI's hot paths.
+    from rbx.box import testset_manifest
+
+    manifest = testset_manifest.read_manifest()
+    if manifest is None:
+        return None
+    if manifest.version != testset_manifest.MANIFEST_VERSION:
+        return None
+    if not manifest.deterministic:
+        return None
+
+    pkg = package.find_problem_package_or_die()
+    built_groups = {group.name for group in manifest.groups}
+    if {group.name for group in pkg.testcases} - built_groups:
+        return None
+
+    tests = []
+    for test in manifest.tests:
+        if test.input_digest is None:
+            return None
+        tests.append((test.group, test.index, test.input_digest))
+    tests.sort()
+    return _digest_model(_TestsSegment(tests=tests))
+
+
+@dataclasses.dataclass(frozen=True)
+class EstimationChecksum:
+    version: str
+    level: str
+    solutions: str
+    interactor: Optional[str] = None
+    tests: Optional[str] = None
+
+    @property
+    def is_heavy(self) -> bool:
+        return self.level == _HEAVY
+
+    def encode(self) -> str:
+        if not self.is_heavy:
+            return '.'.join([self.version, _LIGHT, self.solutions])
+        return '.'.join(
+            [
+                self.version,
+                _HEAVY,
+                self.solutions,
+                self.interactor or _ABSENT,
+                self.tests or _ABSENT,
+            ]
+        )
+
+    @staticmethod
+    def decode(value: str) -> Optional['EstimationChecksum']:
+        """Parse a stored checksum, or None if it is not one we can read.
+
+        Anything unparseable is `None` rather than an error: the field is
+        hand-editable YAML, and a garbled one should cost the user a missing
+        warning, never a failed package build.
+        """
+        parts = value.strip().split('.')
+        if len(parts) == 3 and parts[1] == _LIGHT:
+            return EstimationChecksum(
+                version=parts[0], level=_LIGHT, solutions=parts[2]
+            )
+        if len(parts) == 5 and parts[1] == _HEAVY:
+            return EstimationChecksum(
+                version=parts[0],
+                level=_HEAVY,
+                solutions=parts[2],
+                interactor=parts[3],
+                tests=parts[4],
+            )
+        return None
+
+
+def compute() -> EstimationChecksum:
+    """The checksum of the package as it stands right now.
+
+    Heavy whenever the built tests can be trusted, light otherwise. Callers do
+    not choose the level: the package does.
+    """
+    solutions = _solutions_segment()
+    tests = _tests_segment()
+    if tests is None:
+        return EstimationChecksum(
+            version=CHECKSUM_VERSION, level=_LIGHT, solutions=solutions
+        )
+    return EstimationChecksum(
+        version=CHECKSUM_VERSION,
+        level=_HEAVY,
+        solutions=solutions,
+        interactor=_interactor_segment(),
+        tests=tests,
+    )
+
+
+def compare(
+    recorded: str, current: Optional[EstimationChecksum] = None
+) -> Optional[ChecksumBucket]:
+    """The first bucket where `recorded` and the package disagree.
+
+    None means "no complaint", which covers both a match and every case where the
+    two are not comparable -- an unreadable string, a version this rbx does not
+    speak, or a segment only one side has. Silence is the right answer for all of
+    them: the point of the checksum is to catch a stale estimate, and a checksum
+    we cannot interpret is not evidence of one.
+    """
+    parsed = EstimationChecksum.decode(recorded)
+    if parsed is None or parsed.version != CHECKSUM_VERSION:
+        return None
+    if current is None:
+        current = compute()
+    if parsed.solutions != current.solutions:
+        return ChecksumBucket.SOLUTIONS
+    if not parsed.is_heavy or not current.is_heavy:
+        # One side has no opinion on the interactor or the tests. Comparing the
+        # segments it does not carry would flag every package whose build dir
+        # happens to be clean.
+        return None
+    if parsed.interactor != current.interactor:
+        return ChecksumBucket.INTERACTOR
+    if parsed.tests != current.tests:
+        return ChecksumBucket.TESTS
+    return None
+
+
+def check_profile(profile: str) -> Optional[ChecksumBucket]:
+    """Compare the checksum saved in `profile` against the package.
+
+    None whenever there is nothing to say -- no such profile, a profile that was
+    never estimated (`--strategy inherit`, `--strategy custom`), or a match.
+    """
+    from rbx.box import limits_info
+
+    saved = limits_info.get_saved_limits_profile(profile)
+    if saved is None or saved.estimationChecksum is None:
+        return None
+    return compare(saved.estimationChecksum)
+
+
+def warn_if_stale(profile: str) -> Optional[ChecksumBucket]:
+    """Print the staleness warning for `profile`, if it has one coming."""
+    try:
+        bucket = check_profile(profile)
+    except Exception as e:
+        # Never let a checksum take down a build. The estimate might be stale;
+        # the package is still fine.
+        console.console.print(
+            f'[warning]Could not verify the estimation checksum: '
+            f'{utils.escape_markup(str(e))}[/warning]'
+        )
+        return None
+    if bucket is None:
+        return None
+    console.console.print(
+        f'[warning]The time limit saved in profile [item]{profile}[/item] is stale: '
+        f'{_BUCKET_DESCRIPTION[bucket]} since it was estimated.[/warning]'
+    )
+    console.console.print(
+        f'[warning]Re-run [item]rbx time -p {profile}[/item] to refresh it.[/warning]'
+    )
+    return bucket
+
+
+def describe(profile: str) -> Dict[str, str]:
+    """Human-readable status of a profile's checksum, for `rbx time` to show."""
+    from rbx.box import limits_info
+
+    saved = limits_info.get_saved_limits_profile(profile)
+    if saved is None or saved.estimationChecksum is None:
+        return {}
+    bucket = compare(saved.estimationChecksum)
+    status = 'up to date' if bucket is None else f'stale ({bucket.value} changed)'
+    return {'checksum': saved.estimationChecksum, 'status': status}

--- a/rbx/box/generators.py
+++ b/rbx/box/generators.py
@@ -3,7 +3,7 @@ import collections
 import functools
 import pathlib
 import shutil
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 import typer
 from rich.console import Console
@@ -463,7 +463,14 @@ async def generate_testcases(
     progress: Optional[StatusProgress] = None,
     groups: Optional[Set[str]] = None,
     verification: VerificationLevel = VerificationLevel.NONE,
-):
+) -> Dict[Tuple[str, int], str]:
+    """Build every testcase, returning each one's input digest by group and index.
+
+    The digests are computed here regardless -- duplicate detection below needs
+    them -- so handing them back costs nothing and saves the manifest a second
+    pass over the whole testset.
+    """
+
     def step():
         if progress is not None:
             progress.step()
@@ -477,6 +484,7 @@ async def generate_testcases(
 
     executor = setter_config.get_async_executor(detach=True)
     futures: List[asyncio.Future[IdentifiedResult[GenerationTestcaseEntry, str]]] = []
+    input_digests: Dict[Tuple[str, int], str] = {}
 
     class BuildTestcaseVisitor(TestcaseGroupVisitor):
         def __init__(
@@ -577,7 +585,10 @@ async def generate_testcases(
                     f'is a hash duplicate of [item]{ref_entry.full_repr()}[/item].'
                 )
             tests_with_same_digest.append(entry)
+        input_digests[(entry.group_entry.group, entry.group_entry.index)] = digest
         step()
+
+    return input_digests
 
 
 async def generate_output_for_testcase(

--- a/rbx/box/limits_info.py
+++ b/rbx/box/limits_info.py
@@ -26,6 +26,24 @@ def get_active_profile() -> Optional[str]:
     return profile_var.get()
 
 
+# The profile a solution run falls back to when none was named. `rbx time` writes
+# this one by default, so it is the profile of the *default* workflow rather than
+# a fallback for an unusual one.
+DEFAULT_RUN_PROFILE = 'local'
+
+
+def get_run_profile() -> str:
+    """The profile a solution run is actually judged against.
+
+    Deliberately not `get_active_profile()`, which is None when nothing was
+    named: a plain `rbx run` still resolves its limits from `local`. Every
+    consumer that asks "which profile is this run using?" -- limit resolution,
+    and the staleness check that has to agree with it -- must go through here, or
+    the two answer differently for the commonest invocation there is.
+    """
+    return get_active_profile() or DEFAULT_RUN_PROFILE
+
+
 class use_profile:
     def __init__(
         self, profile: Optional[str], when: Optional[Callable[[], bool]] = None

--- a/rbx/box/packaging/packager.py
+++ b/rbx/box/packaging/packager.py
@@ -10,7 +10,14 @@ from typing import Dict, List, Optional, Type
 import typer
 
 from rbx import console
-from rbx.box import environment, header, limits_info, naming, package
+from rbx.box import (
+    environment,
+    estimation_checksum,
+    header,
+    limits_info,
+    naming,
+    package,
+)
 from rbx.box.contest import contest_package
 from rbx.box.contest.schema import ContestProblem, ContestStatement
 from rbx.box.formatting import href
@@ -249,6 +256,17 @@ async def run_packager(
                 '[error]Build or verification failed, check the report.[/error]'
             )
             raise typer.Exit(1)
+
+    # After the build, not before: the heavy half of the checksum reads the
+    # testset manifest, and only the build that just ran leaves one describing
+    # the tests actually about to be packaged. Checking beforehand would compare
+    # the saved limit against whatever some earlier build happened to leave in
+    # `build/`.
+    #
+    # `--samples-only` restricts the build to one group, which the checksum
+    # detects and answers at its light level -- the solutions still get checked,
+    # the tests do not.
+    estimation_checksum.warn_if_stale(packager_cls.name())
 
     testcase_entries = await extract_generation_testcases_from_groups(built_groups)
     pkg = package.find_problem_package_or_die()

--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -1253,6 +1253,19 @@ across every solution. Presentation-only; never used for limit resolution.
 """,
     )
 
+    estimationChecksum: Optional[str] = Field(
+        default=None,
+        description="""
+A checksum of everything this estimate was computed from -- the solutions that
+bound the limit, and, when the tests were built, the interactor and the test
+inputs. Written by `rbx time`; consumers compare it against the package to warn
+that a saved limit predates the current solutions or testset.
+
+Presentation-only; never used for limit resolution. Absent on a profile whose
+limit was not estimated (inherited from the package, or set by hand).
+""",
+    )
+
     def timelimit_for_language(self, language: Optional[str] = None) -> int:
         assert self.timeLimit is not None
         res = self.timeLimit

--- a/rbx/box/statements/build_statements.py
+++ b/rbx/box/statements/build_statements.py
@@ -6,7 +6,13 @@ import syncer
 import typer
 
 from rbx import annotations, console, utils
-from rbx.box import environment, limits_info, naming, package
+from rbx.box import (
+    environment,
+    estimation_checksum,
+    limits_info,
+    naming,
+    package,
+)
 from rbx.box.exception import describe_exception
 from rbx.box.formatting import href
 from rbx.box.schema import Package, expand_any_vars
@@ -466,6 +472,15 @@ async def execute_build(
     """
     if profile is not None:
         limits_info.get_limits_profile(profile, fallback_to_package_profile=False)
+        # The rendered statement carries the profile's time limit, so a stale one
+        # is about to be printed into a PDF rather than merely used for a run.
+        #
+        # Held to the light level, and not because nothing is built yet: a
+        # statement build only ever builds `samples`, which the manifest records
+        # as a partial build, so the tests segment is never available here. What
+        # `light_only` rules out is reading a manifest some *earlier* full build
+        # left behind and reporting a match about tests this build never touched.
+        estimation_checksum.warn_if_stale(profile, light_only=True)
 
     with limits_info.use_profile(profile, when=lambda: profile is not None):
         pkg = package.find_problem_package_or_die()

--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -128,7 +128,7 @@ def get_limits_for_language(
 ) -> Limits:
     limits = limits_info.get_limits(
         lang,
-        profile=limits_info.get_active_profile() or 'local',
+        profile=limits_info.get_run_profile(),
         verification=verification,
     )
     if timelimit_override is not None:

--- a/rbx/box/testset_manifest.py
+++ b/rbx/box/testset_manifest.py
@@ -26,7 +26,7 @@ from rbx.box.validators import (
     merge_hit_bounds_per_group,
 )
 
-MANIFEST_VERSION = 1
+MANIFEST_VERSION = 2
 
 
 class TestsetGroup(BaseModel):
@@ -68,6 +68,9 @@ class TestsetTest(BaseModel):
     # thousands of files.
     input_size: Optional[int] = None
     output_size: Optional[int] = None
+    # Digest of the input file, as computed during generation. Kept so a reader
+    # can tell two testsets apart without reading a byte of either.
+    input_digest: Optional[str] = None
 
 
 class TestsetGroupValidation(BaseModel):
@@ -88,6 +91,12 @@ class TestsetManifest(BaseModel):
     # An empty list would read as "nothing is covered", which is a much stronger
     # claim than "we did not look".
     validation: Optional[List[TestsetGroupValidation]] = None
+    # Whether this build proved its generators deterministic -- i.e. ran at
+    # `VerificationLevel.VALIDATE` or above, where a generator producing
+    # different bytes on two runs fails the build outright. False says nothing
+    # about the generators; it says nobody looked, so `input_digest` here is one
+    # observation rather than a property of the testset.
+    deterministic: bool = False
 
 
 def get_manifest_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
@@ -193,6 +202,8 @@ def _build_groups(group_names: Set[str]) -> List[TestsetGroup]:
 def build_manifest(
     entries: List[GenerationTestcaseEntry],
     validation_infos: Optional[List[TestcaseValidationInfo]],
+    input_digests: Optional[Dict[Tuple[str, int], str]] = None,
+    deterministic: bool = False,
 ) -> TestsetManifest:
     group_names = {entry.group_entry.group for entry in entries}
 
@@ -212,6 +223,9 @@ def build_manifest(
                 visualization=_visualization_for_entry(entry),
                 input_size=_size_or_none(testcase.inputPath),
                 output_size=_size_or_none(testcase.outputPath),
+                input_digest=(input_digests or {}).get(
+                    (entry.group_entry.group, entry.group_entry.index)
+                ),
             )
         )
 
@@ -234,12 +248,15 @@ def build_manifest(
         entries=list(entries),
         tests=tests,
         validation=validation,
+        deterministic=deterministic,
     )
 
 
 def write_manifest(
     entries: List[GenerationTestcaseEntry],
     validation_infos: Optional[List[TestcaseValidationInfo]],
+    input_digests: Optional[Dict[Tuple[str, int], str]] = None,
+    deterministic: bool = False,
 ) -> pathlib.Path:
     """Dump the manifest for the build that just finished, replacing any previous one.
 
@@ -251,7 +268,9 @@ def write_manifest(
     thing a reader of it may never be shown. A subset build's testset really is
     only those groups.
     """
-    manifest = build_manifest(entries, validation_infos)
+    manifest = build_manifest(
+        entries, validation_infos, input_digests, deterministic=deterministic
+    )
 
     path = get_manifest_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -262,16 +281,37 @@ def write_manifest(
 def write_manifest_or_warn(
     entries: List[GenerationTestcaseEntry],
     validation_infos: Optional[List[TestcaseValidationInfo]],
+    input_digests: Optional[Dict[Tuple[str, int], str]] = None,
+    deterministic: bool = False,
 ) -> None:
     """`write_manifest`, downgraded to a warning.
 
-    The manifest is a convenience for external readers; nothing rbx itself does
-    reads it back. Failing a build that produced perfectly good testcases over
-    it would be a strictly worse trade.
+    The manifest is the build's record for external readers, plus the one thing
+    rbx reads back itself (the heavy half of the estimation checksum). Neither is
+    worth failing a build that produced perfectly good testcases over: a missing
+    manifest costs the checksum its heavy level, and nothing else.
     """
     try:
-        write_manifest(entries, validation_infos)
+        write_manifest(
+            entries, validation_infos, input_digests, deterministic=deterministic
+        )
     except Exception as e:
         console.console.print(
             f'[warning]Failed writing the testset manifest: {utils.escape_markup(str(e))}[/warning]'
         )
+
+
+def read_manifest(
+    root: pathlib.Path = pathlib.Path(),
+) -> Optional[TestsetManifest]:
+    """The manifest the last build left, or None if there is not a readable one.
+
+    Unreadable is folded into missing on purpose. Every caller is asking "can I
+    trust what is in `build/`?", and a manifest that will not parse answers that
+    question the same way an absent one does.
+    """
+    path = get_manifest_path(root)
+    try:
+        return utils.model_from_yaml(TestsetManifest, path.read_text())
+    except Exception:
+        return None

--- a/rbx/box/testset_manifest.py
+++ b/rbx/box/testset_manifest.py
@@ -97,6 +97,12 @@ class TestsetManifest(BaseModel):
     # about the generators; it says nobody looked, so `input_digest` here is one
     # observation rather than a property of the testset.
     deterministic: bool = False
+    # Whether the build was restricted to a subset of the groups (`rbx build
+    # --groups`, `rbx package --samples-only`). Recorded rather than inferred
+    # from `groups` below: a declared group can legitimately produce no tests, so
+    # a reader comparing declared against built cannot tell a partial build from
+    # an empty group.
+    partial: bool = False
 
 
 def get_manifest_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
@@ -204,6 +210,7 @@ def build_manifest(
     validation_infos: Optional[List[TestcaseValidationInfo]],
     input_digests: Optional[Dict[Tuple[str, int], str]] = None,
     deterministic: bool = False,
+    partial: bool = False,
 ) -> TestsetManifest:
     group_names = {entry.group_entry.group for entry in entries}
 
@@ -249,6 +256,7 @@ def build_manifest(
         tests=tests,
         validation=validation,
         deterministic=deterministic,
+        partial=partial,
     )
 
 
@@ -257,6 +265,7 @@ def write_manifest(
     validation_infos: Optional[List[TestcaseValidationInfo]],
     input_digests: Optional[Dict[Tuple[str, int], str]] = None,
     deterministic: bool = False,
+    partial: bool = False,
 ) -> pathlib.Path:
     """Dump the manifest for the build that just finished, replacing any previous one.
 
@@ -269,7 +278,11 @@ def write_manifest(
     only those groups.
     """
     manifest = build_manifest(
-        entries, validation_infos, input_digests, deterministic=deterministic
+        entries,
+        validation_infos,
+        input_digests,
+        deterministic=deterministic,
+        partial=partial,
     )
 
     path = get_manifest_path()
@@ -283,6 +296,7 @@ def write_manifest_or_warn(
     validation_infos: Optional[List[TestcaseValidationInfo]],
     input_digests: Optional[Dict[Tuple[str, int], str]] = None,
     deterministic: bool = False,
+    partial: bool = False,
 ) -> None:
     """`write_manifest`, downgraded to a warning.
 
@@ -293,7 +307,11 @@ def write_manifest_or_warn(
     """
     try:
         write_manifest(
-            entries, validation_infos, input_digests, deterministic=deterministic
+            entries,
+            validation_infos,
+            input_digests,
+            deterministic=deterministic,
+            partial=partial,
         )
     except Exception as e:
         console.console.print(

--- a/rbx/box/timing.py
+++ b/rbx/box/timing.py
@@ -16,6 +16,7 @@ from rbx import console, utils
 from rbx.box import (
     benchmark,
     environment,
+    estimation_checksum,
     limits_info,
     package,
     safeeval,
@@ -92,6 +93,9 @@ class TimingProfile(BaseModel):
     timeLimitPerLanguage: Dict[str, int] = Field(default_factory=dict)
     groups: Optional[List[schema.TimingGroupReport]] = None
     baseEstimate: Optional[schema.TimingGroupReport] = None
+    # What the estimate was computed from; see `rbx.box.estimation_checksum`.
+    # Stamped after the estimation finishes, not carried through it.
+    estimationChecksum: Optional[str] = None
 
     def to_limits(self):
         return schema.LimitsProfile(
@@ -104,6 +108,7 @@ class TimingProfile(BaseModel):
             },
             groups=self.groups,
             baseEstimate=self.baseEstimate,
+            estimationChecksum=self.estimationChecksum,
         )
 
 
@@ -1825,6 +1830,11 @@ async def compute_time_limits(
     )
     if estimated_tl is None:
         return None
+
+    # Stamped here rather than inside the estimation: the checksum describes the
+    # package the estimate was taken against, and that is only settled once the
+    # estimation has stopped rebuilding and re-running things.
+    estimated_tl.estimationChecksum = estimation_checksum.compute().encode()
 
     limits_path = package.get_limits_file(profile)
     limits = estimated_tl.to_limits()

--- a/tests/rbx/box/contest/test_statements_profile.py
+++ b/tests/rbx/box/contest/test_statements_profile.py
@@ -114,3 +114,81 @@ async def test_contest_build_all_missing_profile_exits(cleandir_with_testdata):
             profile='nonexistent',
         )
     assert exc_info.value.exit_code == 1
+
+
+def _recording_console(monkeypatch):
+    import rich.console
+
+    import rbx.console
+
+    recorder = rich.console.Console(
+        theme=rbx.console.theme, record=True, width=200, color_system=None
+    )
+    monkeypatch.setattr(rbx.console, 'console', recorder)
+    return recorder
+
+
+async def _build_with_profile(monkeypatch):
+    async def fake_build_statement(
+        statement, contest, *, problems_of_interest=None, **kwargs
+    ):
+        return pathlib.Path('fake.pdf')
+
+    monkeypatch.setattr(
+        'rbx.box.contest.statements.build_statement',
+        fake_build_statement,
+    )
+    await _build_async(
+        verification=0,
+        names=None,
+        languages=None,
+        validate=False,
+        output=StatementType.PDF,
+        samples=False,
+        vars=None,
+        install_tex=False,
+        profile='icpc',
+    )
+
+
+@pytest.mark.test_pkg('contests/two_problems')
+async def test_contest_build_names_the_problems_whose_estimate_is_stale(
+    cleandir_with_testdata, monkeypatch
+):
+    """A contest renders each problem's limit into the joined statement, so a
+    stale estimate reaches the PDF. The problems are named in one line rather
+    than warned about individually -- a dozen repeats would bury the build log.
+    """
+    pathlib.Path('A/.limits').mkdir(parents=True, exist_ok=True)
+    pathlib.Path('A/.limits/icpc.yml').write_text(
+        "timeLimit: 5000\nestimationChecksum: 'v1.l.deadbeef'\n"
+    )
+
+    recorder = _recording_console(monkeypatch)
+    await _build_with_profile(monkeypatch)
+
+    text = recorder.export_text()
+    assert 'stale' in text
+    assert 'A' in text
+    assert 'rbx time -p icpc' in text
+
+
+@pytest.mark.test_pkg('contests/two_problems')
+async def test_contest_build_is_quiet_when_every_estimate_is_current(
+    cleandir_with_testdata, monkeypatch
+):
+    from rbx.box import cd, estimation_checksum, package_utils
+
+    with cd.new_package_cd(pathlib.Path('A')):
+        package_utils.clear_package_cache()
+        current = estimation_checksum.compute().encode()
+
+    pathlib.Path('A/.limits').mkdir(parents=True, exist_ok=True)
+    pathlib.Path('A/.limits/icpc.yml').write_text(
+        f"timeLimit: 5000\nestimationChecksum: '{current}'\n"
+    )
+
+    recorder = _recording_console(monkeypatch)
+    await _build_with_profile(monkeypatch)
+
+    assert 'stale' not in recorder.export_text()

--- a/tests/rbx/box/estimation_checksum_test.py
+++ b/tests/rbx/box/estimation_checksum_test.py
@@ -377,6 +377,56 @@ def test_warn_if_stale_accepts_no_active_profile(
     assert estimation_checksum.warn_if_stale(None) is None
 
 
+def _recording_console(monkeypatch):
+    import rich.console
+
+    import rbx.console
+
+    recorder = rich.console.Console(
+        theme=rbx.console.theme, record=True, width=200, color_system=None
+    )
+    monkeypatch.setattr(rbx.console, 'console', recorder)
+    return recorder
+
+
+def _save_profile(profile: str, checksum: str) -> None:
+    from rbx import utils
+    from rbx.box import package
+    from rbx.box.schema import LimitsProfile
+
+    limits_path = package.get_limits_file(profile)
+    limits_path.parent.mkdir(parents=True, exist_ok=True)
+    limits_path.write_text(
+        utils.model_to_yaml(LimitsProfile(timeLimit=1000, estimationChecksum=checksum))
+    )
+
+
+def test_warn_if_stale_says_which_bucket_and_how_to_fix_it(
+    pkg: testing_package.TestingPackage, monkeypatch
+):
+    _save_profile('boca', estimation_checksum.compute().encode())
+    (pkg.root / 'sols' / 'ac.cpp').write_text('int main() { return 7; }\n')
+
+    recorder = _recording_console(monkeypatch)
+    assert estimation_checksum.warn_if_stale('boca') == ChecksumBucket.SOLUTIONS
+
+    text = recorder.export_text()
+    assert 'boca' in text
+    assert 'stale' in text
+    assert 'solutions' in text
+    assert 'rbx time -p boca' in text
+
+
+def test_warn_if_stale_says_nothing_when_the_estimate_is_current(
+    pkg: testing_package.TestingPackage, monkeypatch
+):
+    _save_profile('boca', estimation_checksum.compute().encode())
+
+    recorder = _recording_console(monkeypatch)
+    assert estimation_checksum.warn_if_stale('boca') is None
+    assert recorder.export_text().strip() == ''
+
+
 def test_timing_profile_carries_the_checksum_into_the_limits():
     from rbx.box.timing import TimingProfile
 

--- a/tests/rbx/box/estimation_checksum_test.py
+++ b/tests/rbx/box/estimation_checksum_test.py
@@ -1,5 +1,3 @@
-import pathlib
-
 import pytest
 
 from rbx.box import estimation_checksum
@@ -133,7 +131,7 @@ async def test_checksum_is_heavy_after_a_validated_build(
 
     digests = await generate_testcases(verification=VerificationLevel.VALIDATE)
     entries = await extract_generation_testcases_from_groups(None)
-    write_manifest(entries, None, digests, deterministic=True)
+    write_manifest(entries, None, digests, deterministic=True, partial=False)
 
     checksum = estimation_checksum.compute()
 
@@ -155,7 +153,7 @@ async def test_heavy_checksum_moves_when_a_test_input_changes(
     async def rebuild():
         digests = await generate_testcases(verification=VerificationLevel.VALIDATE)
         entries = await extract_generation_testcases_from_groups(None)
-        write_manifest(entries, None, digests, deterministic=True)
+        write_manifest(entries, None, digests, deterministic=True, partial=False)
 
     await rebuild()
     before = estimation_checksum.compute()
@@ -181,13 +179,13 @@ async def test_checksum_stays_light_when_determinism_was_not_checked(
 
     digests = await generate_testcases(verification=VerificationLevel.NONE)
     entries = await extract_generation_testcases_from_groups(None)
-    write_manifest(entries, None, digests, deterministic=False)
+    write_manifest(entries, None, digests, deterministic=False, partial=False)
 
     assert not estimation_checksum.compute().is_heavy
 
 
 async def test_checksum_stays_light_when_only_some_groups_were_built(
-    testing_pkg: testing_package.TestingPackage,
+    pkg: testing_package.TestingPackage,
 ):
     """A `--samples-only` package build leaves a manifest describing one group.
     Comparing it against an estimate taken over the whole testset would flag
@@ -196,23 +194,54 @@ async def test_checksum_stays_light_when_only_some_groups_were_built(
     from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
     from rbx.box.testset_manifest import write_manifest
 
-    testing_pkg.add_solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED)
-    (testing_pkg.root / 'sols' / 'ac.cpp').write_text('int main() { return 0; }\n')
-    for group in ('main', 'extra'):
-        path = pathlib.Path('manual') / f'{group}.in'
-        testing_pkg.add_file(path)
-        (testing_pkg.root / path).write_text('1\n')
-        testing_pkg.add_testgroup_with_manual_testcases(
-            group, [{'inputPath': str(path)}]
-        )
-
     digests = await generate_testcases(
         groups={'main'}, verification=VerificationLevel.VALIDATE
     )
     entries = await extract_generation_testcases_from_groups({'main'})
-    write_manifest(entries, None, digests, deterministic=True)
+    write_manifest(entries, None, digests, deterministic=True, partial=True)
 
     assert not estimation_checksum.compute().is_heavy
+
+
+async def test_a_group_that_produces_no_tests_keeps_the_heavy_level(
+    testing_pkg: testing_package.TestingPackage,
+):
+    """A declared group can legitimately be empty -- a `testcaseGlob` matching
+    nothing. Inferring "partial build" by comparing declared groups against built
+    ones would read that as a subset build forever, silently disabling the heavy
+    level for the whole package.
+    """
+    from rbx.box.environment import VerificationLevel
+    from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
+    from rbx.box.testset_manifest import write_manifest
+
+    testing_pkg.add_solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    (testing_pkg.root / 'sols' / 'ac.cpp').write_text('int main() { return 0; }\n')
+    _add_manual_test(testing_pkg, 'main', '1\n')
+    testing_pkg.add_testgroup_from_glob('empty', 'nothing/*.in')
+
+    digests = await generate_testcases(verification=VerificationLevel.VALIDATE)
+    entries = await extract_generation_testcases_from_groups(None)
+    write_manifest(entries, None, digests, deterministic=True, partial=False)
+
+    assert estimation_checksum.compute().is_heavy
+
+
+async def test_light_only_ignores_a_manifest_an_earlier_build_left(
+    pkg: testing_package.TestingPackage,
+):
+    """`rbx irun` never builds a testset, so whatever is in `build/` describes
+    some earlier run and must not satisfy the tests segment."""
+    from rbx.box.environment import VerificationLevel
+    from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
+    from rbx.box.testset_manifest import write_manifest
+
+    digests = await generate_testcases(verification=VerificationLevel.VALIDATE)
+    entries = await extract_generation_testcases_from_groups(None)
+    write_manifest(entries, None, digests, deterministic=True, partial=False)
+
+    assert estimation_checksum.compute().is_heavy
+    assert not estimation_checksum.compute(light_only=True).is_heavy
 
 
 # --- Encoding and comparison -------------------------------------------------
@@ -338,6 +367,14 @@ def test_check_profile_flags_a_stale_estimate(pkg: testing_package.TestingPackag
     (pkg.root / 'sols' / 'ac.cpp').write_text('int main() { return 7; }\n')
 
     assert estimation_checksum.check_profile('local') == ChecksumBucket.SOLUTIONS
+
+
+def test_warn_if_stale_accepts_no_active_profile(
+    pkg: testing_package.TestingPackage,
+):
+    """Callers hand over `limits_info.get_active_profile()` directly, which is
+    None whenever no profile was named."""
+    assert estimation_checksum.warn_if_stale(None) is None
 
 
 def test_timing_profile_carries_the_checksum_into_the_limits():

--- a/tests/rbx/box/estimation_checksum_test.py
+++ b/tests/rbx/box/estimation_checksum_test.py
@@ -427,6 +427,30 @@ def test_warn_if_stale_says_nothing_when_the_estimate_is_current(
     assert recorder.export_text().strip() == ''
 
 
+def test_the_default_run_profile_is_the_one_a_plain_run_is_judged_by(
+    pkg: testing_package.TestingPackage, monkeypatch
+):
+    """A plain `rbx run` names no profile, but is still judged against `local` --
+    which is also the profile `rbx time` writes by default. Keying the staleness
+    check on `get_active_profile()` (None here) skipped the commonest workflow
+    there is: estimate, edit a solution, run.
+    """
+    from rbx.box import limits_info
+
+    assert limits_info.get_active_profile() is None
+    assert limits_info.get_run_profile() == 'local'
+
+    _save_profile('local', estimation_checksum.compute().encode())
+    (pkg.root / 'sols' / 'ac.cpp').write_text('int main() { return 7; }\n')
+
+    recorder = _recording_console(monkeypatch)
+    assert (
+        estimation_checksum.warn_if_stale(limits_info.get_run_profile())
+        == ChecksumBucket.SOLUTIONS
+    )
+    assert 'local' in recorder.export_text()
+
+
 def test_timing_profile_carries_the_checksum_into_the_limits():
     from rbx.box.timing import TimingProfile
 

--- a/tests/rbx/box/estimation_checksum_test.py
+++ b/tests/rbx/box/estimation_checksum_test.py
@@ -1,0 +1,348 @@
+import pathlib
+
+import pytest
+
+from rbx.box import estimation_checksum
+from rbx.box.estimation_checksum import (
+    ChecksumBucket,
+    EstimationChecksum,
+)
+from rbx.box.generators import generate_testcases
+from rbx.box.schema import ExpectedOutcome, InferenceRole
+from rbx.box.testing import testing_package
+
+pytestmark = pytest.mark.shared_cache
+
+
+def _add_manual_test(
+    pkg: testing_package.TestingPackage, group: str, contents: str
+) -> None:
+    pkg.add_file('manual/000.in', src=None)
+    (pkg.root / 'manual' / '000.in').write_text(contents)
+    pkg.add_testgroup_with_manual_testcases(group, [{'inputPath': 'manual/000.in'}])
+
+
+@pytest.fixture
+def pkg(testing_pkg: testing_package.TestingPackage):
+    """A package with one accepted and one slow solution, and one manual test."""
+    testing_pkg.add_solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    (testing_pkg.root / 'sols' / 'ac.cpp').write_text('int main() { return 0; }\n')
+    testing_pkg.add_solution(
+        'sols/slow.cpp', outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED
+    )
+    (testing_pkg.root / 'sols' / 'slow.cpp').write_text('int main() { for(;;); }\n')
+    _add_manual_test(testing_pkg, 'main', '1 2\n')
+    return testing_pkg
+
+
+# --- The light level ---------------------------------------------------------
+
+
+def test_checksum_is_stable_across_calls(pkg: testing_package.TestingPackage):
+    assert estimation_checksum.compute() == estimation_checksum.compute()
+
+
+def test_checksum_is_light_without_a_build(pkg: testing_package.TestingPackage):
+    checksum = estimation_checksum.compute()
+
+    assert not checksum.is_heavy
+    assert checksum.encode().startswith('v1.l.')
+    assert checksum.encode().count('.') == 2
+
+
+def test_checksum_moves_when_a_solution_body_changes(
+    pkg: testing_package.TestingPackage,
+):
+    before = estimation_checksum.compute()
+
+    (pkg.root / 'sols' / 'ac.cpp').write_text('int main() { return 1; }\n')
+
+    assert estimation_checksum.compute().solutions != before.solutions
+
+
+def test_checksum_moves_when_a_solution_joins_the_set(
+    pkg: testing_package.TestingPackage,
+):
+    before = estimation_checksum.compute()
+
+    pkg.add_solution('sols/other.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    (pkg.root / 'sols' / 'other.cpp').write_text('int main() { return 0; }\n')
+
+    assert estimation_checksum.compute().solutions != before.solutions
+
+
+def test_checksum_ignores_a_solution_that_bounds_nothing(
+    pkg: testing_package.TestingPackage,
+):
+    """`accepted-or-tle` is neither good nor slow, so it never feeds the estimate.
+
+    Adding one must not make a saved limit look stale: nothing about the number
+    it produced has changed.
+    """
+    before = estimation_checksum.compute()
+
+    pkg.add_solution('sols/borderline.cpp', outcome=ExpectedOutcome.ACCEPTED_OR_TLE)
+    (pkg.root / 'sols' / 'borderline.cpp').write_text('int main() { return 0; }\n')
+
+    assert estimation_checksum.compute().solutions == before.solutions
+
+
+def test_checksum_moves_when_an_inference_role_changes(
+    pkg: testing_package.TestingPackage,
+):
+    """Same bytes, different meaning: a solution promoted to an upper bound
+    changes what the estimate was validated against."""
+    before = estimation_checksum.compute()
+
+    pkg.yml.solutions[1].inference = InferenceRole.LOWER
+    pkg.yml.solutions[1].outcome = ExpectedOutcome.ACCEPTED
+    pkg.save()
+
+    assert estimation_checksum.compute().solutions != before.solutions
+
+
+def test_checksum_moves_when_a_header_in_the_closure_changes(
+    testing_pkg: testing_package.TestingPackage,
+):
+    """The bytes of the solution itself never move here -- only the header it
+    includes, which is where a C++ solution's hot loop often lives."""
+    testing_pkg.add_solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    (testing_pkg.root / 'sols' / 'ac.cpp').write_text(
+        '#include "lib.h"\nint main() { return f(); }\n'
+    )
+    testing_pkg.add_file('sols/lib.h')
+    header = testing_pkg.root / 'sols' / 'lib.h'
+    header.write_text('int f() { return 0; }\n')
+    _add_manual_test(testing_pkg, 'main', '1\n')
+
+    before = estimation_checksum.compute()
+    header.write_text('int f() { return 1; }\n')
+
+    assert estimation_checksum.compute().solutions != before.solutions
+
+
+# --- The heavy level ---------------------------------------------------------
+
+
+async def test_checksum_is_heavy_after_a_validated_build(
+    pkg: testing_package.TestingPackage,
+):
+    from rbx.box.environment import VerificationLevel
+    from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
+    from rbx.box.testset_manifest import write_manifest
+
+    digests = await generate_testcases(verification=VerificationLevel.VALIDATE)
+    entries = await extract_generation_testcases_from_groups(None)
+    write_manifest(entries, None, digests, deterministic=True)
+
+    checksum = estimation_checksum.compute()
+
+    assert checksum.is_heavy
+    assert checksum.encode().startswith('v1.h.')
+    assert checksum.encode().count('.') == 4
+    # No interactor in this package: the segment is present but empty, so a
+    # package that later gains one still reads as a change.
+    assert checksum.interactor == '-'
+
+
+async def test_heavy_checksum_moves_when_a_test_input_changes(
+    pkg: testing_package.TestingPackage,
+):
+    from rbx.box.environment import VerificationLevel
+    from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
+    from rbx.box.testset_manifest import write_manifest
+
+    async def rebuild():
+        digests = await generate_testcases(verification=VerificationLevel.VALIDATE)
+        entries = await extract_generation_testcases_from_groups(None)
+        write_manifest(entries, None, digests, deterministic=True)
+
+    await rebuild()
+    before = estimation_checksum.compute()
+
+    (pkg.root / 'manual' / '000.in').write_text('3 4\n')
+    await rebuild()
+    after = estimation_checksum.compute()
+
+    assert after.solutions == before.solutions
+    assert after.tests != before.tests
+    assert estimation_checksum.compare(before.encode()) == ChecksumBucket.TESTS
+
+
+async def test_checksum_stays_light_when_determinism_was_not_checked(
+    pkg: testing_package.TestingPackage,
+):
+    """A `-v0` build never proved its generators reproducible, so its digests
+    describe one run rather than the testset. Hashing them would warn on every
+    package with an unseeded generator, forever."""
+    from rbx.box.environment import VerificationLevel
+    from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
+    from rbx.box.testset_manifest import write_manifest
+
+    digests = await generate_testcases(verification=VerificationLevel.NONE)
+    entries = await extract_generation_testcases_from_groups(None)
+    write_manifest(entries, None, digests, deterministic=False)
+
+    assert not estimation_checksum.compute().is_heavy
+
+
+async def test_checksum_stays_light_when_only_some_groups_were_built(
+    testing_pkg: testing_package.TestingPackage,
+):
+    """A `--samples-only` package build leaves a manifest describing one group.
+    Comparing it against an estimate taken over the whole testset would flag
+    every such build."""
+    from rbx.box.environment import VerificationLevel
+    from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
+    from rbx.box.testset_manifest import write_manifest
+
+    testing_pkg.add_solution('sols/ac.cpp', outcome=ExpectedOutcome.ACCEPTED)
+    (testing_pkg.root / 'sols' / 'ac.cpp').write_text('int main() { return 0; }\n')
+    for group in ('main', 'extra'):
+        path = pathlib.Path('manual') / f'{group}.in'
+        testing_pkg.add_file(path)
+        (testing_pkg.root / path).write_text('1\n')
+        testing_pkg.add_testgroup_with_manual_testcases(
+            group, [{'inputPath': str(path)}]
+        )
+
+    digests = await generate_testcases(
+        groups={'main'}, verification=VerificationLevel.VALIDATE
+    )
+    entries = await extract_generation_testcases_from_groups({'main'})
+    write_manifest(entries, None, digests, deterministic=True)
+
+    assert not estimation_checksum.compute().is_heavy
+
+
+# --- Encoding and comparison -------------------------------------------------
+
+
+def test_encode_round_trips():
+    for checksum in (
+        EstimationChecksum(version='v1', level='l', solutions='aaaaaaaa'),
+        EstimationChecksum(
+            version='v1',
+            level='h',
+            solutions='aaaaaaaa',
+            interactor='bbbbbbbb',
+            tests='cccccccc',
+        ),
+    ):
+        assert EstimationChecksum.decode(checksum.encode()) == checksum
+
+
+@pytest.mark.parametrize(
+    'value',
+    ['', 'nonsense', 'v1.l', 'v1.h.aaaaaaaa', 'v1.x.aaaaaaaa', 'v1.l.a.b.c.d'],
+)
+def test_decode_rejects_anything_it_cannot_read(value: str):
+    assert EstimationChecksum.decode(value) is None
+
+
+def test_compare_is_silent_for_a_version_it_does_not_speak():
+    """A newer rbx must not greet an old package with a warning about a format
+    it cannot evaluate."""
+    assert estimation_checksum.compare('v99.l.aaaaaaaa') is None
+
+
+def test_compare_is_silent_for_an_unreadable_checksum():
+    assert estimation_checksum.compare('hand-edited nonsense') is None
+
+
+def test_compare_names_the_solutions_bucket():
+    current = EstimationChecksum(version='v1', level='l', solutions='bbbbbbbb')
+    recorded = EstimationChecksum(version='v1', level='l', solutions='aaaaaaaa')
+
+    assert (
+        estimation_checksum.compare(recorded.encode(), current)
+        == ChecksumBucket.SOLUTIONS
+    )
+
+
+def test_compare_names_the_interactor_bucket():
+    recorded = EstimationChecksum(
+        version='v1', level='h', solutions='a', interactor='b', tests='c'
+    )
+    current = EstimationChecksum(
+        version='v1', level='h', solutions='a', interactor='B', tests='c'
+    )
+
+    assert (
+        estimation_checksum.compare(recorded.encode(), current)
+        == ChecksumBucket.INTERACTOR
+    )
+
+
+def test_compare_matches():
+    checksum = EstimationChecksum(
+        version='v1', level='h', solutions='a', interactor='b', tests='c'
+    )
+
+    assert estimation_checksum.compare(checksum.encode(), checksum) is None
+
+
+def test_compare_ignores_heavy_segments_when_the_current_side_is_light():
+    """The common case on a clean checkout: the profile remembers the tests, the
+    working tree has not built them. The solutions still get compared."""
+    recorded = EstimationChecksum(
+        version='v1', level='h', solutions='a', interactor='b', tests='c'
+    )
+    light = EstimationChecksum(version='v1', level='l', solutions='a')
+
+    assert estimation_checksum.compare(recorded.encode(), light) is None
+
+    moved = EstimationChecksum(version='v1', level='l', solutions='z')
+    assert (
+        estimation_checksum.compare(recorded.encode(), moved)
+        == ChecksumBucket.SOLUTIONS
+    )
+
+
+# --- Wiring into a profile ---------------------------------------------------
+
+
+def test_check_profile_is_silent_without_a_profile(
+    pkg: testing_package.TestingPackage,
+):
+    assert estimation_checksum.check_profile('local') is None
+
+
+def test_check_profile_is_silent_for_a_profile_that_was_never_estimated(
+    pkg: testing_package.TestingPackage,
+):
+    """`--strategy inherit` and `--strategy custom` write no checksum, so their
+    profiles are never warned about."""
+    from rbx.box import timing
+
+    timing.set_time_limit(1000, profile='local')
+
+    assert estimation_checksum.check_profile('local') is None
+
+
+def test_check_profile_flags_a_stale_estimate(pkg: testing_package.TestingPackage):
+    from rbx import utils
+    from rbx.box import package
+    from rbx.box.schema import LimitsProfile
+
+    limits = LimitsProfile(
+        timeLimit=1000,
+        estimationChecksum=estimation_checksum.compute().encode(),
+    )
+    limits_path = package.get_limits_file('local')
+    limits_path.parent.mkdir(parents=True, exist_ok=True)
+    limits_path.write_text(utils.model_to_yaml(limits))
+
+    assert estimation_checksum.check_profile('local') is None
+
+    (pkg.root / 'sols' / 'ac.cpp').write_text('int main() { return 7; }\n')
+
+    assert estimation_checksum.check_profile('local') == ChecksumBucket.SOLUTIONS
+
+
+def test_timing_profile_carries_the_checksum_into_the_limits():
+    from rbx.box.timing import TimingProfile
+
+    profile = TimingProfile(timeLimit=1000, estimationChecksum='v1.l.aaaaaaaa')
+
+    assert profile.to_limits().estimationChecksum == 'v1.l.aaaaaaaa'

--- a/tests/rbx/box/statements/test_build_statements.py
+++ b/tests/rbx/box/statements/test_build_statements.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 import typer
 
-from rbx.box import limits_info
+from rbx.box import limits_info, package
 from rbx.box.schema import Statement
 from rbx.box.statements.build_statements import (
     execute_build,
@@ -182,6 +182,93 @@ class TestExecuteBuildStrictProfile:
             profile='icpc',
         )
         assert seen['profile'] == 'icpc'
+
+    @pytest.mark.test_pkg('problems/box1')
+    async def test_execute_build_warns_when_the_profile_is_stale(
+        self, pkg_from_testdata, monkeypatch
+    ):
+        """The rendered statement carries the profile's time limit, so a stale
+        estimate is about to be printed into a PDF."""
+        import rich.console
+
+        import rbx.console
+        from rbx.box import estimation_checksum
+
+        pathlib.Path('.limits').mkdir(exist_ok=True)
+        pathlib.Path('.limits/icpc.yml').write_text(
+            'timeLimit: 5000\n'
+            f"estimationChecksum: '{estimation_checksum.compute().encode()}'\n"
+        )
+
+        solution = pathlib.Path(package.find_problem_package_or_die().solutions[0].path)
+        solution.write_text(solution.read_text() + '\n// nudged\n')
+
+        async def fake_execute_build_on_statements(statements, *args, **kwargs):
+            return
+
+        monkeypatch.setattr(
+            'rbx.box.statements.build_statements.execute_build_on_statements',
+            fake_execute_build_on_statements,
+        )
+        recorder = rich.console.Console(
+            theme=rbx.console.theme, record=True, width=200, color_system=None
+        )
+        monkeypatch.setattr(rbx.console, 'console', recorder)
+
+        await execute_build(
+            verification=0,
+            names=None,
+            languages=None,
+            output=StatementType.PDF,
+            samples=False,
+            vars=None,
+            validate=False,
+            profile='icpc',
+        )
+
+        text = recorder.export_text()
+        assert 'stale' in text
+        assert 'rbx time -p icpc' in text
+
+    @pytest.mark.test_pkg('problems/box1')
+    async def test_execute_build_is_quiet_when_the_profile_is_current(
+        self, pkg_from_testdata, monkeypatch
+    ):
+        import rich.console
+
+        import rbx.console
+        from rbx.box import estimation_checksum
+
+        pathlib.Path('.limits').mkdir(exist_ok=True)
+        pathlib.Path('.limits/icpc.yml').write_text(
+            'timeLimit: 5000\n'
+            f"estimationChecksum: '{estimation_checksum.compute().encode()}'\n"
+        )
+
+        async def fake_execute_build_on_statements(statements, *args, **kwargs):
+            return
+
+        monkeypatch.setattr(
+            'rbx.box.statements.build_statements.execute_build_on_statements',
+            fake_execute_build_on_statements,
+        )
+        recorder = rich.console.Console(
+            theme=rbx.console.theme, record=True, width=200, color_system=None
+        )
+        monkeypatch.setattr(rbx.console, 'console', recorder)
+
+        await execute_build(
+            verification=0,
+            names=None,
+            languages=None,
+            output=StatementType.PDF,
+            samples=False,
+            vars=None,
+            validate=False,
+            profile='icpc',
+        )
+
+        assert 'stale' not in recorder.export_text()
 
     @pytest.mark.test_pkg('problems/box1')
     async def test_execute_build_respects_global_profile_when_local_none(


### PR DESCRIPTION
Closes #823.

## Why

`.limits/<profile>.yml` recorded the time limit `rbx time` computed, but nothing about what it computed it *from*. Edit the accepted solution, add a slow one, rewrite a generator — the limit stays put, indistinguishable from one measured five minutes ago.

Profiles now carry an `estimationChecksum`, and the commands that consume a profile recompute it and say when it no longer matches.

## The checksum

One segmented string — a single field to store and compare, but the segment that differs names the bucket that moved:

```
v1.h.9f3a1c22.4b7e0d81.c1a8f930
│  │ solutions  interactor  tests
│  └ level: `l` or `h`
└ format version
```

**Light** covers the solutions carrying an inference role (`lower`/`upper`), each hashed over its transitive source closure — a C++ solution whose hot loop lives in an included header changes its timing without its own bytes moving. The set is *derived* from the package rather than stored, so the estimator and the checker agree without extra state.

**Heavy** adds the interactor and a digest of every built test input. Built inputs rather than testplan declarations: the inputs are the ground truth the declarations were only trying to produce.

The version prefix means an unknown format compares as "cannot tell", never as a mismatch. Same for an unparseable string — the field is hand-editable YAML, and a garbled one should cost a missing warning, never a failed build.

## When the heavy level is refused

Silently downgraded to light when the digests cannot be trusted:

- no manifest, or one from a different manifest version;
- a build that did not check generator determinism (`-v0`) — an unseeded generator would otherwise mismatch on *every* build and turn the warning into noise;
- a build restricted to a subset of groups (`--samples-only`), whose manifest describes a different testset than the estimate ran against.

## Consumers

| Command | Where | Why there |
| --- | --- | --- |
| `rbx package build` | after `builder.verify` | only the build that just ran leaves a manifest describing the tests actually being packaged |
| `rbx run -p <profile>` | `_set_timing_profile` | naming a profile is asking to be judged by its limits |
| `rbx time` | beside the "Current limits" table | informational — the command exists to replace the estimate |

Always a warning, never an error: only the setter can say whether an edited solution was one whose timing mattered. Profiles written by `--strategy inherit` or a hand-set limit carry no checksum, so they are never checked.

## Notable

The test digests already existed — generation computes them for duplicate/non-determinism detection and threw them away. They are now persisted into `build/testset.yml` (`MANIFEST_VERSION` 1 → 2), which makes the manifest **load-bearing for rbx itself for the first time**; it was written purely for external readers. That is the deliberate cost of making the tests segment free at check time. `write_manifest_or_warn` still downgrades every failure to a warning — a missing manifest costs the checksum its heavy level and nothing else.

## Testing

28 new tests in `tests/rbx/box/estimation_checksum_test.py`. Also ran `test_testset_manifest`, `limits_info_test`, `test_limits_*`, `test_timing*`, `generators_test`, `tests/rbx/box/packaging`, `lazy_cli_test`, `test_schema`, `test_run_cli`, `test_run_profile_cli` — all pass. Two failures in `generators_test` (`test_generator_non_existent`, `test_generator_not_compile`) reproduce identically on unmodified `main`.

Design doc: `docs/plans/2026-08-31-estimation-checksum-design.md`. User docs: a new "When an estimate goes stale" section in `docs/setters/profiling/profiles.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMeu5XDGXFpx7bD7TMkj4x
