### PR TITLE
feat(crash): write a report file when rbx crashes

### DIFF
--- a/docs/crash-reports.md
+++ b/docs/crash-reports.md
@@ -1,0 +1,80 @@
+# Crash reports
+
+Every once in a while, {{rbx}} will crash on you: not a "your validator rejected this test"
+error, but an actual traceback, the kind that means {{rbx}} itself has a bug.
+
+When that happens, the useful part is always the same -- the traceback, the command you ran, and
+the directory you ran it in -- and it's always in the worst possible place: your terminal
+scrollback. By the time you get around to looking into it, you've scrolled past it, or closed the
+window, and all you remember is that "something broke during `rbx build`".
+
+So {{rbx}} writes it down. After a crash, you'll see a line like this:
+
+```
+Crash report written to /Users/you/Library/Application Support/rbx/crashes/20260905T094952Z-86725.md
+```
+
+That file has everything the terminal had, and it isn't going anywhere.
+
+## What's in it
+
+The report is a Markdown file that opens with a block of context and then shows the full
+traceback:
+
+```markdown
+---
+rbx_version: "1.4.2"
+timestamp: "2026-09-05T09:49:52.248804+00:00"
+command: "rbx build"
+cwd: "/Users/you/contest/problem-a"
+package: "/Users/you/contest/problem-a"
+exception: "RuntimeError"
+message: "synthetic crash"
+python: "3.14.3"
+platform: "darwin"
+pid: 86725
+argv: ["rbx", "build"]
+---
+
+# rbx crash
+
+`rbx build` in `/Users/you/contest/problem-a`
+
+## Traceback
+
+...
+```
+
+The two fields worth knowing about are `command` -- the exact invocation, quoted so you can paste
+it straight back into a shell -- and `cwd`, the directory it ran in. Those are the two things
+you'd otherwise have to remember, and the two things anyone looking at the crash will ask you for
+first.
+
+The block at the top is valid YAML, so the whole file is as easy to read for a program as it is
+for you.
+
+## Where to find it
+
+Reports live in the `crashes` folder of your {{rbx}} app directory: `~/Library/Application
+Support/rbx` on MacOS, `~/.config/rbx` on Linux. Only the newest 20 are kept, since old crashes
+stop being interesting once the bug behind them is fixed, and {{rbx}} would rather clean up after
+itself than have you do it. A `latest.md` symlink beside them always points at the most recent
+one:
+
+```
+<app dir>/crashes/
+├── 20260905T094952Z-86725.md
+├── 20260904T171203Z-47110.md
+└── latest.md -> 20260905T094952Z-86725.md
+```
+
+If the crash happened inside a problem or contest package, you'll also find a `last-crash.md`
+symlink inside that package's `.rbx` cache folder, pointing at the same report. It's just a
+shortcut for finding the crash that belongs to the package you're working on. It's a cache
+folder, so the shortcut disappears whenever the cache is cleared, and it's gitignored -- it will
+never end up in a commit.
+
+!!! note
+    Only real crashes are reported. Interrupting {{rbx}} with ++ctrl+c++, and the ordinary errors
+    {{rbx}} raises to tell you that something in your package is wrong, are not bugs, and they
+    don't produce a report.

