### PR TITLE
fix(schema): tolerate unknown fields in a limits profile

### DIFF
--- a/rbx/box/schema.py
+++ b/rbx/box/schema.py
@@ -1020,7 +1020,12 @@ skipped. Presentation-only.""",
 
 
 class TimingGroupReport(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+    # Ignored rather than refused, for the reason `LimitsProfile` gives: this is
+    # reachable only from a profile (`groups`, `baseEstimate`), it is written by
+    # rbx and never by hand, and under `forbid` a field added to it would break
+    # an older rbx's parse of the whole profile just as surely as one added a
+    # level up.
+    model_config = ConfigDict(extra='ignore')
 
     languages: List[str]
     timeLimit: int
@@ -1194,7 +1199,23 @@ class UnitTests(BaseModel):
 
 
 class LimitsProfile(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+    # Unknown keys are ignored, not refused -- the one model in this file that
+    # tolerates them, and deliberately.
+    #
+    # A `limits/<name>.yml` is written by rbx (`rbx time --integrate`, the TUI
+    # limits editor), so a setter reads profiles that a *different* rbx wrote:
+    # a teammate's, or their own after an upgrade or a downgrade. Under
+    # `extra='forbid'` every field added here is a hard break in that direction
+    # -- the older rbx refuses to parse the profile at all, and the limits it
+    # was going to run under are simply unavailable. `estimationChecksum` was
+    # the field that made this concrete.
+    #
+    # Ignoring costs the typo-catching that `forbid` buys elsewhere, which is a
+    # real loss on a file a setter may hand-edit. It is the smaller one: a
+    # mistyped key falls back to a documented default, while a refused profile
+    # stops the command. This is also what `run_report` already relies on for
+    # the same reason -- see its `REPORT_VERSION` note on additive fields.
+    model_config = ConfigDict(extra='ignore')
 
     inheritFromPackage: bool = Field(
         default=False,

--- a/tests/rbx/box/limits_info_test.py
+++ b/tests/rbx/box/limits_info_test.py
@@ -1278,3 +1278,77 @@ class TestGetSavedLimitsProfileCaching:
 
         assert a is not None and b is not None
         assert a.inheritFromPackage and b.inheritFromPackage
+
+
+class TestProfilesFromANewerRbx:
+    """A profile is written by rbx, so it is read by a *different* rbx.
+
+    A teammate's, or the setter's own before or after an upgrade. Every field
+    added to `LimitsProfile` therefore has to be readable by an rbx that has
+    never heard of it, which is what these pin. See the `model_config` comment
+    on `LimitsProfile`.
+    """
+
+    def _write(self, tmp_path, text: str) -> None:
+        limits_dir = tmp_path / 'test_problem' / '.limits'
+        limits_dir.mkdir(parents=True)
+        (limits_dir / 'local.yml').write_text(text)
+
+    def test_an_unknown_top_level_field_does_not_refuse_the_profile(
+        self, pkg_cder, tmp_path
+    ):
+        self._write(
+            tmp_path,
+            'timeLimit: 2000\nsomeFieldFromANewerRbx: "seg:abc123"\n',
+        )
+
+        with pkg_cder(tmp_path / 'test_problem'):
+            profile = limits_info.get_saved_limits_profile('local')
+
+        # The limits the setter asked for are still available.
+        assert profile is not None
+        assert profile.timeLimit == 2000
+
+    def test_an_unknown_field_inside_a_timing_group_is_tolerated(
+        self, pkg_cder, tmp_path
+    ):
+        """`groups` entries are nested in the profile and equally rbx-written,
+        so a field added there must not break the parse either."""
+        self._write(
+            tmp_path,
+            'timeLimit: 2000\n'
+            'groups:\n'
+            '  - languages: ["cpp"]\n'
+            '    timeLimit: 2000\n'
+            '    origin: estimated\n'
+            '    someFieldFromANewerRbx: 7\n',
+        )
+
+        with pkg_cder(tmp_path / 'test_problem'):
+            profile = limits_info.get_saved_limits_profile('local')
+
+        assert profile is not None
+        assert profile.groups is not None
+        assert profile.groups[0].languages == ['cpp']
+
+    def test_estimation_checksum_round_trips(self, pkg_cder, tmp_path):
+        """The field that made the forward-compat problem concrete."""
+        self._write(
+            tmp_path,
+            'timeLimit: 2000\nestimationChecksum: "sols:abc,tests:def"\n',
+        )
+
+        with pkg_cder(tmp_path / 'test_problem'):
+            profile = limits_info.get_saved_limits_profile('local')
+
+        assert profile is not None
+        assert profile.estimationChecksum == 'sols:abc,tests:def'
+
+    def test_a_genuinely_wrong_value_is_still_refused(self, pkg_cder, tmp_path):
+        """Tolerating unknown *keys* must not tolerate a bad value for a known
+        one -- that is a broken profile, not a newer one."""
+        self._write(tmp_path, 'timeLimit: "not_a_number"\n')
+
+        with pkg_cder(tmp_path / 'test_problem'):
+            with pytest.raises(YamlValidationError):
+                limits_info.get_saved_limits_profile('local')


### PR DESCRIPTION
Follow-up to #832, which added `estimationChecksum` to `LimitsProfile`.

## Why

A `limits/<name>.yml` is written by rbx — `rbx time --integrate`, the TUI limits editor — so a setter routinely reads profiles that a *different* rbx wrote: a teammate's, or their own after an upgrade or a downgrade.

`LimitsProfile` was `extra='forbid'`, so **every field added to it is a hard break in that direction**. The older rbx doesn't ignore the field it doesn't know — it refuses to parse the profile at all, so the limits it was about to run under become unavailable rather than merely incomplete.

## What changed

`LimitsProfile` and `TimingGroupReport` now `extra='ignore'`.

`TimingGroupReport` is included because it is reachable only from a profile (`groups`, `baseEstimate`) and is equally rbx-written — a field added there breaks the parse just as surely as one a level up.

`TimingMultipliers` is **deliberately left strict**: unlike the other two it is also embedded in the hand-written `env.rbx.yml` (`environment.py`) and `problem.rbx.yml` (`PackageTiming`), where `forbid` is catching real typos. `LimitModifiers` already had no `model_config`, so it was tolerant already.

`extra='ignore'` rather than `'allow'`: every writer constructs a fresh `LimitsProfile(...)` from known fields rather than round-tripping a parsed one, and `model_to_yaml` uses `exclude_unset=True` — so `'allow'` would not actually preserve unknown keys through a rewrite. `ignore` is also what `run_report`'s models already rely on, for the same forward-compat reason its `REPORT_VERSION` note spells out.

## The honest caveat

**This does not retroactively fix already-released versions.** They have `forbid` compiled in and will still refuse a profile carrying `estimationChecksum`. What it buys is that the *next* field added here costs nothing, and that this is the last version that has to be special-cased.

## The tradeoff

Ignoring unknown keys gives up the typo-catching `forbid` was providing on a file a setter may hand-edit — and `LimitsProfile` has no published JSON schema (it's not in `dump_schemas`), so `forbid` was its only such check.

I took that as the smaller loss: a mistyped key falls back to a documented default, while a refused profile stops the command outright. If you'd rather keep the feedback, the natural middle is `extra='allow'` plus a warning naming unknown keys — that would also read usefully as "this profile came from a newer rbx". Happy to add it; I left it out as beyond the ask.

## Verification

- 4 new tests in `TestProfilesFromANewerRbx` (`limits_info_test.py`), including one that a genuinely bad *value* is still refused — tolerating unknown keys must not tolerate `timeLimit: "not_a_number"`
- Verified the two forward-compat tests actually **fail** under the old `forbid`, so they pin something real
- 346 passed across `limits_info`, `test_limits_profile_groups`, `test_limits_table`, `test_timing_config`, `test_timing_groups`, `test_timing_multipliers`, `test_schema`, `estimation_checksum_test`, `test_run_profile_cli`, `test_yaml_error_handling`, `test_sharing`, `test_boca_limits_table`
- `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bz2xsjpRjMFDSFfu5NfW1