### PR TITLE
fix(crash): report crashes that happen inside the textual apps

### DIFF
--- a/docs/plans/2026-09-05-crash-reports-design.md
+++ b/docs/plans/2026-09-05-crash-reports-design.md
@@ -41,6 +41,26 @@ is also why the `KeyboardInterrupt` suppression in
 knowing.) The `try` block is the seam that survives, because typer re-raises
 into it.
 
+## The Textual apps need their own hook
+
+A crash inside a Textual app never reaches `app()` at all. Textual funnels every
+unhandled exception into `App._handle_exception`, which renders a traceback into
+`_exit_renderables` and closes the app down itself. The exception is consumed
+there; nothing propagates out of the CLI call. This is why `rbx ui` crashed
+without leaving a report while the top-level hook was already in place.
+
+`rbx/box/ui/crash_reporting.py` provides a `CrashReportingMixin`, mixed in ahead
+of `App` by every app in the tree. `_handle_exception` reports and then delegates
+downwards, so an app that recognizes an error and handles it -- as `rbxBaseApp`
+does for `RbxException` and `typer.Exit` -- returns before reaching the mixin and
+never reports.
+
+The hint cannot be appended to `_exit_renderables`: Textual's
+`_print_error_renderables` prints only the *first* of them and collapses the rest
+into a "1 of N errors shown" note, so an appended hint would never be seen. The
+mixin overrides that method instead, printing the path to the same console right
+after the traceback, once the app is down and the terminal is back.
+
 ## Format
 
 Markdown with a YAML frontmatter block. The frontmatter is a clean parse target;

--- a/rbx/box/tooling/boca/ui/app.py
+++ b/rbx/box/tooling/boca/ui/app.py
@@ -25,6 +25,7 @@ from rbx.box.tooling.boca.scraper import (
     BocaScraper,
     get_boca_scraper,
 )
+from rbx.box.ui.crash_reporting import CrashReportingMixin
 from rbx.box.ui.widgets.code_box import CodeBox
 from rbx.box.ui.widgets.diff_box import DiffBox
 from rbx.config import get_app_path
@@ -37,7 +38,7 @@ def _format_time(minutes: int) -> str:
     return f'{hours:02d}:{mins:02d}'
 
 
-class BocaRunsApp(App):
+class BocaRunsApp(CrashReportingMixin, App):
     CSS_PATH = None
 
     # Compact layout styling for filters, mode indicator and teams panel