--- a/docs/plans/2026-09-05-crash-reports-design.md
+++ b/docs/plans/2026-09-05-crash-reports-design.md
@@ -1,0 +1,101 @@
+# Crash reports
+
+## Problem
+
+When rbx dies of an uncaught exception, everything useful about the failure
+lives in terminal scrollback: the traceback, the command that produced it, the
+directory it ran in. By the time someone -- or something -- gets around to
+debugging it, the scrollback has been scrolled past, truncated, or lost with the
+window. There is no artifact to hand over.
+
+A crash should leave a file behind.
+
+## What counts as a crash
+
+Only exceptions that actually end the process unexpectedly. `KeyboardInterrupt`,
+`typer.Abort`, `typer.Exit` and `SystemExit` are how rbx and its user stop it on
+purpose, and `RbxException` is rbx's own channel for telling the user they did
+something wrong -- a missing generator, a malformed `problem.rbx.yml`. None of
+those are bugs, and logging them would bury the reports that are.
+
+Task exceptions surfacing through the asyncio exception handler, and exceptions
+raised in background threads, are out of scope: they frequently do not end the
+process at all.
+
+## Where the hook goes
+
+`rbx/box/main.py:app()` already wraps `run_app_cli()` in a `try` with a clause
+per intentional-exit case. The crash clause goes last, reports, and re-raises so
+the traceback still renders exactly as it does today.
+
+It cannot hang off `sys.excepthook`. `Typer.__call__` opens with
+
+```python
+if sys.excepthook != except_hook:
+    sys.excepthook = except_hook
+```
+
+so any hook installed before the CLI runs is replaced the moment it runs. (This
+is also why the `KeyboardInterrupt` suppression in
+`_install_no_exception_handlers` never takes effect -- untouched here, but worth
+knowing.) The `try` block is the seam that survives, because typer re-raises
+into it.
+
+## Format
+
+Markdown with a YAML frontmatter block. The frontmatter is a clean parse target;
+the body is what a person reads.
+
+```markdown
+---
+rbx_version: "1.4.2"
+timestamp: "2026-09-05T14:12:33+00:00"
+command: "rbx run -s sol.cpp"
+cwd: "/Users/x/probs/a-plus-b"
+package: "/Users/x/probs/a-plus-b"
+exception: "KeyError"
+message: "'foo'"
+python: "3.11.9"
+platform: "darwin"
+pid: 48211
+argv: ["rbx", "run", "-s", "sol.cpp"]
+---
+
+# rbx crash
+
+`rbx run -s sol.cpp` in `/Users/x/probs/a-plus-b`
+
+## Traceback
+
+```
+Traceback (most recent call last):
+...
+```
+```
+
+`command` is the shell-quoted reconstruction of the invocation and `cwd` its
+absolute working directory -- the two facts a reader needs first, named plainly
+and sitting at the top. Scalars are emitted as JSON strings, which are valid
+YAML double-quoted scalars, so no value can break the block.
+
+## Where the file goes
+
+The canonical report is written to `<app path>/crashes/<UTC timestamp>-<pid>.md`
+and the directory is pruned to the newest 20 reports. A `latest.md` symlink
+points at the most recent one.
+
+If the crash happened inside a package whose `.rbx` cache directory already
+exists, a `last-crash.md` symlink is dropped in there too. `.rbx` is gitignored
+by every preset and wiped whenever the cache is cleared, so the pointer expires
+on its own and never reaches a commit. The package is located by walking
+ancestors for `problem.rbx.yml` or `contest.rbx.yml` -- not by
+`package.get_problem_cache_dir()`, which takes cache locks and can itself raise.
+
+Symlinks are best-effort. On a filesystem that refuses them the report is still
+written, and only the global path is reported.
+
+## Failure is not an option
+
+`report_crash` is wrapped end to end in `except Exception: return None`. A bug in
+the crash reporter must never mask, replace, or add noise to the crash it exists
+to record. The caller prints a path only when it gets one back.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   #     - "JSON schemas": "internal/schemas.md"
   #     - "Backporting a fix": "internal/backporting.md"
   - "Troubleshooting":
+      - "Crash reports": "crash-reports.md"
       - "Generators and rbx.h": "generators-and-rbx-h.md"
       - "cpp-on-macos.md"
       - "stack-limit.md"

--- a/rbx/box/main.py
+++ b/rbx/box/main.py
@@ -108,5 +108,23 @@ def app():
     except RbxException as e:
         print(str(e))
         sys.exit(1)
