### PR TITLE
feat(vscode): badge statement vars of a named test group

### DIFF
--- a/docs/plans/2026-08-31-vscode-group-var-hints-design.md
+++ b/docs/plans/2026-08-31-vscode-group-var-hints-design.md
@@ -1,0 +1,149 @@
+# Inline var hints for statically named groups
+
+Extends the inline statement var hints of
+[2026-08-28](2026-08-28-vscode-statement-var-hints-design.md), whose "Not in v1"
+list named group scope and predicted the shape this takes: "a group flag serves
+group scope, and the scanner's rejected-prefix list is where the others would be
+admitted." Both halves held. What that list did not anticipate is which prefix
+had to be admitted, and why the admission has to be narrow.
+
+## G1. Only a statically named group
+
+Three new spellings get a badge, and all three resolve to exactly one value:
+
+```
+\VAR{problem.groups.sub2.vars.AB.max}        = 1000
+\VAR{problem.groups.sub2.AB.max}             = 1000   (GroupView shorthand, #630)
+\VAR{problem.groups['sub-2'].vars.AB.max}    = 1000
+```
+
+A **loop-bound** reference -- `\VAR{g.vars.AB.max}` inside `\BLOCK{for g in
+groups}` -- is still not badged, and that is the standing limit rather than an
+oversight. One source position renders a different value per iteration, so a
+single badge would have to lie, name a group, or list several; D1 rejected all
+three, and nothing here changes that argument.
+
+It is worth being plain about the consequence: the loop is the *common* spelling.
+The bundled fixture
+(`rbx/testdata/contests/statements_v2_group_vars/statements/problem-standalone.rbx.tex`)
+writes its subtasks table as `\subtask{\VAR{g.name}}{\VAR{g.vars.AB.min}}...` and
+names a group statically on exactly one line. So this change lights up the "By
+name:" reference, not the table. The table needs a surface an inlay hint does not
+have -- a hover with a group-by-group table is the obvious candidate -- and that
+is a separate piece of work, not a wider regex.
+
+## G2. `problem.groups`, and nothing else under `problem`
+
+The scanner's `FOREIGN_SCOPE` rejects the whole `problem.` prefix. The spelling
+that has to be admitted is *inside* it, which is not what the earlier design
+assumed: it listed `groups` among the foreign scopes, as though `\VAR{groups.x}`
+were reachable. It is not. `context.problem_jinja_kwargs` lifts only `vars` to
+the top level; `groups` lives solely inside `problem.namespace()`. The `groups.`
+entry in that list has always been dead for a problem statement, and is kept only
+for the reason the comment there already gives.
+
+So `FOREIGN_SCOPE` stops being a blanket reject and becomes a three-way
+classifier: group, foreign, root -- tried in that order, so
+`problem.groups.sub1.N.max` is claimed before the `problem.` rejection can see
+it, and every *other* `problem.` spelling still falls through to that rejection.
+`problem.title` and `problem.params.x` are answered by a resolved statement,
+which `rbx vars` deliberately never loads, so widening past `problem.groups`
+would badge nothing and cost a spawn per keystroke to learn it.
+
+**Both spellings of the group name.** `fields.NameField` permits
+`^[a-zA-Z0-9][a-zA-Z0-9\-_]*$`, so `sub-1` and `1st` are legal group names that
+Jinja can only reach as `problem.groups['sub-1']`. Supporting only the dotted
+form would quietly unbadge every package that names its groups that way, with
+nothing on screen to say why. `JinjaGroupsGetter` serves both, so both are real
+spellings of the same reference.
+
+**The shorthand needs no model-field check.** `problem.groups.sub1.name`
+resolves to the `TestcaseGroup` field, not to a var, and `GroupView` gives model
+fields precedence. The scanner does not have to know that:
+`RESERVED_STATEMENT_VAR_NAMES` (`rbx/box/fields.py`) already lists every one of
+those fields, so no var can be called `name`/`score`/`validator`, the payload
+lookup misses, and no badge is drawn. The existing invariant does the work.
+
+## G3. The payload gains groups behind an opt-in flag
+
+`rbx vars --json --groups` nests what `--json` used to print flat:
+
+```json
+{"vars": {"AB.max": "200"},
+ "groups": {"sub1": {"AB.max": "10"}, "sub2": {"AB.max": "200"}}}
+```
+
+Values stay display *strings* for D3's reason -- `JSON.parse` yields IEEE
+doubles, and a bound of `` py`10**18 + 7` `` would badge wrong -- and the
+non-finite guard now covers every group's set as well as the root one.
+
+Each group's set is **resolved**, not its raw override block: package vars with
+that group's overrides applied, straight from
+`package.get_expanded_vars_for_group`. That is the same distinction
+`statements.context.GroupView` documents, and for the same reason -- a group that
+overrides nothing would otherwise answer nothing at all, which is precisely the
+silent degradation per-group vars exist to remove.
+
+**Opt-in, not always-on.** An rbx older than this change exits non-zero on the
+unknown option, which is what lets the extension notice and fall back to plain
+`--json` and root-only badges. Folding a `groups` key into the flat map instead
+would have been silently wrong in the other direction: an old rbx would answer
+the flat map, and the extension would read the absence as "this package declares
+no groups".
+
+## G4. `--render` takes the group on the line
+
+A filtered group reference has to render, for the same reason a filtered root one
+does (2026-08-29): the pipeline is what decides what the statement shows. So each
+line of `--render` stdin may name its group ahead of a tab:
+
+```
+AB.max | sci            <- root
+sub1\tAB.max | sci      <- group sub1
+```
+
+A line with no tab is a root expression, so the pre-group protocol is a strict
+subset of this one. Keys come back **verbatim**, group prefix and all, so the
+caller looks its answer up under the line it sent and the extension's render
+cache keys per group for free -- `pendingRenders` needed no new concept.
+
+A tab because a group name cannot hold one (`NameField` allows only word
+characters and dashes) and neither can any expression a scanner extracts, so the
+split needs no quoting.
+
+**An unknown group is dropped, not resolved.** `Package.expanded_vars_for_group`
+falls back to the *package* vars for a name it does not know -- right for a sample
+or a unit test, and exactly wrong here: a statement still naming a renamed group
+would badge the package value under the old name, confidently. `--render` checks
+the name against the declared groups first and reports the miss on stderr, like
+any other drop.
+
+## G5. Failure is still an absent badge
+
+Every new failure mode joins D5's list: an rbx too old for `--groups`, a group
+renamed or deleted, a name absent from that group's set, a malformed group in the
+payload. None of them can draw a wrong number, which is the property the whole
+feature rests on.
+
+One new cost: a package whose manifest cannot be read pays *two* spawns per load
+instead of one, because a non-zero exit is ambiguous between "old rbx" and "bad
+package" and the retry resolves it. Sniffing the error message instead would mean
+parsing a Rich panel whose wrapping depends on the terminal width rbx thinks it
+has. The retry is paid once and then cached like any other answer, until the
+`problem.rbx.yml` watcher drops the entry.
+
+## G6. Testing
+
+Python, over `rbx/testdata/contests/statements_v2_group_vars/A` -- the one
+package in the tree with per-group vars, and already shaped for this: two groups
+each override one leaf of a nested block and must keep its sibling, and a third
+overrides nothing. It covers the nested payload, the inherited leaves, the
+non-finite guard reaching a group, the group-column render, filters over it, the
+`vars.`-prefixed spelling, and the unknown group.
+
+TypeScript, in `statementVars.test.ts`: the dotted form, the shorthand, both
+bracket forms, an inherited name, a filtered reference's wire key, an unknown
+group, a name absent from the group, a model field, and -- still rejected -- `g.`,
+`p.groups.`, `problem.title` and `problem.groups` itself.
+`varsPayload.test.ts` covers the nested shape, an empty `groups`, the refusal of
+a flat payload, and the refusal of a malformed group.

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -384,6 +384,7 @@ rbx vars [OPTIONS]
 | :--- | :--- | :--- | :--- |
 | `--json` | BOOLEAN | Print the vars as a JSON object of dotted keys and string values. | `False` |
 | `--render` | BOOLEAN | Read statement expressions from stdin, one per line, and print a JSON object mapping each to what it renders to. | `False` |
