### PR TITLE
feat(contest): run `rbx on`/`rbx each` inline with --inline

### DIFF
--- a/docs/setters/contest-profiling-walkthrough.md
+++ b/docs/setters/contest-profiling-walkthrough.md
@@ -192,6 +192,20 @@ rbx on B time -p boca --auto     # one problem, straight in your terminal
 A single problem is a single command, so {{rbx}} skips the app entirely and runs it in
 place. Two or more and you get the sidebar again.
 
+`-i` (`--inline`) makes that the rule rather than the exception. It runs every problem's
+chain straight in your terminal, one after another, printing which command is running for
+which problem and nothing else:
+
+```bash
+rbx on -i A,C time -p boca --auto
+rbx each --inline time -p boca --auto
+```
+
+You lose the sidebar and the per-problem scrollback, and you get plain, scrollable output
+you can pipe or read in a log -- plus an exit code that is non-zero if any command failed.
+That makes it the mode to reach for over a handful of problems, and the one to use from a
+script or any other tool that can't answer a TUI.
+
 !!! tip
     `-k` (`--keep-going`) keeps a problem's chain running after one of its commands fails.
     It belongs to `rbx on` and `rbx each`, not to `time`, so it has to come **before** the

--- a/rbx/box/cli/commands/flow.py
+++ b/rbx/box/cli/commands/flow.py
@@ -41,8 +41,14 @@ app = typer.Typer(cls=annotations.AliasGroup)
     ```
 
     A single command on a single problem runs directly in your terminal; anything
-    else opens the TUI. Since flags after the problem selector belong to the chained
-    commands, `-k`/`--keep-going` has to come first: `rbx on -k A build :: run`.
+    else opens the TUI. Pass `-i`/`--inline` to keep everything in the terminal
+    instead, running each problem's chain in turn and exiting non-zero if any
+    command failed -- handy for a couple of problems, or for a script that cannot
+    answer a TUI.
+
+    Since flags after the problem selector belong to the chained commands,
+    `-k`/`--keep-going` and `-i`/`--inline` have to come first:
+    `rbx on -ik A build :: run`.
     """)
 )
 def on(
@@ -55,8 +61,9 @@ def on(
         ),
     ],
     keep_going: bool = contest.KEEP_GOING_OPTION,
+    inline: bool = contest.INLINE_OPTION,
 ) -> None:
-    contest.on(ctx, problems, keep_going=keep_going)
+    contest.on(ctx, problems, keep_going=keep_going, inline=inline)
 
 
 @app.command(
@@ -86,6 +93,15 @@ def on(
 
     Commands you type into the TUI later are queued too, but they always run, even
     after a failure.
+
+    Pass `-i`/`--inline` to skip the TUI and run every problem's chain straight in
+    your terminal, one after another. Nothing is interactive in that mode, and the
+    command exits non-zero if any command failed, so it is the mode to reach for
+    from a script.
 """)
-def each(ctx: typer.Context, keep_going: bool = contest.KEEP_GOING_OPTION) -> None:
-    contest.each(ctx, keep_going=keep_going)
+def each(
+    ctx: typer.Context,
+    keep_going: bool = contest.KEEP_GOING_OPTION,
+    inline: bool = contest.INLINE_OPTION,
+) -> None:
+    contest.each(ctx, keep_going=keep_going, inline=inline)

--- a/rbx/box/completion/_spec.py
+++ b/rbx/box/completion/_spec.py
@@ -44,6 +44,16 @@ SPEC = {
                     'value': {'kind': 'none'},
                 },
                 {
+                    'help': 'Run the commands straight in this terminal, one after another, '
+                    'instead of opening the TUI. Must come before the problem '
+                    'selector in `rbx on`.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--inline', '-i'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
                     'help': 'Show this message and exit.',
                     'kind': 'option',
                     'multiple': False,
@@ -66,6 +76,16 @@ SPEC = {
                     'kind': 'option',
                     'multiple': False,
                     'names': ['--keep-going', '-k'],
+                    'takes_value': False,
+                    'value': {'kind': 'none'},
+                },
+                {
+                    'help': 'Run the commands straight in this terminal, one after another, '
+                    'instead of opening the TUI. Must come before the problem '
+                    'selector in `rbx on`.',
+                    'kind': 'option',
+                    'multiple': False,
+                    'names': ['--inline', '-i'],
                     'takes_value': False,
                     'value': {'kind': 'none'},
                 },
@@ -2501,6 +2521,16 @@ SPEC = {
                             'value': {'kind': 'none'},
                         },
                         {
+                            'help': 'Run the commands straight in this terminal, one '
+                            'after another, instead of opening the TUI. Must '
+                            'come before the problem selector in `rbx on`.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--inline', '-i'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        },
+                        {
                             'help': 'Show this message and exit.',
                             'kind': 'option',
                             'multiple': False,
@@ -2531,6 +2561,16 @@ SPEC = {
                             'kind': 'option',
                             'multiple': False,
                             'names': ['--keep-going', '-k'],
+                            'takes_value': False,
+                            'value': {'kind': 'none'},
+                        },
+                        {
+                            'help': 'Run the commands straight in this terminal, one '
+                            'after another, instead of opening the TUI. Must '
+                            'come before the problem selector in `rbx on`.',
+                            'kind': 'option',
+                            'multiple': False,
+                            'names': ['--inline', '-i'],
                             'takes_value': False,
                             'value': {'kind': 'none'},
                         },

--- a/rbx/box/contest/main.py
+++ b/rbx/box/contest/main.py
@@ -1,10 +1,11 @@
 import inspect
 import os
 import pathlib
+import shlex
 import shutil
 import subprocess
 import tempfile
-from typing import Annotated, List, Optional, Tuple
+from typing import TYPE_CHECKING, Annotated, List, Optional, Tuple
 
 import rich.prompt
 import ruyaml
@@ -36,6 +37,9 @@ from rbx.box.yaml_validation import (
     load_yaml_model,
 )
 from rbx.config import open_editor
+
+if TYPE_CHECKING:
+    from rbx.box.ui.command_app import CommandEntry
 
 app = typer.Typer(no_args_is_help=True, cls=annotations.AliasGroup)
 
@@ -418,6 +422,16 @@ KEEP_GOING_OPTION = typer.Option(
     ),
 )
 
+INLINE_OPTION = typer.Option(
+    False,
+    '--inline',
+    '-i',
+    help=(
+        'Run the commands straight in this terminal, one after another, instead '
+        'of opening the TUI. Must come before the problem selector in `rbx on`.'
+    ),
+)
+
 
 def _export_contest_selection() -> None:
     """Make the active contest selection visible to the `rbx` children we spawn.
@@ -461,6 +475,48 @@ def _build_command_argvs_or_die(
         raise typer.Exit(1) from e
 
 
+def _run_inline(commands: List['CommandEntry'], keep_going: bool) -> None:
+    """Run every chain in this terminal instead of opening the TUI.
+
+    Each entry's commands run in order in the entry's directory, and their
+    output goes straight to the terminal -- nothing is captured, so a command
+    that draws its own progress still looks like it does on its own. A failing
+    command skips the rest of that entry's chain unless `keep_going`; other
+    entries run either way, mirroring the TUI. The exit code is non-zero if any
+    command failed, which is what makes the flag usable from a script.
+    """
+    failed = False
+    for command in commands:
+        for argv in command.argvs:
+            line = shlex.join(argv)
+            console.console.print(
+                f'[status]Running [item]{line}[/item] for '
+                f'[item]{command.display_name}[/item]...[/status]'
+            )
+            code = subprocess.call(line, cwd=command.cwd, shell=True)
+            if code == 0:
+                continue
+            failed = True
+            console.console.print(
+                f'[error]Command [item]{line}[/item] failed for '
+                f'[item]{command.display_name}[/item] with exit code {code}.[/error]'
+            )
+            if not keep_going:
+                break
+
+    if failed:
+        raise typer.Exit(1)
+
+
+def _die_with_nothing_to_run() -> None:
+    console.console.print(
+        '[error]No command to run.[/error]\n'
+        '[status]Pass a command to run inline, e.g. '
+        '[item]rbx each --inline build[/item].[/status]'
+    )
+    raise typer.Exit(1)
+
+
 @app.command(
     'each',
     help=(
@@ -476,13 +532,22 @@ def _build_command_argvs_or_die(
     },
 )
 @within_contest
-def each(ctx: typer.Context, keep_going: bool = KEEP_GOING_OPTION) -> None:
+def each(
+    ctx: typer.Context,
+    keep_going: bool = KEEP_GOING_OPTION,
+    inline: bool = INLINE_OPTION,
+) -> None:
     from rbx.box.ui.command_app import CommandEntry, start_command_app
 
     contest = find_contest_package_or_die()
     _export_contest_selection()
-    if not ctx.args and _offer_run_history():
-        return
+    if not ctx.args:
+        # There is nothing to type a command into when running inline, so an
+        # empty `--inline` is a mistake rather than an invitation to browse.
+        if inline:
+            _die_with_nothing_to_run()
+        if _offer_run_history():
+            return
     argvs, placeholder_prefix = _build_command_argvs_or_die(ctx.args)
     commands = [
         CommandEntry(
@@ -494,6 +559,9 @@ def each(ctx: typer.Context, keep_going: bool = KEEP_GOING_OPTION) -> None:
         )
         for problem in contest.problems
     ]
+    if inline:
+        _run_inline(commands, keep_going=keep_going)
+        return
     start_command_app(commands, keep_going=keep_going)
 
 
@@ -527,6 +595,7 @@ def on(
         ),
     ] = None,
     keep_going: bool = KEEP_GOING_OPTION,
+    inline: bool = INLINE_OPTION,
 ) -> None:
     _export_contest_selection()
     if problems is None:
@@ -552,23 +621,17 @@ def on(
         )
         raise typer.Exit(1)
 
-    if not ctx.args and _offer_run_history(
-        [naming.get_contest_problem_label(p) for p in problems_of_interest]
-    ):
-        # A selector but nothing to run: show this problem's history.
-        return
+    if not ctx.args:
+        # See `each`: inline has nowhere to queue a command typed later.
+        if inline:
+            _die_with_nothing_to_run()
+        if _offer_run_history(
+            [naming.get_contest_problem_label(p) for p in problems_of_interest]
+        ):
+            # A selector but nothing to run: show this problem's history.
+            return
 
     argvs, placeholder_prefix = _build_command_argvs_or_die(ctx.args)
-
-    # A single command on a single problem keeps the plain-terminal fast path;
-    # a chain needs the queue, so it opens the app with one tab.
-    if len(problems_of_interest) == 1 and len(argvs) <= 1:
-        command = ' '.join(['rbx'] + ctx.args)
-        console.console.print(
-            f'[status]Running [item]{command}[/item] for [item]{naming.get_contest_problem_label(problems_of_interest[0])}[/item]...[/status]'
-        )
-        subprocess.call(command, cwd=problems_of_interest[0].get_path(), shell=True)
-        return
 
     from rbx.box.ui.command_app import CommandEntry, start_command_app
 
@@ -582,6 +645,14 @@ def on(
         )
         for p in problems_of_interest
     ]
+
+    # A single command on a single problem already reads fine in the terminal,
+    # so it takes the inline path whether or not the flag is there; anything
+    # else needs the queue, and opens the app unless asked to stay inline.
+    if inline or (len(problems_of_interest) == 1 and len(argvs) <= 1):
+        _run_inline(commands, keep_going=keep_going)
+        return
+
     start_command_app(commands, keep_going=keep_going)
 
 

--- a/tests/rbx/box/contest/test_contest_main.py
+++ b/tests/rbx/box/contest/test_contest_main.py
@@ -414,7 +414,7 @@ class TestContestOn:
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
         with (
-            mock.patch.object(contest_main.subprocess, 'call') as call,
+            mock.patch.object(contest_main.subprocess, 'call', return_value=0) as call,
             mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
         ):
             result = runner.invoke(contest_main.app, ['on', 'A', 'build'])
@@ -427,7 +427,7 @@ class TestContestOn:
         self, runner: CliRunner, contest_dir: pathlib.Path
     ):
         with (
-            mock.patch.object(contest_main.subprocess, 'call') as call,
+            mock.patch.object(contest_main.subprocess, 'call', return_value=0) as call,
             mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
         ):
             result = runner.invoke(
@@ -475,7 +475,7 @@ class TestContestOn:
         # `-C` only lives in a contextvar, so the child would otherwise resolve
         # the canonical contest and not find itself in its `problems[]`.
         with (
-            mock.patch.object(contest_main.subprocess, 'call') as call,
+            mock.patch.object(contest_main.subprocess, 'call', return_value=0) as call,
             mock.patch('rbx.box.ui.command_app.start_command_app'),
         ):
             result = runner.invoke(
@@ -513,7 +513,7 @@ class TestContestOn:
         clean_contest_env,
     ):
         with (
-            mock.patch.object(contest_main.subprocess, 'call'),
+            mock.patch.object(contest_main.subprocess, 'call', return_value=0),
             mock.patch('rbx.box.ui.command_app.start_command_app'),
         ):
             result = runner.invoke(contest_main.app, ['on', 'A', 'build'])
@@ -654,3 +654,154 @@ class TestContestEach:
 
         assert result.exit_code == 1
         assert 'No recorded runs' in result.output
+
+
+class TestContestInline:
+    """`--inline`: the whole chain runs in this terminal, TUI untouched."""
+
+    @pytest.fixture
+    def contest_dir(
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        clear_package_caches,
+    ) -> pathlib.Path:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'contest.rbx.yml').write_text(
+            'name: ctt\n'
+            'problems:\n'
+            '  - short_name: A\n    path: probs/a\n'
+            '  - short_name: B\n    path: probs/b\n'
+        )
+        for name in ('a', 'b'):
+            _write_minimal_problem(tmp_path / 'probs' / name, f'prob-{name}')
+        return tmp_path
+
+    def test_each_inline_runs_every_chain_in_the_terminal(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with (
+            mock.patch.object(contest_main.subprocess, 'call', return_value=0) as call,
+            mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
+        ):
+            result = runner.invoke(
+                contest_main.app, ['each', '--inline', 'build', '::', 'run', '-s']
+            )
+
+        assert result.exit_code == 0, result.output
+        start_app.assert_not_called()
+        assert [c.args[0] for c in call.call_args_list] == [
+            'rbx build',
+            'rbx run -s',
+            'rbx build',
+            'rbx run -s',
+        ]
+        assert [str(c.kwargs['cwd']) for c in call.call_args_list] == [
+            'probs/a',
+            'probs/a',
+            'probs/b',
+            'probs/b',
+        ]
+
+    def test_on_inline_runs_a_chain_over_a_range_of_problems(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with (
+            mock.patch.object(contest_main.subprocess, 'call', return_value=0) as call,
+            mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
+        ):
+            result = runner.invoke(
+                contest_main.app, ['on', '-i', 'A..B', 'build', '::', 'run']
+            )
+
+        assert result.exit_code == 0, result.output
+        start_app.assert_not_called()
+        assert [c.args[0] for c in call.call_args_list] == [
+            'rbx build',
+            'rbx run',
+            'rbx build',
+            'rbx run',
+        ]
+
+    def test_a_failing_command_skips_the_rest_of_its_own_chain_only(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        # `rbx build` fails in the first problem; its `rbx run` is skipped, but
+        # the second problem still runs its whole chain.
+        codes = {'rbx build': 1}
+        with mock.patch.object(
+            contest_main.subprocess,
+            'call',
+            side_effect=lambda cmd, **kwargs: codes.pop(cmd, 0),
+        ) as call:
+            result = runner.invoke(
+                contest_main.app, ['each', '--inline', 'build', '::', 'run']
+            )
+
+        assert result.exit_code == 1, result.output
+        assert [c.args[0] for c in call.call_args_list] == [
+            'rbx build',
+            'rbx build',
+            'rbx run',
+        ]
+        assert 'failed' in result.output
+
+    def test_keep_going_runs_the_rest_of_a_failing_chain(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        codes = {'rbx build': 1}
+        with mock.patch.object(
+            contest_main.subprocess,
+            'call',
+            side_effect=lambda cmd, **kwargs: codes.pop(cmd, 0),
+        ) as call:
+            result = runner.invoke(
+                contest_main.app, ['each', '-k', '--inline', 'build', '::', 'run']
+            )
+
+        # The chain kept going, but the failure still shows in the exit code.
+        assert result.exit_code == 1, result.output
+        assert [c.args[0] for c in call.call_args_list] == [
+            'rbx build',
+            'rbx run',
+            'rbx build',
+            'rbx run',
+        ]
+
+    def test_inline_without_a_command_is_an_error(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with (
+            mock.patch('rbx.box.ui.run_picker.open_run_history') as history,
+            mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
+        ):
+            result = runner.invoke(contest_main.app, ['each', '--inline'])
+
+        assert result.exit_code == 1
+        assert 'No command to run' in result.output
+        # Neither the history picker nor a blank session may open in this mode.
+        history.assert_not_called()
+        start_app.assert_not_called()
+
+    def test_on_inline_without_a_command_is_an_error(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with (
+            mock.patch('rbx.box.ui.run_picker.open_run_history') as history,
+            mock.patch('rbx.box.ui.command_app.start_command_app') as start_app,
+        ):
+            result = runner.invoke(contest_main.app, ['on', '-i', 'A'])
+
+        assert result.exit_code == 1
+        assert 'No command to run' in result.output
+        history.assert_not_called()
+        start_app.assert_not_called()
+
+    def test_a_shell_command_stays_unprefixed_inline(
+        self, runner: CliRunner, contest_dir: pathlib.Path
+    ):
+        with mock.patch.object(contest_main.subprocess, 'call', return_value=0) as call:
+            result = runner.invoke(contest_main.app, ['each', '--inline', 'bash', '-c'])
+
+        assert result.exit_code == 0, result.output
+        assert [c.args[0] for c in call.call_args_list] == ['bash -c', 'bash -c']


### PR DESCRIPTION
## What

Adds `-i` / `--inline` to both `rbx on` and `rbx each`. Instead of opening the command app, it runs every selected problem's chain straight in the terminal, one command after another, and exits non-zero if any of them failed.

```bash
rbx on -i A..C build :: run
rbx each --inline package boca
```

The TUI is the wrong shape for a couple of problems, and it is unusable from a script or an agentic tool, which cannot answer a TUI. `--inline` is the mode for both.

Behaviour:

- Each problem's chain runs in order, in the problem's own directory. Output is not captured, so a command that draws its own progress still looks like it does on its own.
- A failing command skips the rest of *that* problem's chain unless `-k`/`--keep-going` is passed. Other problems run either way, mirroring the TUI.
- The exit code is non-zero if any command failed.
- `--inline` with no command is an error -- there is nowhere to type one later, so it must not fall through to the run-history picker or a blank session.
- Like `-k`, `-i` has to come **before** the problem selector on `rbx on`, since flags after it belong to the chained command: `rbx on -ik A..C build :: run`.

## Behaviour change worth a look

`rbx on A build` -- the existing single-command-on-a-single-problem fast path -- now **propagates the child's exit code**. It previously always exited 0 no matter how the command ended. It shares the new inline helper, and leaving one inline path silent while the other reported failures seemed worse than the change. Three existing tests needed `return_value=0` on their mocked `subprocess.call` as a result.

## Test plan

- 7 new tests in `tests/rbx/box/contest/test_contest_main.py` covering both commands: chain order and per-problem cwd, chain-skip on failure vs. `--keep-going`, exit codes, the empty-command error, and shell commands staying unprefixed.
- `uv run pytest tests/rbx/box/contest/ tests/rbx/box/completion/ tests/rbx/box/lazy_cli_test.py` -> 1264 passed.
- `ruff check .` and `ruff format --check` clean.
- Regenerated the committed completion spec (`mise run gen-completion-spec`); the diff is only the two new options.
- Driven by hand against a scratch two-problem contest: correct cwd per problem, chain-skip on failure, `-ik` keeping the chain going, exit code 1 either way.

## Docs

Short passage in `docs/setters/contest-profiling-walkthrough.md`, beside the existing explanation of when `rbx on` skips the app. `docs/setters/reference/cli.md` is left alone -- it does not list `--keep-going` for these commands either, so it is already drifted from the generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjuYLR6gxRWUpzEqB8bzhU