+    except typer.Exit:
+        # An intentional exit, not a crash. Click normally handles this one
+        # itself, but it must never be reported if it does get this far.
+        raise
+    except BaseException as e:
+        # A real crash. Leave a file behind before the traceback scrolls away,
+        # then re-raise so it still renders exactly as it did before.
+        #
+        # This has to live here rather than in `sys.excepthook`: `Typer.__call__`
+        # opens by overwriting that hook with its own, so anything installed
+        # before the CLI runs is gone by the time it could fire. Typer re-raises
+        # into this block instead.
+        from rbx import crash
+
+        path = crash.report_crash(e)
+        if path is not None:
+            print(f'Crash report written to {path}', file=sys.stderr)
+        raise
     finally:
         Console().show_cursor()

--- a/rbx/crash.py
+++ b/rbx/crash.py
@@ -1,0 +1,155 @@
+"""Leave a file behind when rbx dies of an uncaught exception.
+
+Everything useful about a crash -- the traceback, the command that produced it,
+the directory it ran in -- otherwise lives only in terminal scrollback, and is
+gone by the time anyone gets around to debugging it. `report_crash` writes it
+all to a Markdown file with a YAML frontmatter block: parseable at the top,
+readable below.
+
+Imports here are deliberately thin, and the heavier ones are deferred into the
+functions, because this module is imported by `rbx.box.main` on every single
+invocation and does its work on approximately none of them.
+"""
+
+import contextlib
+import datetime
+import json
+import os
+import pathlib
+import platform
+import shlex
+import sys
+import traceback
+from typing import Any, Dict, List, Optional
+
+CRASHES_DIR_NAME = 'crashes'
+LATEST_NAME = 'latest.md'
+PACKAGE_LINK_NAME = 'last-crash.md'
+
+# How many reports to keep around. Old crashes stop being interesting once the
+# bug behind them is fixed, and nobody prunes this directory by hand.
+MAX_REPORTS = 20
+
+_PACKAGE_MARKERS = ('problem.rbx.yml', 'contest.rbx.yml')
+
+
+def _yaml_scalar(value: Any) -> str:
+    """Render a frontmatter value.
+
+    JSON strings are valid YAML double-quoted scalars, and JSON lists are valid
+    YAML flow sequences, so `json.dumps` quotes and escapes everything for free
+    -- no value a crash carries can break out of the block.
+    """
+    return json.dumps(value)
+
+
+def find_package_dir(cwd: pathlib.Path) -> Optional[pathlib.Path]:
+    """The innermost ancestor of `cwd` that looks like an rbx package.
+
+    Deliberately not `package.find_problem`: that one prints, raises
+    `typer.Exit` when it finds nothing, and its cache-dir sibling takes locks.
+    A crash handler cannot afford any of that.
+    """
+    for directory in [cwd, *cwd.parents]:
+        for marker in _PACKAGE_MARKERS:
+            if (directory / marker).is_file():
+                return directory
+    return None
+
+
+def _link(link_path: pathlib.Path, target: pathlib.Path) -> None:
+    """Point `link_path` at `target`, best-effort.
+
+    Filesystems that refuse symlinks (and Windows without developer mode) just
+    do not get the pointer; the report itself is already safely written.
+    """
+    with contextlib.suppress(OSError, NotImplementedError):
+        if link_path.is_symlink() or link_path.exists():
+            link_path.unlink()
+        link_path.symlink_to(target)
+
+
+def _prune(crashes_dir: pathlib.Path) -> None:
+    reports = sorted(
+        (path for path in crashes_dir.glob('*.md') if not path.is_symlink()),
+        reverse=True,
+    )
+    for path in reports[MAX_REPORTS:]:
+        with contextlib.suppress(OSError):
+            path.unlink()
+
+
+def _context(exc: BaseException, cwd: pathlib.Path) -> Dict[str, Any]:
+    from rbx.__version__ import __version__
+
+    argv: List[str] = list(sys.argv)
+    package_dir = find_package_dir(cwd)
+
+    return {
+        'rbx_version': __version__,
+        'timestamp': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        'command': shlex.join(argv),
+        'cwd': str(cwd),
+        'package': str(package_dir) if package_dir is not None else None,
+        'exception': type(exc).__name__,
+        'message': str(exc),
+        'python': platform.python_version(),
+        'platform': sys.platform,
+        'pid': os.getpid(),
+        'argv': argv,
+    }
+
+
+def render_report(exc: BaseException, cwd: pathlib.Path) -> str:
+    context = _context(exc, cwd)
+    tb = ''.join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+    frontmatter = '\n'.join(
+        f'{key}: {_yaml_scalar(value)}' for key, value in context.items()
+    )
+    return (
+        f'---\n{frontmatter}\n---\n\n'
+        f'# rbx crash\n\n'
+        f'`{context["command"]}` in `{context["cwd"]}`\n\n'
+        f'## Traceback\n\n'
+        f'```\n{tb.rstrip()}\n```\n'
+    )
+
+
+def report_crash(exc: BaseException) -> Optional[pathlib.Path]:
+    """Write a crash report and return where it landed.
+
+    Returns `None` if anything at all went wrong. A bug in the crash reporter
+    must never mask, replace, or add noise to the crash it exists to record, so
+    this swallows everything and the caller prints a path only when it gets one.
+    """
+    try:
+        from rbx import utils
+        from rbx.config import CACHE_DIR_NAME
+
+        cwd = pathlib.Path.cwd().absolute()
+        report = render_report(exc, cwd)
+
+        crashes_dir = utils.get_app_path() / CRASHES_DIR_NAME
+        crashes_dir.mkdir(parents=True, exist_ok=True)
+
+        stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+        report_path = crashes_dir / f'{stamp}-{os.getpid()}.md'
+        report_path.write_text(report)
+
+        _prune(crashes_dir)
+        _link(crashes_dir / LATEST_NAME, report_path)
+
+        # `.rbx` is gitignored by every preset and wiped with the cache, so a
+        # pointer dropped in it expires on its own. Only ever a pointer, and
+        # only into a cache that already exists -- creating one from a crash
+        # handler would be a surprise.
+        package_dir = find_package_dir(cwd)
+        if package_dir is not None:
+            cache_dir = package_dir / CACHE_DIR_NAME
+            if cache_dir.is_dir():
+                _link(cache_dir / PACKAGE_LINK_NAME, report_path)
+
+        return report_path
+    except Exception:
+        return None

