### PR TITLE
test(timing): give the compute_time_limits tests a real package

### DIFF
--- a/tests/rbx/box/test_timing_run_all_cli.py
+++ b/tests/rbx/box/test_timing_run_all_cli.py
@@ -119,15 +119,24 @@ def _solution(name: str, outcome: ExpectedOutcome) -> Solution:
     return Solution(path=pathlib.Path(name), language='cpp', outcome=outcome)
 
 
+# `compute_time_limits` operates on the package in the cwd throughout -- it stamps
+# the estimate with `estimation_checksum.compute()`, which reads the solutions off
+# disk -- so these need a real package under the cwd even though every step they
+# assert on is mocked out.
 async def _compute(
     tmp_path: pathlib.Path,
     run_all: bool,
     lower: Optional[List[Solution]] = None,
     remaining_ok: bool = True,
+    run_remaining: Optional[mock.AsyncMock] = None,
     **kwargs,
 ):
     lower = lower or [_solution('sols/ac.cpp', ExpectedOutcome.ACCEPTED)]
-    run_remaining = mock.AsyncMock(return_value=remaining_ok)
+    # Taken from the caller when it has to outlive the call -- `compute_time_limits`
+    # raises on a failing extra run, so the test asserting that cannot read the mock
+    # off the return value.
+    if run_remaining is None:
+        run_remaining = mock.AsyncMock(return_value=remaining_ok)
 
     async def _estimate_and_validate(*_, **__):
         return timing.TimingProfile(timeLimit=1000)
@@ -156,14 +165,16 @@ async def _compute(
     return profile, run_remaining
 
 
-async def test_the_extra_run_only_happens_when_asked(tmp_path: pathlib.Path):
+async def test_the_extra_run_only_happens_when_asked(
+    tmp_path: pathlib.Path, testing_pkg: testing_package.TestingPackage
+):
     _, run_remaining = await _compute(tmp_path, run_all=False)
 
     assert not run_remaining.called
 
 
 async def test_the_solutions_the_estimate_ran_are_not_run_again(
-    tmp_path: pathlib.Path,
+    tmp_path: pathlib.Path, testing_pkg: testing_package.TestingPackage
 ):
     lower = [_solution('sols/ac.cpp', ExpectedOutcome.ACCEPTED)]
 
@@ -174,16 +185,24 @@ async def test_the_solutions_the_estimate_ran_are_not_run_again(
     assert 'sols/ac.cpp' in already_run
 
 
-async def test_a_failing_extra_run_fails_the_command(tmp_path: pathlib.Path):
+async def test_a_failing_extra_run_fails_the_command(
+    tmp_path: pathlib.Path, testing_pkg: testing_package.TestingPackage
+):
     import typer
 
+    run_remaining = mock.AsyncMock(return_value=False)
     with pytest.raises(typer.Exit) as exc:
-        await _compute(tmp_path, run_all=True, remaining_ok=False)
+        await _compute(tmp_path, run_all=True, run_remaining=run_remaining)
 
+    # Asserted so the test cannot pass on an exit raised before the extra run ever
+    # happened -- which is exactly how it kept passing while #844 was open.
+    assert run_remaining.called
     assert exc.value.exit_code == 1
 
 
-async def test_a_passing_extra_run_still_returns_the_profile(tmp_path: pathlib.Path):
+async def test_a_passing_extra_run_still_returns_the_profile(
+    tmp_path: pathlib.Path, testing_pkg: testing_package.TestingPackage
+):
     profile, _ = await _compute(tmp_path, run_all=True)
 
     assert profile is not None


### PR DESCRIPTION
Fixes #844 — `main` is red: three tests in `tests/rbx/box/test_timing_run_all_cli.py` fail on every PR.

## Cause

`compute_time_limits` operates on the package in the cwd from end to end, and since #832 it also stamps the estimate with `estimation_checksum.compute()`, which reads the solutions off disk. The four tests that drive it directly mocked out every package reach they knew about and ran from wherever pytest was launched, so the new one aborted them with `Problem not found`.

## Fix

They now take `testing_pkg`, like the other six tests in the file, rather than growing another mock.

I did **not** take the issue's preferred option (1), threading a `root` through `estimation_checksum.compute()`. That API would be half-true: `_fingerprint_code` → `_closure_of` → `graph.expand` resolves the package root as `pathlib.Path()` and `_digest_path` reads relative paths, so the segments would still describe the cwd no matter what root was passed. The cwd is the contract this module is written to — `contest/statements.py:94` points it at another problem with `cd.new_package_cd`, not with a root argument — so a test of a cwd-scoped function belongs inside a package. Threading a root is a real refactor of `graph.expand` and out of scope for unbreaking `main`.

## Also fixed: a test passing for the wrong reason

`test_a_failing_extra_run_fails_the_command` was green throughout, on the wrong exit — it only asserted `Exit(1)`, which the `Problem not found` abort also raises. It now asserts the extra run was actually attempted first. Verified: with the package fixture removed again, it fails on `assert run_remaining.called`, where before it passed.

## Verification

- `uv run pytest tests/rbx/box/test_timing_run_all_cli.py tests/rbx/box/estimation_checksum_test.py -q` → **44 passed** (was 3 failed, 7 passed on `main`).
- `uv run ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBSruDnz1h9LrW6eRGuZg7