### PR TITLE
fix(stress): report a missing solution in a finder cleanly

### DIFF
--- a/rbx/box/stressing/finder_parser.py
+++ b/rbx/box/stressing/finder_parser.py
@@ -441,6 +441,12 @@ def parse(
     expression: str, reference_solution: Optional[Solution] = None
 ) -> lark.ParseTree:
     tree = LARK_PARSER.parse(expression)
-    tree = FinderSolutionResolver().transform(tree)
+    try:
+        tree = FinderSolutionResolver().transform(tree)
+    except lark.exceptions.VisitError as e:
+        # Surface the underlying error (e.g. a non-existing solution, which exits
+        # with a clean message) instead of lark's wrapper, which would reach the
+        # CLI as an unhandled traceback.
+        raise e.orig_exc from None
     validate(tree, reference_solution)
     return tree

--- a/tests/rbx/box/stressing/test_finder_parser.py
+++ b/tests/rbx/box/stressing/test_finder_parser.py
@@ -276,8 +276,28 @@ class TestParseFunction:
         testing_pkg.save()
 
         reference = Solution(path='nonexistent.cpp')
-        with pytest.raises((typer.Exit, lark.exceptions.VisitError)):
+        with pytest.raises(typer.Exit):
             parse('nonexistent.cpp', reference_solution=reference)
+
+    def test_parse_validation_fails_for_missing_solution_in_expression(
+        self, testing_pkg: testing_package.TestingPackage
+    ):
+        """Test that a missing solution fails cleanly even alongside existing ones.
+
+        The solution resolver runs inside a lark Transformer, which wraps any
+        exception raised by a callback. The clean `typer.Exit` must still reach
+        the caller instead of lark's `VisitError`.
+        """
+        testing_pkg.add_solution(
+            'sol.cpp', outcome=ExpectedOutcome.ACCEPTED
+        ).write_text('#include <iostream>\nint main() { return 0; }')
+        testing_pkg.set_checker('checker.cpp', src='checkers/checker.cpp')
+        testing_pkg.save()
+
+        reference = Solution(path='sol.cpp')
+        with pytest.raises(typer.Exit) as exc_info:
+            parse('sol.cpp && nonexistent.cpp', reference_solution=reference)
+        assert exc_info.value.exit_code == 1
 
     def test_parse_validation_fails_for_missing_checker(
         self, testing_pkg: testing_package.TestingPackage
@@ -870,7 +890,7 @@ class TestParseTreeMethods:
         testing_pkg.save()
 
         # parse() runs the resolver which calls expand_solutions,
-        # failing for non-existent solutions (wrapped in VisitError by Lark).
+        # failing for non-existent solutions.
         reference = Solution(path='nonexistent.cpp')
-        with pytest.raises((typer.Exit, lark.exceptions.VisitError)):
+        with pytest.raises(typer.Exit):
             parse('nonexistent.cpp', reference_solution=reference)


### PR DESCRIPTION
Closes #847.

## Problem

Referencing a non-existing solution in a stress finder expression (e.g. `rbx stress -f 'sol.cpp && nope.cpp'`, or a `finder` in a `stresses:` entry) crashed the tool with a traceback:

```
lark.exceptions.VisitError: Error trying to process rule "solution":
```

## Root cause

`FinderSolutionResolver` resolves solution paths through `expand_solutions`, which prints a clean message and raises `typer.Exit(1)` when a solution is missing. But that resolver is a `lark.Transformer`, and lark's `_call_userfunc` wraps **every** exception a callback raises in a `VisitError`. So the clean exit never reached Typer — it escaped `parse()` as an unhandled `VisitError` and `main.py`'s excepthook printed a traceback, right after the correct error message had already been printed.

`validate()` has a nicer, finder-specific message for this case, but it runs *after* the resolver, so it was never reached for solutions named in the expression. (It still fires for a main solution declared in `problem.rbx.yml` that is missing on disk, so it is not dead code.)

## Fix

Unwrap the `VisitError` in `finder_parser.parse()` and re-raise the original exception — the same pattern `parse_and_transform` already uses in `rbx/box/stressing/generator_script_parser.py`.

The user now gets `Solution nope.cpp could not be found.` and exit code 1, with no traceback.

## Tests

- Added `test_parse_validation_fails_for_missing_solution_in_expression`, covering a missing solution alongside an existing one and asserting the exit code is 1.
- Tightened two existing tests that accepted `(typer.Exit, lark.exceptions.VisitError)` — that tolerance was encoding the bug.

`uv run pytest tests/rbx/box/stressing/` → 231 passed. `tests/rbx/box/test_stress_promote.py` + `solutions_test.py` → 121 passed. Ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FRkyYuhATTRZrtVSJH1LH