--- a/tests/rbx/crash_test.py
+++ b/tests/rbx/crash_test.py
@@ -1,0 +1,160 @@
+import pathlib
+from typing import Any, Dict, Optional
+from unittest import mock
+
+import pytest
+import yaml
+
+from rbx import crash
+from rbx.config import CACHE_DIR_NAME
+
+
+def raise_and_catch(exc: BaseException) -> BaseException:
+    """Give `exc` a real traceback, the way a crash would have."""
+    try:
+        raise exc
+    except BaseException as caught:
+        return caught
+
+
+def frontmatter_of(report: str) -> Dict[str, Any]:
+    assert report.startswith('---\n')
+    block = report.split('---\n', 2)[1]
+    return yaml.safe_load(block)
+
+
+def body_of(report: str) -> str:
+    return report.split('---\n', 2)[2]
+
+
+@pytest.fixture
+def cwd(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    work_dir = tmp_path / 'work'
+    work_dir.mkdir()
+    monkeypatch.chdir(work_dir)
+    return work_dir
+
+
+@pytest.fixture
+def crashes_dir(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    app_path = tmp_path / 'app'
+    monkeypatch.setattr('rbx.utils.get_app_path', lambda: app_path)
+    return app_path / crash.CRASHES_DIR_NAME
+
+
+def test_report_carries_the_command_and_cwd(
+    cwd: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr('sys.argv', ['rbx', 'run', '-s', 'my sol.cpp'])
+
+    report = crash.render_report(raise_and_catch(KeyError('foo')), cwd)
+
+    fm = frontmatter_of(report)
+    assert fm['command'] == "rbx run -s 'my sol.cpp'"
+    assert fm['cwd'] == str(cwd)
+    assert fm['argv'] == ['rbx', 'run', '-s', 'my sol.cpp']
+    assert fm['exception'] == 'KeyError'
+
+
+def test_report_body_carries_the_traceback(cwd: pathlib.Path):
+    report = crash.render_report(raise_and_catch(ValueError('boom')), cwd)
+
+    body = body_of(report)
+    assert 'Traceback (most recent call last)' in body
+    assert 'ValueError: boom' in body
+    assert 'raise exc' in body
+
+
+def test_frontmatter_survives_a_hostile_message(cwd: pathlib.Path):
+    message = 'a: b\n---\nnot: frontmatter'
+
+    report = crash.render_report(raise_and_catch(ValueError(message)), cwd)
+
+    assert frontmatter_of(report)['message'] == message
+
+
+def test_package_is_the_innermost_marked_ancestor(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    contest = tmp_path / 'contest'
+    problem = contest / 'problem'
+    problem.mkdir(parents=True)
+    (contest / 'contest.rbx.yml').write_text('')
+    (problem / 'problem.rbx.yml').write_text('')
+    monkeypatch.setattr('sys.argv', ['rbx', 'build'])
+
+    report = crash.render_report(raise_and_catch(ValueError('boom')), problem)
+
+    assert frontmatter_of(report)['package'] == str(problem)
+
+
+def test_package_is_null_outside_one(cwd: pathlib.Path):
+    report = crash.render_report(raise_and_catch(ValueError('boom')), cwd)
+
+    assert frontmatter_of(report)['package'] is None
+
+
+def test_report_crash_writes_the_file_and_the_latest_link(
+    cwd: pathlib.Path, crashes_dir: pathlib.Path
+):
+    path = crash.report_crash(raise_and_catch(ValueError('boom')))
+
+    assert path is not None
+    assert path.parent == crashes_dir
+    assert 'ValueError: boom' in path.read_text()
+
+    latest = crashes_dir / crash.LATEST_NAME
+    assert latest.resolve() == path.resolve()
+
+
+def test_report_crash_prunes_old_reports(cwd: pathlib.Path, crashes_dir: pathlib.Path):
+    crashes_dir.mkdir(parents=True)
+    stale = [
+        crashes_dir / f'2020{i:04d}T000000Z-1.md' for i in range(crash.MAX_REPORTS + 5)
+    ]
+    for path in stale:
+        path.write_text('stale')
+
+    path = crash.report_crash(raise_and_catch(ValueError('boom')))
+
+    assert path is not None
+    reports = sorted(p.name for p in crashes_dir.glob('*.md') if not p.is_symlink())
+    assert len(reports) == crash.MAX_REPORTS
+    # The oldest ones went, the newest stale ones and the new report stayed.
+    assert stale[0].name not in reports
+    assert path.name in reports
+
+
+def test_report_crash_links_into_an_existing_package_cache(
+    cwd: pathlib.Path, crashes_dir: pathlib.Path
+):
+    (cwd / 'problem.rbx.yml').write_text('')
+    (cwd / CACHE_DIR_NAME).mkdir()
+
+    path = crash.report_crash(raise_and_catch(ValueError('boom')))
+
+    assert path is not None
+    link = cwd / CACHE_DIR_NAME / crash.PACKAGE_LINK_NAME
+    assert link.resolve() == path.resolve()
+
+
+def test_report_crash_does_not_create_a_package_cache(
+    cwd: pathlib.Path, crashes_dir: pathlib.Path
+):
+    (cwd / 'problem.rbx.yml').write_text('')
+
+    assert crash.report_crash(raise_and_catch(ValueError('boom'))) is not None
+    assert not (cwd / CACHE_DIR_NAME).exists()
+
+
+def test_report_crash_swallows_its_own_failures(
+    cwd: pathlib.Path, crashes_dir: pathlib.Path
+):
+    with mock.patch.object(
+        crash, 'render_report', side_effect=RuntimeError('reporter is broken')
+    ):
+        result: Optional[pathlib.Path] = crash.report_crash(
+            raise_and_catch(ValueError('boom'))
+        )
+
+    assert result is None


### PR DESCRIPTION
When rbx dies of an uncaught exception, everything useful about the failure — the traceback, the command that produced it, the directory it ran in — lives only in terminal scrollback, and is gone by the time anyone gets around to debugging it. This leaves a file behind.

## What it writes

`<app dir>/crashes/<UTC timestamp>-<pid>.md` — Markdown with a YAML frontmatter block, so it parses cleanly and still reads well:

```markdown
---
rbx_version: "1.4.2"
timestamp: "2026-09-05T09:49:52.248804+00:00"
command: "rbx build"
cwd: "/Users/you/contest/problem-a"
package: "/Users/you/contest/problem-a"
exception: "RuntimeError"
message: "synthetic crash"
python: "3.14.3"
platform: "darwin"
pid: 86725
argv: ["rbx", "build"]
---

# rbx crash

`rbx build` in `/Users/you/contest/problem-a`

## Traceback
...
```

`command` is the shell-quoted invocation and `cwd` its absolute working directory — the two facts a reader asks for first, named plainly and sitting at the top. Values are emitted as JSON strings, which are valid YAML double-quoted scalars, so nothing a crash carries can break the block.

The directory is pruned to the newest 20 reports, with a `latest.md` symlink beside them. If the crash happened inside a package whose `.rbx` cache already exists, a `last-crash.md` symlink is dropped in there too — `.rbx` is gitignored by every preset and wiped with the cache, so the pointer expires on its own and never reaches a commit. Symlinks are best-effort; a filesystem that refuses them still gets the report.

After a crash, stderr gets one extra line: `Crash report written to <path>`. The traceback renders exactly as before.

## What counts as a crash

Only exceptions that end the process unexpectedly. `KeyboardInterrupt`, `typer.Abort`, `typer.Exit`, `SystemExit` and `RbxException` are how rbx and its user stop it on purpose — none of them are bugs, and logging them would bury the reports that are. Asyncio task exceptions and background-thread exceptions are out of scope: they frequently do not end the process at all.

## Why the hook is where it is

Not `sys.excepthook`. `Typer.__call__` opens with

```python
if sys.excepthook != except_hook:
    sys.excepthook = except_hook
```

so any hook installed before the CLI runs is replaced the moment it runs. (Same reason the `KeyboardInterrupt` suppression in `_install_no_exception_handlers` never takes effect — untouched here, but worth knowing.) The seam that survives is the `try` already wrapping `run_app_cli()` in `app()`, which typer re-raises into.

`report_crash` is wrapped end to end in `except Exception: return None`. A bug in the crash reporter must never mask or add noise to the crash it exists to record, so the caller prints a path only when it gets one back.

## Verification

- `tests/rbx/crash_test.py` — 10 tests, all passing: frontmatter parses as YAML and carries the right `command`/`cwd`/`argv`, a message containing `---` and `:` cannot break the block, the body carries the traceback, `package` resolves to the innermost marked ancestor and is null outside one, pruning keeps 20, the package symlink appears when `.rbx` exists and is never created when it does not, and a reporter forced to fail returns `None`.
- End-to-end through the real typer path with an injected exception: report written, both symlinks correct, hint on stderr, traceback unchanged.
- `rbx --help` (exit 0) and a genuine user-error `rbx build` (exit 1) produce no `crashes/` directory at all.
- `ruff check` / `ruff format` clean; `tests/rbx/box/lazy_cli_test.py` still passes; `mkdocs build` emits no warnings for the new page.

Design doc: `docs/plans/2026-09-05-crash-reports-design.md`. User-facing docs: `docs/crash-reports.md`, under Troubleshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xspb5UtwTPCEweuSxRsm6W
