### PR TITLE
fix(packaging): stop leaking absolute setter paths into packages

### DIFF
--- a/rbx/box/dependencies/amalgamation.py
+++ b/rbx/box/dependencies/amalgamation.py
@@ -84,12 +84,39 @@ def _resolve(
     return None
 
 
+def _render_provenance(
+    target: pathlib.Path,
+    relative_to: Optional[pathlib.Path],
+    extra_roots: Sequence[pathlib.Path],
+) -> str:
+    """How an inlined file is named in the ``// amalgamated from`` comment.
+
+    Absolute when there is no anchor, which is what a caller inspecting a build on
+    the machine that produced it wants. With an anchor -- packagers pass the package
+    root -- the comment must not leak anything about that machine, since it travels
+    inside the shipped package: a file under the anchor is named relative to it, one
+    coming from an ``extra_roots`` search directory is labelled ``<builtin>/``, and
+    anything else is reduced to its bare name under ``<external>/`` rather than to a
+    ``../..`` path that would still spell out the directories above the package.
+    """
+    if relative_to is None:
+        return str(target)
+    for root, label in [(relative_to, ''), *((r, '<builtin>') for r in extra_roots)]:
+        try:
+            relative = target.relative_to(utils.abspath(root))
+        except ValueError:
+            continue
+        return f'{label}/{relative.as_posix()}' if label else relative.as_posix()
+    return f'<external>/{target.name}'
+
+
 def amalgamate(
     root: pathlib.Path,
     *,
     extra_roots: Sequence[pathlib.Path] = (),
     keep: Optional[Callable[[str], bool]] = None,
     scanner: Optional[DependencyScanner] = None,
+    relative_to: Optional[pathlib.Path] = None,
 ) -> AmalgamationResult:
     """Reduce ``root`` and its dependency closure to one self-contained source.
 
@@ -103,6 +130,11 @@ def amalgamate(
     A directive that cannot be resolved raises :class:`AmalgamationError` naming the
     including file and the spelling, unless ``keep`` returns ``True`` for it, in which
     case the directive survives verbatim.
+
+    ``relative_to`` anchors the ``// amalgamated from`` provenance comments, which
+    are absolute paths on the running machine without it. Callers that ship the
+    result -- packagers -- must pass one, or the setter's own directory layout
+    travels inside the package; see :func:`_render_provenance`.
 
     ``extra_roots`` are extra search directories for otherwise unresolvable spellings.
     This is how callers make builtin headers (``testlib.h``, ``rbx.h``) inlinable
@@ -145,7 +177,8 @@ def amalgamate(
                         'drop the reference.'
                     )
             else:
-                out += f'// amalgamated from {target}\n'.encode()
+                provenance = _render_provenance(target, relative_to, extra_roots)
+                out += f'// amalgamated from {provenance}\n'.encode()
                 out += render(target)
                 out += b'\n'
             pos = end

--- a/rbx/box/packaging/domjudge/packager.py
+++ b/rbx/box/packaging/domjudge/packager.py
@@ -432,7 +432,9 @@ class DomjudgePackager(BasePackager):
         """
         if solution.path.suffix.lower() in _AMALGAMATABLE_SUFFIXES:
             try:
-                result = amalgamate(utils.abspath(solution.path))
+                result = amalgamate(
+                    utils.abspath(solution.path), relative_to=package.find_problem()
+                )
             except AmalgamationError as e:
                 console.console.print(
                     f'[error]Cannot package {solution.href()} for DOMjudge.[/error]\n'

--- a/rbx/box/packaging/moj/packager.py
+++ b/rbx/box/packaging/moj/packager.py
@@ -1209,7 +1209,9 @@ class MojPackager(BasePackager):
     def _amalgamate(self, code: CodeItem, what: str) -> bytes:
         try:
             result = amalgamate(
-                utils.abspath(code.path), extra_roots=self._builtin_header_roots()
+                utils.abspath(code.path),
+                extra_roots=self._builtin_header_roots(),
+                relative_to=package.find_problem(),
             )
         except AmalgamationError as e:
             console.console.print(

--- a/tests/rbx/box/dependencies/test_amalgamation.py
+++ b/tests/rbx/box/dependencies/test_amalgamation.py
@@ -126,3 +126,55 @@ def test_amalgamated_output_compiles(tmp_path):
         text=True,
     )
     assert proc.returncode == 0, proc.stderr
+
+
+def test_provenance_is_absolute_without_relative_to(tmp_path):
+    (tmp_path / 'lib.h').write_text('int helper();\n')
+    root = tmp_path / 'main.cpp'
+    root.write_text('#include "lib.h"\nint main(){}\n')
+
+    text = amalgamate(root).content.decode()
+
+    assert f'// amalgamated from {(tmp_path / "lib.h").resolve()}\n' in text
+
+
+def test_provenance_is_relative_to_the_given_anchor(tmp_path):
+    (tmp_path / 'sols').mkdir()
+    (tmp_path / 'sols' / 'lib.h').write_text('int helper();\n')
+    root = tmp_path / 'sols' / 'main.cpp'
+    root.write_text('#include "lib.h"\nint main(){}\n')
+
+    text = amalgamate(root, relative_to=tmp_path).content.decode()
+
+    assert '// amalgamated from sols/lib.h\n' in text
+    assert str(tmp_path) not in text
+
+
+def test_provenance_of_a_builtin_header_is_labelled(tmp_path):
+    builtin = tmp_path / 'app' / 'resources'
+    builtin.mkdir(parents=True)
+    (builtin / 'testlib.h').write_text('int testlib_marker;\n')
+    pkg = tmp_path / 'pkg'
+    pkg.mkdir()
+    root = pkg / 'main.cpp'
+    root.write_text('#include "testlib.h"\nint main(){}\n')
+
+    text = amalgamate(root, extra_roots=[builtin], relative_to=pkg).content.decode()
+
+    assert '// amalgamated from <builtin>/testlib.h\n' in text
+    assert str(tmp_path) not in text
+
+
+def test_provenance_outside_every_root_is_reduced_to_a_name(tmp_path):
+    outside = tmp_path / 'secret-contest-2026'
+    outside.mkdir()
+    (outside / 'lib.h').write_text('int helper();\n')
+    pkg = tmp_path / 'pkg'
+    pkg.mkdir()
+    root = pkg / 'main.cpp'
+    root.write_text('#include "../secret-contest-2026/lib.h"\nint main(){}\n')
+
+    text = amalgamate(root, relative_to=pkg).content.decode()
+
+    assert '// amalgamated from <external>/lib.h\n' in text
+    assert 'secret-contest-2026' not in text

--- a/tests/rbx/box/packaging/moj/test_packager.py
+++ b/tests/rbx/box/packaging/moj/test_packager.py
@@ -640,6 +640,16 @@ def test_solutions_are_amalgamated(testing_pkg, tmp_path):
     text = (into_path / 'sols' / 'good' / 'sol.cpp').read_text()
     assert 'int k()' in text
     assert '#include "lib.h"' not in text
+    # Nothing about the packaging machine ships with the package: the provenance
+    # comment is anchored at the package root.
+    assert '// amalgamated from lib.h' in text
+    assert str(testing_pkg.root) not in text
+
+    # The checker inlines `testlib.h`, which lives outside the package, in rbx's own
+    # resources -- labelled rather than named by an absolute path.
+    checker = (into_path / 'scripts' / 'checker.cpp').read_text()
+    assert '// amalgamated from <builtin>/testlib.h' in checker
+    assert str(testing_pkg.root) not in checker
 
 
 # -- language scripts -------------------------------------------------------

--- a/tests/rbx/box/packaging/test_domjudge.py
+++ b/tests/rbx/box/packaging/test_domjudge.py
@@ -335,6 +335,11 @@ def test_submissions_are_amalgamated(testing_pkg, tmp_path):
     shipped = (submissions_dir / 'accepted' / 'ac.cpp').read_text()
     assert 'int k() { return 1; }' in shipped
     assert '#include "lib.h"' not in shipped
+    # The provenance comment travels to the judge, and (once jury solutions become
+    # public) to contestants, so it names the file relative to the package rather
+    # than spelling out the setter's home directory and contest layout.
+    assert '// amalgamated from sols/lib.h' in shipped
+    assert str(testing_pkg.root) not in shipped
 
 
 def test_submissions_do_not_reach_for_builtin_headers(testing_pkg, tmp_path):


### PR DESCRIPTION
Closes #855.

`amalgamate()` stamped every inlined file with its **absolute path on the setter's machine**, and that comment ships inside MOJ (`scripts/checker.cpp`, `sols/`) and DOMjudge (`submissions/`) packages — leaking the setter's username, directory layout and often the contest name to judges, and to contestants wherever jury solutions or checkers become public.

## What changed

The provenance comment stays — it keeps a shipped package debuggable by hand, and dropping it is not needed to fix the leak — but `amalgamate()` now takes an optional `relative_to` anchor that decides how the file is named:

| where the file lives | rendered as |
|---|---|
| under the anchor (the package root) | `sols/summer.h` |
| under an `extra_roots` search dir (builtin headers) | `<builtin>/testlib.h` |
| anywhere else | `<external>/lib.h` |

The last case is deliberately reduced to a bare name rather than a `../..` relative path, which would still spell out the directories above the package — the contest name being exactly one of the things #855 is about.

Without an anchor the comment stays absolute, as before, so the only behaviour that changes is the two packagers', which now pass `relative_to=package.find_problem()`. `amalgamation.py` still knows nothing about packages.

## Tests

- `test_amalgamation.py`: four tests pinning the rendered form — absolute by default, relative to the anchor, `<builtin>/`, `<external>/`.
- The existing MOJ and DOMjudge amalgamation tests now also assert the rendered comment and that the package root's absolute path appears nowhere in the shipped solution (and, for MOJ, in the shipped checker).

`tests/rbx/box/dependencies`, `tests/rbx/box/packaging/test_domjudge.py`, `tests/rbx/box/packaging/moj/test_packager.py` and `tests/rbx/box/runners/moj` all pass (the last because the MOJ runner's testrun cache is keyed on the amalgamated bytes — it invalidates once, then becomes machine-independent, which is a small bonus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St4enmqXbbAH43iDfqE29S