+| `--groups` | BOOLEAN | Also show the resolved vars of each testcase group. Ignored with --render, which takes the group per expression. | `False` |
 | `--target` | [FilterTarget][rbx.box.statements.latex_jinja.FilterTarget] | What the --render expressions are being formatted for. Ignored without --render. | `FilterTarget.TEXT` |
 
 

--- a/docs/setters/variables.md
+++ b/docs/setters/variables.md
@@ -216,6 +216,37 @@ answers to -- is left out of the map instead of guessed at, and named on
 `stderr`. The command still exits 0, so one bad expression does not cost you
 the rest.
 
+A test group may override a variable for its own testcases, and `--groups`
+shows what each group ends up with. Each group's set is the *resolved* one --
+the package values with that group's overrides applied -- so a variable the
+group does not override still appears, holding what it inherits:
+
+```bash
+$ rbx vars --groups
+M.max = 200000
+N.max = 100000
+groups.sub1
+  M.max = 200000
+  N.max = 1000
+```
+
+With `--json` alongside it, the flat map moves under `vars` and the groups
+arrive beside it:
+
+```bash
+$ rbx vars --json --groups
+{"vars": {"N.max": "100000"}, "groups": {"sub1": {"N.max": "1000"}}}
+```
+
+`--render` takes the group per expression instead, ahead of a tab, since one
+run may need to render against several. A line without a tab is a package-level
+expression, and every key comes back exactly as you wrote it:
+
+```bash
+$ printf 'N.max | sci\nsub1\tN.max\n' | rbx vars --render
+{"N.max | sci": "10⁵", "sub1\tN.max": "1000"}
+```
+
 !!! tip "Right there in your statement"
 
     The [VS Code extension](../tools/vscode.md#variables-in-a-statement) reads

--- a/docs/tools/vscode.md
+++ b/docs/tools/vscode.md
@@ -197,16 +197,32 @@ Only the spelling changes. What a filter *decides* is the same in both places,
 so `sci` leaving `250000` as its digits in the PDF leaves it as its digits in
 the hint too.
 
+A reference to a
+[test group's own variables](../setters/statements/context.md#building-a-subtasks-table-from-testgroup-vars)
+is hinted too, as long as it names the group:
+
+```{.latex .no-copy}
+\item In subtask 1, $N \le \VAR{problem.groups.sub1.vars.N.max}$    10
+```
+
+The value is that group's *resolved* set -- the package variables with the
+group's overrides applied -- so a name the group does not override is hinted
+with the value it inherits, exactly as it renders. The shorthand
+`\VAR{problem.groups.sub1.N.max}` is hinted the same way, and a group whose name
+holds a dash is reached the only way {{Jinja2}} can reach it, as
+`\VAR{problem.groups['sub-1'].N.max}`.
+
 A hint is shown only where it can be exactly right, and there are three places
 it deliberately is not:
 
-- **Problem-root references only.** `\VAR{N.max}` and `\VAR{vars.N.max}` are
-  the ones that get a value. A group reference such as `\VAR{g.N.max}` almost
-  always sits inside a `\BLOCK{for g in groups}` loop and renders a different
-  number per group, so a single hint would have to lie or to name a group;
-  `\VAR{p.N.max}`, `\VAR{problem.N.max}` and `\VAR{contest.year}` resolve
-  against variable sets that are not this problem's own. None of them get a
-  hint.
+- **Only a group you name.** A reference like `\VAR{g.N.max}` inside a
+  `\BLOCK{for g in groups}` loop renders a different number per group, so one
+  hint on one line would have to lie or to pick a group; it gets nothing. This
+  is worth knowing because the loop is how a subtasks table is usually written
+  -- the table stays unhinted, while a constraint that names its group does
+  not. `\VAR{p.N.max}`, `\VAR{problem.title}` and `\VAR{contest.year}` resolve
+  against variable sets that are not this problem's own, and get nothing
+  either.
 - **Nothing is ever guessed.** A name no variable answers to, an expression
   that is not a plain dotted name, a commented-out line, an escaped `\\VAR` --
   all get nothing, and neither does a half-typed pipeline like

--- a/rbx/box/cli/commands/vars_cmd.py
+++ b/rbx/box/cli/commands/vars_cmd.py
@@ -16,7 +16,7 @@ statement. See
 import json
 import math
 import sys
-from typing import Annotated, Dict, List
+from typing import Annotated, Any, Dict, List, NamedTuple, Optional
 
 import rich.markup
 import typer
@@ -26,6 +26,14 @@ from rbx.box import fields, package
 from rbx.box.statements import latex_jinja
 
 app = typer.Typer(cls=annotations.AliasGroup)
+
+# What separates a group name from the expression it is to be rendered against,
+# on a line of `--render` stdin. A tab rather than a colon or a space because a
+# group name cannot hold one (`fields.NameField` allows only word characters and
+# dashes) and neither can any expression a scanner extracts, so the split is
+# unambiguous without quoting. A line with no tab is a root expression, which is
+# what keeps the pre-group protocol a strict subset of this one.
+GROUP_SEPARATOR = '\t'
 
 
 @app.command(
@@ -50,6 +58,14 @@ def vars_command(
             'a JSON object mapping each to what it renders to.',
         ),
     ] = False,
+    groups: Annotated[
+        bool,
+        typer.Option(
+            '--groups',
+            help='Also show the resolved vars of each testcase group. '
+            'Ignored with --render, which takes the group per expression.',
+        ),
+    ] = False,
     target: Annotated[
         latex_jinja.FilterTarget,
         typer.Option(
@@ -72,21 +88,80 @@ def vars_command(
 
     expanded = package.find_problem_package_or_die().expanded_vars
     if render:
-        typer.echo(_render_from_stdin(expanded, target))
+        typer.echo(_render_from_stdin(target))
         return
+    group_vars = _group_vars() if groups else None
     if json_output:
-        typer.echo(_dump_json(expanded))
+        typer.echo(_dump_json(expanded, group_vars))
         return
-    for name, value in sorted(expanded.items()):
+    _print_vars(expanded)
+    for group_name, vars in (group_vars or {}).items():
+        console.console.print(
+            f'[status]groups.{rich.markup.escape(group_name)}[/status]'
+        )
+        _print_vars(vars, indent='  ')
+
+
+def _print_vars(vars: fields.Vars, indent: str = '') -> None:
+    for name, value in sorted(vars.items()):
         # Both halves are setter-controlled YAML rendered as markup, so a var
         # named or valued with brackets would otherwise style the output or
         # blow up with a MarkupError.
         escaped_name = rich.markup.escape(name)
         escaped_value = rich.markup.escape(str(value))
-        console.console.print(f'[item]{escaped_name}[/item] = {escaped_value}')
+        console.console.print(f'{indent}[item]{escaped_name}[/item] = {escaped_value}')
 
 
-def _read_expressions() -> List[str]:
+def _declared_group_names() -> List[str]:
+    """The names of the package's top-level testcase groups, in declared order.
+
+    Only top-level groups can carry `vars` (a subgroup name never reaches the
+    validator), so this is the whole set a group reference can name.
+    """
+    return [group.name for group in package.find_problem_package_or_die().testcases]
+
+
+def _group_vars() -> Dict[str, fields.Vars]:
+    """Each group's *resolved* var set: the package vars with its overrides on top.
+
+    Resolved rather than raw, for the reason `statements.context.GroupView`
+    spells out: a subtasks table reads the same name for every group, and a
+    group that overrides nothing would otherwise answer nothing at all.
+    """
+    return {
+        name: package.get_expanded_vars_for_group(name)
+        for name in _declared_group_names()
+    }
+
+
+def _vars_for_group(group: str) -> Optional[fields.Vars]:
+    """The resolved set of `group`, or `None` if no such group is declared.
+
+    The existence check is not a formality. `Package.expanded_vars_for_group`
+    falls back to the *package* vars for a name it does not know -- the right
+    answer for a sample or a unit test, and exactly the wrong one here: a
+    statement still naming a group that has since been renamed would badge the
+    package value under the old name, confidently and wrongly. D5 asks for an
+    absent badge instead.
+    """
+    if group not in _declared_group_names():
+        return None
+    return package.get_expanded_vars_for_group(group)
+
+
+class _Line(NamedTuple):
+    """One line of `--render` stdin, split into the parts it names.
+
+    `raw` is kept because it is the key the caller gets its answer back under:
+    the consumer holds the line it sent, not a re-derived spelling of it.
+    """
+
+    raw: str
+    group: Optional[str]
+    expression: str
+
+
+def _read_expressions() -> List[_Line]:
     """Read the expressions to render off stdin, one per line.
 
     Stdin rather than a repeatable flag: `|` is a quoting trap in every shell,
@@ -97,16 +172,33 @@ def _read_expressions() -> List[str]:
     Reading from a terminal blocks until EOF, which is the usual bargain for a
     filter (`cat`, `jq`); a human poking at it by hand ends the list with
     Ctrl-D.
+
+    A line may name the testcase group to resolve against, ahead of a tab:
+    `sub1\\tAB.max`. Without one it is a package-level expression, which is what
+    every line was before groups were addressable. Deduplication is on the whole
+    line, so the same expression against two groups is two requests -- they are
+    two different questions with two different answers.
     """
-    seen: Dict[str, None] = {}
-    for line in sys.stdin.read().splitlines():
-        expression = line.strip()
-        if expression:
-            seen.setdefault(expression, None)
-    return list(seen)
+    seen: Dict[str, _Line] = {}
+    for raw in sys.stdin.read().splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        group, separator, expression = line.partition(GROUP_SEPARATOR)
+        parsed = (
+            _Line(line, group.strip(), expression.strip())
+            if separator
+            else _Line(line, None, line)
+        )
+        # A line whose expression half is empty (`sub1\t`) names nothing to
+        # render, and passing it on would only cost a Jinja error per keystroke
+        # of a half-typed reference.
+        if parsed.expression:
+            seen.setdefault(line, parsed)
+    return list(seen.values())
 
 
-def _render_from_stdin(expanded: fields.Vars, target: latex_jinja.FilterTarget) -> str:
+def _render_from_stdin(target: latex_jinja.FilterTarget) -> str:
     """Render each expression read from stdin, dropping the ones that fail.
 
     An expression that does not render -- an unknown filter, a bad argument, a
@@ -132,12 +224,35 @@ def _render_from_stdin(expanded: fields.Vars, target: latex_jinja.FilterTarget) 
     # come from a resolved statement, which this command deliberately does not
     # load. So `problem.title` and `params.foo` render to nothing and are
     # dropped. That gap cannot reach a badge: the extension's scanner rejects a
-    # `problem.`/`contest.`/`p.`/`g.`-prefixed expression before it is ever sent.
-    wrapper = latex_jinja.JinjaDictWrapper.from_dict(dict(expanded), wrapper_key='vars')
-    namespace = {**wrapper, 'vars': wrapper}
+    # `problem.`/`contest.`/`p.`-prefixed expression, and every loop-bound `g.`
+    # one, before it is ever sent. A *group* reference does reach here, but it
+    # arrives already split: the group rides on the line and the expression is
+    # the same plain dotted name a root reference sends.
+    #
+    # One namespace per group named on stdin, built on first mention: a
+    # statement usually names two or three groups and the expansion behind each
+    # is cached anyway, so building them all up front would only pay for the
+    # ones no expression asks about.
+    namespaces: Dict[Optional[str], Optional[Dict[str, Any]]] = {}
+
+    def namespace_for(group: Optional[str]) -> Optional[Dict[str, Any]]:
+        if group not in namespaces:
+            namespaces[group] = _make_namespace(group)
+        return namespaces[group]
 
     rendered: Dict[str, str] = {}
-    for expression in _read_expressions():
+    for line in _read_expressions():
+        namespace = namespace_for(line.group)
+        if namespace is None:
+            # Said out loud for the same reason a failed render is: from the
+            # consumer's side a renamed group and a mistyped filter are both
+            # just a badge that never appears.
+            console.stderr_console.print(
+                f'[warning]Could not render[/warning] '
+                f'{rich.markup.escape(line.expression)}[warning]: no testcase '
+                f'group named[/warning] {rich.markup.escape(str(line.group))}[warning].[/warning]'
+            )
+            continue
         try:
             # Wrapped in `\VAR{...}` rather than `{{ ... }}` because an rbxTeX
             # statement holds it that way. This is not universal -- a Markdown
@@ -147,7 +262,9 @@ def _render_from_stdin(expanded: fields.Vars, target: latex_jinja.FilterTarget) 
             # brackets before honouring an end delimiter, so an expression that
             # closes its own brackets (every expression a scanner can extract)
             # lexes identically either way.
-            rendered[expression] = env.from_string(f'\\VAR{{{expression}}}').render(
+            # Keyed by the *raw line*, group prefix and all, because that is
+            # what the caller sent and what it will look the answer up under.
+            rendered[line.raw] = env.from_string(f'\\VAR{{{line.expression}}}').render(
                 **namespace
             )
         except Exception as err:
@@ -157,7 +274,7 @@ def _render_from_stdin(expanded: fields.Vars, target: latex_jinja.FilterTarget) 
             # appears -- and neither leaves a trace to diagnose.
             console.stderr_console.print(
                 f'[warning]Could not render[/warning] '
-                f'{rich.markup.escape(expression)}[warning]:[/warning] '
+                f'{rich.markup.escape(line.raw)}[warning]:[/warning] '
                 f'{type(err).__name__}: {rich.markup.escape(str(err))}'
             )
             continue
@@ -165,7 +282,33 @@ def _render_from_stdin(expanded: fields.Vars, target: latex_jinja.FilterTarget) 
     return json.dumps(rendered, ensure_ascii=False)
 
 
-def _dump_json(expanded: fields.Vars) -> str:
+def _make_namespace(group: Optional[str]) -> Optional[Dict[str, Any]]:
+    """The template namespace an expression for `group` renders against.
+
+    Half of `statements/context._lift`: the vars wrapper bound both under
+    `vars` and lifted to the top level, because `\\VAR{N.max}` is shorthand for
+    `\\VAR{vars.N.max}` and the scanner may send either spelling -- and the same
+    holds inside a group, where `problem.groups.sub1.AB.max` and
+    `problem.groups.sub1.vars.AB.max` are one reference.
+
+    `None` for a group the package does not declare, which the caller reports.
+    """
+    vars = (
+        package.find_problem_package_or_die().expanded_vars
+        if group is None
+        else _vars_for_group(group)
+    )
+    if vars is None:
+        return None
+    wrapper = latex_jinja.JinjaDictWrapper.from_dict(
+        dict(vars), wrapper_key='vars' if group is None else f'groups.{group}.vars'
+    )
+    return {**wrapper, 'vars': wrapper}
+
+
+def _dump_json(
+    expanded: fields.Vars, groups: Optional[Dict[str, fields.Vars]] = None
+) -> str:
     """Serialize the vars as a flat map of dotted name to *display string*.
 
     Every value crosses as a JSON string holding the text the statement would
@@ -185,11 +328,21 @@ def _dump_json(expanded: fields.Vars) -> str:
     `repr`, and a `bool` `True`/`False`. Note that last one is deliberately
     *not* the `1`/`0` of `fields.render_var_on_command_line`: that spelling
     exists for testlib/jngen argument parsing, not for statement display.
+
+    With `groups`, the flat map is nested one level down instead, under `vars`,
+    beside a `groups` map of the same shape per testcase group. A separate shape
+    behind an opt-in flag rather than an extra key on the flat map, so that an
+    rbx too old to know about groups *fails* on the flag instead of answering
+    the root vars to a caller that would read the silence as "this package has
+    no groups".
     """
     offenders = sorted(
-        name
-        for name, value in expanded.items()
-        if isinstance(value, float) and not math.isfinite(value)
+        _offenders(expanded)
+        + [
+            f'groups.{group}.{name}'
+            for group, vars in (groups or {}).items()
+            for name in _offenders(vars)
+        ]
     )
     if offenders:
         # `str(float('inf'))` is a perfectly good JSON string, so this no longer
@@ -205,4 +358,23 @@ def _dump_json(expanded: fields.Vars) -> str:
             f'{rich.markup.escape(detail)}.[/error]'
         )
         raise typer.Exit(1)
-    return json.dumps({name: str(value) for name, value in expanded.items()})
+    if groups is None:
+        return json.dumps(_stringify(expanded))
+    return json.dumps(
+        {
+            'vars': _stringify(expanded),
+            'groups': {group: _stringify(vars) for group, vars in groups.items()},
+        }
+    )
+
+
+def _offenders(vars: fields.Vars) -> List[str]:
+    return sorted(
+        name
+        for name, value in vars.items()
+        if isinstance(value, float) and not math.isfinite(value)
+    )
+
+
+def _stringify(vars: fields.Vars) -> Dict[str, str]:
+    return {name: str(value) for name, value in vars.items()}

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -1102,6 +1102,15 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': 'Also show the resolved vars of each testcase group. Ignored '
+                    'with --render, which takes the group per expression.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--groups'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'What the --render expressions are being formatted for. Ignored '
                     'without --render.',
                     'kind': 'option',

--- a/tests/rbx/box/vars_cmd_test.py
+++ b/tests/rbx/box/vars_cmd_test.py
@@ -262,3 +262,125 @@ def test_render_creates_no_cache_dir(pkg_from_testdata: pathlib.Path):
 
     assert result.exit_code == 0, result.output
     assert not cache.exists()
+
+
+# `contests/statements_v2_group_vars/A` is the one package in `testdata` that
+# declares per-group `vars`, and it is shaped for exactly what the group payload
+# has to get right: two groups each override one leaf of a nested block and must
+# keep its sibling, and a third overrides nothing at all.
+GROUP_VARS_PKG = 'contests/statements_v2_group_vars/A'
+
+
+@pytest.mark.test_pkg(GROUP_VARS_PKG)
+def test_vars_json_groups_dumps_every_groups_resolved_set(
+    pkg_from_testdata: pathlib.Path,
+):
+    """Resolved sets, not the raw override blocks.
+
+    `sub1` overrides only `AB.max`, and its payload must still carry the
+    inherited `AB.min`: the extension badges `\\VAR{problem.groups.sub1.AB.min}`
+    off this map, and a raw override block would leave that reference blank --
+    the silent degradation per-group vars exist to remove.
+    """
+    result = runner.invoke(app, ['vars', '--json', '--groups'])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        'vars': {'AB.min': '1', 'AB.max': '200'},
+        'groups': {
+            'sub1': {'AB.min': '1', 'AB.max': '10'},
+            'sub2': {'AB.min': '100', 'AB.max': '200'},
+            'sub3': {'AB.min': '1', 'AB.max': '200'},
+        },
+    }
+
+
+@pytest.mark.test_pkg(GROUP_VARS_PKG)
+def test_vars_json_without_groups_stays_the_flat_map(pkg_from_testdata: pathlib.Path):
+    """The flag is opt-in so an older rbx fails loudly instead of lying.
+
+    The extension asks with `--groups` and falls back to this shape when the
+    spawn fails, which is how a statement keeps its root badges under an rbx
+    that predates group scope.
+    """
+    result = runner.invoke(app, ['vars', '--json'])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'AB.min': '1', 'AB.max': '200'}
+
+
+@pytest.mark.test_pkg(GROUP_VARS_PKG)
+def test_vars_json_groups_fails_cleanly_on_a_non_finite_group_var(
+    pkg_from_testdata: pathlib.Path,
+):
+    """The non-finite guard has to cover the group sets, not just the root one."""
+    yml = pathlib.Path('problem.rbx.yml')
+    yml.write_text(yml.read_text().replace('max: 10 #', "max: py`float('inf')` #"))
+
+    result = runner.invoke(app, ['vars', '--json', '--groups'])
+
+    assert result.exit_code == 1
+    assert 'AB.max' in _plain(result.output)
+    assert 'sub1' in _plain(result.output)
+
+
+@pytest.mark.test_pkg(GROUP_VARS_PKG)
+def test_vars_groups_prints_a_section_per_group_without_json(
+    pkg_from_testdata: pathlib.Path,
+):
+    output = _plain(runner.invoke(app, ['vars', '--groups']).output)
+
+    assert 'AB.max = 200' in output
+    assert 'sub1' in output
+    assert 'AB.max = 10' in output
+
+
+@pytest.mark.test_pkg(GROUP_VARS_PKG)
+def test_render_evaluates_an_expression_against_a_named_group(
+    pkg_from_testdata: pathlib.Path,
+):
+    """The group rides in on the line, tab-separated, so one spawn still serves
+    a whole statement however many groups it names."""
+    result = runner.invoke(
+        app, ['vars', '--render', '--target', 'text'], input='sub1\tAB.max\nAB.max\n'
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'sub1\tAB.max': '10', 'AB.max': '200'}
+
+
+@pytest.mark.test_pkg(GROUP_VARS_PKG)
+def test_render_applies_filters_to_a_group_expression(pkg_from_testdata: pathlib.Path):
+    result = runner.invoke(
+        app,
+        ['vars', '--render', '--target', 'latex'],
+        input='sub1\tAB.max | sci\n',
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'sub1\tAB.max | sci': '10'}
+
+
+@pytest.mark.test_pkg(GROUP_VARS_PKG)
+def test_render_reaches_the_vars_namespace_of_a_group_too(
+    pkg_from_testdata: pathlib.Path,
+):
+    """`problem.groups.sub1.AB.max` and `...sub1.vars.AB.max` are one reference;
+    the scanner strips the prefix and sends the shorter spelling either way."""
+    result = runner.invoke(app, ['vars', '--render'], input='sub1\tvars.AB.max\n')
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'sub1\tvars.AB.max': '10'}
+
+
+@pytest.mark.test_pkg(GROUP_VARS_PKG)
+def test_render_omits_an_expression_for_a_group_that_does_not_exist(
+    pkg_from_testdata: pathlib.Path,
+):
+    """A renamed group is an absent badge, like every other failure (D5)."""
+    result = runner.invoke(
+        app, ['vars', '--render'], input='nosuchgroup\tAB.max\nAB.max\n'
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {'AB.max': '200'}

--- a/vscode/src/rbx/statementVars.test.ts
+++ b/vscode/src/rbx/statementVars.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { test } from 'node:test';
 
-import { scanStatementVars, Vars } from './statementVars';
+import { scanStatementVars, Vars, VarsPayload } from './statementVars';
 
 /**
  * The foreign-scope keys are deliberately *resolvable*, so that the scope
@@ -32,7 +32,26 @@ const VARS: Vars = {
   'vars.problem.N.max': '7',
 };
 
-const scan = (text: string) => scanStatementVars(text, VARS);
+/**
+ * Two groups whose sets differ from the root one and from each other, plus a
+ * name only reachable through the bracket form.
+ *
+ * `sub1` overrides `N.max` and inherits `A.max`, which is the pairing that
+ * makes a badge worth drawing at all: the extension resolves against the
+ * group's *resolved* set, so the inherited name has to answer here exactly as
+ * the overridden one does.
+ */
+const GROUPS: Readonly<Record<string, Vars>> = {
+  sub1: { 'N.max': '10', 'A.max': '1000000000' },
+  sub2: { 'N.max': '1000', 'A.max': '1000000000' },
+  // A legal group name (`fields.NameField` allows dashes and a leading digit)
+  // that Jinja cannot reach with a dot.
+  'sub-3': { 'N.max': '100000', 'A.max': '1000000000' },
+};
+
+const PAYLOAD: VarsPayload = { vars: VARS, groups: GROUPS };
+
+const scan = (text: string) => scanStatementVars(text, PAYLOAD);
 
 /**
  * The badge texts of a scan, a filtered reference contributing none.
@@ -261,4 +280,83 @@ test('offsets are absolute across lines, and a comment ends at its newline', () 
 test('scanning is repeatable, so no regex state leaks between calls', () => {
   const text = '\\VAR{N.max} \\VAR{A.max}';
   assert.deepStrictEqual(scan(text), scan(text));
+});
+
+test('a statically named group resolves against that group', () => {
+  assert.deepStrictEqual(scan('$N \\le \\VAR{problem.groups.sub1.vars.N.max}$'), [
+    {
+      end: 43,
+      expression: 'sub1\tN.max',
+      filtered: false,
+      group: 'sub1',
+      text: '10',
+    },
+  ]);
+});
+
+test('the group shorthand keys the same as the long form', () => {
+  // `g.N.max` is shorthand for `g.vars.N.max` (#630), and both spellings share
+  // one wire key: rbx resolves them identically, so the shorter one is what
+  // crosses and one render answers both.
+  const shorthand = scan('\\VAR{problem.groups.sub2.N.max}');
+  const longForm = scan('\\VAR{problem.groups.sub2.vars.N.max}');
+  assert.deepStrictEqual(texts('\\VAR{problem.groups.sub2.N.max}'), ['1000']);
+  assert.strictEqual(shorthand[0].expression, 'sub2\tN.max');
+  assert.strictEqual(longForm[0].expression, 'sub2\tN.max');
+});
+
+test('a group reaches its inherited names, not only its overrides', () => {
+  // The payload carries each group's *resolved* set, so a name no group
+  // overrides badges the package value rather than nothing at all.
+  assert.deepStrictEqual(texts('\\VAR{problem.groups.sub1.A.max}'), ['1000000000']);
+});
+
+test('the bracket form reaches a group a dot cannot', () => {
+  // `sub-3` is a legal group name and `problem.groups.sub-3.N.max` is not a
+  // Jinja expression, so the quoted form is the only spelling a statement can
+  // use -- and dropping it would silently unbadge whole packages.
+  assert.deepStrictEqual(texts("\\VAR{problem.groups['sub-3'].vars.N.max}"), ['100000']);
+  assert.deepStrictEqual(texts('\\VAR{problem.groups["sub-3"].N.max}'), ['100000']);
+});
+
+test('a filtered group reference carries the group on its wire key', () => {
+  assert.deepStrictEqual(
+    scan('\\VAR{problem.groups.sub1.N.max | sci}').map((hint) => hint.expression),
+    ['sub1\tN.max | sci'],
+  );
+});
+
+test('a group the payload does not hold is left alone', () => {
+  // A renamed or deleted group. The badge would otherwise have to come from
+  // the root set, which is the wrong number under the old name.
+  assert.deepStrictEqual(scan('\\VAR{problem.groups.nosuch.N.max}'), []);
+});
+
+test('a name absent from a group is left alone', () => {
+  // `flag` is a root var and no group carries it; the group scope answers only
+  // out of its own resolved set.
+  assert.deepStrictEqual(scan('\\VAR{problem.groups.sub1.flag}'), []);
+});
+
+test('a group model field is left alone', () => {
+  // `problem.groups.sub1.name` is the *model* field, and `GroupView` gives it
+  // precedence over the var shorthand. No var can be called `name`
+  // (RESERVED_STATEMENT_VAR_NAMES), so the lookup misses and nothing is drawn.
+  assert.deepStrictEqual(scan('\\VAR{problem.groups.sub1.name}'), []);
+});
+
+test('the rest of the problem scope stays foreign', () => {
+  // Only `problem.groups.<name>` is admitted: everything else under `problem`
+  // is answered by a resolved statement, which `rbx vars` deliberately never
+  // loads.
+  for (const expression of [
+    'problem.title',
+    'problem.params.foo',
+    'problem.groups',
+    'problem.groups.sub1',
+    'p.groups.sub1.N.max',
+    'g.N.max',
+  ]) {
+    assert.deepStrictEqual(scan(`\\VAR{${expression}}`), [], expression);
+  }
 });

--- a/vscode/src/rbx/statementVars.ts
+++ b/vscode/src/rbx/statementVars.ts
@@ -3,14 +3,23 @@
  *
  * Pure: no `vscode` import, so `node --test` covers it directly.
  *
- * Only *problem-root* references are badged -- `\VAR{N.max}` and
- * `\VAR{vars.N.max}`. A group reference (`\VAR{g.N.max}`) renders a different
- * value per loop iteration, so a single badge would have to lie or to name the
- * group; contest and problem scopes resolve against var sets this map does not
- * hold. Every one of those, and every expression that is not a plain dotted
- * name, yields no hint: an absent badge is never wrong.
+ * Two scopes are badged, and both resolve to exactly one value:
  *
- * See docs/plans/2026-08-28-vscode-statement-var-hints-design.md (D1).
+ * - *problem-root* references -- `\VAR{N.max}` and `\VAR{vars.N.max}`.
+ * - a *statically named group* -- `\VAR{problem.groups.sub1.vars.N.max}`, its
+ *   `vars`-less shorthand, and the `problem.groups['sub-1']` form that a group
+ *   name holding a dash can only be reached through.
+ *
+ * A *loop-bound* group reference (`\VAR{g.N.max}` inside `\BLOCK{for g in
+ * groups}`) is still not badged, and that is the standing limit rather than an
+ * oversight: one source position renders a different value per iteration, so a
+ * single badge would have to lie, name a group, or list several. Contest and
+ * the rest of the problem scope resolve against var sets this map does not hold.
+ * Every one of those, and every expression that is not a plain dotted name,
+ * yields no hint: an absent badge is never wrong.
+ *
+ * See docs/plans/2026-08-28-vscode-statement-var-hints-design.md (D1) and
+ * docs/plans/2026-08-31-vscode-group-var-hints-design.md.
  */
 
 /**
@@ -24,15 +33,45 @@
  */
 export type Vars = Readonly<Record<string, string>>;
 
+/**
+ * Everything `rbx vars --json --groups` knows about one package.
+ *
+ * `groups` holds each testcase group's **resolved** set -- the package vars
+ * with that group's overrides applied -- not its raw override block. That is
+ * the whole point of asking rbx for it: a subtasks table reads the same name
+ * for every group, and a group that overrides nothing would answer nothing at
+ * all under the raw block. See `statements/context.GroupView`.
+ *
+ * An rbx too old to know the flag leaves `groups` empty, and every group
+ * reference then simply goes unbadged.
+ */
+export interface VarsPayload {
+  readonly vars: Vars;
+  readonly groups: Readonly<Record<string, Vars>>;
+}
+
 interface VarReference {
   /** Offset just past the reference's closing brace. */
   readonly end: number;
+  /**
+   * The testcase group this reference resolves against, absent for a root one.
+   *
+   * Carried for legibility rather than for lookup -- `expression` already
+   * spells it -- and so a consumer can tell the two scopes apart without
+   * re-parsing a wire key.
+   */
+  readonly group?: string;
   /**
    * The canonical expression this reference asks for, ready to hand to
    * `rbx vars --render`. Stripped of any `vars.` prefix, respaced around each
    * pipe, and guaranteed to hold no newline -- it crosses to rbx as one line
    * of stdin and comes back as a key, so a newline in it would be a request
    * nothing could answer.
+   *
+   * A group reference is prefixed with its group and a tab
+   * (`sub1\tN.max | sci`), which is the line protocol `rbx vars --render`
+   * reads. So this doubles as the render cache key, and the same name under
+   * two groups keys twice -- two questions with two answers.
    *
    * Two spellings that differ only in the spacing around a pipe are therefore
    * one cache key -- *except* where the pipeline holds a quote, which
@@ -92,6 +131,58 @@ export type VarHint = ResolvedVarHint | FilteredVarHint;
  *   badge is never wrong.
  */
 const FOREIGN_SCOPE = /^(vars\.)?(g|p|problem|contest|groups)\./;
+
+/**
+ * A reference into one statically named testcase group, and the rest of it.
+ *
+ * Tried *before* `FOREIGN_SCOPE`, which claims the whole `problem.` prefix:
+ * this is the one corner of that scope whose values the payload holds, and the
+ * relaxation is deliberately this narrow. `problem.title` and `problem.params.x`
+ * come from a resolved statement, which `rbx vars` never loads.
+ *
+ * Anchored on `problem.groups` and nothing shorter, because a problem statement
+ * has no top-level `groups`: `context.problem_jinja_kwargs` lifts only `vars`,
+ * and `groups` lives solely inside `problem.namespace()`.
+ *
+ * Both spellings, because the dotted one is not always available.
+ * `fields.NameField` permits `^[a-zA-Z0-9][a-zA-Z0-9\-_]*$`, so `sub-1` and
+ * `1st` are legal group names that Jinja can only reach as
+ * `problem.groups['sub-1']` -- supporting only the dot would quietly unbadge
+ * every package that names its groups that way. `JinjaGroupsGetter` serves
+ * both, so both are real.
+ *
+ * The quote is backreferenced so `'x"` is not read as a name, and the name
+ * itself is matched against the same character class rbx enforces rather than
+ * `[^'"]*`: a payload lookup would turn away anything else anyway, and keeping
+ * the class here means the regex says what a group name *is*.
+ */
+const GROUP_REFERENCE =
+  /^problem\.groups(?:\.([A-Za-z0-9][\w-]*)|\[\s*(['"])([A-Za-z0-9][\w-]*)\2\s*\])\.([^]*)$/;
+
+/** A reference split into the scope it names and the expression within it. */
+interface ScopedReference {
+  /** Absent for a root reference. */
+  readonly group?: string;
+  /** What follows the scope: a dotted name and an optional filter pipeline. */
+  readonly rest: string;
+}
+
+/**
+ * Which var set `inner` asks about, or `undefined` for a scope with no answer.
+ *
+ * Group first, then the foreign-scope guard, then root. The order is what makes
+ * the narrow relaxation safe: `problem.groups.sub1.N.max` is claimed here
+ * before `FOREIGN_SCOPE` can reject it for its `problem.` prefix, and every
+ * other `problem.` spelling still falls through to that rejection.
+ */
+function classify(inner: string): ScopedReference | undefined {
+  const grouped = GROUP_REFERENCE.exec(inner);
+  if (grouped) {
+    // One of the two name groups matched; the other is undefined.
+    return { group: grouped[1] ?? grouped[3], rest: grouped[4] };
+  }
+  return FOREIGN_SCOPE.test(inner) ? undefined : { rest: inner };
+}
 
 /**
  * A plain dotted name, and the filter pipeline it is piped through, if any.
@@ -162,6 +253,15 @@ function isEscaped(text: string, offset: number): boolean {
   return backslashesBefore(text, offset) % 2 === 1;
 }
 
+/** The resolved set of `group`, or `undefined` if the payload has no such group. */
+function varsForGroup(payload: VarsPayload, group: string): Vars | undefined {
+  // Own-property only, for the reason `lookup` gives: a group cannot be named
+  // `constructor` (`fields.NameField` would allow it, but the payload is built
+  // from the declared groups), and reading one off `Object.prototype` would be
+  // a var set that is not a var set.
+  return Object.hasOwn(payload.groups, group) ? payload.groups[group] : undefined;
+}
+
 /** The value `name` holds, or `undefined` if the map does not hold it. */
 function lookup(vars: Vars, name: string): string | undefined {
   // Own-property only: a name like `constructor` or `toString` is a typo, not
@@ -215,7 +315,7 @@ function canonicalize(name: string, pipeline: string | undefined): string | unde
   return expression.includes('\n') ? undefined : expression;
 }
 
-export function scanStatementVars(text: string, vars: Vars): VarHint[] {
+export function scanStatementVars(text: string, payload: VarsPayload): VarHint[] {
   const hints: VarHint[] = [];
   // A fresh regex per scan: a `/g` one carries `lastIndex` between calls, so
   // sharing the constant would leak where the previous scan stopped.
@@ -228,11 +328,22 @@ export function scanStatementVars(text: string, vars: Vars): VarHint[] {
     }
 
     const inner = match[1].trim();
-    if (FOREIGN_SCOPE.test(inner)) {
+    const scoped = classify(inner);
+    if (scoped === undefined) {
       continue;
     }
 
-    const parsed = REFERENCE.exec(inner);
+    // A group the payload does not hold -- renamed, deleted, or one an rbx too
+    // old for `--groups` never reported. Resolving it against the root set
+    // instead would badge the package value under a group that no longer
+    // carries it, which is precisely the confident lie D5 forbids.
+    const vars =
+      scoped.group === undefined ? payload.vars : varsForGroup(payload, scoped.group);
+    if (vars === undefined) {
+      continue;
+    }
+
+    const parsed = REFERENCE.exec(scoped.rest.trim());
     if (!parsed) {
       continue;
     }
@@ -258,16 +369,22 @@ export function scanStatementVars(text: string, vars: Vars): VarHint[] {
     // A pipeline `canonicalize` refuses yields no hint at all, rather than a
     // bare-name hint: the badge would then show the unfiltered value, which is
     // the very lie this scanner reports the pipeline to avoid.
-    const expression = canonicalize(name, pipeline);
-    if (expression === undefined) {
+    const canonical = canonicalize(name, pipeline);
+    if (canonical === undefined) {
       continue;
     }
+    // The wire key, which is also the line `rbx vars --render` reads. A root
+    // reference keeps the bare expression, so the protocol from before groups
+    // were addressable is exactly the subset it was.
+    const expression =
+      scoped.group === undefined ? canonical : `${scoped.group}\t${canonical}`;
+    const scope = scoped.group === undefined ? {} : { group: scoped.group };
 
     const end = start + match[0].length;
     hints.push(
       pipeline === undefined
-        ? { end, expression, filtered: false, text: value }
-        : { end, expression, filtered: true },
+        ? { end, ...scope, expression, filtered: false, text: value }
+        : { end, ...scope, expression, filtered: true },
     );
   }
 

--- a/vscode/src/rbx/varsPayload.test.ts
+++ b/vscode/src/rbx/varsPayload.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { test } from 'node:test';
 
-import { parseVarsPayload } from './varsPayload';
+import { parseVarsPayload, parseVarsWithGroups } from './varsPayload';
 
 test('a flat map of display strings is accepted', () => {
   assert.deepStrictEqual(parseVarsPayload('{"N.max": "100000", "flag": "True"}'), {
@@ -88,6 +88,38 @@ test('the render map is read by this same parser', () => {
   assert.deepStrictEqual(
     parseVarsPayload('{"N.max | sci": "10⁵", "M.max | rsci": "2×10⁹ + 7"}'),
     { 'N.max | sci': '10⁵', 'M.max | rsci': '2×10⁹ + 7' },
+  );
+});
+
+test('the grouped payload carries the root set and one set per group', () => {
+  assert.deepStrictEqual(
+    parseVarsWithGroups(
+      '{"vars": {"N.max": "100000"}, "groups": {"sub1": {"N.max": "10"}}}',
+    ),
+    { vars: { 'N.max': '100000' }, groups: { sub1: { 'N.max': '10' } } },
+  );
+});
+
+test('a package with no groups is a grouped payload with none', () => {
+  assert.deepStrictEqual(parseVarsWithGroups('{"vars": {"N.max": "5"}, "groups": {}}'), {
+    vars: { 'N.max': '5' },
+    groups: {},
+  });
+});
+
+test('the flat payload is not a grouped one', () => {
+  // What an rbx too old for `--groups` prints when the flag is dropped. Reading
+  // it as a grouped payload would leave every group silently empty, so it is
+  // refused and the caller falls back to the flat reader deliberately.
+  assert.strictEqual(parseVarsWithGroups('{"N.max": "100000"}'), undefined);
+});
+
+test('a group whose set is not a map of strings is refused whole', () => {
+  // Same rule as the flat parser: a shape mismatch ends the read rather than
+  // yielding a half-trusted payload.
+  assert.strictEqual(
+    parseVarsWithGroups('{"vars": {"N.max": "5"}, "groups": {"sub1": {"N.max": 10}}}'),
+    undefined,
   );
 });
 

--- a/vscode/src/rbx/varsPayload.ts
+++ b/vscode/src/rbx/varsPayload.ts
@@ -6,7 +6,7 @@
  *
  * Pure: no `vscode` import, so `node --test` covers it directly.
  */
-import { Vars } from './statementVars';
+import { Vars, VarsPayload } from './statementVars';
 
 /**
  * The payload's own text, with whatever printed before it dropped.
@@ -48,17 +48,18 @@ function parseLeadingObject(raw: string): unknown {
   return undefined;
 }
 
-export function parseVarsPayload(stdout: string): Vars | undefined {
-  const parsed = parseLeadingObject(stdout);
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+/** Whether `value` is a plain object, the shape every payload here is built of. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** A flat map of strings, or `undefined` if `value` is not one. */
+function readVars(value: unknown): Vars | undefined {
+  if (!isRecord(value)) {
     return undefined;
   }
-
-  // Deliberately out here, not inside `parseLeadingObject`'s loop: a shape
-  // mismatch must end the read, not resume the scan. Retrying from the next
-  // brace would step *into* `{"a": {"b": "1"}}` and accept the inner map.
-  const entries = Object.entries(parsed as Record<string, unknown>);
-  if (!entries.every(([, value]) => typeof value === 'string')) {
+  const entries = Object.entries(value);
+  if (!entries.every(([, entry]) => typeof entry === 'string')) {
     return undefined;
   }
   // `fromEntries` *defines* each key, so a var named `__proto__` lands as an
@@ -66,4 +67,48 @@ export function parseVarsPayload(stdout: string): Vars | undefined {
   // result's prototype is left alone. `statementVars.ts` looks names up with
   // `Object.hasOwn`, so that is exactly what it needs to find.
   return Object.fromEntries(entries) as Vars;
+}
+
+export function parseVarsPayload(stdout: string): Vars | undefined {
+  // Deliberately out here, not inside `parseLeadingObject`'s loop: a shape
+  // mismatch must end the read, not resume the scan. Retrying from the next
+  // brace would step *into* `{"a": {"b": "1"}}` and accept the inner map.
+  return readVars(parseLeadingObject(stdout));
+}
+
+/**
+ * Read what `rbx vars --json --groups` printed: the root set plus one per group.
+ *
+ * A separate reader rather than a tolerant `parseVarsPayload`, and it refuses
+ * the flat shape outright. The two payloads are answers to two different
+ * questions, and quietly reading a flat one as "a package with no groups" would
+ * turn an rbx that dropped the flag into a package whose groups all silently
+ * vanished. The caller falls back to the flat reader on purpose, having decided
+ * that is what happened -- it does not discover it here.
+ */
+export function parseVarsWithGroups(stdout: string): VarsPayload | undefined {
+  const parsed = parseLeadingObject(stdout);
+  if (!isRecord(parsed) || !isRecord(parsed.groups)) {
+    return undefined;
+  }
+  const vars = readVars(parsed.vars);
+  if (vars === undefined) {
+    return undefined;
+  }
+
+  const named: [string, Vars][] = [];
+  for (const [name, value] of Object.entries(parsed.groups)) {
+    const groupVars = readVars(value);
+    // One malformed group fails the whole payload rather than being dropped:
+    // a dropped group is indistinguishable from a group that does not exist,
+    // and the scanner would then leave its references unbadged forever without
+    // anything saying why.
+    if (groupVars === undefined) {
+      return undefined;
+    }
+    named.push([name, groupVars]);
+  }
+  // `fromEntries` for the same reason `readVars` uses it -- keys are defined,
+  // never assigned through a prototype setter.
+  return { vars, groups: Object.fromEntries(named) };
 }

--- a/vscode/src/statementVarHints.ts
+++ b/vscode/src/statementVarHints.ts
@@ -60,8 +60,8 @@ export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
     // and answers `undefined` -- so there is nothing here to guard against.
     // It is also the only suspension point, and a cold package waits on a
     // process spawn behind it, which is time enough to be cancelled twice.
-    const vars = await this.vars.varsFor(declared.root);
-    if (vars === undefined || token.isCancellationRequested) {
+    const payload = await this.vars.varsFor(declared.root);
+    if (payload === undefined || token.isCancellationRequested) {
       return [];
     }
 
@@ -71,7 +71,7 @@ export class StatementVarHintsProvider implements vscode.InlayHintsProvider {
     // edge, and offsets from a slice would all need shifting back. A statement
     // is a few kilobytes of prose, so the scan is not worth optimizing -- but a
     // pathologically large one would pay for it on every keystroke.
-    const scanned = scanStatementVars(document.getText(), vars);
+    const scanned = scanStatementVars(document.getText(), payload);
     // The index's map itself, which a batch settling later writes into. The
     // loop below never suspends, so every hint in one pass is still drawn
     // against the same contents.

--- a/vscode/src/statementVarsIndex.ts
+++ b/vscode/src/statementVarsIndex.ts
@@ -20,8 +20,8 @@
 import * as vscode from 'vscode';
 
 import { log } from './log';
-import { Vars } from './rbx/statementVars';
-import { parseVarsPayload } from './rbx/varsPayload';
+import { VarsPayload } from './rbx/statementVars';
+import { parseVarsPayload, parseVarsWithGroups } from './rbx/varsPayload';
 import { resolveRbx, run } from './rbxProcess';
 
 /**
@@ -87,7 +87,7 @@ export class StatementVarsIndex {
    * makes `invalidate` during a spawn safe: the stale promise has no way to
    * overwrite the entry a later miss put there. Its result is simply dropped.
    */
-  private readonly index = new Map<string, Promise<Vars | undefined>>();
+  private readonly index = new Map<string, Promise<VarsPayload | undefined>>();
 
   /**
    * What each root's filtered expressions render to.
@@ -101,7 +101,7 @@ export class StatementVarsIndex {
   private readonly renders = new Map<string, RootRenders>();
 
   /** The vars of the package at `root`, or `undefined` if rbx could not say. */
-  varsFor(root: string): Promise<Vars | undefined> {
+  varsFor(root: string): Promise<VarsPayload | undefined> {
     const cached = this.index.get(root);
     if (cached !== undefined) {
       return cached;
@@ -271,7 +271,7 @@ export class StatementVarsIndex {
     }
   }
 
-  private async load(root: string): Promise<Vars | undefined> {
+  private async load(root: string): Promise<VarsPayload | undefined> {
     // The whole body, because a *rejection* is the one failure mode that is
     // not an absent badge: it would be cached like any other answer, re-thrown
     // into every later hint request for this root, and -- because the promise
@@ -286,32 +286,65 @@ export class StatementVarsIndex {
         return undefined;
       }
 
-      const result = await run(rbx, ['vars', '--json'], root, VARS_TIMEOUT_MS);
+      const grouped = await run(
+        rbx,
+        ['vars', '--json', '--groups'],
+        root,
+        VARS_TIMEOUT_MS,
+      );
       // Split from the exit code below because `run` spells both failures with
       // a null code, and a process that never started wrote no stderr either:
       // the error is the only thing that says what happened.
-      if (result.spawnError !== undefined) {
-        log(`Could not start rbx in ${root}: ${result.spawnError.message}`);
+      if (grouped.spawnError !== undefined) {
+        log(`Could not start rbx in ${root}: ${grouped.spawnError.message}`);
         return undefined;
       }
-      if (result.code !== 0) {
-        // A bad package is the common case here -- `rbx vars` exits non-zero
-        // on one -- and it is the setter's own half-typed manifest, not a bug
-        // to report. A null code that reaches here is the timeout, which `run`
-        // reports in the stderr it hands back.
+      if (grouped.code === 0) {
+        const payload = parseVarsWithGroups(grouped.stdout);
+        if (payload === undefined) {
+          log(`Could not read the vars rbx printed for ${root}.`);
+          return undefined;
+        }
+        return payload;
+      }
+      // A non-zero exit is *either* an rbx too old to know `--groups` (which
+      // exits 2 on the unknown option) or a package that could not be read at
+      // all -- a half-typed manifest, the common case. Retrying without the
+      // flag rather than sniffing the message, because the message is a Rich
+      // panel whose wrapping depends on the terminal width rbx thinks it has,
+      // and reading the wrong half of it would cost every badge in the package.
+      // The retry costs one extra spawn per broken manifest, once, since the
+      // answer -- `undefined` included -- is cached until the watcher fires.
+      log(
+        `rbx vars --groups failed in ${root} (exit ${grouped.code ?? 'none'}): ` +
+          grouped.stderr.trim(),
+      );
+
+      const flat = await run(rbx, ['vars', '--json'], root, VARS_TIMEOUT_MS);
+      if (flat.spawnError !== undefined) {
+        log(`Could not start rbx in ${root}: ${flat.spawnError.message}`);
+        return undefined;
+      }
+      if (flat.code !== 0) {
+        // Both spawns failed, so this is the package rather than the flag. A
+        // null code that reaches here is the timeout, which `run` reports in
+        // the stderr it hands back.
         log(
-          `rbx vars failed in ${root} (exit ${result.code ?? 'none'}): ` +
-            result.stderr.trim(),
+          `rbx vars failed in ${root} (exit ${flat.code ?? 'none'}): ` +
+            flat.stderr.trim(),
         );
         return undefined;
       }
 
-      const vars = parseVarsPayload(result.stdout);
+      const vars = parseVarsPayload(flat.stdout);
       if (vars === undefined) {
         log(`Could not read the vars rbx printed for ${root}.`);
         return undefined;
       }
-      return vars;
+      // An rbx that cannot report groups leaves every group reference
+      // unbadged, which is exactly what this extension did before it could ask.
+      log(`rbx in ${root} does not support --groups; group var hints are off there.`);
+      return { vars, groups: {} };
     } catch (error) {
       log(`Asking rbx for the vars of ${root} threw: ${String(error)}`);
       return undefined;


### PR DESCRIPTION
Extends #803. Inline statement var hints now badge a reference into a **statically named** test group, not only a problem-root one.

```latex
\item In subtask 1, $N \le \VAR{problem.groups.sub1.vars.N.max}$    10
```

Three spellings are admitted, all with exactly one value: the long form above, the `GroupView` shorthand (`problem.groups.sub1.N.max`, #630), and `problem.groups['sub-1'].N.max` — the only spelling Jinja can use for a group name holding a dash, which `fields.NameField` permits.

## Why it isn't just a wider regex

The scanner's `FOREIGN_SCOPE` rejected the whole `problem.` prefix, and the spelling we need is inside it. It is *not* reachable as a bare `groups.`: `context.problem_jinja_kwargs` lifts only `vars` to the top level, so `groups` lives solely inside `problem.namespace()` — the `groups` entry in that reject list has always been dead for a problem statement. So the guard becomes a three-way classifier (group → foreign → root), and the relaxation is exactly `problem.groups.<name>`; `problem.title` and `problem.params.x` come from a resolved statement, which `rbx vars` deliberately never loads.

The shorthand needs no model-field check: `problem.groups.sub1.name` is the `TestcaseGroup` field, and `RESERVED_STATEMENT_VAR_NAMES` already forbids a var named after any of them, so the payload lookup misses and nothing is drawn.

## Standing limit

A **loop-bound** `\VAR{g.vars.N.max}` inside `\BLOCK{for g in groups}` still gets no badge — one source position renders a different value per iteration. That is the common spelling of a subtasks table, so this lights up a constraint that names its group, not the table. A hover with a per-group table is the surface that would fix that, and it is separate work.

## CLI

- `rbx vars --json --groups` nests the flat map under `vars` and adds each group's **resolved** set (package vars + that group's overrides) beside it. Opt-in so an older rbx fails on the flag instead of answering a flat map the extension would read as "this package has no groups"; the extension retries without it and falls back to root-only badges.
- `rbx vars --render` takes the group ahead of a tab per line (`sub1\tN.max | sci`), keys answers back verbatim, and so keeps one spawn per statement. A line with no tab is a root expression, making the old protocol a strict subset.
- An unknown group is **dropped, not resolved**: `Package.expanded_vars_for_group` falls back to the package vars for a name it does not know, which would badge a renamed group with a value it does not carry.

## Verification

- `tests/rbx/box/vars_cmd_test.py`: 24 pass, 8 new over `rbx/testdata/contests/statements_v2_group_vars/A` (nested payload, inherited leaves, non-finite guard reaching a group, group-column render, filters, `vars.` spelling, unknown group).
- Extension: 537 pass, 0 fail; `tsc --noEmit` clean. `npm run lint` could not run — no `eslint` binary in this environment.
- `tests/rbx/box/completion` + `lazy_cli_test` + `statements`: 1845 pass, 1 skipped.
- End-to-end: `rbx vars --json --groups` in the fixture emits exactly the shape `parseVarsWithGroups` accepts.

Design: `docs/plans/2026-08-31-vscode-group-var-hints-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcoZpvRnNCAmE8FYS9jodd