### PR TITLE
feat(issues): add `rbx issues` and `rbx contest issues`

### DIFF
--- a/docs/plans/2026-08-31-issues-view-design.md
+++ b/docs/plans/2026-08-31-issues-view-design.md
@@ -1,0 +1,267 @@
+# `rbx issues`: a run-issues view for problems and contests
+
+Tracked by [#792](https://github.com/rsalesc/rbx/issues/792).
+
+## The problem
+
+After `rbx run` finishes, telling whether the problem is in a good state is
+harder than it should be. Did every solution meet its expectation? Was anything
+merely borderline? Did something compile with warnings? The answers are spread
+across a solution table, an issue tree, and a few warnings printed at various
+points during the run, and none of them survive the process. Ask the same
+question five minutes later and the only way to get an answer is to run again.
+
+At contest level it is worse: the state of ten problems lives in ten separate
+`.rbx/runs` directories, and the only way to see them together is `rbx each`.
+
+## What already exists
+
+Most of the facts are already on disk. `.rbx/runs/` holds:
+
+- `report.yml` (`rbx/box/run_report.py`) -- per solution: `status`,
+  `matchesExpectation`, `pooledMatchesExpectation`, `failedGroups`, `score` and
+  `expectedScore`, `maxTime`/`maxMemory`, `runUnderDoubleTl`,
+  `doubleTlVerdicts`, `unexpectedNoTleVerdicts`, `sanitizerWarnings`, plus the
+  same per group.
+- `skeleton.yml` -- solutions, groups, limits, the run's `verification` level
+  and its `sanitized` / `only_accepted` flags, and `compilation`
+  (`rbx/box/compilation_findings.py`): every solution that failed to compile or
+  compiled with warnings, with parsed warnings and a log path.
+- `compilation/N.log`, the `.eval` / `.out` / `.err` artifacts.
+
+What is *not* on disk is the accumulation of issues themselves.
+`rbx/box/sanitizers/issue_stack.py` is a contextvar stack of `Issue` objects
+rendered straight to a Rich tree at process exit, and
+`rbx/box/sanitizers/warning_stack.py` is a second, unrelated accumulator for
+compiler, sanitizer and linter output.
+
+## Decisions
+
+### `rbx issues`, alongside `rbx summary`
+
+`rbx summary` already exists and answers a different question -- what this
+problem *is*: limits, test counts, solutions bucketed by their *declared*
+outcome. It stays exactly as it is.
+
+The new command answers what the last *run* revealed:
+
+```
+rbx summary   -> what this problem IS
+rbx issues    -> what the last RUN revealed
+```
+
+with `rbx contest issues` as the contest-level aggregate.
+
+### Issues are derived, not persisted
+
+`rbx issues` is a registry of pure detector functions run over the artifacts
+already in `.rbx/runs`. There is no new file to write, no write path to get
+wrong, and no second copy of the truth to drift.
+
+This was the main fork. The alternative -- having commands append structured
+issue records to an `issues.yml` -- buys coverage of the few producers that have
+no on-disk source (linter warnings, statement build failures) at the cost of a
+persisted artifact whose staleness has to be reasoned about per producer. Those
+producers are deferred instead; see *Deferred* below.
+
+Widening `report.yml` with an `issues:` list was also rejected: that file is
+deliberately lean and structured-not-rendered, and it is cleared on every new
+run, so anything not produced by `rbx run` would keep vanishing from it.
+
+### `rbx run` re-reads from disk
+
+The post-run render does not pass in-memory objects to the detectors. By the
+time a run ends, `RunReportWriter` has already written the complete file; the
+file is a few KB. Re-reading it makes it structurally impossible for the
+post-run view and a later `rbx issues` to disagree -- the same anti-drift
+argument `run_report.py` makes for the facts it publishes.
+
+### The VS Code extension shells out
+
+Detectors are Python. If the extension re-derived them it would reintroduce
+exactly the cross-language drift `run_report.py` exists to prevent. So
+`rbx issues --format json` is a versioned output contract
+(`ISSUES_FORMAT_VERSION`) and the extension renders that. One implementation of
+the logic, and the CLI and the extension cannot disagree because they are the
+same code path.
+
+### No freshness verdict
+
+A contest row shows *when* the problem last ran ("4m ago", "3d ago", "never")
+and nothing more. Deriving a stale/fresh verdict -- whether by mtime heuristics
+or by asking the build cache -- was considered and dropped: a wrong verdict on
+that is worse than no verdict, and the timestamp is enough for the reader to
+judge.
+
+## Architecture
+
+```
+.rbx/runs/skeleton.yml --+
+.rbx/runs/report.yml   --+--> load_run_state() -> RunState -> DETECTORS -> List[Issue]
+.rbx/runs/compilation/ --+                                                     |
+                                            +----------------+----------------+
+                                            |                |                |
+                                     render_compact   render_detailed       to_json
+                                            |                |                |
+                                     rbx run /          rbx issues -d      VS Code
+                                     rbx issues
+```
+
+### Layout
+
+```
+rbx/box/issues/
+  __init__.py     public API only: load_run_state, detect_all, Issue, IssueSeverity
+  schema.py       Issue discriminated union, IssueSeverity, ISSUES_FORMAT_VERSION
+  run_state.py    RunState + load_run_state()
+  detectors.py    the pure detector functions + the DETECTORS registry
+  rendering.py    render_compact / render_detailed / render_contest_table / to_json
+```
+
+`run_state.py` rather than `state.py`: `rbx/box/state.py` already exists, and
+with absolute imports mandatory the two would read confusingly side by side.
+
+Callers -- `rbx/box/cli/commands/issues.py`, `rbx/box/contest/main.py`, and the
+post-run hook in `rbx/box/solutions.py` -- import from `rbx.box.issues` and
+never reach into a submodule.
+
+### The issue model
+
+Following `run_report.py`'s structured-not-rendered rule: the model carries
+fields, never prerendered strings. Wording belongs to the renderer, and a client
+with a different surface may reasonably word it differently.
+
+```python
+ISSUES_FORMAT_VERSION = 1
+
+class IssueSeverity(str, Enum):
+    ERROR = 'error'
+    WARNING = 'warning'
+
+class UnmetExpectationIssue(BaseModel):
+    kind: Literal['unmet_expectation'] = 'unmet_expectation'
+    solution: str
+    expected: ExpectedOutcome
+    got: Optional[Outcome]
+    status: str                     # SolutionOutcomeStatus value
+    failedGroups: List[str] = []
+    pooledMatchesExpectation: bool  # so the renderer never accuses an expectation that held
+
+class UnexpectedScoreIssue      -> solution, score, expectedScore
+class CompilationFailedIssue    -> solution, reason, log
+class CompilationWarningsIssue  -> solution, warnings, log
+class BorderlineTleIssue        -> solution, groups, doubleTlVerdicts
+class HiddenVerdictIssue        -> solution, groups, unexpectedNoTleVerdicts
+class UntunedLimitsIssue        -> affectedSolutions
+
+Issue = Annotated[Union[...], Field(discriminator='kind')]
+```
+
+Severity is a property of the kind rather than a stored field. Errors:
+unmet expectation, unexpected score, compilation failed. Warnings: the rest.
+
+`pooledMatchesExpectation` is carried for the reason `run_report.py` publishes
+it: a solution declaring `outcome: incorrect` with an `outcomePerGroup` can fail
+only the per-group layer, and saying "expected INCORRECT, got WA" there accuses
+an expectation that in fact held.
+
+### Detectors
+
+```python
+DETECTORS: List[Callable[[RunState], List[Issue]]] = [
+    detect_unmet_expectations,
+    detect_unexpected_scores,
+    detect_compilation,
+    detect_borderline_tle,
+    detect_hidden_verdicts,
+    detect_untuned_limits,
+]
+```
+
+Each is a pure function from `RunState` to a list of issues. None touches a
+contextvar, a console, or the filesystem beyond the state it was handed. That is
+the main practical gain over the issue stack: every detector is unit-testable
+against a hand-built `RunState`, with no sandbox, no compilation and no fixture
+package.
+
+`RunState` is `{skeleton, report, runs_dir, ran_at}`, where `ran_at` is
+`report.yml`'s mtime. `load_run_state` returns `None` when there is no report --
+that is the "never run" state, not an error.
+
+### CLI
+
+- `rbx issues [-d/--detailed] [--format rich|json]`, implemented in
+  `rbx/box/cli/commands/issues.py` with a matching row in `ENTRIES` carrying the
+  same `help=` and `rich_help_panel=`, per the lazy-CLI contract that
+  `tests/rbx/box/lazy_cli_test.py` pins.
+- `rbx contest issues [-d] [--format json]` in `rbx/box/contest/main.py`,
+  reusing `cd.new_package_cd` and `clear_package_cache` the way
+  `print_contest_summary` already does.
+- Both exit 0 regardless of findings. `rbx issues` is a viewer; `rbx run`
+  remains the CI gate.
+
+### Rendering
+
+Compact by default everywhere -- one line per issue, grouped by severity, errors
+first:
+
+```
+$ rbx issues
+  2 errors, 2 warnings   (last run 4m ago)
+  x sol/wa.cpp    expected wrong-answer, got accepted
+  x sol/bad.cpp   failed to compile
+  ! sol/slow.cpp  slow only within 2x TL
+  ! limits may not be tuned  -> rbx time
+```
+
+`-d/--detailed` expands each into its full explanation -- which groups, which
+verdicts, log paths, the `rbx time` rationale. The post-run section of `rbx run`
+and standalone `rbx issues` call the same renderer, so nothing renders
+differently depending on how the reader got there.
+
+The contest view is one row per problem:
+
+```
+  #  Problem      Last run   Err  Warn  Worst issue
+  A  add-two      4m ago       0     0  -
+  B  paths        4m ago       2     1  sol/wa.cpp: expected WA, got AC
+  C  tree-query   never        -     -  not run
+  D  strings      3d ago       0     2  compiler warnings (2 solutions)
+```
+
+with `-d` following that table with each problem's issues in full.
+
+### What gets retired
+
+`FailedSolutionIssue`, `FailedToCompileSolutionIssue` and `TimingIssue` are
+removed from `rbx/box/solutions.py` -- the detectors supersede them, and the end
+of `rbx run` renders detector output instead of the issue tree.
+
+`issue_stack` itself survives, for `TooMuchStderrIssue`, the statement-build
+issues and the sandbox stack/memory-limit warnings. Those have no on-disk source
+yet.
+
+### Error handling
+
+A missing or unparseable `report.yml` reads as "never run". A `report.version`
+newer than `REPORT_VERSION` is refused rather than guessed at, which is that
+file's own stated rule. At contest level a problem that fails to load becomes an
+error row and never aborts the table, matching what `print_contest_summary`
+already does.
+
+## Deferred
+
+Each of these gets its own issue:
+
+- A sanitizer-finding detector. The flag is already in `report.yml`; the case
+  that matters is a run that otherwise passed.
+- A noisy-stderr detector, migrating `TooMuchStderrIssue`. Derivable by sizing
+  the `.err` artifact.
+- Persisting linter warnings, then a detector over them.
+- Persisting statement build failures, then a detector over them.
+- Run-context caveats: `sanitized`, `only_accepted`, a subset run, a
+  `--fail-fast` abort. All on the skeleton already; they qualify every other
+  issue rather than being issues themselves, so they need a rendering decision
+  first.
+- Config-level checks that need no run at all -- no ACCEPTED solution declared,
+  no validator, no samples. These may belong in `rbx summary` rather than here.

--- a/docs/setters/cheatsheet.md
+++ b/docs/setters/cheatsheet.md
@@ -20,6 +20,8 @@ Where a command has a page of its own, the :material-open-in-new: next to it tak
 | Generate all testcases [:material-open-in-new:](/setters/testset#building-the-testset) | `rbx build` |
 | Generate all testcases and their visualizations [:material-open-in-new:](/setters/testset/visualizers) | `rbx build --visualize` |
 | Print a summary of the problem | `rbx summary` |
+| See what the last run revealed | `rbx issues` |
+| Explain each issue in full | `rbx issues -d` |
 | Print the expanded variables of the problem [:material-open-in-new:](/setters/variables#seeing-the-expanded-values) | `rbx vars` |
 | Print the expanded variables as JSON | `rbx vars --json` |
 | Print what statement expressions read from stdin render to [:material-open-in-new:](/setters/variables#seeing-the-expanded-values) | `rbx vars --render` |
@@ -106,6 +108,7 @@ Where a command has a page of its own, the :material-open-in-new: next to it tak
 | Reopen a past run and read its output           | `rbx contest each`                    |
 | Reopen past runs touching problem A             | `rbx contest on A`                    |
 | Print a summary of the contest                  | `rbx contest summary`                 |
+| See what each problem's last run revealed       | `rbx contest issues`                  |
 | List all contests in the current directory      | `rbx contest list`                    |
 | Scaffold a new contest variant                  | `rbx contest add_variant div2`        |
 | Run a command against a contest variant         | `rbx -C div2 contest statements build` |

--- a/docs/setters/reference/cli.md
+++ b/docs/setters/reference/cli.md
@@ -136,6 +136,23 @@ rbx run <SOLUTIONS> [OPTIONS]
 
 ---
 
+## issues
+
+Show what the last run revealed about the problem.
+
+**Usage:**
+```bash
+rbx issues [OPTIONS]
+```
+
+| Name | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `--detailed`, `-d` | BOOLEAN | Explain each issue instead of summarizing it in one line. | `False` |
+| `--format` | TEXT | How to print the issues. Use `json` to consume them from a tool. | `rich` |
+
+
+---
+
 ## summary (sum)
 
 Print a summary of the problem.
@@ -1131,6 +1148,23 @@ Print a summary of the contest.
 ```bash
 rbx contest summary [OPTIONS]
 ```
+
+
+---
+
+### issues
+
+Show what each problem's last run revealed.
+
+**Usage:**
+```bash
+rbx contest issues [OPTIONS]
+```
+
+| Name | Type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `--detailed`, `-d` | BOOLEAN | Follow the table with every problem's issues in full. | `False` |
+| `--format` | TEXT | How to print the issues. Use `json` to consume them from a tool. | `rich` |
 
 
 ---

--- a/rbx/box/cli/__init__.py
+++ b/rbx/box/cli/__init__.py
@@ -65,6 +65,12 @@ _COMMANDS = [
         rich_help_panel='Testing',
     ),
     LazyCommand(
+        'issues',
+        'rbx.box.cli.commands.issues:app',
+        help='Show what the last run revealed about the problem.',
+        rich_help_panel='Testing',
+    ),
+    LazyCommand(
         'time, t',
         'rbx.box.cli.commands.time_cmd:app',
         help=(

--- a/rbx/box/cli/commands/issues.py
+++ b/rbx/box/cli/commands/issues.py
@@ -1,0 +1,57 @@
+"""`rbx issues`.
+
+Registered lazily from `rbx.box.cli.ENTRIES`, so this module is imported
+only when the command is invoked. A command added here needs a row there too.
+
+Kept apart from `run.py` on purpose: this reads two YAML files and prints, and
+sharing a module with `rbx run` would make it pay for the whole solution-running
+import graph on every invocation.
+"""
+
+from typing import Annotated
+
+import typer
+
+from rbx import annotations, console
+from rbx.box import issues, package
+from rbx.box.issues import IssuesFormat
+
+app = typer.Typer(cls=annotations.AliasGroup)
+
+
+@app.command(
+    'issues',
+    rich_help_panel='Testing',
+    help='Show what the last run revealed about the problem.',
+)
+@package.within_problem
+def issues_cmd(
+    detailed: Annotated[
+        bool,
+        typer.Option(
+            '--detailed',
+            '-d',
+            help='Explain each issue instead of summarizing it in one line.',
+        ),
+    ] = False,
+    format: Annotated[
+        IssuesFormat,
+        typer.Option(
+            '--format',
+            help='How to print the issues. Use `json` to consume them from a tool.',
+        ),
+    ] = IssuesFormat.RICH,
+):
+    try:
+        report = issues.build_report(package.get_problem_runs_dir())
+    except issues.UnsupportedReportVersion as exception:
+        console.console.print(f'[error]{exception}[/error]')
+        raise typer.Exit(1) from exception
+
+    if format is IssuesFormat.JSON:
+        # Straight to stdout, not through the themed console: this output is
+        # parsed, and Rich would wrap and highlight it.
+        print(issues.to_json(report))
+        return
+
+    issues.print_report(report, detailed=detailed)

--- a/rbx/box/cli/commands/run.py
+++ b/rbx/box/cli/commands/run.py
@@ -327,6 +327,8 @@ async def run(
         if fail_fast:
             _print_fail_fast_warning(console.console)
 
+        _print_issues()
+
         vscode_extension.print_outdated_hint()
 
         if not ok:
@@ -339,6 +341,35 @@ async def run(
         # Ctrl-C, on a backend that had already dispatched every solution.
         # `LocalRunner.close` is a no-op, so this costs a local run nothing.
         await solution_result.close()
+
+
+def _print_issues() -> None:
+    """The issues section at the end of a run.
+
+    Reads the report back off disk rather than being handed the in-memory one.
+    `RunReportWriter` has already written it -- it rewrites the file as each
+    solution lands -- and going through the same path `rbx issues` uses makes it
+    impossible for the two to word the same finding differently, or for one to
+    notice something the other misses.
+
+    Never fatal: `rbx run`'s exit code is the report's verdict, and a problem
+    reading this view must not turn a passing run into a failing one.
+    """
+    from rbx.box import issues
+
+    try:
+        report = issues.build_report(package.get_problem_runs_dir())
+    except issues.UnsupportedReportVersion:
+        return
+    if report.neverRun or not report.issues:
+        return
+
+    console.console.print()
+    console.console.rule('[status]Issues[/status]', style='status')
+    issues.print_report(report)
+    console.console.print(
+        '[info]Run [item]rbx issues -d[/item] to expand these.[/info]'
+    )
 
 
 @app.command(

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -309,6 +309,39 @@ SPEC = {
             ],
         },
         {
+            'help': 'Show what the last run revealed about the...',
+            'is_group': False,
+            'name': 'issues',
+            'panel': 'Testing',
+            'params': [
+                {
+                    'help': 'Explain each issue instead of summarizing it in one line.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--detailed', '-d'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'How to print the issues. Use `json` to consume them from a '
+                    'tool.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--format'],
+                    'takes_value': True,
+                    'value': {'choices': ['rich', 'json'], 'kind': 'choice'},
+                },
+                {
+                    'help': 'Show this message and exit.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--help'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+            ],
+        },
+        {
             'help': 'Estimate a time limit for the problem...',
             'is_group': False,
             'name': 'time, t',
@@ -2549,6 +2582,40 @@ SPEC = {
                             'takes_value': False,
                             'value': {'kind': 'none'},
                         }
+                    ],
+                },
+                {
+                    'help': "Show what each problem's last run revealed.",
+                    'is_group': False,
+                    'name': 'issues',
+                    'panel': None,
+                    'params': [
+                        {
+                            'help': "Follow the table with every problem's issues in "
+                            'full.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--detailed', '-d'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        },
+                        {
+                            'help': 'How to print the issues. Use `json` to consume '
+                            'them from a tool.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--format'],
+                            'takes_value': True,
+                            'value': {'choices': ['rich', 'json'], 'kind': 'choice'},
+                        },
+                        {
+                            'help': 'Show this message and exit.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--help'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        },
                     ],
                 },
                 {

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -12,7 +12,7 @@ import syncer
 import typer
 
 from rbx import annotations, console, utils
-from rbx.box import cd, creation, naming, presets, summary
+from rbx.box import cd, creation, issues, naming, presets, summary
 from rbx.box.contest import (
     contest_package,
     contest_state,
@@ -594,6 +594,40 @@ def on(
 async def summary_cmd():
     contest = find_contest_package_or_die()
     await summary.print_contest_summary(contest, get_problems(contest))
+
+
+@app.command(
+    'issues',
+    help="Show what each problem's last run revealed.",
+)
+@within_contest
+def issues_cmd(
+    detailed: Annotated[
+        bool,
+        typer.Option(
+            '--detailed',
+            '-d',
+            help="Follow the table with every problem's issues in full.",
+        ),
+    ] = False,
+    format: Annotated[
+        issues.IssuesFormat,
+        typer.Option(
+            '--format',
+            help='How to print the issues. Use `json` to consume them from a tool.',
+        ),
+    ] = issues.IssuesFormat.RICH,
+):
+    contest = find_contest_package_or_die()
+    rows = issues.collect_contest_rows(contest, get_problems(contest))
+
+    if format is issues.IssuesFormat.JSON:
+        # Straight to stdout, not through the themed console: this output is
+        # parsed, and Rich would wrap and highlight it.
+        print(issues.contest_to_json(rows))
+        return
+
+    issues.print_contest_report(rows, detailed=detailed)
 
 
 @app.command('list, ls', help='List all contests in the current directory.')

--- a/rbx/box/issues/__init__.py
+++ b/rbx/box/issues/__init__.py
@@ -1,0 +1,59 @@
+"""What the last run revealed.
+
+`rbx summary` answers what a problem *is*; this answers what running it turned
+up. Both questions were previously answerable only by reading a run scroll past,
+because the accumulated issues lived in a contextvar stack that was rendered at
+process exit and then lost.
+
+Here they are derived instead: a registry of pure detectors over the artifacts
+`.rbx/runs` already holds. Nothing new is written, so there is no staleness to
+reason about and no second copy of the truth to drift -- and `rbx run`'s own
+post-run section calls the same detectors on the same files, so it can never
+word a finding differently from a later `rbx issues`.
+
+Callers import from here, never from a submodule.
+
+See docs/plans/2026-08-31-issues-view-design.md.
+"""
+
+from rbx.box.issues.contest import build_report, collect_contest_rows
+from rbx.box.issues.detectors import DETECTORS, detect_all
+from rbx.box.issues.rendering import (
+    IssuesFormat,
+    contest_to_json,
+    print_contest_report,
+    print_report,
+    to_json,
+)
+from rbx.box.issues.run_state import (
+    RunState,
+    UnsupportedReportVersion,
+    load_run_state,
+)
+from rbx.box.issues.schema import (
+    ISSUES_FORMAT_VERSION,
+    ContestIssueRow,
+    Issue,
+    IssueReport,
+    IssueSeverity,
+)
+
+__all__ = [
+    'DETECTORS',
+    'ISSUES_FORMAT_VERSION',
+    'ContestIssueRow',
+    'Issue',
+    'IssueReport',
+    'IssueSeverity',
+    'IssuesFormat',
+    'RunState',
+    'UnsupportedReportVersion',
+    'build_report',
+    'collect_contest_rows',
+    'contest_to_json',
+    'detect_all',
+    'load_run_state',
+    'print_contest_report',
+    'print_report',
+    'to_json',
+]

--- a/rbx/box/issues/contest.py
+++ b/rbx/box/issues/contest.py
@@ -1,0 +1,76 @@
+"""Collecting issues across every problem in a contest.
+
+Read-only, and deliberately so: this never builds, never runs and never judges.
+It reads each problem's `.rbx/runs` exactly the way the problem-level command
+does, so a contest-wide view costs about as much as listing the directories.
+
+That means a problem nobody has run shows up as "never run" rather than being
+run on the spot. Which is the honest answer -- and at contest level it is
+usually the most important row in the table.
+"""
+
+import pathlib
+from typing import List
+
+from rbx.box import cd, package, package_utils
+from rbx.box.contest.schema import Contest
+from rbx.box.issues.detectors import detect_all
+from rbx.box.issues.run_state import load_run_state
+from rbx.box.issues.schema import ContestIssueRow, IssueReport
+from rbx.box.schema import Package
+
+
+def collect_contest_rows(
+    contest: Contest, problems: List[Package]
+) -> List[ContestIssueRow]:
+    """One row per problem, in contest order.
+
+    A problem that cannot be read becomes a `failed_to_load` row instead of
+    aborting the table, matching what `summary.print_contest_summary` does: one
+    broken package must not hide the state of the other nine.
+    """
+    rows: List[ContestIssueRow] = []
+    for index, problem in enumerate(problems):
+        contest_problem = contest.problems[index]
+        short_name = contest_problem.short_name
+        # `get_path()`, never the raw `path`: it is None for a problem that
+        # relies on the default `./{short_name}/` layout, and reading the field
+        # directly sends every such problem to the contest root instead.
+        problem_path = contest_problem.get_path()
+
+        try:
+            with cd.new_package_cd(problem_path):
+                package_utils.clear_package_cache()
+                rows.append(
+                    ContestIssueRow(
+                        short_name=short_name,
+                        name=problem.name,
+                        report=build_report(package.get_problem_runs_dir()),
+                    )
+                )
+        except Exception:
+            rows.append(
+                ContestIssueRow(
+                    short_name=short_name,
+                    name=problem.name,
+                    failed_to_load=True,
+                )
+            )
+    return rows
+
+
+def build_report(runs_dir: pathlib.Path) -> IssueReport:
+    """Everything the last run in `runs_dir` reveals.
+
+    The single place a `RunState` becomes an `IssueReport`, so the problem
+    command, the contest table and the post-run section cannot disagree about
+    what "no run" or "no issues" looks like.
+    """
+    state = load_run_state(runs_dir)
+    if state is None:
+        return IssueReport(neverRun=True)
+    return IssueReport(
+        ranAt=state.ran_at,
+        runsDir=str(state.runs_dir),
+        issues=detect_all(state),
+    )

--- a/rbx/box/issues/detectors.py
+++ b/rbx/box/issues/detectors.py
@@ -1,0 +1,227 @@
+"""The detectors: pure functions from a run to the issues in it.
+
+Each one takes a `RunState` and returns a list of issues. None of them touches a
+contextvar, a console, or the filesystem beyond the state it was handed, which
+is the whole point -- the issue stack this replaces could only be exercised by
+running a real package through a real sandbox, while every detector here is
+testable against a `RunState` built by hand.
+
+Detectors never *recompute* a verdict. Everything they read has already been
+decided by `solutions.get_solution_outcome_report` and published by
+`run_report`; a detector's job is to notice, not to judge. Anything that would
+need `ExpectedOutcome.match` or the per-layer verdict sets belongs upstream, as
+a field on the report -- see `untunedLimitsSuspected`.
+"""
+
+from typing import Callable, List
+
+from rbx.box.compilation_findings import SolutionCompilation
+from rbx.box.issues.run_state import RunState
+from rbx.box.issues.schema import (
+    BorderlineTleIssue,
+    CompilationFailedIssue,
+    CompilationWarningsIssue,
+    HiddenVerdictIssue,
+    Issue,
+    IssueSeverity,
+    TightTimeMarginIssue,
+    UnexpectedScoreIssue,
+    UnmetExpectationIssue,
+    UntunedLimitsIssue,
+)
+
+# How much of its time limit a passing solution may use before it is worth a
+# mention. 0.8 rather than something tighter because the measurement is one
+# machine's, on one run: flagging at 0.95 would only fire once the limit is
+# already effectively broken, and flagging at 0.5 would fire on every package
+# whose limits are deliberately snug.
+TIGHT_TIME_MARGIN_RATIO = 0.8
+
+
+def detect_unmet_expectations(state: RunState) -> List[Issue]:
+    """Solutions that did not behave the way the package says they do."""
+    issues: List[Issue] = []
+    for solution in state.report.solutions:
+        if solution.matchesExpectation:
+            continue
+        # An unexpected *score* is reported by its own detector, which can say
+        # what the range was. Reporting both would name one failure twice.
+        if solution.status == 'UNEXPECTED_SCORE':
+            continue
+        issues.append(
+            UnmetExpectationIssue(
+                solution=solution.path,
+                expected=solution.expectedOutcome,
+                got=solution.outcome,
+                status=solution.status,
+                failedGroups=list(solution.failedGroups),
+                pooledMatchesExpectation=solution.pooledMatchesExpectation,
+            )
+        )
+    return issues
+
+
+def detect_unexpected_scores(state: RunState) -> List[Issue]:
+    """Solutions that scored outside their declared range."""
+    issues: List[Issue] = []
+    for solution in state.report.solutions:
+        if solution.status != 'UNEXPECTED_SCORE':
+            continue
+        # The range is what makes this issue sayable; without it there is
+        # nothing to report beyond "the score was wrong", which the verdict
+        # already covers.
+        if solution.expectedScore is None:
+            continue
+        issues.append(
+            UnexpectedScoreIssue(
+                solution=solution.path,
+                score=solution.score,
+                maxScore=solution.maxScore,
+                expectedScore=solution.expectedScore,
+            )
+        )
+    return issues
+
+
+def detect_compilation(state: RunState) -> List[Issue]:
+    """Solutions the compiler failed or complained about.
+
+    Read off the skeleton rather than the report: a solution that failed to
+    compile never ran, so it has no report entry at all. This is the only record
+    that it exists.
+    """
+    issues: List[Issue] = []
+    for compilation in state.skeleton.compilation:
+        issues.append(_compilation_issue(compilation))
+    return issues
+
+
+def _compilation_issue(compilation: SolutionCompilation) -> Issue:
+    if compilation.status == 'FAILED':
+        return CompilationFailedIssue(
+            solution=str(compilation.path),
+            reason=compilation.reason,
+            log=compilation.log,
+        )
+    return CompilationWarningsIssue(
+        solution=str(compilation.path),
+        warnings=list(compilation.warnings),
+        log=compilation.log,
+    )
+
+
+def detect_borderline_tle(state: RunState) -> List[Issue]:
+    """Solutions declared slow that were only slow inside the doubled TL."""
+    issues: List[Issue] = []
+    for solution in state.report.solutions:
+        if not solution.runUnderDoubleTl:
+            continue
+        issues.append(
+            BorderlineTleIssue(
+                solution=solution.path,
+                groups=[
+                    group.name for group in solution.groups if group.runUnderDoubleTl
+                ],
+                doubleTlVerdicts=list(solution.doubleTlVerdicts),
+            )
+        )
+    return issues
+
+
+def detect_hidden_verdicts(state: RunState) -> List[Issue]:
+    """Verdicts a soft TLE hid that no expectation accepts.
+
+    Pooled up from the groups, because that is the only place the report
+    publishes them: `RunGroupReport.unexpectedNoTleVerdicts` has already been
+    intersected with whichever expectation layer covers the group, so a group
+    that ran clean cannot inherit a verdict hidden three groups away.
+    """
+    issues: List[Issue] = []
+    for solution in state.report.solutions:
+        groups = [group for group in solution.groups if group.unexpectedNoTleVerdicts]
+        if not groups:
+            continue
+        verdicts = sorted(
+            {verdict for group in groups for verdict in group.unexpectedNoTleVerdicts},
+            key=lambda verdict: verdict.name,
+        )
+        issues.append(
+            HiddenVerdictIssue(
+                solution=solution.path,
+                groups=[group.name for group in groups],
+                verdicts=verdicts,
+            )
+        )
+    return issues
+
+
+def detect_tight_time_margin(state: RunState) -> List[Issue]:
+    """Solutions that passed, but with little room left against the TL.
+
+    Only solutions that met their expectation: one declared slow is *supposed*
+    to sit against the limit, and one that failed has a louder issue already.
+    """
+    issues: List[Issue] = []
+    for solution in state.report.solutions:
+        if not solution.matchesExpectation:
+            continue
+        if solution.maxTime is None or not solution.timeLimit:
+            continue
+        # A solution declared slow is expected to be up against the limit; that
+        # is the declaration working, not a margin worth warning about.
+        if solution.expectedOutcome.is_slow():
+            continue
+        if solution.maxTime < solution.timeLimit * TIGHT_TIME_MARGIN_RATIO:
+            continue
+        issues.append(
+            TightTimeMarginIssue(
+                solution=solution.path,
+                maxTime=solution.maxTime,
+                timeLimit=solution.timeLimit,
+            )
+        )
+    return issues
+
+
+def detect_untuned_limits(state: RunState) -> List[Issue]:
+    """Timing failures on a package whose limits were never tuned here.
+
+    One issue for the whole package, not one per solution: the remedy is a
+    single `rbx time`, and repeating it per solution would bury the actual
+    verdict failures under copies of the same advice.
+    """
+    affected = [
+        solution.path
+        for solution in state.report.solutions
+        if solution.untunedLimitsSuspected
+    ]
+    if not affected:
+        return []
+    return [UntunedLimitsIssue(affectedSolutions=affected)]
+
+
+DETECTORS: List[Callable[[RunState], List[Issue]]] = [
+    detect_unmet_expectations,
+    detect_unexpected_scores,
+    detect_compilation,
+    detect_borderline_tle,
+    detect_hidden_verdicts,
+    detect_tight_time_margin,
+    detect_untuned_limits,
+]
+
+
+def detect_all(state: RunState) -> List[Issue]:
+    """Every issue in a run, worst first.
+
+    Sorted by severity and then by detector order, which puts the verdict
+    failures above the compilation warnings above the advice. Within a detector
+    the order is the report's, which is the order the solutions were declared --
+    so the list lines up with the run's own table.
+    """
+    issues: List[Issue] = []
+    for detector in DETECTORS:
+        issues.extend(detector(state))
+    # `sorted` is stable, so this reorders by severity while leaving the
+    # detector-then-declaration order intact inside each band.
+    return sorted(issues, key=lambda issue: issue.severity != IssueSeverity.ERROR)

--- a/rbx/box/issues/rendering.py
+++ b/rbx/box/issues/rendering.py
@@ -304,6 +304,13 @@ def print_contest_report(rows: List[ContestIssueRow], detailed: bool = False) ->
     console.console.print(table)
 
     if not detailed:
+        # Only when there is something to expand: the table names one issue per
+        # problem, so a contest with findings is exactly the case where the
+        # reader needs telling that the rest are a flag away.
+        if any(row.report.issues for row in rows if not row.failed_to_load):
+            console.console.print(
+                '[info]Run [item]rbx contest issues -d[/item] to expand these.[/info]'
+            )
         return
 
     for row in rows:

--- a/rbx/box/issues/rendering.py
+++ b/rbx/box/issues/rendering.py
@@ -1,0 +1,336 @@
+"""Turning issues into something to look at.
+
+Wording lives here and only here. The detectors produce facts; this module is
+the one place that decides an unmet expectation reads as "expected wrong-answer,
+got accepted", so the post-run section of `rbx run` and a later `rbx issues`
+cannot word the same finding two ways.
+
+Two levels, and the *same* renderer serves both surfaces at each level:
+
+- compact, one line per issue, which is what you get by default everywhere;
+- detailed (`-d`), which expands each issue into what it actually means and
+  where to look next.
+"""
+
+import json
+import pathlib
+import time
+from enum import Enum
+from typing import List, Optional
+
+from rich.padding import Padding
+from rich.table import Table
+from rich.text import Text
+
+from rbx import console
+from rbx.box.formatting import get_formatted_time, href
+from rbx.box.issues.schema import (
+    BorderlineTleIssue,
+    CompilationFailedIssue,
+    CompilationWarningsIssue,
+    ContestIssueRow,
+    HiddenVerdictIssue,
+    Issue,
+    IssueReport,
+    IssueSeverity,
+    TightTimeMarginIssue,
+    UnexpectedScoreIssue,
+    UnmetExpectationIssue,
+    UntunedLimitsIssue,
+)
+
+
+class IssuesFormat(str, Enum):
+    """How to print issues.
+
+    Lives here rather than in either command so the problem-level and
+    contest-level flags cannot drift into accepting different spellings.
+    """
+
+    RICH = 'rich'
+    JSON = 'json'
+
+
+_SEVERITY_MARKER = {
+    IssueSeverity.ERROR: '[error]x[/error]',
+    IssueSeverity.WARNING: '[warning]![/warning]',
+}
+
+
+def humanize_since(timestamp: Optional[float]) -> str:
+    """ "4m ago", roughly.
+
+    Deliberately coarse. The reader is asking "is this from the run I just did,
+    or from before lunch?", and a precise duration invites a precision the
+    number does not have.
+    """
+    if timestamp is None:
+        return 'never'
+    seconds = max(0, int(time.time() - timestamp))
+    if seconds < 60:
+        return 'just now'
+    for amount, unit in ((60, 'm'), (3600, 'h'), (86400, 'd')):
+        if seconds < amount * 60 or unit == 'd':
+            return f'{seconds // amount}{unit} ago'
+    return f'{seconds // 86400}d ago'
+
+
+def _resolve(path: pathlib.Path, runs_dir: Optional[str]) -> pathlib.Path:
+    """A path relative to the runs dir, made openable from here.
+
+    Compilation logs are stored relative so a package read on another host still
+    resolves them; a terminal hyperlink needs the other form.
+    """
+    if runs_dir is None:
+        return path
+    return pathlib.Path(runs_dir) / path
+
+
+def _solution_of(issue: Issue) -> Optional[str]:
+    return getattr(issue, 'solution', None)
+
+
+def _verdicts(outcomes) -> str:
+    return ' '.join(outcome.name for outcome in outcomes)
+
+
+def summarize(issue: Issue) -> str:
+    """One line: what is wrong, and with what."""
+    if isinstance(issue, UnmetExpectationIssue):
+        # Never name the pooled expectation when the pooled layer is the one
+        # that held -- doing so accuses an expectation that did its job. The
+        # groups are the honest answer there.
+        if not issue.pooledMatchesExpectation:
+            got = issue.got.name if issue.got is not None else 'nothing'
+            return f'expected {issue.expected}, got {got}'
+        if issue.failedGroups:
+            return f'failed group(s): {", ".join(issue.failedGroups)}'
+        return 'did not meet its expectation'
+    if isinstance(issue, UnexpectedScoreIssue):
+        low, high = issue.expectedScore
+        return (
+            f'scored {issue.score}/{issue.maxScore}, expected between {low} and {high}'
+        )
+    if isinstance(issue, CompilationFailedIssue):
+        return (
+            f'failed to compile: {issue.reason}'
+            if issue.reason
+            else 'failed to compile'
+        )
+    if isinstance(issue, CompilationWarningsIssue):
+        return f'compiled with {len(issue.warnings)} warning(s)'
+    if isinstance(issue, BorderlineTleIssue):
+        return 'slow only within 2x the time limit'
+    if isinstance(issue, HiddenVerdictIssue):
+        return f'a soft TLE hid: {_verdicts(issue.verdicts)}'
+    if isinstance(issue, TightTimeMarginIssue):
+        return (
+            f'used {get_formatted_time(int(issue.maxTime * 1000))} of a '
+            f'{get_formatted_time(int(issue.timeLimit * 1000))} limit'
+        )
+    if isinstance(issue, UntunedLimitsIssue):
+        return 'the time limit may not be tuned to this machine'
+    return 'unknown issue'
+
+
+def explain(issue: Issue, runs_dir: Optional[str] = None) -> List[str]:
+    """The detail lines under an issue in `-d` mode.
+
+    Empty when the one-liner already says everything -- padding every issue out
+    to a paragraph would make the detailed view harder to read than the compact
+    one, not easier.
+    """
+    if isinstance(issue, UnmetExpectationIssue):
+        lines = [f'expected: {issue.expected}']
+        if issue.got is not None:
+            lines.append(f'got:      {issue.got.name}')
+        if issue.failedGroups:
+            lines.append(f'groups:   {", ".join(issue.failedGroups)}')
+        if issue.pooledMatchesExpectation and issue.failedGroups:
+            lines.append(
+                'the solution-wide expectation held; only per-group ones failed'
+            )
+        return lines
+    if isinstance(issue, (CompilationFailedIssue, CompilationWarningsIssue)):
+        lines = []
+        for warning in getattr(issue, 'warnings', [])[:5]:
+            flag = f' [{warning.flag}]' if warning.flag else ''
+            lines.append(f'{warning.file}:{warning.line}{flag} {warning.msg}')
+        remaining = len(getattr(issue, 'warnings', [])) - 5
+        if remaining > 0:
+            lines.append(f'... and {remaining} more')
+        lines.append(f'log: {href(_resolve(issue.log, runs_dir))}')
+        return lines
+    if isinstance(issue, BorderlineTleIssue):
+        lines = [
+            'rbx judges at 2x the time limit and reports TLE past 1x, so this '
+            'solution timed out but finished inside the doubled window -- the '
+            'testset does not prove it is decisively slow.'
+        ]
+        if issue.groups:
+            lines.append(f'groups:   {", ".join(issue.groups)}')
+        if issue.doubleTlVerdicts:
+            lines.append(
+                f'without a TL it would have: {_verdicts(issue.doubleTlVerdicts)}'
+            )
+        return lines
+    if isinstance(issue, HiddenVerdictIssue):
+        lines = [
+            'reported TLE at 1x the time limit, but underneath it was doing '
+            'something the declaration does not allow.'
+        ]
+        if issue.groups:
+            lines.append(f'groups:   {", ".join(issue.groups)}')
+        return lines
+    if isinstance(issue, TightTimeMarginIssue):
+        ratio = issue.maxTime / issue.timeLimit
+        return [
+            f'{ratio:.0%} of the time limit on this machine. Fine here, tight '
+            f'on a slower judge.'
+        ]
+    if isinstance(issue, UntunedLimitsIssue):
+        return [
+            'Solutions failed their expectations by being too fast or too slow, '
+            'and this run used the limits declared in the package rather than a '
+            'profile. They may simply not suit this hardware.',
+            f'affected: {", ".join(issue.affectedSolutions)}',
+            'run [item]rbx time[/item] to estimate limits here.',
+        ]
+    return []
+
+
+def _headline(report: IssueReport) -> str:
+    if report.neverRun:
+        return '[warning]This problem has not been run yet.[/warning]'
+    errors = len(report.errors())
+    warnings = len(report.warnings())
+    when = f'[info](last run {humanize_since(report.ranAt)})[/info]'
+    if not errors and not warnings:
+        return f'[success]No issues.[/success] {when}'
+    parts = []
+    if errors:
+        parts.append(f'[error]{errors} error(s)[/error]')
+    if warnings:
+        parts.append(f'[warning]{warnings} warning(s)[/warning]')
+    return f'{", ".join(parts)} {when}'
+
+
+def print_report(report: IssueReport, detailed: bool = False) -> None:
+    """The problem-level view, compact or detailed."""
+    console.console.print(_headline(report))
+    if report.neverRun:
+        console.console.print('[info]Run [item]rbx run[/item] to populate it.[/info]')
+        return
+    if not report.issues:
+        return
+    console.console.print()
+
+    for issue in report.issues:
+        marker = _SEVERITY_MARKER[issue.severity]
+        solution = _solution_of(issue)
+        # A `Path`, not the string: `href` takes its display text before it
+        # absolutizes, so this shows the declared relative path but links
+        # somewhere a terminal can actually open.
+        where = f'{href(pathlib.Path(solution))} ' if solution else ''
+        console.console.print(f'{marker} {where}{summarize(issue)}')
+        if not detailed:
+            continue
+        for line in explain(issue, report.runsDir):
+            # Padded rather than prefixed with spaces: Rich wraps a long line at
+            # the console width and a prefix only indents the first row of it,
+            # which puts the continuation hard against the left margin.
+            console.console.print(
+                Padding(Text.from_markup(f'[info]{line}[/info]'), (0, 0, 0, 4))
+            )
+        console.console.print()
+
+
+def print_contest_report(rows: List[ContestIssueRow], detailed: bool = False) -> None:
+    """The contest-level view: one row per problem, worst first within a row.
+
+    The table answers "which problems need me", not "what exactly is wrong with
+    problem C" -- that is what `-d`, or cd'ing into the problem, is for.
+    """
+    table = Table(title='Issues')
+    table.add_column('#', justify='center', style='bold cyan')
+    table.add_column('Problem', style='bold')
+    table.add_column('Last run', justify='right')
+    table.add_column('Err', justify='right')
+    table.add_column('Warn', justify='right')
+    table.add_column('Worst issue')
+
+    for row in rows:
+        if row.failed_to_load:
+            table.add_row(
+                row.short_name,
+                row.name,
+                '[error]error[/error]',
+                '-',
+                '-',
+                '[error]could not read this problem[/error]',
+            )
+            continue
+        report = row.report
+        if report.neverRun:
+            table.add_row(
+                row.short_name,
+                row.name,
+                '[warning]never[/warning]',
+                '-',
+                '-',
+                '[warning]not run[/warning]',
+            )
+            continue
+
+        errors = len(report.errors())
+        warnings = len(report.warnings())
+        worst = report.issues[0] if report.issues else None
+        if worst is None:
+            worst_str = '[success]-[/success]'
+        else:
+            solution = _solution_of(worst)
+            prefix = f'{solution}: ' if solution else ''
+            worst_str = f'{prefix}{summarize(worst)}'
+
+        table.add_row(
+            row.short_name,
+            row.name,
+            humanize_since(report.ranAt),
+            f'[error]{errors}[/error]' if errors else '[info]0[/info]',
+            f'[warning]{warnings}[/warning]' if warnings else '[info]0[/info]',
+            worst_str,
+        )
+
+    console.console.print(table)
+
+    if not detailed:
+        return
+
+    for row in rows:
+        if row.failed_to_load or not row.report.issues:
+            continue
+        console.console.print()
+        console.console.rule(f'[item]{row.short_name}. {row.name}[/item]')
+        print_report(row.report, detailed=True)
+
+
+def to_json(report: IssueReport) -> str:
+    return json.dumps(report.model_dump(mode='json'), indent=2)
+
+
+def contest_to_json(rows: List[ContestIssueRow]) -> str:
+    return json.dumps(
+        {
+            'version': IssueReport().version,
+            'problems': [
+                {
+                    'shortName': row.short_name,
+                    'name': row.name,
+                    'failedToLoad': row.failed_to_load,
+                    'report': row.report.model_dump(mode='json'),
+                }
+                for row in rows
+            ],
+        },
+        indent=2,
+    )

--- a/rbx/box/issues/run_state.py
+++ b/rbx/box/issues/run_state.py
@@ -1,0 +1,113 @@
+"""The on-disk state the detectors run over.
+
+`rbx issues` is meant to be instant -- it computes nothing, it reads what the
+last run already wrote. So this module reads `.rbx/runs` and nothing else: no
+package is loaded, no testcases are extracted, no sandbox is touched.
+
+That is also why it does not import `rbx.box.solutions` to parse `skeleton.yml`.
+That module is thousands of lines and pulls in most of the box, and paying for
+it would defeat the point of a command that only reads two YAML files. Instead
+`SkeletonView` below picks out the handful of skeleton fields the detectors
+actually need; Pydantic ignores the rest. `skeleton_view_test.py` pins the two
+together so the narrow read cannot silently drift from the real model.
+"""
+
+import pathlib
+from typing import List, Optional
+
+import yaml
+from pydantic import BaseModel
+
+from rbx.box import run_report
+from rbx.box.compilation_findings import SolutionCompilation
+
+SKELETON_FILENAME = 'skeleton.yml'
+
+
+class UnsupportedReportVersion(Exception):
+    """The report on disk is newer than this rbx knows how to read.
+
+    Raised rather than tolerated: `run_report` states the rule -- a reader that
+    meets a version it does not know must ignore the report rather than guess --
+    and for this command guessing would mean reporting verdicts that may not
+    mean what they used to.
+    """
+
+    def __init__(self, found: int):
+        super().__init__(
+            f'The run report on disk is version {found}, but this rbx only '
+            f'understands up to {run_report.REPORT_VERSION}. Upgrade rbx, or '
+            f're-run to regenerate it.'
+        )
+        self.found = found
+
+
+class SkeletonView(BaseModel):
+    """The slice of `skeleton.yml` the detectors read.
+
+    Deliberately narrow. Every field here has to keep meaning exactly what
+    `solutions.SolutionReportSkeleton` means by it, so add to it only when a
+    detector genuinely needs the field.
+    """
+
+    compilation: List[SolutionCompilation] = []
+
+
+class RunState(BaseModel):
+    """One package's last run, as the detectors see it."""
+
+    report: run_report.RunReport
+    skeleton: SkeletonView
+    runs_dir: pathlib.Path
+    # `report.yml`'s mtime, as a POSIX timestamp. When the run happened, near
+    # enough: the report is rewritten as each solution lands, so it is stamped
+    # at the end of the run rather than the start.
+    ran_at: float
+
+
+def _load_yaml(path: pathlib.Path) -> Optional[dict]:
+    """Parse a YAML mapping, or None when it is missing or unusable.
+
+    A half-written or corrupt artifact reads as absent on purpose. The report is
+    rewritten whole on every solution, so catching it mid-write is a real
+    possibility, and "no run to show" is a far better answer to that than a
+    traceback.
+    """
+    if not path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text())
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_run_state(runs_dir: pathlib.Path) -> Optional[RunState]:
+    """The last run in `runs_dir`, or None when there was not one.
+
+    None means "never run", which is a state worth reporting rather than an
+    error: a problem nobody has run is exactly what a contest-wide view needs to
+    call out.
+    """
+    report_data = _load_yaml(run_report.report_path(runs_dir))
+    if report_data is None:
+        return None
+
+    version = report_data.get('version', run_report.REPORT_VERSION)
+    if isinstance(version, int) and version > run_report.REPORT_VERSION:
+        raise UnsupportedReportVersion(version)
+
+    report = run_report.RunReport.model_validate(report_data)
+
+    # The skeleton is optional in a way the report is not: it is written first,
+    # so a report can never outlive it, but treating a missing one as fatal
+    # would turn a partially cleaned `.rbx` into a crash. The detectors that
+    # read it simply find nothing.
+    skeleton_data = _load_yaml(runs_dir / SKELETON_FILENAME) or {}
+
+    return RunState(
+        report=report,
+        skeleton=SkeletonView.model_validate(skeleton_data),
+        runs_dir=runs_dir,
+        ran_at=run_report.report_path(runs_dir).stat().st_mtime,
+    )

--- a/rbx/box/issues/schema.py
+++ b/rbx/box/issues/schema.py
@@ -1,0 +1,259 @@
+"""What an issue with a run *is*, as data.
+
+Structured, never rendered -- the same rule `rbx.box.run_report` follows, and
+for the same reason. An issue carries the facts that make it an issue: which
+solution, which groups, what was expected, what happened. Turning that into
+"expected wrong-answer, got accepted" is `rbx.box.issues.rendering`'s business,
+and the VS Code extension reading `--format json` may reasonably word it
+differently.
+
+Severity is a property of the *kind*, not a field a producer chooses: two
+unmet expectations are never one an error and one a warning. It is exposed as a
+computed field so it still lands in the JSON, and no client has to keep its own
+table of which kinds are which.
+"""
+
+import pathlib
+from enum import Enum
+from typing import Annotated, List, Literal, Optional, Tuple, Union
+
+from pydantic import BaseModel, Field, computed_field
+
+from rbx.box.compilation_findings import CompilationWarning
+from rbx.box.schema import ExpectedOutcome
+from rbx.grading.steps import Outcome
+
+# Bump when a change would make an older reader misread the output.
+#
+# Adding a new issue *kind* is such a change only in the sense that an older
+# reader will not know how to word it; the discriminated union means it can
+# still read `kind` and `severity` and show something. Adding an optional field
+# to an existing kind is not a change at all.
+ISSUES_FORMAT_VERSION = 1
+
+
+class IssueSeverity(str, Enum):
+    # Something is wrong: the package does not behave the way it says it does.
+    ERROR = 'error'
+    # Something is worth a look, but the package may well be fine.
+    WARNING = 'warning'
+
+
+class _BaseIssue(BaseModel):
+    # The solution this issue is about, as its declared path. Every kind has one
+    # today; it stays on the subclasses rather than here so a future issue that
+    # is about the package as a whole does not have to invent a fake one.
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        raise NotImplementedError
+
+
+class UnmetExpectationIssue(_BaseIssue):
+    """A solution did not behave the way `problem.rbx.yml` says it does."""
+
+    kind: Literal['unmet_expectation'] = 'unmet_expectation'
+    solution: str
+    expected: ExpectedOutcome
+    # Absent when nothing was evaluated, which is what an interrupted run looks
+    # like.
+    got: Optional[Outcome] = None
+    # `SolutionOutcomeStatus`, as its value.
+    status: str
+    failedGroups: List[str] = []
+    # Whether the *pooled* expectation held on its own.
+    #
+    # Carried so the renderer never accuses an expectation that was met: a
+    # solution declaring `outcome: incorrect` with an `outcomePerGroup` can fail
+    # only the per-group layer, and saying "expected incorrect, got wrong-answer"
+    # there names the one layer that did its job.
+    pooledMatchesExpectation: bool = True
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.ERROR
+
+
+class UnexpectedScoreIssue(_BaseIssue):
+    """A solution scored outside the range it declared."""
+
+    kind: Literal['unexpected_score'] = 'unexpected_score'
+    solution: str
+    score: int
+    maxScore: int
+    expectedScore: Tuple[int, int]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.ERROR
+
+
+class CompilationFailedIssue(_BaseIssue):
+    """A solution did not compile.
+
+    Worth surfacing loudly because it is otherwise close to invisible: a
+    solution that failed to compile is filtered out of the skeleton's
+    `solutions`, so it is absent from the run entirely rather than showing up
+    with a bad verdict.
+    """
+
+    kind: Literal['compilation_failed'] = 'compilation_failed'
+    solution: str
+    # Why, when there is a one-line answer: "'g++' was not found".
+    reason: Optional[str] = None
+    # Relative to the runs dir, e.g. `compilation/0.log`.
+    log: pathlib.Path
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.ERROR
+
+
+class CompilationWarningsIssue(_BaseIssue):
+    """A solution compiled, but the compiler had something to say."""
+
+    kind: Literal['compilation_warnings'] = 'compilation_warnings'
+    solution: str
+    warnings: List[CompilationWarning] = []
+    log: pathlib.Path
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.WARNING
+
+
+class BorderlineTleIssue(_BaseIssue):
+    """A solution declared slow was only slow inside the doubled time limit.
+
+    Under `-v4` (the default) rbx judges at 2x the time limit and rewrites an
+    over-TL run to TLE, so a solution that fits inside that doubled window is
+    borderline rather than decisively slow -- the testset does not really prove
+    what the declaration claims. The run itself passes, which is exactly why
+    this needs saying: `status` is OK and the expectation matched.
+    """
+
+    kind: Literal['borderline_tle'] = 'borderline_tle'
+    solution: str
+    # The groups that contributed, empty when only the pooled layer did.
+    groups: List[str] = []
+    # The verdicts the solution would have had without the time limit: it
+    # finished inside double TL, but wrongly.
+    doubleTlVerdicts: List[Outcome] = []
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.WARNING
+
+
+class HiddenVerdictIssue(_BaseIssue):
+    """A soft TLE hid a verdict that no expectation accepts.
+
+    The solution was reported TLE at 1x, but underneath it was doing something
+    else -- a wrong answer, a crash -- that the declaration does not allow.
+    """
+
+    kind: Literal['hidden_verdict'] = 'hidden_verdict'
+    solution: str
+    groups: List[str] = []
+    verdicts: List[Outcome] = []
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.WARNING
+
+
+class TightTimeMarginIssue(_BaseIssue):
+    """A solution that passed came uncomfortably close to the time limit."""
+
+    kind: Literal['tight_time_margin'] = 'tight_time_margin'
+    solution: str
+    maxTime: float  # seconds
+    timeLimit: float  # seconds
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.WARNING
+
+
+class UntunedLimitsIssue(_BaseIssue):
+    """Expectations failed on timing, and the limits were never tuned here.
+
+    A package-level issue rather than a per-solution one: the answer is a single
+    `rbx time`, not one per solution, so the affected solutions are listed on one
+    issue instead of producing several that all say the same thing.
+    """
+
+    kind: Literal['untuned_limits'] = 'untuned_limits'
+    affectedSolutions: List[str] = []
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.WARNING
+
+
+Issue = Annotated[
+    Union[
+        UnmetExpectationIssue,
+        UnexpectedScoreIssue,
+        CompilationFailedIssue,
+        CompilationWarningsIssue,
+        BorderlineTleIssue,
+        HiddenVerdictIssue,
+        TightTimeMarginIssue,
+        UntunedLimitsIssue,
+    ],
+    Field(discriminator='kind'),
+]
+
+
+class IssueReport(BaseModel):
+    """Everything `rbx issues` found, and enough context to read it.
+
+    `ranAt` is a POSIX timestamp rather than a rendered "4m ago": the client
+    decides how to say it, and a machine reader wants the number. It is absent
+    only alongside an empty `issues` on a package that was never run -- which
+    `neverRun` says outright, since "no issues" and "no run" are opposite news.
+    """
+
+    version: int = ISSUES_FORMAT_VERSION
+    neverRun: bool = False
+    ranAt: Optional[float] = None
+    # The runs directory the relative paths on these issues hang off -- a
+    # compilation log is `compilation/0.log`, and on its own that resolves
+    # against whatever the reader's working directory happens to be. Published
+    # rather than left implicit because a client is not necessarily running from
+    # the package root, and the contest view is never running from any of them.
+    runsDir: Optional[str] = None
+    issues: List[Issue] = []
+
+    def errors(self) -> List[Issue]:
+        return [issue for issue in self.issues if issue.severity == IssueSeverity.ERROR]
+
+    def warnings(self) -> List[Issue]:
+        return [
+            issue for issue in self.issues if issue.severity == IssueSeverity.WARNING
+        ]
+
+
+class ContestIssueRow(BaseModel):
+    """One problem's line in the contest-wide view.
+
+    `failedToLoad` is its own state rather than an empty report: a problem whose
+    package could not be read is not a problem without issues, and a contest
+    table that renders the two the same way is lying about the one case the
+    reader most needs to see.
+    """
+
+    short_name: str
+    name: str
+    report: IssueReport = IssueReport()
+    failed_to_load: bool = False

--- a/rbx/box/run_report.py
+++ b/rbx/box/run_report.py
@@ -159,6 +159,27 @@ class RunSolutionReport(BaseModel):
     # subset run or a `--fail-fast` abort leaves that set and the one a client
     # finds on disk disagreeing.
     sanitizerWarnings: bool = False
+    # The time limit this solution was judged against, in seconds.
+    #
+    # The *enforced* limit, so it is absent exactly when none was enforced (a
+    # sanitized run drops it). Published because `maxTime` alone cannot answer
+    # the question a reader actually has -- how much headroom is left -- and
+    # because the limit a solution runs under is not the package's `timeLimit`
+    # whenever a language modifier or a `--profile` applies. Resolving that
+    # needs `skeleton.get_solution_limits`, which is `solutions` state a client
+    # has no business reimplementing.
+    timeLimit: Optional[float] = None
+    # Whether this solution's failure is the kind that untuned limits explain.
+    #
+    # True when a slow verdict went unmatched -- declared slow and wasn't, or
+    # wasn't and was -- on a run that used the package's own limits and skipped
+    # nothing. It is what makes rbx suggest `rbx time`.
+    #
+    # Answered here rather than left to the client for the reason
+    # `unexpectedNoTleVerdicts` is: deciding it needs the per-layer
+    # `bad_verdicts` sets, which are internal shape no artifact publishes, and a
+    # client approximating it from `outcome` would quietly disagree with rbx.
+    untunedLimitsSuspected: bool = False
     groups: List[RunGroupReport] = []
 
 
@@ -284,6 +305,11 @@ def build_solution_report(
         runUnderDoubleTl=report.runUnderDoubleTl,
         doubleTlVerdicts=_sorted_outcomes(report.doubleTlVerdicts),
         sanitizerWarnings=report.sanitizerWarnings,
+        # Milliseconds on `Limits`, seconds here: every other duration the
+        # report publishes comes off `eval.log.time`, which is in seconds, and a
+        # file mixing the two units would be a trap.
+        timeLimit=report.limits.time / 1000 if report.limits.time is not None else None,
+        untunedLimitsSuspected=report.untunedLimitsSuspected,
         groups=groups,
     )
 

--- a/rbx/box/solutions.py
+++ b/rbx/box/solutions.py
@@ -75,7 +75,7 @@ from rbx.box.rendering import CellSlot, Throttling
 # to break -- and the board has to be a real class here, not a string, because a
 # dataclass default_factory is evaluated at runtime.
 from rbx.box.runners.base import RunProgress
-from rbx.box.sanitizers import compilation_warnings, issue_stack
+from rbx.box.sanitizers import compilation_warnings
 from rbx.box.schema import (
     ExpectedOutcome,
     GeneratorCall,
@@ -429,17 +429,6 @@ class RunSolutionResult:
         await self.runner.close()
 
 
-class FailedSolutionIssue(issue_stack.Issue):
-    def __init__(self, solution: Solution):
-        self.solution = solution
-
-    def get_detailed_section(self) -> Tuple[str, ...]:
-        return ('solutions',)
-
-    def get_detailed_message(self) -> str:
-        return f'{self.solution.href()} has an unexpected outcome.'
-
-
 def is_fast(solution: Solution) -> bool:
     # A solution expected to be slow anywhere -- for the whole testset or for a
     # single group -- is not a fast solution.
@@ -504,32 +493,6 @@ def get_exact_matching_solutions(expected_outcome: ExpectedOutcome) -> List[Solu
         if solution.outcome == expected_outcome:
             res.append(solution)
     return res
-
-
-class FailedToCompileSolutionIssue(issue_stack.Issue):
-    def __init__(self, solution: Solution, exception: Optional[BaseException] = None):
-        self.solution = solution
-        self.exception = exception
-
-    def get_detailed_section(self) -> Tuple[str, ...]:
-        return ('solutions',)
-
-    def _reason(self) -> Optional[str]:
-        if (
-            isinstance(self.exception, steps.CompilationError)
-            and self.exception.not_found_executable
-        ):
-            return f"'{self.exception.not_found_executable}' was not found"
-        return None
-
-    def get_detailed_message(self) -> str:
-        reason = self._reason()
-        if reason is not None:
-            return (
-                f'{self.solution.href()} could not be compiled ({reason}) '
-                'and was skipped.'
-            )
-        return f'{self.solution.href()} could not be compiled and was skipped.'
 
 
 class SolutionCompilationTask(live_tasks.CompilationTask):
@@ -605,9 +568,6 @@ async def compile_solutions(
                     failures[key.solution.path] = exception
                 if exception.not_found_executable:
                     key.skip_reason = f"'{exception.not_found_executable}' not found"
-                issue_stack.add_issue(
-                    FailedToCompileSolutionIssue(key.solution, exception=exception)
-                )
 
         streamer = SolutionCompilationStreamer(
             setter_config.get_async_executor(detach=True)
@@ -2029,6 +1989,19 @@ class SolutionOutcomeReport(BaseModel):
     # here rather than by whoever renders it.
     unexpectedNoTleVerdicts: Set[Outcome]
     sanitizerWarnings: bool
+    # Whether this solution's failure is the kind that untuned limits explain.
+    #
+    # True when a slow verdict went unmatched -- the solution was declared slow
+    # and wasn't, or wasn't and was -- on a run that used the package's own
+    # limits (no `--profile`) and skipped nothing. All three conditions matter:
+    # a limits profile means the setter already chose the limits deliberately,
+    # and a truncated run only looks "too fast" because the testcase that would
+    # have timed out never ran.
+    #
+    # Stored rather than re-derived because the answer needs `bad_verdicts`,
+    # which is per-expectation-layer state that no published artifact carries.
+    # See `run_report.RunSolutionReport.untunedLimitsSuspected`.
+    untunedLimitsSuspected: bool = False
     verification: VerificationLevel
     scoring: ScoreType
 
@@ -2322,26 +2295,6 @@ def _get_evals_per_group(
     return res
 
 
-class TimingIssue(issue_stack.Issue):
-    def __init__(self):
-        pass
-
-    def get_detailed_section(self) -> Optional[Tuple[str, ...]]:
-        return ('timing',)
-
-    def get_detailed_message(self) -> str:
-        return (
-            'A few solutions in your problem have failed expectations either '
-            'because they were too fast or too slow. The limits for this problem '
-            'are being consumed from the package and might not be tuned to your machine. '
-            'Consider running [item]rbx time[/item] if you need more accurate limits '
-            'for your hardware.'
-        )
-
-    def get_severity(self) -> issue_stack.IssueSeverity:
-        return issue_stack.IssueSeverity.WARNING
-
-
 def get_solution_outcome_report(
     solution: Solution,
     skeleton: SolutionReportSkeleton,
@@ -2497,13 +2450,12 @@ def get_solution_outcome_report(
     # reaches the testcase that would have timed out, so it looks "too fast" only
     # because the rest never ran. Blaming the limits for that is misleading.
     has_skipped_eval = any(eval.result.outcome == Outcome.SKIPPED for eval in evals)
-    if (
+    untuned_limits_suspected = (
         report_issues
         and not has_skipped_eval
         and limits.profile is None
         and has_unmatched_slow_verdict
-    ):
-        issue_stack.add_issue(TimingIssue())
+    )
 
     return SolutionOutcomeReport(
         solution=solution,
@@ -2524,6 +2476,7 @@ def get_solution_outcome_report(
         doubleTlVerdicts=double_tl_verdicts,
         unexpectedNoTleVerdicts=verdict_report.unexpected_no_tle_verdicts,
         sanitizerWarnings=verdict_report.has_sanitizer_warnings,
+        untunedLimitsSuspected=untuned_limits_suspected,
         verification=verification,
         scoring=scoring,
     )
@@ -2542,8 +2495,6 @@ def _print_solution_outcome(
     report = get_solution_outcome_report(
         solution, skeleton, evals, verification, subset
     )
-    if not report.status:
-        issue_stack.add_issue(FailedSolutionIssue(solution))
     console.print(
         report.get_outcome_markup(
             skeleton=skeleton,

--- a/rbx/box/summary.py
+++ b/rbx/box/summary.py
@@ -1,4 +1,3 @@
-import pathlib
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel
@@ -391,8 +390,11 @@ async def print_contest_summary(contest: Contest, problems: List[Package]):
         row_data: list[str] = []
         short_name = contest.problems[i].short_name
 
-        raw_path = contest.problems[i].path
-        problem_path = pathlib.Path(raw_path) if raw_path else pathlib.Path('.')
+        # `get_path()`, never the raw `path`: it is None for a problem that
+        # relies on the default `./{short_name}/` layout, and reading the field
+        # directly sent every such problem to the contest root -- where no
+        # package is found, so the row was dropped and the table came out empty.
+        problem_path = contest.problems[i].get_path()
 
         row_data.append(short_name)
         row_data.append(problem.name)

--- a/tests/rbx/box/issues_test.py
+++ b/tests/rbx/box/issues_test.py
@@ -10,8 +10,10 @@ import json
 import pathlib
 import time
 import typing
+from unittest import mock
 
 import pytest
+import rich.console
 import yaml
 
 from rbx.box import run_report
@@ -577,3 +579,46 @@ class TestJsonOutput:
         )
 
         assert parsed == report
+
+
+class TestContestHint:
+    """The contest table shows one issue per problem, so it has to say how to
+    see the rest -- but only when there is a rest to see."""
+
+    def _render(self, rows, detailed=False) -> str:
+        recorder = rich.console.Console(record=True, width=200)
+        with mock.patch.object(rendering.console, 'console', recorder):
+            rendering.print_contest_report(rows, detailed=detailed)
+        return recorder.export_text()
+
+    def _row_with_issues(self) -> schema.ContestIssueRow:
+        return schema.ContestIssueRow(
+            short_name='A',
+            name='paths',
+            report=schema.IssueReport(
+                ranAt=time.time(),
+                issues=[schema.UntunedLimitsIssue(affectedSolutions=['sol/a.cpp'])],
+            ),
+        )
+
+    def test_points_at_detailed_when_a_problem_has_issues(self):
+        assert 'rbx contest issues -d' in self._render([self._row_with_issues()])
+
+    def test_stays_quiet_when_every_problem_is_clean(self):
+        row = schema.ContestIssueRow(
+            short_name='A', name='clean', report=schema.IssueReport(ranAt=time.time())
+        )
+
+        assert 'rbx contest issues -d' not in self._render([row])
+
+    def test_stays_quiet_when_nothing_has_been_run(self):
+        row = schema.ContestIssueRow(
+            short_name='A', name='fresh', report=schema.IssueReport(neverRun=True)
+        )
+
+        assert 'rbx contest issues -d' not in self._render([row])
+
+    def test_does_not_point_at_a_flag_the_reader_already_passed(self):
+        assert 'rbx contest issues -d' not in self._render(
+            [self._row_with_issues()], detailed=True
+        )

--- a/tests/rbx/box/issues_test.py
+++ b/tests/rbx/box/issues_test.py
@@ -1,0 +1,579 @@
+"""Tests for the issue detectors.
+
+Every detector is a pure function over a `RunState`, so these build one by hand
+rather than running a package: no sandbox, no compilation, no fixture. That is
+the point of the design -- the issue stack these replaced could only be
+exercised by running a real package end to end.
+"""
+
+import json
+import pathlib
+import time
+import typing
+
+import pytest
+import yaml
+
+from rbx.box import run_report
+from rbx.box.compilation_findings import CompilationWarning, SolutionCompilation
+from rbx.box.issues import detectors, rendering, run_state, schema
+from rbx.box.issues.contest import build_report
+from rbx.box.run_report import RunGroupReport, RunReport, RunSolutionReport
+from rbx.box.schema import ExpectedOutcome
+from rbx.grading.steps import Outcome
+
+
+def make_state(
+    solutions=None,
+    compilation=None,
+) -> run_state.RunState:
+    return run_state.RunState(
+        report=RunReport(solutions=solutions or []),
+        skeleton=run_state.SkeletonView(compilation=compilation or []),
+        runs_dir=pathlib.Path('.rbx/runs'),
+        ran_at=time.time(),
+    )
+
+
+def solution(**kwargs) -> RunSolutionReport:
+    defaults = dict(
+        path='sol/main.cpp',
+        index=0,
+        expectedOutcome=ExpectedOutcome.ACCEPTED,
+        outcome=Outcome.ACCEPTED,
+        status='OK',
+    )
+    defaults.update(kwargs)
+    return RunSolutionReport(**defaults)
+
+
+def kinds(issues) -> list:
+    return [issue.kind for issue in issues]
+
+
+class TestUnmetExpectations:
+    def test_reports_a_solution_that_missed_its_expectation(self):
+        state = make_state(
+            [
+                solution(
+                    path='sol/wa.cpp',
+                    expectedOutcome=ExpectedOutcome.WRONG_ANSWER,
+                    outcome=Outcome.ACCEPTED,
+                    status='UNEXPECTED_VERDICTS',
+                    matchesExpectation=False,
+                    pooledMatchesExpectation=False,
+                )
+            ]
+        )
+
+        (issue,) = detectors.detect_unmet_expectations(state)
+
+        assert issue == schema.UnmetExpectationIssue(
+            solution='sol/wa.cpp',
+            expected=ExpectedOutcome.WRONG_ANSWER,
+            got=Outcome.ACCEPTED,
+            status='UNEXPECTED_VERDICTS',
+            failedGroups=[],
+            pooledMatchesExpectation=False,
+        )
+        assert issue.severity == schema.IssueSeverity.ERROR
+
+    def test_stays_quiet_when_the_expectation_was_met(self):
+        assert detectors.detect_unmet_expectations(make_state([solution()])) == []
+
+    def test_carries_the_pooled_result_so_a_met_expectation_is_not_accused(self):
+        """A solution can fail only its per-group layer.
+
+        Saying "expected INCORRECT, got WA" there names the one expectation that
+        actually held, which is why the flag has to survive to the renderer.
+        """
+        state = make_state(
+            [
+                solution(
+                    path='sol/grp.cpp',
+                    expectedOutcome=ExpectedOutcome.INCORRECT,
+                    outcome=Outcome.WRONG_ANSWER,
+                    status='UNEXPECTED_VERDICTS',
+                    matchesExpectation=False,
+                    pooledMatchesExpectation=True,
+                    failedGroups=['big'],
+                )
+            ]
+        )
+
+        (issue,) = detectors.detect_unmet_expectations(state)
+
+        assert issue.pooledMatchesExpectation
+        assert issue.failedGroups == ['big']
+
+    def test_leaves_an_unexpected_score_to_its_own_detector(self):
+        """Otherwise one failure is reported twice, in two different words."""
+        state = make_state(
+            [
+                solution(
+                    status='UNEXPECTED_SCORE',
+                    matchesExpectation=False,
+                    score=40,
+                    maxScore=100,
+                    expectedScore=(80, 100),
+                )
+            ]
+        )
+
+        assert detectors.detect_unmet_expectations(state) == []
+        assert kinds(detectors.detect_unexpected_scores(state)) == ['unexpected_score']
+
+
+class TestUnexpectedScores:
+    def test_reports_the_declared_range(self):
+        state = make_state(
+            [
+                solution(
+                    status='UNEXPECTED_SCORE',
+                    matchesExpectation=False,
+                    score=40,
+                    maxScore=100,
+                    expectedScore=(80, 100),
+                )
+            ]
+        )
+
+        (issue,) = detectors.detect_unexpected_scores(state)
+
+        assert issue.score == 40
+        assert issue.maxScore == 100
+        assert issue.expectedScore == (80, 100)
+
+    def test_says_nothing_without_a_declared_range(self):
+        """With no range there is nothing to say that the verdict does not."""
+        state = make_state(
+            [solution(status='UNEXPECTED_SCORE', matchesExpectation=False, score=40)]
+        )
+
+        assert detectors.detect_unexpected_scores(state) == []
+
+
+class TestCompilation:
+    def test_reports_a_failure_as_an_error(self):
+        state = make_state(
+            compilation=[
+                SolutionCompilation(
+                    path=pathlib.Path('sol/bad.cpp'),
+                    outcome=ExpectedOutcome.ACCEPTED,
+                    status='FAILED',
+                    log=pathlib.Path('compilation/0.log'),
+                    reason="'g++' was not found",
+                )
+            ]
+        )
+
+        (issue,) = detectors.detect_compilation(state)
+
+        assert issue.kind == 'compilation_failed'
+        assert issue.severity == schema.IssueSeverity.ERROR
+        assert issue.reason == "'g++' was not found"
+
+    def test_reports_warnings_as_a_warning(self):
+        state = make_state(
+            compilation=[
+                SolutionCompilation(
+                    path=pathlib.Path('sol/warn.cpp'),
+                    outcome=ExpectedOutcome.ACCEPTED,
+                    status='WARNINGS',
+                    log=pathlib.Path('compilation/1.log'),
+                    warnings=[
+                        CompilationWarning(
+                            file='sol/warn.cpp', line=12, flag='-Wall', msg='unused'
+                        )
+                    ],
+                )
+            ]
+        )
+
+        (issue,) = detectors.detect_compilation(state)
+
+        assert issue.kind == 'compilation_warnings'
+        assert issue.severity == schema.IssueSeverity.WARNING
+        assert len(issue.warnings) == 1
+
+    def test_finds_a_solution_that_never_reached_the_report(self):
+        """A solution that failed to compile is absent from the run entirely.
+
+        It is filtered out of the skeleton's `solutions`, so the compilation
+        record is the only trace of it -- which is exactly why this detector
+        reads the skeleton instead of the report.
+        """
+        state = make_state(
+            solutions=[],
+            compilation=[
+                SolutionCompilation(
+                    path=pathlib.Path('sol/bad.cpp'),
+                    outcome=ExpectedOutcome.ACCEPTED,
+                    status='FAILED',
+                    log=pathlib.Path('compilation/0.log'),
+                )
+            ],
+        )
+
+        assert kinds(detectors.detect_all(state)) == ['compilation_failed']
+
+
+class TestTimingRisk:
+    def test_flags_a_solution_slow_only_within_double_tl(self):
+        state = make_state(
+            [
+                solution(
+                    path='sol/slow.cpp',
+                    expectedOutcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED,
+                    outcome=Outcome.TIME_LIMIT_EXCEEDED,
+                    runUnderDoubleTl=True,
+                    doubleTlVerdicts=[Outcome.ACCEPTED],
+                    groups=[RunGroupReport(name='main', runUnderDoubleTl=True)],
+                )
+            ]
+        )
+
+        (issue,) = detectors.detect_borderline_tle(state)
+
+        assert issue.groups == ['main']
+        assert issue.doubleTlVerdicts == [Outcome.ACCEPTED]
+        # The run itself passed -- which is the whole reason this needs saying.
+        assert state.report.solutions[0].matchesExpectation
+
+    def test_pools_hidden_verdicts_up_from_the_groups(self):
+        state = make_state(
+            [
+                solution(
+                    groups=[
+                        RunGroupReport(
+                            name='main',
+                            unexpectedNoTleVerdicts=[Outcome.WRONG_ANSWER],
+                        ),
+                        RunGroupReport(name='clean'),
+                    ]
+                )
+            ]
+        )
+
+        (issue,) = detectors.detect_hidden_verdicts(state)
+
+        # Only the group that actually hid something.
+        assert issue.groups == ['main']
+        assert issue.verdicts == [Outcome.WRONG_ANSWER]
+
+    def test_flags_a_passing_solution_close_to_the_limit(self):
+        state = make_state([solution(maxTime=0.95, timeLimit=1.0)])
+
+        (issue,) = detectors.detect_tight_time_margin(state)
+
+        assert issue.maxTime == 0.95
+        assert issue.timeLimit == 1.0
+
+    def test_leaves_a_comfortable_solution_alone(self):
+        state = make_state([solution(maxTime=0.2, timeLimit=1.0)])
+
+        assert detectors.detect_tight_time_margin(state) == []
+
+    def test_never_flags_a_solution_declared_slow(self):
+        """A solution declared slow is supposed to sit against the limit."""
+        state = make_state(
+            [
+                solution(
+                    expectedOutcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED,
+                    outcome=Outcome.TIME_LIMIT_EXCEEDED,
+                    maxTime=1.0,
+                    timeLimit=1.0,
+                )
+            ]
+        )
+
+        assert detectors.detect_tight_time_margin(state) == []
+
+    def test_needs_a_time_limit_to_compare_against(self):
+        """A sanitized run enforces none, so there is no margin to speak of."""
+        state = make_state([solution(maxTime=9.0, timeLimit=None)])
+
+        assert detectors.detect_tight_time_margin(state) == []
+
+    def test_collects_untuned_limits_into_one_issue(self):
+        state = make_state(
+            [
+                solution(path='sol/a.cpp', untunedLimitsSuspected=True),
+                solution(path='sol/b.cpp', untunedLimitsSuspected=True),
+                solution(path='sol/c.cpp'),
+            ]
+        )
+
+        (issue,) = detectors.detect_untuned_limits(state)
+
+        assert issue.affectedSolutions == ['sol/a.cpp', 'sol/b.cpp']
+
+    def test_says_nothing_when_no_solution_suspects_the_limits(self):
+        assert detectors.detect_untuned_limits(make_state([solution()])) == []
+
+
+class TestDetectAll:
+    def test_puts_errors_before_warnings(self):
+        state = make_state(
+            [
+                solution(path='sol/tight.cpp', maxTime=0.95, timeLimit=1.0),
+                solution(
+                    path='sol/wa.cpp',
+                    expectedOutcome=ExpectedOutcome.WRONG_ANSWER,
+                    status='UNEXPECTED_VERDICTS',
+                    matchesExpectation=False,
+                    pooledMatchesExpectation=False,
+                ),
+            ]
+        )
+
+        issues = detectors.detect_all(state)
+
+        assert kinds(issues) == ['unmet_expectation', 'tight_time_margin']
+
+    def test_a_clean_run_has_no_issues(self):
+        assert detectors.detect_all(make_state([solution()])) == []
+
+
+class TestLoadRunState:
+    def _write(self, runs_dir: pathlib.Path, report: RunReport) -> None:
+        run_report.write_report(run_report.report_path(runs_dir), report)
+
+    def test_reads_a_report_back_off_disk(self, tmp_path: pathlib.Path):
+        self._write(tmp_path, RunReport(solutions=[solution(path='sol/a.cpp')]))
+
+        state = run_state.load_run_state(tmp_path)
+
+        assert state is not None
+        assert [s.path for s in state.report.solutions] == ['sol/a.cpp']
+
+    def test_a_missing_report_means_never_run(self, tmp_path: pathlib.Path):
+        assert run_state.load_run_state(tmp_path) is None
+        assert build_report(tmp_path).neverRun
+
+    def test_a_corrupt_report_reads_as_never_run(self, tmp_path: pathlib.Path):
+        """The report is rewritten per solution, so it can be caught mid-write."""
+        run_report.report_path(tmp_path).write_text('{[not yaml')
+
+        assert run_state.load_run_state(tmp_path) is None
+
+    def test_refuses_a_report_from_a_newer_rbx(self, tmp_path: pathlib.Path):
+        path = run_report.report_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            yaml.safe_dump({'version': run_report.REPORT_VERSION + 1, 'solutions': []})
+        )
+
+        with pytest.raises(run_state.UnsupportedReportVersion):
+            run_state.load_run_state(tmp_path)
+
+    def test_tolerates_a_missing_skeleton(self, tmp_path: pathlib.Path):
+        self._write(tmp_path, RunReport(solutions=[solution()]))
+
+        state = run_state.load_run_state(tmp_path)
+
+        assert state is not None
+        assert state.skeleton.compilation == []
+
+    def test_reads_compilation_findings_off_the_skeleton(self, tmp_path: pathlib.Path):
+        self._write(tmp_path, RunReport())
+        (tmp_path / run_state.SKELETON_FILENAME).write_text(
+            yaml.safe_dump(
+                {
+                    'compilation': [
+                        {
+                            'path': 'sol/bad.cpp',
+                            'outcome': 'accepted',
+                            'status': 'FAILED',
+                            'log': 'compilation/0.log',
+                        }
+                    ]
+                }
+            )
+        )
+
+        state = run_state.load_run_state(tmp_path)
+
+        assert state is not None
+        assert [c.path for c in state.skeleton.compilation] == [
+            pathlib.Path('sol/bad.cpp')
+        ]
+
+    def test_report_records_where_relative_paths_hang_off(self, tmp_path: pathlib.Path):
+        self._write(tmp_path, RunReport())
+
+        assert build_report(tmp_path).runsDir == str(tmp_path)
+
+
+class TestSkeletonViewDoesNotDrift:
+    def test_parses_a_real_skeleton(self):
+        """`SkeletonView` is a narrow read of a model it does not import.
+
+        That is deliberate -- importing `solutions` would cost `rbx issues` the
+        whole box -- but it means nothing else stops the two disagreeing. So
+        assert the field is really there, and really means what is read here.
+        """
+        from rbx.box.solutions import SolutionReportSkeleton
+
+        field = SolutionReportSkeleton.model_fields['compilation']
+        view_field = run_state.SkeletonView.model_fields['compilation']
+
+        assert field.annotation == view_field.annotation
+
+
+class TestPublishedReportFields:
+    def test_untuned_limits_rides_the_report(self):
+        """The detector cannot re-derive this, so the report must carry it."""
+        assert 'untunedLimitsSuspected' in RunSolutionReport.model_fields
+
+    def test_time_limit_rides_the_report(self):
+        assert 'timeLimit' in RunSolutionReport.model_fields
+
+    def test_both_are_additive_and_default_off(self):
+        """Additive fields must not change how an existing report reads."""
+        entry = RunSolutionReport(
+            path='sol/a.cpp',
+            index=0,
+            expectedOutcome=ExpectedOutcome.ACCEPTED,
+            status='OK',
+        )
+
+        assert entry.untunedLimitsSuspected is False
+        assert entry.timeLimit is None
+
+
+class TestRendering:
+    """The wording lives in one place, so it is asserted in one place.
+
+    These replace the two `FailedToCompileSolutionIssue` message tests that used
+    to live in `solutions_test.py`: the messages moved here when the rendering
+    left the issue stack.
+    """
+
+    def test_a_compile_failure_names_the_reason(self):
+        issue = schema.CompilationFailedIssue(
+            solution='sols/wa.py',
+            reason="'python3' was not found",
+            log=pathlib.Path('compilation/0.log'),
+        )
+
+        assert 'python3' in rendering.summarize(issue)
+
+    def test_a_compile_failure_without_a_reason_still_reads(self):
+        issue = schema.CompilationFailedIssue(
+            solution='sols/wa.py', log=pathlib.Path('compilation/0.log')
+        )
+
+        assert rendering.summarize(issue) == 'failed to compile'
+
+    def test_never_names_a_pooled_expectation_that_held(self):
+        """Saying "expected INCORRECT, got WA" accuses the layer that worked."""
+        issue = schema.UnmetExpectationIssue(
+            solution='sol/grp.cpp',
+            expected=ExpectedOutcome.INCORRECT,
+            got=Outcome.WRONG_ANSWER,
+            status='UNEXPECTED_VERDICTS',
+            failedGroups=['big'],
+            pooledMatchesExpectation=True,
+        )
+
+        summary = rendering.summarize(issue)
+
+        assert 'INCORRECT' not in summary
+        assert 'big' in summary
+
+    def test_names_the_pooled_expectation_when_it_is_the_one_that_failed(self):
+        issue = schema.UnmetExpectationIssue(
+            solution='sol/wa.cpp',
+            expected=ExpectedOutcome.WRONG_ANSWER,
+            got=Outcome.ACCEPTED,
+            status='UNEXPECTED_VERDICTS',
+            pooledMatchesExpectation=False,
+        )
+
+        summary = rendering.summarize(issue)
+
+        assert 'WRONG_ANSWER' in summary
+        assert 'ACCEPTED' in summary
+
+    def test_a_log_link_resolves_against_the_runs_dir(self):
+        """The stored path is relative, so on its own it points nowhere."""
+        issue = schema.CompilationFailedIssue(
+            solution='sols/wa.py', log=pathlib.Path('compilation/0.log')
+        )
+
+        lines = rendering.explain(issue, runs_dir='/pkg/.rbx/runs')
+
+        assert any('/pkg/.rbx/runs/compilation/0.log' in line for line in lines)
+
+    def test_every_kind_has_a_summary_and_a_severity(self):
+        """A new kind must not fall through to 'unknown issue'."""
+        samples = [
+            schema.UnmetExpectationIssue(
+                solution='s', expected=ExpectedOutcome.ACCEPTED, status='OK'
+            ),
+            schema.UnexpectedScoreIssue(
+                solution='s', score=1, maxScore=2, expectedScore=(2, 2)
+            ),
+            schema.CompilationFailedIssue(solution='s', log=pathlib.Path('a.log')),
+            schema.CompilationWarningsIssue(solution='s', log=pathlib.Path('a.log')),
+            schema.BorderlineTleIssue(solution='s'),
+            schema.HiddenVerdictIssue(solution='s'),
+            schema.TightTimeMarginIssue(solution='s', maxTime=1.0, timeLimit=1.0),
+            schema.UntunedLimitsIssue(),
+        ]
+
+        # Every member of the union is covered.
+        assert {type(sample) for sample in samples} == set(
+            typing.get_args(typing.get_args(schema.Issue)[0])
+        )
+        for sample in samples:
+            assert rendering.summarize(sample) != 'unknown issue'
+            assert sample.severity in tuple(schema.IssueSeverity)
+
+    def test_humanizes_a_missing_timestamp_as_never(self):
+        assert rendering.humanize_since(None) == 'never'
+
+    def test_humanizes_a_recent_run(self):
+        assert rendering.humanize_since(time.time() - 5) == 'just now'
+        assert rendering.humanize_since(time.time() - 260) == '4m ago'
+
+
+class TestJsonOutput:
+    def test_carries_a_version_and_the_severity_of_each_issue(self):
+        report = schema.IssueReport(
+            ranAt=1.0,
+            issues=[schema.UntunedLimitsIssue(affectedSolutions=['sol/a.cpp'])],
+        )
+
+        payload = json.loads(rendering.to_json(report))
+
+        assert payload['version'] == schema.ISSUES_FORMAT_VERSION
+        assert payload['issues'][0]['kind'] == 'untuned_limits'
+        # Published, so a client keeps no table of which kinds are which.
+        assert payload['issues'][0]['severity'] == 'warning'
+
+    def test_a_never_run_package_says_so_rather_than_looking_clean(self):
+        payload = json.loads(rendering.to_json(schema.IssueReport(neverRun=True)))
+
+        assert payload['neverRun'] is True
+        assert payload['issues'] == []
+
+    def test_round_trips_through_the_discriminated_union(self):
+        report = schema.IssueReport(
+            issues=[
+                schema.UnmetExpectationIssue(
+                    solution='sol/wa.cpp',
+                    expected=ExpectedOutcome.WRONG_ANSWER,
+                    got=Outcome.ACCEPTED,
+                    status='UNEXPECTED_VERDICTS',
+                    pooledMatchesExpectation=False,
+                )
+            ]
+        )
+
+        parsed = schema.IssueReport.model_validate(
+            json.loads(rendering.to_json(report))
+        )
+
+        assert parsed == report

--- a/tests/rbx/box/solutions_test.py
+++ b/tests/rbx/box/solutions_test.py
@@ -33,7 +33,6 @@ from rbx.box.schema import (
 from rbx.box.solutions import (
     AbortContext,
     EvaluationItem,
-    FailedToCompileSolutionIssue,
     GroupOutcomeReport,
     GroupSkeleton,
     LiveRunReporter,
@@ -41,7 +40,6 @@ from rbx.box.solutions import (
     SolutionOutcomeStatus,
     SolutionReportSkeleton,
     SolutionSkeleton,
-    TimingIssue,
     TraditionalRunReporter,
     _AbortGate,  # noqa: SLF001
     _gates_report,  # noqa: SLF001
@@ -63,7 +61,6 @@ from rbx.box.testcase_extractors import extract_generation_testcases_from_groups
 from rbx.box.testcase_schema import TestcaseEntry
 from rbx.grading.limits import Limits
 from rbx.grading.steps import (
-    CompilationError,
     Evaluation,
     Outcome,
     RunTiming,
@@ -75,9 +72,7 @@ from tests.rbx.box.conftest import make_evaluation, make_generation_entry
 
 # The heaviest file in the suite: every test re-runs the same `box1` solutions
 # in a fresh problem directory. Sharing the problem cache takes it from 84s to
-# 42s. Compilation is a means here, never the assertion -- the two compilation
-# tests in this file exercise `FailedToCompileSolutionIssue` messages built by
-# hand, without compiling anything.
+# 42s. Compilation is a means here, never the assertion.
 pytestmark = pytest.mark.shared_cache
 
 
@@ -1260,7 +1255,11 @@ async def test_partial_reports_do_not_add_timing_issues(
     it. The timing heuristic reads too-fast/too-slow off the evals it is handed,
     so an all-accepted group that finishes before the slow group has started
     looks too fast in isolation, and used to collect a bogus `rbx time` warning
-    that way even though the final report was clean."""
+    that way even though the final report was clean.
+
+    The warning now rides the report as `untunedLimitsSuspected` instead of
+    being pushed onto an issue stack, but the gate is the same one and this
+    still pins it."""
     solution = Solution(
         path=pathlib.Path('sol.cpp'),
         outcome=ExpectedOutcome.TIME_LIMIT_EXCEEDED,
@@ -1281,40 +1280,29 @@ async def test_partial_reports_do_not_add_timing_issues(
         },
     )
 
-    with (
-        fresh_issue_stack() as issues,
-        patch('rbx.box.solutions.package.get_scoring', return_value=ScoreType.POINTS),
-    ):
+    with patch('rbx.box.solutions.package.get_scoring', return_value=ScoreType.POINTS):
         await drive_reporter(
             LiveRunReporter(result, VerificationLevel.FULL, recording_console()),
             skeleton,
         )
 
-    # Exactly one: the report at solution end, which is the one entitled to speak
-    # about the run. Both group ends also built a report, to render their score.
-    assert len([i for i in issues.issues if isinstance(i, TimingIssue)]) == 1
-
     # The very evals the group-1 partial report saw. As a rendering-only report
-    # they raise nothing; as a final one they still do, so `report_issues` is the
-    # only difference between the two calls.
+    # it must not suspect the limits; as a final one it still does, so
+    # `report_issues` is the only difference between the two calls.
     partial_evals = [make_evaluation(Outcome.ACCEPTED) for _ in range(2)]
-    with fresh_issue_stack() as issues:
-        get_solution_outcome_report(
-            solution,
-            skeleton,
-            partial_evals,
-            VerificationLevel.FULL,
-            report_issues=False,
-        )
+    partial = get_solution_outcome_report(
+        solution,
+        skeleton,
+        partial_evals,
+        VerificationLevel.FULL,
+        report_issues=False,
+    )
+    assert not partial.untunedLimitsSuspected
 
-    assert [issue for issue in issues.issues if isinstance(issue, TimingIssue)] == []
-
-    with fresh_issue_stack() as issues:
-        get_solution_outcome_report(
-            solution, skeleton, partial_evals, VerificationLevel.FULL
-        )
-
-    assert any(isinstance(issue, TimingIssue) for issue in issues.issues)
+    final = get_solution_outcome_report(
+        solution, skeleton, partial_evals, VerificationLevel.FULL
+    )
+    assert final.untunedLimitsSuspected
 
 
 def test_report_evals_are_not_clobbered_by_the_per_group_loop(tmp_path, mock_skeleton):
@@ -1634,30 +1622,6 @@ def test_solution_outcome_report_points_scoring_with_dependencies(
     assert report.gotScore == 60
 
 
-def test_failed_to_compile_issue_includes_not_found_reason():
-    sol = Solution(
-        path=pathlib.Path('sols/wa.py'), outcome=ExpectedOutcome.WRONG_ANSWER
-    )
-    exc = CompilationError()
-    exc.not_found_executable = 'python3'
-    issue = FailedToCompileSolutionIssue(sol, exception=exc)
-
-    msg = issue.get_detailed_message()
-    assert 'python3' in msg
-    assert 'sols/wa.py' in msg
-
-
-def test_failed_to_compile_issue_generic_message_without_reason():
-    sol = Solution(
-        path=pathlib.Path('sols/wa.py'), outcome=ExpectedOutcome.WRONG_ANSWER
-    )
-    issue = FailedToCompileSolutionIssue(sol)
-
-    msg = issue.get_detailed_message()
-    assert 'could not be compiled and was skipped' in msg
-    assert 'sols/wa.py' in msg
-
-
 @pytest.mark.parametrize('outcome', list(Outcome))
 def test_outcome_styles_are_valid_rich_styles(outcome: Outcome):
     # Rich has no plain 'orange' color, and an invalid style blows up at render
@@ -1911,21 +1875,19 @@ def test_timing_issues_are_not_raised_off_a_truncated_run(
     wrong_answer = make_evaluation(Outcome.WRONG_ANSWER)
 
     # Ran to the end and never timed out: the limits really may be untuned.
-    with fresh_issue_stack() as issues:
-        get_solution_outcome_report(
-            solution, skeleton, [wrong_answer], VerificationLevel.FULL
-        )
-    assert any(isinstance(issue, TimingIssue) for issue in issues.issues)
+    complete = get_solution_outcome_report(
+        solution, skeleton, [wrong_answer], VerificationLevel.FULL
+    )
+    assert complete.untunedLimitsSuspected
 
     # Same verdicts, but the run stopped: the missing TLE says nothing.
-    with fresh_issue_stack() as issues:
-        get_solution_outcome_report(
-            solution,
-            skeleton,
-            [wrong_answer, make_evaluation(Outcome.SKIPPED, time_ms=None)],
-            VerificationLevel.FULL,
-        )
-    assert [issue for issue in issues.issues if isinstance(issue, TimingIssue)] == []
+    truncated = get_solution_outcome_report(
+        solution,
+        skeleton,
+        [wrong_answer, make_evaluation(Outcome.SKIPPED, time_ms=None)],
+        VerificationLevel.FULL,
+    )
+    assert not truncated.untunedLimitsSuspected
 
 
 async def test_plain_report_drops_the_timing_summary_when_timing_is_off(


### PR DESCRIPTION
Part of #792. Design: [`docs/plans/2026-08-31-issues-view-design.md`](docs/plans/2026-08-31-issues-view-design.md).

## The problem

After `rbx run`, telling whether the problem is in a good state means reading a scroll of output — verdicts in the solution table, warnings printed as the run went, an issue tree rendered from a contextvar stack at process exit. None of it survives the process, so asking again five minutes later means running again. At contest level the state of ten problems lives in ten `.rbx/runs` directories, with only `rbx each` to bring them together.

## What this adds

`rbx issues` answers what the last run revealed. `rbx summary` keeps answering what the problem *is*.

```
$ rbx issues
2 errors, 2 warnings   (last run 4m ago)

x sol/wa.cpp    expected WRONG_ANSWER, got ACCEPTED
x sol/bad.cpp   failed to compile: 'g++' was not found
! sol/slow.cpp  slow only within 2x the time limit
! the time limit may not be tuned to this machine

$ rbx contest issues
  #  Problem      Last run   Err  Warn  Worst issue
  A  add-two      4m ago       0     0  -
  B  paths        4m ago       2     1  sol/wa.cpp: expected WA, got AC
  C  tree-query   never        -     -  not run
```

`-d/--detailed` expands each issue; `--format json` is a versioned contract for tooling.

## Design decisions

**Issues are derived, not persisted.** A registry of pure detectors over the artifacts `.rbx/runs` already holds (`report.yml`, `skeleton.yml`, `compilation/*.log`). No new file, no write path, no second copy of the truth to drift. Widening `report.yml` with an `issues:` list was rejected — it's deliberately lean and cleared per run, so anything not produced by `rbx run` would keep vanishing.

**`rbx run` re-reads from disk** rather than passing in-memory objects to the renderer. `RunReportWriter` has already written the file; going through the same path `rbx issues` uses makes it impossible for the two to word a finding differently.

**The VS Code extension shells out** to `--format json`. If it re-derived the detectors in TypeScript that would reintroduce exactly the cross-language drift `run_report.py` exists to prevent.

**No freshness verdict.** A contest row shows *when* the problem last ran and nothing more — a wrong stale/fresh verdict is worse than none.

## Detectors

Seven, each a pure `RunState -> List[Issue]`: unmet expectations, unexpected scores, compilation failures, compilation warnings, borderline TLE, verdicts a soft TLE hid, tight time margins, untuned limits.

Purity is the practical gain over the issue stack: that could only be exercised by running a real package through a real sandbox, while the whole detector suite runs in **0.08s** against `RunState`s built by hand.

## Two additive report fields

Both on `RunSolutionReport`, both optional, so no `REPORT_VERSION` bump:

- `untunedLimitsSuspected` — needs the per-layer `bad_verdicts` sets, which no artifact publishes. A client approximating it from `outcome` would quietly disagree with rbx, so rbx answers instead (same argument as `unexpectedNoTleVerdicts`).
- `timeLimit` — the enforced limit the solution ran under, which is not the package's `timeLimit` whenever a language modifier or `--profile` applies.

## Retired

`FailedSolutionIssue`, `FailedToCompileSolutionIssue`, `TimingIssue`. `issue_stack` stays for its non-run producers (statement builds, sandbox limit warnings, too-much-stderr) — those have no on-disk source yet.

## Also fixed

Separate commit: `rbx contest summary` read `ContestProblem.path` directly, which is `None` for the default `./{short_name}/` layout — so a contest that never set explicit paths printed "Failed to summarize problem" per problem and an **empty table**. Found while writing the contest collector, which copied the same line.

## Verification

- `tests/rbx/box/issues_test.py` — 41 new tests, no sandbox
- 1301 passed across `issues`, `solutions`, `run_report`, `summary`, `lazy_cli`, `completion`, `compilation_findings`, both compile-failure suites
- Manually exercised all four states end to end: clean, with issues, never-run, failed-to-load — problem and contest level, rich and JSON
- Completion spec regenerated; CLI reference and cheatsheet updated by hand

## Follow-ups

Filed separately: sanitizer-finding detector, noisy-stderr detector, persisting linter warnings, persisting statement build failures, run-context caveats, config-level checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bz2xsjpRjMFDSFfu5NfW1