--- a/rbx/box/ui/CLAUDE.md
+++ b/rbx/box/ui/CLAUDE.md
@@ -263,3 +263,23 @@ The help panel lives in `help_panel.py` (`HelpPanelMixin`, also a `DOMNode` subc
 - `rbx.grading.steps` -- `Evaluation` data model
 
 Also reused by `rbx/box/tooling/boca/ui/app.py` which imports `CodeBox` and `DiffBox`.
+
+## Crash reporting (`crash_reporting.py`)
+
+A crash in a Textual app never reaches the handler in `rbx/box/main.py`. Textual funnels
+every unhandled exception into `App._handle_exception`, which renders a traceback into
+`_exit_renderables` and closes the app down itself -- the exception is consumed there, so
+nothing propagates out of the CLI call. `rbx ui` therefore died without leaving a crash
+report while the top-level hook was already in place.
+
+`CrashReportingMixin` is mixed in **ahead of `App`** by every app in the tree --
+`rbxBaseApp` (so `rbxApp`, `rbxDifferApp`, `RunPickerApp`, `rbxCommandApp`),
+`rbxReviewApp`, and `BocaRunsApp` in `tooling/boca/ui/app.py`. It calls
+`rbx.crash.report_crash` and then delegates downwards, so an app that recognizes an error
+and handles it -- as `rbxBaseApp` does for `RbxException` and `typer.Exit` -- returns
+before reaching the mixin and is never reported. **A new `App` subclass that forgets the
+mixin crashes silently**; `test_crash_reporting.py` asserts every one of them carries it.
+
+The path is printed by overriding `_print_error_renderables`, not by appending to
+`_exit_renderables`: Textual prints only the *first* of those and collapses the rest into
+a "1 of N errors shown" note, so an appended hint would never be seen.

--- a/rbx/box/ui/crash_reporting.py
+++ b/rbx/box/ui/crash_reporting.py
@@ -1,0 +1,45 @@
+"""Crash reporting for the Textual apps.
+
+A crash inside a Textual app never reaches the handler in `rbx/box/main.py`.
+Textual funnels every unhandled exception into `App._handle_exception`, which
+renders a traceback into `_exit_renderables` and closes the app down itself --
+the exception is consumed there and nothing propagates out of the CLI call. So
+the apps have to report for themselves.
+"""
+
+from typing import Optional
+
+from rich.text import Text
+
+
+class CrashReportingMixin:
+    """Write a crash report when a Textual app dies of an exception.
+
+    Mix in *before* `App`, so `_handle_exception` runs on the way down to
+    Textual's own. An app that recognizes an error and handles it -- as
+    `rbxBaseApp` does for `RbxException` and `typer.Exit` -- returns before
+    delegating, and so never reports: those are diagnostics, not crashes.
+    """
+
+    _crash_report_path: Optional[object] = None
+
+    def _handle_exception(self, error: Exception) -> None:
+        from rbx import crash
+
+        self._crash_report_path = crash.report_crash(error)
+        super()._handle_exception(error)  # type: ignore[misc]
+
+    def _print_error_renderables(self) -> None:
+        """Print the hint once the app is down and the terminal is back.
+
+        Not appended to `_exit_renderables`: Textual prints only the first of
+        those and collapses the rest into a "1 of N errors shown" note, so the
+        hint would never be seen. This runs right after them, on the same
+        console.
+        """
+        super()._print_error_renderables()  # type: ignore[misc]
+        if self._crash_report_path is not None:
+            self.error_console.print(  # type: ignore[attr-defined]
+                Text(f'\nCrash report written to {self._crash_report_path}')
+            )
+            self._crash_report_path = None

--- a/rbx/box/ui/main.py
+++ b/rbx/box/ui/main.py
@@ -12,6 +12,7 @@ from textual.widgets import Footer, Header, OptionList
 from rbx import console
 from rbx.box import remote
 from rbx.box.exception import RbxException
+from rbx.box.ui.crash_reporting import CrashReportingMixin
 from rbx.box.ui.help_panel import HelpPanelMixin
 from rbx.box.ui.screens.differ import DifferScreen
 from rbx.box.ui.screens.error_modal import ErrorModal
@@ -27,7 +28,7 @@ SCREEN_OPTIONS = [
 ]
 
 
-class rbxBaseApp(VimNavMixin, HelpPanelMixin, App):
+class rbxBaseApp(VimNavMixin, HelpPanelMixin, CrashReportingMixin, App):
     BINDING_GROUP_TITLE = 'Global'
 
     def run(self, *args, **kwargs):

--- a/rbx/box/ui/review_app.py
+++ b/rbx/box/ui/review_app.py
@@ -2,10 +2,11 @@ import pathlib
 
 from textual.app import App
 
+from rbx.box.ui.crash_reporting import CrashReportingMixin
 from rbx.box.ui.screens.review import ReviewScreen
 
 
-class rbxReviewApp(App):
+class rbxReviewApp(CrashReportingMixin, App):
     TITLE = 'rbx review'
     CSS_PATH = 'css/app.tcss'
 

--- a/tests/rbx/box/ui/test_crash_reporting.py
+++ b/tests/rbx/box/ui/test_crash_reporting.py
@@ -1,0 +1,113 @@
+"""A crash inside a Textual app still leaves a crash report behind.
+
+Textual funnels every unhandled exception into `App._handle_exception`, which
+renders a traceback and closes the app down itself. The exception is consumed
+there, so it never reaches the handler in `rbx/box/main.py` -- which is why
+`rbx ui` used to die without writing anything.
+"""
+
+import pathlib
+
+import pytest
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Label
+
+from rbx import crash
+from rbx.box.exception import RbxException
+from rbx.box.ui.crash_reporting import CrashReportingMixin
+from rbx.box.ui.main import rbxApp
+from rbx.box.ui.review_app import rbxReviewApp
+from rbx.box.ui.screens.error_modal import ErrorModal
+
+
+class _CrashOnMountScreen(Screen):
+    def compose(self) -> ComposeResult:
+        yield Label('loading')
+
+    def on_mount(self) -> None:
+        raise KeyError('some-missing-key')
+
+
+class _RbxErrorOnMountScreen(Screen):
+    def compose(self) -> ComposeResult:
+        yield Label('loading')
+
+    def on_mount(self) -> None:
+        exc = RbxException()
+        exc.print('problem.rbx.yml: 1 validation error')
+        raise exc
+
+
+@pytest.fixture
+def crashes_dir(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    app_path = tmp_path / 'app'
+    monkeypatch.setattr('rbx.utils.get_app_path', lambda: app_path)
+    return app_path / crash.CRASHES_DIR_NAME
+
+
+def _reports(crashes_dir: pathlib.Path):
+    if not crashes_dir.is_dir():
+        return []
+    return [path for path in crashes_dir.glob('*.md') if not path.is_symlink()]
+
+
+async def test_crash_in_the_ui_writes_a_report(crashes_dir: pathlib.Path):
+    with pytest.raises(KeyError):
+        async with rbxApp().run_test() as pilot:
+            await pilot.app.push_screen(_CrashOnMountScreen())
+            await pilot.pause()
+
+    reports = _reports(crashes_dir)
+    assert len(reports) == 1
+    report = reports[0].read_text()
+    assert 'exception: "KeyError"' in report
+    assert 'some-missing-key' in report
+
+
+async def test_the_report_path_is_shown_on_the_way_out(
+    crashes_dir: pathlib.Path, capsys: pytest.CaptureFixture
+):
+    """The hint has to be printed, not appended to `_exit_renderables`.
+
+    Textual prints only the first of those and collapses the rest into a
+    "1 of N errors shown" note, so an appended hint is never seen.
+    """
+    with pytest.raises(KeyError):
+        async with rbxApp().run_test() as pilot:
+            await pilot.app.push_screen(_CrashOnMountScreen())
+            await pilot.pause()
+
+    err = capsys.readouterr().err
+    assert 'Crash report written to' in err
+    assert _reports(crashes_dir)[0].name in err
+
+
+async def test_a_handled_rbx_error_is_not_a_crash(crashes_dir: pathlib.Path):
+    """`RbxException` opens the modal and never reaches the reporting mixin."""
+    async with rbxApp().run_test() as pilot:
+        app = pilot.app
+        await app.push_screen(_RbxErrorOnMountScreen())
+        await pilot.pause()
+
+        assert isinstance(app.screen, ErrorModal)
+
+    assert _reports(crashes_dir) == []
+
+
+def test_every_textual_app_reports():
+    """A new app that forgets the mixin would crash silently, as `rbx ui` did."""
+    from rbx.box.tooling.boca.ui.app import BocaRunsApp
+    from rbx.box.ui.command_app import rbxCommandApp
+    from rbx.box.ui.main import rbxDifferApp
+    from rbx.box.ui.run_picker import RunPickerApp
+
+    for app_cls in (
+        rbxApp,
+        rbxDifferApp,
+        rbxReviewApp,
+        RunPickerApp,
+        rbxCommandApp,
+        BocaRunsApp,
+    ):
+        assert issubclass(app_cls, CrashReportingMixin), app_cls.__name__


### PR DESCRIPTION
Follow-up to #849. `rbx ui` crashed with a `KeyError` and left no crash report, even though #849 was already merged.

## Why the hook missed it

Textual never lets the exception out. Every unhandled exception goes to `App._handle_exception`, which renders a Rich traceback into `_exit_renderables` and closes the app down itself. The exception is consumed there, so nothing propagates out of `run_app_cli()` and the handler in `rbx/box/main.py` never sees it. #849 only ever covered the non-TUI path.

## The fix

`rbx/box/ui/crash_reporting.py` adds a `CrashReportingMixin`, mixed in ahead of `App` by every app in the tree:

- `rbxBaseApp` — covers `rbxApp`, `rbxDifferApp`, `RunPickerApp`, `rbxCommandApp`
- `rbxReviewApp`
- `BocaRunsApp` (`rbx/box/tooling/boca/ui/app.py`)

`_handle_exception` reports and then delegates downwards. An app that recognizes an error and handles it — as `rbxBaseApp` does for `RbxException` and `typer.Exit` — returns before reaching the mixin, so the error modal still works and neither is logged as a crash.

A new `App` subclass that forgets the mixin would crash silently in exactly the same way, so `test_every_textual_app_reports` asserts all six carry it.

## A second bug, found while testing

My first attempt appended the "Crash report written to …" hint to `_exit_renderables`. That silently does nothing useful: `App._print_error_renderables` prints only element `[0]` and collapses everything else into `NOTE: 1 of N errors shown`, so the hint would never have been visible to anyone. The mixin overrides that method instead and prints the path to the same console, right after the traceback, once the app is down and the terminal is restored.

The test asserts on captured stderr rather than on the renderables list, so it pins user-visible behavior — `_exit_renderables` is cleared as soon as it is printed, and asserting against it would have passed while the user saw nothing.

## Verification

- `tests/rbx/box/ui/test_crash_reporting.py` — a `KeyError` in a screen's `on_mount` writes a report carrying `exception: "KeyError"` and the key name; the path is printed to stderr; an `RbxException` opens the modal and writes no report; all six apps carry the mixin.
- `tests/rbx/box/ui` + `tests/rbx/crash_test.py`: 194 passed.
- `ruff check rbx/` clean.

`rbx/box/ui/CLAUDE.md` and the design doc record the two Textual seams and why the hint cannot ride along in `_exit_renderables`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xspb5UtwTPCEweuSxRsm6W
