### PR TITLE
feat(runners): cache DOMjudge judgements and uploads across runs

### DIFF
--- a/docs/_partials/domjudge-backend.md
+++ b/docs/_partials/domjudge-backend.md
@@ -24,7 +24,10 @@ for everyone else.
 
 The account needs **admin** rights. {{rbx}} creates a private `rbx-timing` contest the first
 time it runs, uploads a throwaway `rbxt-…` problem into it, and submits as the built-in
-`domjudge` team — none of which a plain jury account may do. The contest has no scoreboard
+`domjudge` team — none of which a plain jury account may do. The problem is named from the slug
+in `.rbx-id` at the package root — the one identity your package has on any remote judge, shared
+with the MOJ backend — so it stays the same problem as
+your testset grows, rather than leaving a trail of abandoned ones behind. The contest has no scoreboard
 anyone reads, and nothing {{rbx}} does there touches a real contest.
 
 Before uploading anything, {{rbx}} checks the instance and **refuses by name** what cannot

--- a/docs/_partials/moj-backend.md
+++ b/docs/_partials/moj-backend.md
@@ -19,10 +19,15 @@ its session and never handles your credentials. On macOS the CLI also needs a ba
 the one the system ships; if it refuses to start, see
 [The MOJ CLI needs bash 4 or newer](/setters/packaging/moj#the-moj-cli-needs-bash-4-or-newer).
 
-{{rbx}} uploads a **throwaway problem** of its own, derived from the id recorded in a committed
-`.moj-id`, so two setters on the same package reach the same one. It never touches a problem it
-did not create: a package already bound to a real MOJ problem is refused by name rather than
-overwritten.
+{{rbx}} uploads a **throwaway problem** of its own, named `<your login>#rbxt-<slug>` from the
+slug in `.rbx-id` at the package root — the one identity your package has on any remote judge,
+shared with the DOMjudge backend. The slug is
+minted once and then kept, so every later run reuses the same problem instead of orphaning one;
+commit `.rbx-id` if you want a co-setter to reach that problem too. The id is also written to
+`.moj-id`, which is what the `moj` CLI itself reads.
+
+It never touches a problem it did not create: a package already bound to a real MOJ problem is
+refused by name rather than overwritten.
 
 A judge reports **less** than the local sandbox does. It hands back a verdict, not the bytes
 your solution wrote, so some of what a local run shows you has no counterpart at all:

--- a/docs/plans/2026-09-08-domjudge-runner-caching-design.md
+++ b/docs/plans/2026-09-08-domjudge-runner-caching-design.md
@@ -19,10 +19,9 @@ is re-measured from scratch every time it comes back around.
 
 ## 2. A real package fingerprint
 
-Both caches turn on one question: *is the judge configured identically?* Neither
-the `rbxt-` problem id nor `_package_fingerprint` can answer it -- the latter
-hashes the package name and testcase count only, deliberately, so the probe
-problem does not churn and strand dead problems on the server.
+Both caches turn on one question: *is the judge configured identically?* The
+`rbxt-` problem id cannot answer it -- it names *which* problem, deliberately
+stable across edits (see §5), and says nothing about what is in it.
 
 So `_build_probe` now also returns `_directory_fingerprint` of the built package
 tree: sorted relative POSIX paths and contents, lengths framed. It covers exactly
@@ -33,7 +32,9 @@ ships no statement and no submissions.
 Taken over the tree rather than the zip: `shutil.make_archive` stamps every entry
 with its mtime, so two builds of an identical package produce different archives.
 
-The problem id is left exactly as it was.
+The two questions stay separate on purpose: *which problem* is the slug's job and
+must not move when a testcase changes, while *what is in it* is the
+fingerprint's and must.
 
 ## 3. The upload fast path
 
@@ -90,7 +91,44 @@ measurements -- the validation phase exists to measure exactly them -- and they
 are the slowest solutions in the package, so they are what a re-run most wants
 back for free.
 
-## 5. What this deliberately does not do
+## 5. One problem identity, shared with MOJ
+
+The caches above are per package, so they raise a question the runner had been
+answering badly: *what is this package called on the server?*
+
+DOMjudge derived its `rbxt-` id from `sha256(f'{pkg.name}:{len(entries)}')[:8]`.
+That moves whenever a testcase is added -- the run then stages a brand new
+problem and abandons the previous one -- and two packages that happen to agree on
+name and testcase count collide on a shared instance. MOJ, meanwhile, minted its
+own slug into `.moj-id`. One package, two unrelated identities, neither stable
+for the reason the other was.
+
+`rbx.box.runners.problem_id` now holds the one identity: a random slug in
+`.rbx-id` at the package root, minted once and then kept. Each backend renders
+its own id from it -- `<login>#rbxt-<slug>` for MOJ, whose ids are scoped by org;
+`rbxt-<slug>-<purpose>` for DOMjudge, whose ids are flat and whose two phases pin
+different limits. `RBXT_PREFIX`, the marker for "a problem rbx may overwrite",
+moves there too: it belongs to every backend rather than to one.
+
+The slug is random rather than derived from anything, and both halves of that
+matter. Not the package name: rbx names are not unique, so two setters working
+through the same tutorial package would collide on a shared server and one would
+write over the other's problem. Not the testset: it changes constantly, and every
+change would strand a dead problem.
+
+**Migration runs one way.** A `.moj-id` written before `.rbx-id` existed names a
+problem MOJ already holds, so `ensure_moj_id` *adopts* its slug into the shared
+file rather than overwriting it from there. An existing shared slug always wins,
+so a package holding both keeps both and neither backend is moved off the problem
+it has been using. A foreign binding -- `.moj-id` is written by `moj upload` too,
+so a package may be bound to a real, published problem -- is neither adopted nor
+rewritten.
+
+DOMjudge probe problems staged before this change keep their old hash-derived
+ids and are simply left behind: they are private, throwaway, and in a contest
+with no scoreboard.
+
+## 6. What this deliberately does not do
 
 - **No `--no-cache` flag.** "I changed something" is what the key is for; "I want
   to see the variance" is not a workflow this backend supports at all, since

--- a/docs/plans/2026-09-08-domjudge-runner-caching-design.md
+++ b/docs/plans/2026-09-08-domjudge-runner-caching-design.md
@@ -1,0 +1,105 @@
+# DOMjudge runner caching -- design
+
+Companion to [the DOMjudge remote runner design](2026-09-08-domjudge-remote-runner-design.md).
+That document leaves every run paying full price; this one makes a re-run cost
+nothing. It mirrors what the MOJ runner already does, and the parts where it
+does not mirror it are the interesting parts.
+
+## 1. The problem
+
+`rbx time` is a command a setter runs *again*: tweak a solution, re-estimate,
+change the profile, look at the table once more. Every re-run re-stages the whole
+probe package -- four requests and a zip upload of the entire testset -- and
+re-submits every solution, including ones whose source has not changed by a byte.
+
+A submission occupies the judgehost for as long as the solution takes on every
+test, and `MAX_INFLIGHT_SUBMISSIONS = 1` makes that strictly serial. The picker
+also alternates between the two phases as it narrows, so a limit already probed
+is re-measured from scratch every time it comes back around.
+
+## 2. A real package fingerprint
+
+Both caches turn on one question: *is the judge configured identically?* Neither
+the `rbxt-` problem id nor `_package_fingerprint` can answer it -- the latter
+hashes the package name and testcase count only, deliberately, so the probe
+problem does not churn and strand dead problems on the server.
+
+So `_build_probe` now also returns `_directory_fingerprint` of the built package
+tree: sorted relative POSIX paths and contents, lengths framed. It covers exactly
+what the upload sends -- `domjudge-problem.ini` (which carries the pinned limit),
+`problem.yaml`, `data/`, `output_validators/` -- and nothing else, because a probe
+ships no statement and no submissions.
+
+Taken over the tree rather than the zip: `shutil.make_archive` stamps every entry
+with its mtime, so two builds of an identical package produce different archives.
+
+The problem id is left exactly as it was.
+
+## 3. The upload fast path
+
+`<problem cache>/domjudge-runner.json`, a map from `<server>|<problem id>` to the
+fingerprint this machine last staged there. On a match `prepare` skips
+`stage_problem` and says so in one durable line.
+
+Two departures from MOJ's equivalent:
+
+- **Keyed by server.** `rbxt-` ids are derived from the package, so the same id
+  on a staging instance and on a production one collides by construction.
+- **The record is not trusted alone.** The problem must also still be listed in
+  the probe contest -- the server's own answer, which catches a probe problem
+  deleted by hand or a record carried onto an instance that was wiped.
+  `stage_problem` fetches that list anyway on the path this skips, so the check
+  costs a request only when it is about to save an upload.
+
+The record is cleared *before* an upload, so a crash mid-upload re-uploads next
+time rather than trusting a stale record.
+
+## 4. The judgement cache
+
+`<problem cache>/domjudge-judgements/<key>.json`, one file per key, written whole
+then `replace`d.
+
+**The key** is everything the judge's answer depended on: the cache version, the
+server, the contest, the problem id, the package fingerprint, the solution's
+filename, the DOMjudge language id, and the exact amalgamated bytes submitted.
+The pinned limit needs no term of its own -- it is in the ini, which the
+fingerprint covers -- so the validation phase misses on every solution by
+construction, which is right: a timing taken under a 2.5s kill is not a timing
+under a 4s one.
+
+**What is stored** is the API's own answer: the judgement object and the final
+run list, never the derived evaluations. The derivation depends on which
+testcases *this* run asked about, so storing its output would bake one run's
+testset into an entry the next run reuses. A hit publishes the stored runs into
+the same `_Judging` a fresh submission publishes into, so a hit and a miss are
+provably the same measurement -- pairing, the mismatch guard and the
+unknown-verdict refusal all still apply.
+
+**A hit is consulted before the concurrency slot**, not inside it. It costs one
+file read and no judge time, and with the cap at one, queueing it would make
+every hit wait out every miss ahead of it.
+
+**Never written** when the judging has no runs at all (a compile error, a
+judgehost that fell over -- the analogue of MOJ's `ran_nothing`), when the run
+list was refused as unpairable, or when any run carries a verdict outside
+`_OUTCOMES`. Each is a thing the setter is about to *fix*, and a cached failure
+would make the fix appear to change nothing.
+
+A WA, an RE or a TLE **is** cached. Those are legitimate, reproducible
+measurements -- the validation phase exists to measure exactly them -- and they
+are the slowest solutions in the package, so they are what a re-run most wants
+back for free.
+
+## 5. What this deliberately does not do
+
+- **No `--no-cache` flag.** "I changed something" is what the key is for; "I want
+  to see the variance" is not a workflow this backend supports at all, since
+  `nruns > 1` is refused outright. The blind spot no flag could fix -- a park
+  whose hardware or load moved underneath the numbers -- is answered by deleting
+  a directory under the disposable problem cache.
+- **No expiry, no size cap, no eviction.** An entry is a few hundred bytes, and a
+  stale one is unreachable rather than wrong: its key names a package fingerprint
+  no later run will ever produce again.
+- **Nothing is committed.** Both caches say what *a* server answered at *a*
+  moment, from *this* machine. Losing either must cost redundant work, never a
+  wrong measurement, which is why they live in `.rbx/`.

--- a/docs/setters/profiling/remote.md
+++ b/docs/setters/profiling/remote.md
@@ -74,6 +74,11 @@ The estimation package pins a deliberately generous limit. DOMjudge kills a run 
 so a package pinned near the answer you are looking for would truncate exactly the measurements
 that matter most.
 
+Finished judgings are cached, and so is the upload: re-running `rbx time`, or regrouping back
+onto limits already probed, re-submits only the solutions whose source changed, and re-uploads
+the package only when the package itself changed. A judging {{rbx}} could not read — a compile
+error above all — is never cached, so fixing it and running again really does try again.
+
 `--skip-slow` stops after the estimate, which is the one-upload path:
 
 ```bash

--- a/rbx/box/CLAUDE.md
+++ b/rbx/box/CLAUDE.md
@@ -161,6 +161,36 @@ a no-op, because its work happens inside the deferred the consumer awaits. Await
 *unresolved* deferred after `close` is not supported; a resolved one keeps answering from
 its memo, which is what lets `timing` close before the group picker opens.
 
+### One problem identity, shared by every remote runner (`runners/problem_id.py`)
+
+Every remote backend needs a name to put its throwaway problem under, and needs that
+name to be *the same name next time*: an id that moves between runs orphans a problem on
+the server and re-uploads the whole testset to a fresh one. Each backend used to answer
+that its own way -- MOJ from a slug it minted into `.moj-id`, DOMjudge from
+`sha256(f'{pkg.name}:{len(entries)}')[:8]` -- so one package had two unrelated identities,
+and DOMjudge's **moved whenever a testcase was added**.
+
+There is now one slug, in `.rbx-id` at the package root, and each backend renders its own
+id from it: `<login>#rbxt-<slug>` for MOJ (ids are scoped by org, and the org is whoever
+is logged in), `rbxt-<slug>-<purpose>` for DOMjudge (ids are flat, and the two `rbx time`
+phases pin different limits). The slug is **random, minted once, then kept** -- never
+derived from the package name (rbx names are not unique, so two setters on the same
+tutorial package would collide on a shared server) and never from the testset (which
+changes constantly). `RBXT_PREFIX` lives here too: the marker for "a problem rbx may
+overwrite" belongs to every backend, not to one.
+
+`.rbx-id` sits beside `problem.rbx.yml` rather than under `.rbx/` -- the cache is
+regenerated freely, and a slug that vanished with it would leave a dead problem on the
+server after every clean. The default preset git-ignores it, alongside `.moj-id`.
+
+**Migration is via `adopt_slug`, and only in that direction.** A `.moj-id` written before
+this file existed carries a perfectly good slug naming a problem MOJ already holds, so
+`ensure_moj_id` offers it to `.rbx-id` rather than overwriting it from there; an existing
+shared slug always wins, so a package with both keeps both and neither backend is moved
+off the problem it is using. A **foreign** binding (a real, published problem -- `.moj-id`
+is written by `moj upload` too) is neither adopted nor rewritten: it is the other server's
+naming, not an identity rbx may hand to another judge.
+
 **Two `moj` trees, different jobs.** `runners/moj/` is the *client*: a typed wrapper
 over the judge's `moj` CLI (`problem_id.py`, `cli.py`) that a `MojRunner` drives to
 upload, calibrate and testrun. `packaging/moj/` is the *packager* that produces what it
@@ -251,10 +281,11 @@ rather than four, pinned by `test_a_second_run_re_uploads_neither_phase`.
 A *suffix* on the slug, not a second prefix, and derived rather than stored. `is_rbxt_id`
 is what stands between a timing package and a setter's published problem, so it keeps one
 marker and one regex; and `.moj-id` holds one id because that is the `moj` CLI's own
-convention (`moj testrun <dir>` reads that file), so the committed binding stays exactly
-what it always was and every `.moj-id` already committed keeps working. The guard runs
-*before* the derivation -- a binding rbx did not create is refused rather than having a
-second problem derived from it in someone else's namespace.
+convention (`moj testrun <dir>` reads that file), so it stays exactly what it always was
+and every `.moj-id` already written keeps working. The slug inside it now comes from
+`.rbx-id` (see above), which is what makes MOJ and DOMjudge name the same package the
+same way. The guard runs *before* the derivation -- a binding rbx did not create is
+refused rather than having a second problem derived from it in someone else's namespace.
 
 The upload record is a **map** keyed by problem id for the same reason: a single record
 would have each phase evict the other's, which is the original bug moved rather than

--- a/rbx/box/runners/domjudge/runner.py
+++ b/rbx/box/runners/domjudge/runner.py
@@ -44,6 +44,7 @@ from rbx.box.runners.domjudge.api import (
     DomjudgeApiError,
     credentials_from_env,
 )
+from rbx.box.runners.problem_id import ensure_slug
 from rbx.grading.steps import (
     CheckerResult,
     Evaluation,
@@ -229,8 +230,10 @@ class DomjudgeRunner:
             ctx.progress.update('Building the DOMjudge probe package...')
 
         timelimit_ms = _probe_timelimit_ms(ctx)
-        fingerprint = _package_fingerprint(ctx)
-        problem_id = staging.probe_problem_id(fingerprint, ctx.purpose)
+        # The package's one identity on any remote judge, shared with every other
+        # runner rather than derived here. See `rbx.box.runners.problem_id`.
+        slug = ensure_slug(package.find_problem())
+        problem_id = staging.probe_problem_id(slug, ctx.purpose)
         self._problem_id = problem_id
 
         packager, zip_path, fingerprint = self._build_probe(
@@ -1024,19 +1027,6 @@ def _probe_timelimit_ms(ctx: RunContext) -> int:
 # problem limit, and is generous enough that an accepted solution is measured
 # rather than killed.
 _DEFAULT_PROBE_TIMELIMIT_MS = 10_000
-
-
-def _package_fingerprint(ctx: RunContext) -> str:
-    """A short, stable name for "this package's testset".
-
-    Part of the remote problem id, so two problems on one server do not collide.
-    Derived from the package name and the testset shape rather than from the
-    built bytes: it only has to separate problems, and a content hash would move
-    on every regeneration and leave a trail of dead problems behind.
-    """
-    pkg = package.find_problem_package_or_die()
-    material = f'{pkg.name}:{len(ctx.skeleton.entries)}'
-    return hashlib.sha256(material.encode()).hexdigest()[:8]
 
 
 # -- the upload record -----------------------------------------------------------

--- a/rbx/box/runners/domjudge/runner.py
+++ b/rbx/box/runners/domjudge/runner.py
@@ -10,11 +10,14 @@ Everything expensive is once per run, which is what `prepare` is: one upload
 serves however many solutions get measured, because a submission carries its own
 source in the request rather than being read out of the package.
 
-Design: `docs/plans/2026-09-08-domjudge-remote-runner-design.md`.
+Design: `docs/plans/2026-09-08-domjudge-remote-runner-design.md`, and
+`docs/plans/2026-09-08-domjudge-runner-caching-design.md` for what makes a
+re-run cheap.
 """
 
 import asyncio
 import hashlib
+import json
 import pathlib
 import tempfile
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -74,6 +77,32 @@ JUDGEMENT_POLL_ATTEMPTS = 400
 # comparable. Since comparability is the entire point of measuring remotely,
 # serialising costs wall-clock and buys correctness.
 MAX_INFLIGHT_SUBMISSIONS = 1
+
+# Where the fingerprint of the last probe package this machine successfully staged
+# is kept, one entry per server-and-problem. Under the disposable problem cache
+# rather than beside anything the setter owns: it is a per-machine observation
+# ("*I* put this package there"), and losing it must cost one redundant upload
+# rather than correctness. See `_recorded_fingerprint`.
+UPLOAD_STATE_NAME = 'domjudge-runner.json'
+
+# Where finished judgings are remembered, one JSON file per cache key.
+#
+# Beside the upload record, under the problem cache, and for the same reason: a
+# judging is an observation this machine made about a package it staged, not
+# anything that belongs to the package itself. Nothing here may be committed --
+# it says what *a* judgehost answered at *a* moment -- and losing it must cost a
+# redundant submission, never a wrong measurement. See `_cache_key`.
+JUDGEMENT_CACHE_DIR_NAME = 'domjudge-judgements'
+
+# Bumped when a change would make an older entry read wrong. It is part of the
+# key rather than a field to validate, so entries of another version simply never
+# match -- there is nothing to migrate and nothing to delete, and the cost of a
+# bump is one redundant submission per solution.
+JUDGEMENT_CACHE_VERSION = 1
+
+# The DOMjudge verdict for a submission that did not build. Never cached: see
+# `_is_cacheable`.
+COMPILATION_ERROR_VERDICT = 'CE'
 
 # What `TestcaseLog.exitstatus` says for a testcase somebody else ran. rbx never
 # saw a process, so there is no exit status to report; these name the absence
@@ -160,6 +189,11 @@ class DomjudgeRunner:
         self._team_id: Optional[str] = None
         self._packager: Optional[DomjudgePackager] = None
         self._languages: List[Dict[str, Any]] = []
+        # A digest over the probe package this run built, settled by `prepare`.
+        # It is what "the judge is configured identically" means here, and it is
+        # shared by the upload fast path and the judgement cache so the two can
+        # never disagree about it. See `_directory_fingerprint`.
+        self._fingerprint: Optional[str] = None
         # Created on first use rather than here: an `asyncio.Semaphore` belongs
         # to the loop that first awaits it, and nothing guarantees this object
         # was constructed inside the loop that will run it.
@@ -199,13 +233,34 @@ class DomjudgeRunner:
         problem_id = staging.probe_problem_id(fingerprint, ctx.purpose)
         self._problem_id = problem_id
 
-        packager, zip_path = self._build_probe(ctx, problem_id, timelimit_ms)
+        packager, zip_path, fingerprint = self._build_probe(
+            ctx, problem_id, timelimit_ms
+        )
         self._packager = packager
+        self._fingerprint = fingerprint
+
+        if await self._is_already_staged(problem_id, fingerprint):
+            # Said out loud, because otherwise it is unobservable: everything
+            # above is spinner text that vanishes, so a setter watching two
+            # phases go past would have no way to tell the cheap one from the
+            # expensive one.
+            console.console.print(
+                f'[status]domjudge[/status] · {api.server} · reused `{problem_id}`, '
+                f'package unchanged since the last upload.'
+            )
+            return
+
+        # Cleared *before* the upload, not after: from the moment the server
+        # starts receiving a new package, the recorded fingerprint no longer
+        # describes what is up there. A crash mid-upload must leave the next run
+        # re-uploading, never trusting a stale record.
+        _forget_upload(api.server, problem_id)
 
         if ctx.progress:
             ctx.progress.update(f'Uploading the probe package to `{problem_id}`...')
 
         await staging.stage_problem(api, self._contest, problem_id, zip_path)
+        _record_upload(api.server, problem_id, fingerprint)
 
         # One durable line, because everything above is spinner text that
         # vanishes. This is the only evidence afterwards that a phase re-uploaded
@@ -216,13 +271,45 @@ class DomjudgeRunner:
             f'at a {timelimit_ms} ms limit.'
         )
 
+    async def _is_already_staged(self, problem_id: str, fingerprint: str) -> bool:
+        """Whether the server already holds exactly this package, under this id.
+
+        Two conditions, and the second is what this has over the equivalent MOJ
+        fast path. **This machine last uploaded this fingerprint there** -- which
+        is a record of what rbx did, not of what the server holds. And **the
+        problem is still linked into the probe contest** -- which is the server's
+        own answer, and is what catches a probe problem deleted by hand, a
+        contest recreated, or a record carried onto an instance that was wiped.
+        `stage_problem` asks for that list anyway on the path this skips, so the
+        check costs a request only when it is about to save an upload.
+
+        What neither condition can see is somebody else uploading *over* this
+        problem id between two runs. That is why the record lives in the
+        disposable problem cache: the escape hatch is to delete it, and the cost
+        of the blind spot is bounded by the fact that the ids rbx stages to are
+        its own (`rbxt-`).
+        """
+        assert self._api is not None
+        assert self._contest is not None
+
+        if _recorded_fingerprint(self._api.server, problem_id) != fingerprint:
+            return False
+        problems = await self._api.problems(self._contest)
+        return any(problem.get('id') == problem_id for problem in problems)
+
     def _build_probe(
         self, ctx: RunContext, problem_id: str, timelimit_ms: int
-    ) -> Tuple[DomjudgePackager, pathlib.Path]:
+    ) -> Tuple[DomjudgePackager, pathlib.Path, str]:
         """Build the throwaway package this run measures against.
 
         Built directly rather than through `run_packager`, whose full local
         verification run is the exact work a remote runner exists to avoid.
+
+        Hands back the package's fingerprint along with the zip. It is taken over
+        the built *tree* rather than over the zip's bytes, because
+        `shutil.make_archive` stamps every entry with its mtime -- so two builds
+        of an identical package produce different archives, and a fingerprint
+        over them would never match anything.
         """
         packager = DomjudgePackager(
             testcase_entries=list(ctx.skeleton.entries),
@@ -242,7 +329,7 @@ class DomjudgeRunner:
             raise DomjudgeRunnerError(
                 'Could not build the DOMjudge probe package; see the error above.'
             ) from e
-        return packager, zip_path
+        return packager, zip_path, _directory_fingerprint(into_dir)
 
     # -- run_solution ---------------------------------------------------------
 
@@ -340,6 +427,12 @@ class DomjudgeRunner:
         list *grows* as judging proceeds. Reading it live turns a submission from
         one long silence into a testcase-by-testcase report, which is what a
         local run looks like.
+
+        **The cache is consulted before the semaphore, not inside it.** A hit
+        costs one file read and no judge time at all, so making it queue behind a
+        real submission would serialize free work behind expensive work -- and
+        with `MAX_INFLIGHT_SUBMISSIONS = 1` that means every hit waiting out every
+        miss ahead of it, for nothing.
         """
         assert self._api is not None
         assert self._contest is not None
@@ -349,6 +442,27 @@ class DomjudgeRunner:
 
         content = self._solution_content(solution)
         language_id = self._language_id_for(solution)
+
+        key = self._cache_key(solution, language_id, content)
+        cached = _load_cached_judgement(key)
+        if cached is not None:
+            submission_id, judgement, runs = cached
+            self._say(
+                board,
+                solution,
+                RunnerChip(f'#{submission_id}'),
+                RunnerChip('cached', style='green'),
+            )
+            # Put through the *same* `_Judging` a fresh submission publishes
+            # into, rather than storing derived evaluations. That is what makes a
+            # hit and a miss provably the same measurement: there is one path
+            # from a DOMjudge run to an rbx `Evaluation`, and both take it --
+            # pairing, the mismatch guard and the unknown-verdict refusal
+            # included, which still apply to a file that has been on disk since
+            # the last run and may have been anything by the time it is read.
+            await judging.publish(runs)
+            await judging.finish(judgement)
+            return
 
         async with self._slots:
             self._say(board, solution, RunnerChip('submitting'))
@@ -362,7 +476,12 @@ class DomjudgeRunner:
             )
             submission_id = str(submission['id'])
 
-            await self._poll_until_judged(solution, submission_id, judging, board)
+            judgement, runs = await self._poll_until_judged(
+                solution, submission_id, judging, board
+            )
+
+        if _is_cacheable(judgement, runs, judging.mismatched):
+            _store_cached_judgement(key, submission_id, judgement, runs)
 
     async def _poll_until_judged(
         self,
@@ -370,7 +489,7 @@ class DomjudgeRunner:
         submission_id: str,
         judging: '_Judging',
         board: RunProgress,
-    ) -> None:
+    ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
         """Poll until the judging is *finished*, publishing runs as they arrive.
 
         **Finished is `end_time`, not a verdict.** DOMjudge sets
@@ -381,11 +500,16 @@ class DomjudgeRunner:
         Per-testcase results are still handed out the moment they appear, so
         waiting for `end_time` costs the *report* nothing: it only decides when a
         testcase that never arrived is finally called SKIPPED.
+
+        Hands back the finished judgement and the last run list it read, which is
+        what the cache stores: the judge's own answer, rather than anything
+        derived from it. See `_store_cached_judgement`.
         """
         assert self._api is not None
         assert self._contest is not None
 
         judgement_id: Optional[str] = None
+        runs: List[Dict[str, Any]] = []
         # Real elapsed, not `attempt * interval`. Each attempt also spends a
         # request or two, so the nominal figure understates the wait -- by more
         # the busier the judge is, which is exactly when a setter reads it to
@@ -422,7 +546,7 @@ class DomjudgeRunner:
                     RunnerChip(f'#{submission_id}'),
                     RunnerChip(str(verdict or 'done')),
                 )
-                return
+                return judgement, runs
 
             await asyncio.sleep(JUDGEMENT_POLL_INTERVAL_SECONDS)
 
@@ -493,6 +617,69 @@ class DomjudgeRunner:
                 f'The extensions it does accept are: {known}.'
             )
         return language_id
+
+    def _cache_key(
+        self, solution: 'SolutionSkeleton', language_id: str, content: bytes
+    ) -> str:
+        """What makes a cached judging *the same measurement* as a fresh one.
+
+        Everything the judge's answer depended on, and nothing else:
+
+        - **the package the judge holds**, as `prepare`'s `_directory_fingerprint`
+          of the built probe. Everything the submission is measured *against* is
+          in there -- the testcases, the output validator, `problem.yaml`, and the
+          pinned limit -- so a package that fingerprints equal is a problem
+          configured identically. Reusing that fingerprint rather than inventing
+          a second key is what stops the cache and the upload fast path
+          disagreeing about what "the same package" means.
+        - **the exact bytes submitted**, not the solution's path and not its
+          mtime. `solution_content` amalgamates, so a change in an included
+          header changes the program without touching the file rbx names -- and,
+          the other way round, a whitespace-only edit that amalgamates to the
+          same bytes really is the same submission.
+        - **the language it was submitted under**, because that is what DOMjudge
+          compiles it with. Very nearly implied by the file name, but it is the
+          instance's own answer (`cpp` here, `cxx` elsewhere) and it is what the
+          judgehost acted on.
+        - **the server and the problem id**, because a timing is a measurement of
+          a park, and two instances holding the same package are two different
+          measurements. The problem id is very nearly implied by the fingerprint,
+          but it is where the numbers were actually observed.
+
+        **The limit needs no term of its own.** It is written into
+        `domjudge-problem.ini`, which the fingerprint covers -- so the validation
+        phase, which re-stages at `ceil(TL_lang x timeLimitToTle)`, misses on
+        every solution by construction, which is right: a timing taken under a
+        2.5s kill is not a timing under a 4s one. A picker round trip that lands
+        back on a limit already probed hits the cache instead.
+
+        **What this cannot see** is the park itself: its hardware, its load, a
+        judgehost joining or leaving, or somebody uploading over the probe
+        problem between two runs. A cached timing is a measurement from whenever
+        it was taken. That is why the cache lives in the disposable problem
+        cache, where throwing the observations away is one `rm -rf`.
+        """
+        assert self._api is not None
+        assert self._contest is not None
+        assert self._problem_id is not None
+        assert self._fingerprint is not None
+
+        digest = hashlib.sha256()
+        # Framed with lengths, like `_directory_fingerprint`, so no field can be
+        # made to look like part of the next one.
+        for part in (
+            f'v{JUDGEMENT_CACHE_VERSION}'.encode(),
+            self._api.server.encode(),
+            self._contest.encode(),
+            self._problem_id.encode(),
+            self._fingerprint.encode(),
+            solution.path.name.encode(),
+            language_id.encode(),
+            content,
+        ):
+            digest.update(f'{len(part)}:'.encode())
+            digest.update(part)
+        return digest.hexdigest()
 
     def _say(
         self, board: RunProgress, solution: 'SolutionSkeleton', *chips: RunnerChip
@@ -628,6 +815,16 @@ class _Judging:
             if self._failure is not None:
                 raise self._failure
             return self._runs.get(ordinal)
+
+    @property
+    def mismatched(self) -> bool:
+        """Whether the run list grew past the testset, so nothing may be paired.
+
+        Read by the cache before it writes anything: an entry that cannot be
+        paired is not a measurement of this testset, and remembering it would
+        turn one confusing run into every run after it.
+        """
+        return self._mismatched
 
     def chips(self) -> Tuple[RunnerChip, ...]:
         """What the progress board says about how far along the judging is.
@@ -840,6 +1037,251 @@ def _package_fingerprint(ctx: RunContext) -> str:
     pkg = package.find_problem_package_or_die()
     material = f'{pkg.name}:{len(ctx.skeleton.entries)}'
     return hashlib.sha256(material.encode()).hexdigest()[:8]
+
+
+# -- the upload record -----------------------------------------------------------
+#
+# What this machine last staged, per server and problem id, so a re-run does not
+# push the same package onto a server that already holds it. `stage_problem` is
+# four requests and a zip upload, and the two `rbx time` phases alternate over and
+# over as the picker narrows -- so this is the difference between a re-run that
+# costs nothing and one that re-uploads the whole testset every time.
+#
+# Keyed by server as well as by problem id, unlike MOJ's equivalent: `rbxt-` ids
+# are derived from the package, so the same id on a staging instance and on a
+# production one is two entirely different problems.
+
+
+def _upload_state_path() -> pathlib.Path:
+    return package.get_problem_cache_dir() / UPLOAD_STATE_NAME
+
+
+def _upload_state_key(server: str, problem_id: str) -> str:
+    return f'{server}|{problem_id}'
+
+
+def _read_upload_state() -> Dict[str, str]:
+    """Every problem this machine has staged to, and what it last sent.
+
+    A **map**, not a single record: `rbx time` stages one problem per phase, and
+    a single record would have each phase evict the other's -- which would make
+    the fast path unreachable in exactly the run that needs it most. Anything
+    unreadable or of an unrecognised shape reads as empty; the only cost is a
+    redundant upload, and that is the direction to fail in.
+    """
+    path = _upload_state_path()
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text())
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return {
+        key: value
+        for key, value in payload.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+
+
+def _write_upload_state(state: Dict[str, str]) -> None:
+    try:
+        _upload_state_path().write_text(json.dumps(state, indent=2) + '\n')
+    except OSError:
+        # A record that cannot be written is a record that is not there: the next
+        # run re-uploads. Nothing about the package just staged is affected, and
+        # there is nothing the setter would do about it.
+        return
+
+
+def _recorded_fingerprint(server: str, problem_id: str) -> Optional[str]:
+    return _read_upload_state().get(_upload_state_key(server, problem_id))
+
+
+def _record_upload(server: str, problem_id: str, fingerprint: str) -> None:
+    state = _read_upload_state()
+    state[_upload_state_key(server, problem_id)] = fingerprint
+    _write_upload_state(state)
+
+
+def _forget_upload(server: str, problem_id: str) -> None:
+    """Drop what is recorded for one problem, leaving every other one intact."""
+    state = _read_upload_state()
+    if state.pop(_upload_state_key(server, problem_id), None) is None:
+        return
+    _write_upload_state(state)
+
+
+def _directory_fingerprint(path: pathlib.Path) -> str:
+    """A digest over every file in the built package, path and contents.
+
+    Deterministic across machines (sorted relative POSIX paths, lengths framed so
+    a rename cannot be absorbed into a neighbouring file's bytes) and covers
+    exactly what the upload sends: change a testcase, the limit, `problem.yaml`
+    or the output validator, and this moves.
+    """
+    digest = hashlib.sha256()
+    for file_path in sorted(p for p in path.rglob('*') if p.is_file()):
+        rel = file_path.relative_to(path).as_posix().encode()
+        content = file_path.read_bytes()
+        digest.update(f'{len(rel)}:'.encode())
+        digest.update(rel)
+        digest.update(f'{len(content)}:'.encode())
+        digest.update(content)
+    return digest.hexdigest()
+
+
+# -- the judgement cache ---------------------------------------------------------
+#
+# `rbx time` is a command a setter runs *again*: tweak a solution, re-estimate,
+# change the profile, look at the table once more. Every re-run used to re-submit
+# every solution, including ones whose source had not changed by a byte -- and a
+# submission occupies the whole judgehost for as long as the solution takes on
+# every test, with `MAX_INFLIGHT_SUBMISSIONS = 1` making that strictly serial. So
+# a finished judging is remembered, keyed (see `_cache_key`) so that a hit is
+# provably the same measurement rather than merely a similar one.
+#
+# **There is no `--no-cache` flag**, deliberately. The two questions a flag would
+# answer both have better answers already: "I changed something" is what the key
+# is for, and it covers everything rbx can observe; "I want to see the variance"
+# is not a workflow this backend supports at all, since `nruns > 1` is refused
+# outright (`RunnerCapabilities.supports_nruns`). What is left is the blind spot
+# no flag can fix either -- a park whose hardware or load changed underneath the
+# numbers -- and for that the honest escape hatch is to throw the observations
+# away, which is one `rm -rf` of a directory under the problem cache.
+#
+# No expiry, no size cap, no eviction, for want of a problem they would solve: an
+# entry is a few hundred bytes of JSON, entries are only written for packages that
+# were really staged, and a stale entry is unreachable rather than wrong -- its
+# key names a package fingerprint no later run will ever produce again.
+
+
+def _judgement_cache_dir() -> pathlib.Path:
+    path = package.get_problem_cache_dir() / JUDGEMENT_CACHE_DIR_NAME
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _is_cacheable(
+    judgement: Dict[str, Any], runs: List[Dict[str, Any]], mismatched: bool
+) -> bool:
+    """Whether this judging is a measurement worth remembering.
+
+    Three refusals, and every one of them is a thing the setter is about to
+    *fix*, where answering the next run from the cache would make the fix appear
+    to change nothing:
+
+    - **no runs at all.** The submission never entered the testset: a compile
+      error, a judgehost that fell over, a judging that died. This is the
+      analogue of MOJ's `ran_nothing` check, and it is what keeps a `CE` out of
+      the cache -- the one a setter is guaranteed to hit, and the one that would
+      be maddening to have remembered.
+    - **a run list rbx refused to pair** (more runs than the testset). Nothing
+      was attributed to anything, so there is nothing to remember.
+    - **a verdict rbx cannot read.** `_evaluation_for` raises on it by name so
+      the fix is a one-line table entry; caching the response would mean the fix
+      did nothing until the cache was cleared.
+
+    A non-accepted judging **is** cached, on purpose. A WA, an RE or a TLE is a
+    legitimate, reproducible measurement of a solution that is *supposed* to fail
+    -- the validation phase exists to measure exactly those -- and its timings are
+    as real as an accepted solution's. Only "rbx could not read this" is refused,
+    never "the judge did not like the solution".
+    """
+    if mismatched or not runs:
+        return False
+    if str(judgement.get('judgement_type_id') or '') == COMPILATION_ERROR_VERDICT:
+        # Belt and braces: DOMjudge reports a compile error with no runs, so the
+        # check above already covers it. It stays because the rule being applied
+        # here is "never remember a build failure", and leaving that to be
+        # inferred from an empty list is how such a rule gets lost.
+        return False
+    return all(
+        str(run.get('judgement_type_id') or '') in _OUTCOMES
+        for run in runs
+        if run.get('ordinal') is not None
+    )
+
+
+def _load_cached_judgement(
+    key: str,
+) -> Optional[Tuple[str, Dict[str, Any], List[Dict[str, Any]]]]:
+    """The submission id, judgement and runs remembered under `key`, if any.
+
+    Anything unreadable -- absent, truncated, not JSON, not the shape it was
+    written in, written by a version of this code that meant something else by it
+    -- reads as a miss. That is the direction to fail in: a miss costs one
+    redundant submission, while trusting a half-written file costs a wrong timing
+    in the number `rbx time` is about to write into a limits profile.
+    """
+    path = _judgement_cache_dir() / f'{key}.json'
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    submission = payload.get('submission')
+    judgement = payload.get('judgement')
+    runs = payload.get('runs')
+    if not isinstance(submission, str) or not submission:
+        return None
+    if not isinstance(judgement, dict) or not isinstance(runs, list):
+        return None
+    if not all(isinstance(run, dict) for run in runs):
+        return None
+    return submission, judgement, runs
+
+
+def _store_cached_judgement(
+    key: str,
+    submission_id: str,
+    judgement: Dict[str, Any],
+    runs: List[Dict[str, Any]],
+) -> None:
+    """Remember a judging rbx was able to read in full.
+
+    **Only ever called for a judging that passed `_is_cacheable`**, which is what
+    keeps a failure out of the cache.
+
+    What is stored is the API's own answer -- the judgement object and the run
+    list -- rather than the evaluations derived from them. The derivation depends
+    on which testcases *this* run asked about, so storing its output would bake
+    one run's testset into an entry the next run reuses. Storing the input instead
+    means a hit re-derives, through the same `_Judging`, against whatever the
+    current run asked for.
+
+    Written whole and then moved into place, because a poll interrupted mid-write
+    would otherwise leave a truncated JSON file under a key that says it describes
+    a real measurement. `_load_cached_judgement` tolerates that anyway; this makes
+    it not happen.
+    """
+    directory = _judgement_cache_dir()
+    path = directory / f'{key}.json'
+    payload = {
+        'submission': submission_id,
+        'judgement': judgement,
+        'runs': runs,
+    }
+    try:
+        # Same directory, so the replace is atomic on every filesystem rbx runs
+        # on.
+        with tempfile.NamedTemporaryFile(
+            'w', dir=directory, prefix=f'.{key}-', suffix='.tmp', delete=False
+        ) as tmp:
+            tmp.write(json.dumps(payload, indent=2) + '\n')
+            temporary = pathlib.Path(tmp.name)
+        temporary.replace(path)
+    except OSError:
+        # A cache that cannot be written is a cache that is not there. The
+        # measurement in hand is unaffected, and saying anything here would be
+        # said from a background task, about something the setter did not ask for
+        # and cannot act on.
+        return
 
 
 # Re-exported so `registry` can name the class without knowing the module layout.

--- a/rbx/box/runners/domjudge/staging.py
+++ b/rbx/box/runners/domjudge/staging.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional
 
 from rbx.box.runners.base import RunnerCapabilityError, RunPurpose
 from rbx.box.runners.domjudge.api import DomjudgeApi
+from rbx.box.runners.problem_id import RBXT_PREFIX
 
 # The contest every probe problem lives in. One contest, many problems: a
 # problem is per package and per purpose, while the contest is just the place
@@ -65,15 +66,21 @@ def probe_label(problem_id: str) -> str:
     return problem_id
 
 
-def probe_problem_id(fingerprint: str, purpose: RunPurpose) -> str:
+def probe_problem_id(slug: str, purpose: RunPurpose) -> str:
     """The remote problem this package, for this purpose, belongs to.
+
+    `slug` is the package's one identity on any remote judge, out of `.rbx-id` --
+    the same slug MOJ renders `<login>#rbxt-<slug>` from. It used to be a hash of
+    the package name and its testcase count, which moved every time a testcase
+    was added: the run then staged a fresh problem and left the previous one
+    behind, and two packages that happened to agree on both collided.
 
     Purpose is part of the id because the two `rbx time` phases pin *different*
     time limits, and the limits live in the package. Sharing one remote problem
     would make every alternation between phases a fresh upload -- exactly the
     thrash `RunPurpose` was introduced to prevent.
     """
-    return f'rbxt-{fingerprint}-{_purpose_suffix(purpose)}'
+    return f'{RBXT_PREFIX}{slug}-{_purpose_suffix(purpose)}'
 
 
 def _purpose_suffix(purpose: RunPurpose) -> str:

--- a/rbx/box/runners/moj/problem_id.py
+++ b/rbx/box/runners/moj/problem_id.py
@@ -2,27 +2,35 @@
 
 MOJ identifies a problem as `<org>#<slug>`, where the org is a login. rbx uses
 throwaway, private problems -- `<login>#rbxt-<slug>` and ids derived from it --
-purely as places to run timings, and records the base one in `.moj-id` at the
-package root. See `derived_id` for why there is more than one.
+purely as places to run timings.
+
+**The slug comes from `.rbx-id`**, the one identity a package has on any remote
+judge -- see `rbx.box.runners.problem_id`. What lives here is only what is
+*MOJ's* about an id: the org, the `<org>#<slug>` spelling, the per-phase suffix,
+and the fact that this file is shared with somebody else's CLI.
 
 `.moj-id` is **the CLI's own convention**, not an invention: `moj testrun` accepts
-a directory in place of an id and reads exactly this file out of it. Committing it
-is what makes two setters on the same problem reach the same remote problem
-instead of each orphaning one on the server.
+a directory in place of an id and reads exactly this file out of it. So it is
+still written, and it is still what the `moj` CLI reads -- but it is now a
+rendering of the shared slug rather than the place the slug is decided. The one
+case where it stays authoritative is a package bound *before* `.rbx-id` existed:
+its slug is adopted rather than replaced, so a run keeps the problem it has been
+using. See `ensure_moj_id`.
 """
 
 import json
 import os
 import pathlib
 import re
-import secrets
 from typing import Any, Dict
+
+from rbx.box.runners import problem_id
 
 MOJ_ID_NAME = '.moj-id'
 
-# The prefix marks a problem as one rbx created for its own use, so a human
-# browsing the server can tell it apart from a real, published problem.
-RBXT_PREFIX = 'rbxt-'
+# Re-exported: the marker belongs to every remote runner, not to MOJ, but the
+# guard below and its callers read it from here.
+RBXT_PREFIX = problem_id.RBXT_PREFIX
 
 _RBXT_ID = re.compile(r'^(?P<org>[^#]+)#' + re.escape(RBXT_PREFIX) + r'(?P<slug>.+)$')
 
@@ -59,11 +67,12 @@ def derived_id(moj_id: str, suffix: str) -> str:
 
 
 def moj_id_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
-    """Where the binding lives: beside `problem.rbx.yml`, and git-tracked.
+    """Where the binding lives: beside `problem.rbx.yml`.
 
     Relative to the package root rather than under the cache directory, the same
-    way `.limits` is: the cache is per-machine and disposable, and a binding that
-    did not survive a clone would give every setter their own remote problem.
+    way `.limits` is, and for the same reason `.rbx-id` is: the cache is
+    regenerated freely, and a binding that vanished with it would leave a dead
+    problem on the server after every clean.
     """
     return root / MOJ_ID_NAME
 
@@ -110,28 +119,23 @@ def ensure_moj_id(login: str, root: pathlib.Path = pathlib.Path()) -> str:
             # does not exist, and would destroy a binding rbx never created.
             # Returning it is therefore right, and is also the hazard `is_rbxt_id`
             # exists for: what comes back here must not be uploaded over.
+            #
+            # Nothing is adopted from it either: a foreign id's slug is the other
+            # server's naming, not an identity rbx may hand to another judge.
             return current
-        slug = match.group('slug')
+        # A package bound before `.rbx-id` existed. Its slug is the one the
+        # server already knows this package by, so it is offered to the shared
+        # file rather than overwritten from it -- and `adopt_slug` keeps an
+        # existing shared slug, so a package that has both simply keeps both.
+        slug = problem_id.adopt_slug(match.group('slug'), root)
     else:
-        slug = _new_slug()
+        slug = problem_id.ensure_slug(root)
 
     moj_id = f'{login}#{RBXT_PREFIX}{slug}'
     if moj_id != current:
         payload['id'] = moj_id
         _write_payload(path, payload)
     return moj_id
-
-
-def _new_slug() -> str:
-    """A slug that no other package will pick.
-
-    Random rather than derived from the problem's name: ids share one namespace
-    across every setter on the server, and rbx package names are not unique --
-    two setters both working through the same tutorial package would otherwise
-    collide on the server, and one of them would be writing over the other's
-    problem. Stability comes from committing `.moj-id`, not from derivation.
-    """
-    return secrets.token_hex(4)
 
 
 def _read_payload(path: pathlib.Path) -> Dict[str, Any]:

--- a/rbx/box/runners/problem_id.py
+++ b/rbx/box/runners/problem_id.py
@@ -1,0 +1,138 @@
+"""The one identity an rbx package has on any remote judge.
+
+Every remote runner needs a name to put its throwaway problem under, and every
+one of them needs that name to be *the same name next time*: an id that moved
+between runs would orphan a problem on the server and re-upload the whole testset
+to a fresh one. Each backend used to answer that question its own way -- MOJ from
+a slug it minted into `.moj-id`, DOMjudge from a hash of the package name and its
+testcase count -- so one package had two unrelated identities, and DOMjudge's
+moved whenever a testcase was added.
+
+There is now one slug, in `.rbx-id` at the package root, and each backend renders
+its own id from it:
+
+- MOJ: `<login>#rbxt-<slug>`, because MOJ scopes ids by org and the org is
+  whoever is logged in.
+- DOMjudge: `rbxt-<slug>-<purpose>`, because DOMjudge's ids are flat and the two
+  `rbx time` phases pin different limits.
+
+**The slug is not derived from anything.** Not from the package name (rbx names
+are not unique -- two setters working through the same tutorial package would
+collide on a shared server, and one would be writing over the other's problem),
+and not from the testset (which changes constantly, and every change would strand
+a dead problem). It is random, minted once, and then kept.
+
+**`rbxt-` is the marker that a problem is rbx's to overwrite.** It is what stands
+between a timing package and a setter's real, published problem, and it belongs
+to this module rather than to any one backend for that reason.
+"""
+
+import json
+import os
+import pathlib
+import secrets
+from typing import Any, Dict, Optional
+
+# Where the slug lives: beside `problem.rbx.yml`, not under `.rbx/`. The cache is
+# regenerated freely and a slug that vanished with it would leave a dead problem
+# on the server after every `rbx clean`.
+RBX_ID_NAME = '.rbx-id'
+
+# The prefix marks a problem as one rbx created for its own use, so a human
+# browsing the server can tell it apart from a real, published problem.
+RBXT_PREFIX = 'rbxt-'
+
+
+def rbx_id_path(root: pathlib.Path = pathlib.Path()) -> pathlib.Path:
+    return root / RBX_ID_NAME
+
+
+def ensure_slug(root: pathlib.Path = pathlib.Path()) -> str:
+    """This package's slug, minting and recording one on first use.
+
+    Idempotent, and that is the whole contract: two calls, two runs, two backends
+    and two commands all have to get the same answer, or each of them binds to a
+    problem of its own.
+    """
+    slug = read_slug(root)
+    if slug is not None:
+        return slug
+    slug = _new_slug()
+    _write_payload(rbx_id_path(root), {'slug': slug})
+    return slug
+
+
+def read_slug(root: pathlib.Path = pathlib.Path()) -> Optional[str]:
+    """The recorded slug, or `None` when there is not a usable one.
+
+    Anything unreadable -- absent, truncated, not JSON, not the shape it was
+    written in -- reads as absent rather than raising. This file is a binding to
+    a disposable `rbxt-` problem, never authored content: a half-written or
+    hand-mangled one has nothing worth preserving, and refusing to run until the
+    setter deletes a file they have most likely never heard of trades a working
+    run for a puzzle. Nothing is lost by rebinding -- the old remote problem is
+    simply left behind on the server.
+    """
+    payload = _read_payload(rbx_id_path(root))
+    slug = payload.get('slug')
+    if not isinstance(slug, str):
+        return None
+    slug = slug.strip()
+    return slug or None
+
+
+def adopt_slug(slug: str, root: pathlib.Path = pathlib.Path()) -> str:
+    """Record `slug` as this package's, unless it already has one.
+
+    How a package that predates this file keeps the problem it is already using.
+    A `.moj-id` committed months ago carries a perfectly good slug, and minting a
+    fresh one beside it would silently move MOJ's problem to a new server-side
+    problem the next time the two were reconciled.
+
+    **An existing slug always wins**, even against a binding that looks more
+    authoritative. Overwriting it would move whichever backend had already bound
+    to it, which is the one outcome this module exists to prevent; the backends
+    are then free to disagree, and each stays on the problem it is already using.
+    """
+    existing = read_slug(root)
+    if existing is not None:
+        return existing
+    _write_payload(rbx_id_path(root), {'slug': slug})
+    return slug
+
+
+def _new_slug() -> str:
+    """A slug that no other package will pick."""
+    return secrets.token_hex(4)
+
+
+def _read_payload(path: pathlib.Path) -> Dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text())
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def _write_payload(path: pathlib.Path, payload: Dict[str, Any]) -> None:
+    """Rewrite the file, keeping every field somebody else put there.
+
+    JSON with one key rather than a bare line of text, so a later need for a
+    second field is an addition rather than a format change -- and so a reader
+    that finds something unexpected can tell "not the shape I write" from
+    "corrupt".
+
+    Written through a temporary file and an atomic rename, so an interrupted
+    write leaves the previous binding intact rather than the half-written file
+    `_read_payload` exists to tolerate.
+    """
+    merged = _read_payload(path)
+    merged.update(payload)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f'{path.name}.tmp')
+    tmp.write_text(json.dumps(merged, indent=2) + '\n')
+    os.replace(tmp, path)

--- a/rbx/resources/presets/default/problem-interactive/.gitignore
+++ b/rbx/resources/presets/default/problem-interactive/.gitignore
@@ -3,6 +3,7 @@ build/
 .limits/local.yml
 __pycache__/
 .moj-id
+.rbx-id
 
 .DS_Store
 .vscode/

--- a/rbx/resources/presets/default/problem/.gitignore
+++ b/rbx/resources/presets/default/problem/.gitignore
@@ -3,6 +3,7 @@ build/
 .limits/local.yml
 __pycache__/
 .moj-id
+.rbx-id
 
 .DS_Store
 .vscode/

--- a/tests/rbx/box/runners/domjudge/conftest.py
+++ b/tests/rbx/box/runners/domjudge/conftest.py
@@ -1,0 +1,322 @@
+"""A DOMjudge that answers, minus the DOMjudge.
+
+The runner's other tests are unit-level -- they drive `_Judging`, `staging` and
+the API wrapper directly. The cache is not testable that way: what it claims is
+about *whole runs*, and specifically about what the second one does. So this
+fixes the API at its own boundary (`DomjudgeApi`, faked wholesale) and drives
+`prepare` / `run_solution` / `close` for real, package build included.
+
+Nothing here touches the network.
+"""
+
+import asyncio
+import pathlib
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import pytest
+
+from rbx.box import header
+from rbx.box.environment import VerificationLevel
+from rbx.box.generation_schema import GenerationMetadata, GenerationTestcaseEntry
+from rbx.box.runners.base import RunContext, RunPurpose
+from rbx.box.runners.domjudge import runner as runner_module
+from rbx.box.runners.domjudge.api import Credentials
+from rbx.box.runners.domjudge.runner import DomjudgeRunner
+from rbx.box.schema import ExpectedOutcome, Testcase
+from rbx.box.solutions import SolutionReportSkeleton, SolutionSkeleton
+from rbx.box.testcase_schema import TestcaseEntry
+from rbx.grading.limits import Limits
+
+CHECKER = '#include "testlib.h"\nint main(){ quitf(_ok, "ok"); }\n'
+ACCEPTED_SOL = 'int main(){ return 0; }\n'
+
+SERVER = 'http://domjudge.test'
+
+
+def run(ordinal: int, verdict: str = 'AC', run_time: float = 0.1) -> Dict[str, Any]:
+    """One judging run, in the shape `/judgements/{id}/runs` returns."""
+    return {
+        'id': str(ordinal),
+        'ordinal': ordinal,
+        'judgement_type_id': verdict,
+        'run_time': run_time,
+    }
+
+
+class FakeApi:
+    """One DOMjudge instance that judges whatever it is told to judge.
+
+    Every submission is answered from `results`, keyed by the *filename* rbx
+    submits under -- which is the solution's own name, so a test says
+    `fake.results['sol.cpp'] = [...]` and means it.
+
+    The list of submissions is the assertion in almost every test here: the whole
+    claim of the cache is which submissions a second run does *not* make.
+    """
+
+    def __init__(self, entries: int = 2, server: str = SERVER):
+        # An instance attribute, not a constant: the upload record is keyed by
+        # server, so a test has to be able to be a *different* instance.
+        self.server = server
+        self._entries = entries
+        # filename -> the runs the judgehost reports for it. Absent means "all
+        # accepted", which is what a test that does not care wants.
+        self.results: Dict[str, List[Dict[str, Any]]] = {}
+        # filename -> the run-level verdict, when it is not derived from the runs.
+        # A compile error is the case that needs it: no runs, and a `CE`.
+        self.verdicts: Dict[str, str] = {}
+        # (submission id, filename), in submission order.
+        self.submissions: List[Tuple[str, str]] = []
+        self.uploads: List[str] = []
+        self.staged: List[str] = []
+        self._problems: List[Dict[str, Any]] = []
+        self._contests: List[Dict[str, Any]] = []
+        # Set to make every submission hang inside the concurrency slot, which is
+        # how a test keeps one occupied while another solution is dispatched.
+        self.hold: Optional[asyncio.Event] = None
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> 'FakeApi':
+        monkeypatch.setattr(
+            runner_module,
+            'credentials_from_env',
+            lambda: Credentials(server=self.server, username='jury', password='jury'),
+        )
+        monkeypatch.setattr(runner_module, 'DomjudgeApi', lambda credentials: self)
+        return self
+
+    # -- preflight and staging ------------------------------------------------
+
+    async def version(self) -> Dict[str, Any]:
+        return {'api_version': 4}
+
+    async def config(self) -> Dict[str, Any]:
+        return {}
+
+    async def judgehosts(self) -> List[Dict[str, Any]]:
+        return [{'id': '1', 'enabled': True, 'polltime': str(2**31)}]
+
+    async def contests(self) -> List[Dict[str, Any]]:
+        return list(self._contests)
+
+    async def create_contest(self, contest: Dict[str, Any]) -> str:
+        self._contests.append({'id': contest['id']})
+        return contest['id']
+
+    async def teams(self) -> List[Dict[str, Any]]:
+        return [{'id': 'domjudge'}]
+
+    async def languages(self, contest: str) -> List[Dict[str, Any]]:
+        return [{'id': 'cpp', 'extensions': ['cpp', 'cc', 'cxx']}]
+
+    async def problems(self, contest: str) -> List[Dict[str, Any]]:
+        return list(self._problems)
+
+    async def add_problem_data(self, contest, problem_id, label, name):
+        self._problems.append({'id': problem_id})
+        return [problem_id]
+
+    async def upload_problem(self, contest, problem_id, zip_path):
+        self.uploads.append(problem_id)
+        return {'problem_id': problem_id}
+
+    async def unlink_problem(self, contest, problem_id) -> None:
+        return None
+
+    async def link_problem(self, contest, problem_id, label, lazy_eval_results):
+        self.staged.append(problem_id)
+        return {'id': problem_id}
+
+    # -- submitting and judging -----------------------------------------------
+
+    async def submit(
+        self, contest, problem_id, language_id, team_id, filename, source
+    ) -> Dict[str, Any]:
+        if self.hold is not None:
+            await self.hold.wait()
+        submission_id = str(len(self.submissions) + 1)
+        self.submissions.append((submission_id, filename))
+        return {'id': submission_id}
+
+    async def judgements(self, contest, submission) -> List[Dict[str, Any]]:
+        filename = dict(self.submissions)[submission]
+        return [
+            {
+                'id': submission,
+                'submission_id': submission,
+                'judgement_type_id': self._verdict(filename),
+                # Judged in one poll: what these tests are about is which
+                # submissions happen, not how a judging is watched -- which
+                # `test_pairing.py` covers on `_Judging` directly.
+                'end_time': '2026-09-08T12:00:00+00:00',
+                'max_run_time': 0.2,
+            }
+        ]
+
+    async def runs(self, contest, judgement) -> List[Dict[str, Any]]:
+        return list(self._runs_for(dict(self.submissions)[judgement]))
+
+    def _runs_for(self, filename: str) -> List[Dict[str, Any]]:
+        if filename in self.results:
+            return self.results[filename]
+        return [run(ordinal) for ordinal in range(1, self._entries + 1)]
+
+    def _verdict(self, filename: str) -> str:
+        if filename in self.verdicts:
+            return self.verdicts[filename]
+        verdicts = [
+            str(item.get('judgement_type_id')) for item in self._runs_for(filename)
+        ]
+        return next((item for item in verdicts if item != 'AC'), 'AC')
+
+    def forget_problems(self) -> None:
+        """Drop every problem, as a wiped instance or a hand-deleted probe would.
+
+        The contest is left alone: what this models is somebody removing the
+        probe problem, not the whole server going away.
+        """
+        self._problems.clear()
+
+    # -- what a test asserts on -----------------------------------------------
+
+    @property
+    def submitted(self) -> List[str]:
+        """The filename of every submission made, in order."""
+        return [filename for _, filename in self.submissions]
+
+
+def entry(
+    tmp_path: pathlib.Path, group: str, index: int, content: str
+) -> GenerationTestcaseEntry:
+    """A built testcase entry backed by real files.
+
+    The packager only requires that `copied_to.inputPath` exists, so it can be
+    exercised without a full sandboxed build.
+    """
+    group_dir = tmp_path / 'built' / group
+    group_dir.mkdir(parents=True, exist_ok=True)
+    input_path = group_dir / f'{index:03d}.in'
+    output_path = group_dir / f'{index:03d}.out'
+    input_path.write_text(content)
+    output_path.write_text('42\n')
+    testcase_entry = TestcaseEntry(group=group, index=index)
+    return GenerationTestcaseEntry(
+        group_entry=testcase_entry,
+        subgroup_entry=testcase_entry,
+        metadata=GenerationMetadata(
+            copied_to=Testcase(inputPath=input_path, outputPath=output_path)
+        ),
+    )
+
+
+def build_entries(
+    tmp_path: pathlib.Path, groups: Optional[List[str]] = None
+) -> List[GenerationTestcaseEntry]:
+    return [
+        entry(tmp_path, group, index, f'{group} {index}\n')
+        for group in (groups or ['samples'])
+        for index in range(2)
+    ]
+
+
+def minimal_package(
+    testing_pkg, solutions: Optional[List[Tuple[str, ExpectedOutcome]]] = None
+) -> None:
+    """The smallest package the DOMjudge packager will build: a checker and a
+    solution per declared entry."""
+    testing_pkg.add_file('check.cpp').write_text(CHECKER)
+    testing_pkg.set_checker('check.cpp')
+    for path, outcome in solutions or [('sol.cpp', ExpectedOutcome.ACCEPTED)]:
+        testing_pkg.add_solution(path, outcome=outcome.value).write_text(ACCEPTED_SOL)
+    testing_pkg.save()
+    header.generate_header()
+
+
+def limits_for(
+    timelimit_override: Optional[Union[int, Dict[str, int]]],
+) -> Dict[str, Limits]:
+    """The per-language limits `_get_report_skeleton` would have resolved.
+
+    The runner pins the probe package's limit from these, so a context built by
+    hand has to carry what a real run does -- an empty table would make packages
+    that should differ compare equal, which is precisely what the cache keys on.
+    """
+    if isinstance(timelimit_override, dict):
+        return {
+            language: Limits(time=limit_ms)
+            for language, limit_ms in timelimit_override.items()
+        }
+    if isinstance(timelimit_override, int) and timelimit_override > 0:
+        return {'cpp': Limits(time=timelimit_override)}
+    return {'cpp': Limits(time=1000)}
+
+
+def purpose_for(
+    timelimit_override: Optional[Union[int, Dict[str, int]]],
+) -> RunPurpose:
+    """The purpose the caller that passes this override would have declared."""
+    if isinstance(timelimit_override, dict):
+        return RunPurpose.VALIDATION
+    if isinstance(timelimit_override, int) and timelimit_override > 0:
+        return RunPurpose.ESTIMATION
+    return RunPurpose.RUN
+
+
+def context(
+    tmp_path: pathlib.Path,
+    solutions: Optional[List[Tuple[str, ExpectedOutcome]]] = None,
+    entries: Optional[List[GenerationTestcaseEntry]] = None,
+    timelimit_override: Optional[Union[int, Dict[str, int]]] = -1,
+    purpose: Optional[RunPurpose] = None,
+) -> RunContext:
+    """A `RunContext` carrying what `prepare` and `run_solution` read.
+
+    `timelimit_override` defaults to **-1**, rbx's "no override" sentinel, and
+    the limits and the purpose are derived from it exactly as the caller that
+    passes that shape would have set them.
+    """
+    if solutions is None:
+        solutions = [('sol.cpp', ExpectedOutcome.ACCEPTED)]
+    if entries is None:
+        entries = build_entries(tmp_path)
+    skeleton = SolutionReportSkeleton(
+        solutions=[
+            SolutionSkeleton(
+                path=pathlib.Path(path),
+                outcome=outcome,
+                runs_dir=tmp_path / 'runs' / path,
+            )
+            for path, outcome in solutions
+        ],
+        entries=entries,
+        groups=[],
+        limits=limits_for(timelimit_override),
+        compiled_solutions={},
+        verification=VerificationLevel.ALL_SOLUTIONS,
+    )
+    return RunContext(
+        skeleton=skeleton,
+        checker_digest=None,
+        interactor_digest=None,
+        verification=VerificationLevel.ALL_SOLUTIONS,
+        timelimit_override=timelimit_override,
+        nruns=1,
+        progress=None,
+        abort_on=None,
+        purpose=purpose_for(timelimit_override) if purpose is None else purpose,
+    )
+
+
+async def time_run(ctx: RunContext) -> Dict[str, List]:
+    """One whole `rbx time` run: prepare, then every solution to completion."""
+    runner = DomjudgeRunner()
+    await runner.prepare(ctx)
+    try:
+        evaluations = {}
+        for solution in ctx.skeleton.solutions:
+            deferreds = runner.run_solution(solution, ctx.skeleton.entries, ctx)
+            evaluations[str(solution.path)] = [
+                await asyncio.wait_for(deferred(), timeout=10) for deferred in deferreds
+            ]
+        return evaluations
+    finally:
+        await runner.close()

--- a/tests/rbx/box/runners/domjudge/test_cache.py
+++ b/tests/rbx/box/runners/domjudge/test_cache.py
@@ -1,0 +1,545 @@
+"""The judgement cache: a re-run of `rbx time --runner domjudge` costs no judging.
+
+`rbx time` is a command a setter runs *again* -- tweak a solution, re-estimate,
+look at the table once more -- and every re-run used to re-stage the whole package
+and re-submit every solution, including the ones whose source had not changed by a
+byte. A submission occupies the judgehost for as long as the solution takes on
+every test, and `MAX_INFLIGHT_SUBMISSIONS = 1` makes that strictly serial, so that
+is not a small waste.
+
+What these tests are really about is the **key**: a hit has to be provably the
+same measurement, not merely a similar one. So they change one thing at a time --
+a solution's source, the limit pinned in the package, the verdict the judge
+reports -- and assert exactly which submissions and uploads the next run makes.
+
+Nothing here touches the network; `FakeApi` from `conftest.py` is the whole judge.
+"""
+
+import asyncio
+import json
+import pathlib
+from typing import Dict, List
+
+import pytest
+
+from rbx.box.runners.base import RunPurpose
+from rbx.box.runners.domjudge import runner as runner_module
+from rbx.box.runners.domjudge.runner import DomjudgeRunner, DomjudgeRunnerError
+from rbx.box.schema import ExpectedOutcome
+from tests.rbx.box.runners.domjudge.conftest import (
+    FakeApi,
+    build_entries,
+    context,
+    minimal_package,
+    run,
+    time_run,
+)
+
+pytestmark = pytest.mark.shared_cache
+
+TWO_SOLUTIONS = [
+    ('sol.cpp', ExpectedOutcome.ACCEPTED),
+    ('other.cpp', ExpectedOutcome.WRONG_ANSWER),
+]
+
+
+@pytest.fixture(autouse=True)
+def _instant_polls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runner_module, 'JUDGEMENT_POLL_INTERVAL_SECONDS', 0)
+
+
+def _cache_dir(testing_pkg) -> pathlib.Path:
+    return testing_pkg.root / '.rbx' / runner_module.JUDGEMENT_CACHE_DIR_NAME
+
+
+def _entries(testing_pkg) -> List[pathlib.Path]:
+    directory = _cache_dir(testing_pkg)
+    return sorted(directory.glob('*.json')) if directory.is_dir() else []
+
+
+def _dump(evaluations: Dict[str, List]) -> Dict[str, List[dict]]:
+    return {
+        path: [evaluation.model_dump(mode='json') for evaluation in evals]
+        for path, evals in evaluations.items()
+    }
+
+
+# -- the hit ---------------------------------------------------------------------
+
+
+async def test_a_second_run_over_an_unchanged_package_submits_nothing(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """THE test. Nothing changed, so nothing is judged again."""
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+    assert fake.submitted == ['sol.cpp']
+
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp']
+
+
+async def test_a_hit_produces_exactly_the_evaluations_a_miss_did(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The cache may change how long a run takes and nothing else.
+
+    Every field of every `Evaluation` -- the outcome, the timing, the checker
+    message, the artifact path -- has to come out the same, because the estimate
+    `rbx time` writes into a limits profile is computed from exactly these. A
+    cache that changed one of them would move a time limit, silently, depending
+    on whether the setter had run the command before.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    fake.results['sol.cpp'] = [run(1, 'TLE', 2.81), run(2, 'WA', 0.2)]
+    ctx = context(tmp_path)
+
+    missed = await time_run(ctx)
+    hit = await time_run(ctx)
+
+    assert _dump(hit) == _dump(missed)
+
+
+async def test_a_testcase_the_judge_never_reported_stays_unreported_on_a_hit(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """A partial judging is remembered as partial, not completed by the cache.
+
+    A run list short of the testset resolves the missing testcases as SKIPPED,
+    and the entry stores the judge's own answer rather than the derivation -- so
+    a hit re-derives the same shortfall instead of inventing results for the
+    testcases nobody measured.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    fake.results['sol.cpp'] = [run(1, 'AC', 0.1)]
+    ctx = context(tmp_path)
+
+    missed = await time_run(ctx)
+    hit = await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp']
+    assert _dump(hit) == _dump(missed)
+    assert hit['sol.cpp'][1].result.outcome.name == 'SKIPPED'
+
+
+async def test_the_cache_lives_in_the_disposable_problem_cache(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """Losing it must cost a redundant submission, never a wrong measurement.
+
+    Same place, and for the same reason, as `prepare`'s upload record: what a
+    judgehost answered at a moment is an observation this machine made, not part
+    of the package. It must never be committed.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+
+    entries = _entries(testing_pkg)
+    assert len(entries) == 1
+    # The judge's own answer, stored whole -- the judgement and the runs, rather
+    # than the evaluations derived from them, so a hit re-derives against
+    # whatever the current run asks for.
+    payload = json.loads(entries[0].read_text())
+    assert payload['submission'] == fake.submissions[0][0]
+    assert [item['ordinal'] for item in payload['runs']] == [1, 2]
+    assert payload['judgement']['judgement_type_id'] == 'AC'
+
+
+# -- the miss --------------------------------------------------------------------
+
+
+async def test_a_changed_solution_is_the_only_one_measured_again(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """THE other test. The key is the *amalgamated bytes*, per solution."""
+    minimal_package(testing_pkg, solutions=TWO_SOLUTIONS)
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path, solutions=TWO_SOLUTIONS)
+
+    await time_run(ctx)
+    assert sorted(fake.submitted) == ['other.cpp', 'sol.cpp']
+
+    (testing_pkg.root / 'other.cpp').write_text('int main(){ return 1; }\n')
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp', 'other.cpp', 'other.cpp']
+
+
+async def test_editing_the_model_solution_invalidates_only_itself(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The difference from MOJ, and it is a real one.
+
+    A MOJ probe ships its solutions inside the package, so editing any of them
+    moves the package fingerprint and invalidates every other solution's timing.
+    A DOMjudge probe deliberately ships **no** submissions -- DOMjudge would judge
+    them for real and race the measured runs -- so the model solution is nothing
+    but another submission here, and editing it costs one re-measurement rather
+    than all of them.
+    """
+    minimal_package(testing_pkg, solutions=TWO_SOLUTIONS)
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path, solutions=TWO_SOLUTIONS)
+
+    await time_run(ctx)
+    (testing_pkg.root / 'sol.cpp').write_text('int main(){ return 2; }\n')
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp', 'other.cpp', 'sol.cpp']
+    # And the package itself did not move, so nothing was re-uploaded either.
+    assert len(fake.uploads) == 1
+
+
+async def test_a_changed_limit_invalidates_every_solution(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The limit is *in* the package, so a new limit is a new measurement of
+    everything.
+
+    It is written into `domjudge-problem.ini`, which the package fingerprint
+    covers -- so it needs no term of its own in the key, and the validation phase
+    (which re-stages at `timeLimitToTle x TL`) misses on every solution by
+    construction. Timings taken under a 2.5s kill are not timings under a 4s one:
+    a solution killed at the first limit may finish under the second.
+    """
+    minimal_package(testing_pkg, solutions=TWO_SOLUTIONS)
+    fake = FakeApi().install(monkeypatch)
+
+    await time_run(context(tmp_path, solutions=TWO_SOLUTIONS, timelimit_override=2500))
+    await time_run(context(tmp_path, solutions=TWO_SOLUTIONS, timelimit_override=4000))
+
+    assert len(fake.uploads) == 2
+    assert fake.submitted == ['sol.cpp', 'other.cpp', 'sol.cpp', 'other.cpp']
+
+
+async def test_the_two_phases_do_not_share_entries(testing_pkg, tmp_path, monkeypatch):
+    """Estimation and validation stage different problems, so they key apart.
+
+    They pin different limits and live under different `rbxt-` ids by design; an
+    entry from one must never answer for the other even when the bytes submitted
+    are identical.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+
+    await time_run(context(tmp_path, timelimit_override=2500))
+    await time_run(
+        context(tmp_path, timelimit_override=2500, purpose=RunPurpose.VALIDATION)
+    )
+
+    assert fake.submitted == ['sol.cpp', 'sol.cpp']
+
+
+async def test_bumping_the_cache_version_invalidates_every_entry(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The version is *in* the key, so an old entry is unreachable, not wrong.
+
+    That is what a bump is for: a change in what an entry means costs one
+    redundant submission per solution and needs no migration and no deletion
+    pass.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+    monkeypatch.setattr(
+        runner_module,
+        'JUDGEMENT_CACHE_VERSION',
+        runner_module.JUDGEMENT_CACHE_VERSION + 1,
+    )
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp', 'sol.cpp']
+
+
+async def test_an_entry_that_parses_but_is_not_the_right_shape_reads_as_a_miss(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """Valid JSON is not a valid measurement.
+
+    A file rbx wrote in some other version, or something that landed under this
+    name by accident, must send the run back to the judge rather than resolve
+    into whatever it happens to coerce to.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+    for entry in _entries(testing_pkg):
+        entry.write_text(json.dumps({'submission': '1', 'runs': 'all of them'}))
+
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp', 'sol.cpp']
+
+
+async def test_an_unreadable_entry_reads_as_a_miss(testing_pkg, tmp_path, monkeypatch):
+    """Half a file is not half a measurement.
+
+    Anything that does not parse into the shape it was written in has to re-run,
+    because the alternative is feeding a time limit off bytes nobody can vouch
+    for.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+    for entry in _entries(testing_pkg):
+        entry.write_text('{"submission": "1", "run')
+
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp', 'sol.cpp']
+
+
+# -- what may never be cached ----------------------------------------------------
+
+
+async def test_a_compile_error_is_never_cached(testing_pkg, tmp_path, monkeypatch):
+    """THE constraint. A remembered `CE` would be maddening.
+
+    The setter reads "it did not build on the judge", fixes the code, runs again
+    -- and a cache that remembered the failure would tell them the same thing
+    forever, with no submission to show for it. DOMjudge reports a compile error
+    as a judging with a `CE` verdict and no runs at all, which is why "no runs"
+    is the rule rather than a special case for one verdict.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    fake.results['sol.cpp'] = []
+    fake.verdicts['sol.cpp'] = 'CE'
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+    assert _entries(testing_pkg) == []
+
+    # The setter fixes it. (The source did not have to change for the judge to
+    # answer differently -- a compile error can be the instance's own compile
+    # script -- so this run has the same key as the failed one, deliberately.)
+    fake.results.pop('sol.cpp')
+    fake.verdicts.pop('sol.cpp')
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp', 'sol.cpp']
+
+
+async def test_a_verdict_rbx_could_not_read_is_never_cached(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The same rule, for the other thing the runner refuses to interpret.
+
+    An unrecognised verdict fails the solution by name so the fix is a one-line
+    table entry. Caching the response would mean the fix appeared to do nothing
+    until the cache was cleared.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    fake.results['sol.cpp'] = [run(1), run(2, 'AWOOGA')]
+    ctx = context(tmp_path)
+
+    with pytest.raises(DomjudgeRunnerError):
+        await time_run(ctx)
+    assert _entries(testing_pkg) == []
+
+    fake.results.pop('sol.cpp')
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp', 'sol.cpp']
+
+
+async def test_a_judging_rbx_refused_to_pair_is_never_cached(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """More runs than the testset means nothing was attributed to anything.
+
+    The remote problem holds testcases this run does not know about, so every
+    ordinal is refused and every testcase comes back SKIPPED. There is no
+    measurement in that to remember -- and remembering it would turn one
+    confusing run into every run after it.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    fake.results['sol.cpp'] = [run(1), run(2), run(3)]
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+    assert _entries(testing_pkg) == []
+
+    fake.results.pop('sol.cpp')
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp', 'sol.cpp']
+
+
+async def test_a_solution_the_judge_rejected_is_still_cached(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """ "Do not cache a failure" means a judging rbx could not read, not a bad
+    verdict.
+
+    A WA, an RE or a TLE is a legitimate, reproducible measurement -- the
+    validation phase exists to measure exactly the solutions that are supposed to
+    fail, and their timings are as real as an accepted solution's. Refusing to
+    cache them would re-submit, on every re-run, the slowest solutions in the
+    package: the very ones that cost the judgehost the most.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    fake.results['sol.cpp'] = [run(1, 'TLE', 9.9), run(2, 'WA', 0.2)]
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+    await time_run(ctx)
+
+    assert fake.submitted == ['sol.cpp']
+
+
+# -- how a hit is dispatched -----------------------------------------------------
+
+
+async def test_a_hit_does_not_queue_behind_the_submission_in_flight(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The cache is consulted before the concurrency slot, not inside it.
+
+    A hit costs one file read and no judge time at all, so making it wait for the
+    slot that bounds how much of the judgehost rbx occupies would serialize free
+    work behind expensive work. That matters more, not less, with the cap at one:
+    the hit would otherwise wait out every miss ahead of it.
+
+    `sol.cpp` is deliberately last, so the slot is taken by a solution the judge
+    is still chewing on by the time its turn comes.
+    """
+    solutions = [
+        ('other.cpp', ExpectedOutcome.WRONG_ANSWER),
+        ('third.cpp', ExpectedOutcome.WRONG_ANSWER),
+        ('sol.cpp', ExpectedOutcome.ACCEPTED),
+    ]
+    # Declared with the model solution first, because the schema requires it, and
+    # dispatched with it last, which is what this test is about.
+    minimal_package(testing_pkg, solutions=list(reversed(solutions)))
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path, solutions=solutions)
+
+    await time_run(ctx)
+
+    # Only `sol.cpp` still hits.
+    for path in ('other.cpp', 'third.cpp'):
+        (testing_pkg.root / path).write_text('int main(){ return 1; }\n')
+
+    runner = DomjudgeRunner()
+    await runner.prepare(ctx)
+    # The judge answers nobody until this is set, so the slot stays occupied.
+    fake.hold = asyncio.Event()
+    batches = [
+        runner.run_solution(solution, ctx.skeleton.entries, ctx)
+        for solution in ctx.skeleton.solutions
+    ]
+
+    # A bound, so a regression is a failing test rather than a hung suite.
+    cached = [await asyncio.wait_for(deferred(), timeout=5) for deferred in batches[2]]
+
+    assert len(cached) == 2
+    # The hit resolved while a real submission was still in flight and unanswered
+    # -- that is the whole claim -- and never went back to the judge itself.
+    assert 'sol.cpp' not in fake.submitted[3:]
+
+    fake.hold.set()
+    await runner.close()
+
+
+# -- the upload fast path --------------------------------------------------------
+#
+# `stage_problem` is four requests and a zip upload of the whole testset. A
+# re-run whose package is byte-identical to what this machine last put there has
+# nothing to say to the server, and the phases of `rbx time` alternate over and
+# over as the picker narrows -- so this is the other half of what makes a re-run
+# cheap.
+
+
+async def test_a_second_run_does_not_re_upload_an_unchanged_package(
+    testing_pkg, tmp_path, monkeypatch
+):
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+    await time_run(ctx)
+
+    assert len(fake.uploads) == 1
+
+
+async def test_a_changed_package_is_uploaded_again(testing_pkg, tmp_path, monkeypatch):
+    """The record says what was uploaded, not merely where.
+
+    A new testcase is a different package under the same `rbxt-` id -- the id is
+    derived from the package *name* and testcase count, so it does not have to
+    move for the content to.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi(entries=4).install(monkeypatch)
+
+    await time_run(context(tmp_path))
+    await time_run(
+        context(tmp_path, entries=build_entries(tmp_path, ['samples', 'main']))
+    )
+
+    assert len(fake.uploads) == 2
+
+
+async def test_a_probe_problem_that_vanished_is_uploaded_again(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """The record is a claim about this machine; the problem list is the server's
+    own answer, and it wins.
+
+    Without the second check a probe problem deleted in the jury interface -- or
+    a record carried onto an instance that was since wiped -- would leave every
+    run submitting to a problem that is not there.
+    """
+    minimal_package(testing_pkg)
+    fake = FakeApi().install(monkeypatch)
+    ctx = context(tmp_path)
+
+    await time_run(ctx)
+    fake.forget_problems()
+    await time_run(ctx)
+
+    assert len(fake.uploads) == 2
+
+
+async def test_the_record_does_not_carry_across_servers(
+    testing_pkg, tmp_path, monkeypatch
+):
+    """Two instances holding the same package are two different measurements.
+
+    `rbxt-` ids are derived from the package, so the same id on a staging server
+    and on a production one collides by construction -- which is why the record
+    and the cache key both name the server.
+    """
+    minimal_package(testing_pkg)
+    ctx = context(tmp_path)
+
+    first = FakeApi().install(monkeypatch)
+    await time_run(ctx)
+
+    second = FakeApi(server='http://elsewhere.test').install(monkeypatch)
+    await time_run(ctx)
+
+    assert len(first.uploads) == 1
+    assert len(second.uploads) == 1
+    assert second.submitted == ['sol.cpp']

--- a/tests/rbx/box/runners/domjudge/test_cache.py
+++ b/tests/rbx/box/runners/domjudge/test_cache.py
@@ -483,12 +483,16 @@ async def test_a_second_run_does_not_re_upload_an_unchanged_package(
     assert len(fake.uploads) == 1
 
 
-async def test_a_changed_package_is_uploaded_again(testing_pkg, tmp_path, monkeypatch):
+async def test_a_changed_package_is_uploaded_again_to_the_same_problem(
+    testing_pkg, tmp_path, monkeypatch
+):
     """The record says what was uploaded, not merely where.
 
-    A new testcase is a different package under the same `rbxt-` id -- the id is
-    derived from the package *name* and testcase count, so it does not have to
-    move for the content to.
+    A new testcase is a different package under the *same* `rbxt-` id, because
+    the id comes from the package's slug (`.rbx-id`) and nothing else. That is
+    the second half of the claim here: before the slug, the id was a hash of the
+    package name and its testcase count, so adding a testcase staged a brand new
+    problem and left the previous one behind on the server for good.
     """
     minimal_package(testing_pkg)
     fake = FakeApi(entries=4).install(monkeypatch)
@@ -499,6 +503,7 @@ async def test_a_changed_package_is_uploaded_again(testing_pkg, tmp_path, monkey
     )
 
     assert len(fake.uploads) == 2
+    assert fake.uploads[0] == fake.uploads[1]
 
 
 async def test_a_probe_problem_that_vanished_is_uploaded_again(

--- a/tests/rbx/box/runners/test_problem_id.py
+++ b/tests/rbx/box/runners/test_problem_id.py
@@ -1,0 +1,147 @@
+"""The one identity a package has on any remote judge.
+
+Each backend used to answer "what is this package called on the server?" its own
+way, so one package had two unrelated identities -- and DOMjudge's moved whenever
+a testcase was added, stranding the problem it had been using. These pin the
+shared slug both now render from: that it is stable, that it is not derived from
+anything that changes, and that a package which predates the file keeps the
+problem it is already bound to.
+"""
+
+import json
+import pathlib
+
+from rbx.box.runners.moj.problem_id import ensure_moj_id
+from rbx.box.runners.problem_id import (
+    adopt_slug,
+    ensure_slug,
+    rbx_id_path,
+    read_slug,
+)
+
+
+def test_the_slug_lives_at_the_package_root(tmp_path: pathlib.Path):
+    """Beside `problem.rbx.yml`, not under `.rbx/`. The cache is regenerated
+    freely, and a slug that vanished with it would leave a dead problem on the
+    server after every clean."""
+    assert rbx_id_path(tmp_path) == tmp_path / '.rbx-id'
+
+
+def test_a_slug_does_not_change_when_asked_again(tmp_path: pathlib.Path):
+    """The whole contract. Two calls, two runs, two backends and two commands all
+    have to get the same answer, or each binds to a problem of its own."""
+    assert ensure_slug(tmp_path) == ensure_slug(tmp_path)
+
+
+def test_two_packages_do_not_share_a_slug(tmp_path: pathlib.Path):
+    """Ids share one namespace on the server, across every setter and package.
+
+    Random rather than derived from the package name: rbx names are not unique,
+    so two setters working through the same tutorial package would otherwise
+    collide, and one would be writing over the other's problem.
+    """
+    (tmp_path / 'a').mkdir()
+    (tmp_path / 'b').mkdir()
+
+    assert ensure_slug(tmp_path / 'a') != ensure_slug(tmp_path / 'b')
+
+
+def test_nothing_is_recorded_until_a_slug_is_asked_for(tmp_path: pathlib.Path):
+    """A package nobody has run remotely carries no binding."""
+    assert read_slug(tmp_path) is None
+    assert not rbx_id_path(tmp_path).is_file()
+
+
+def test_a_corrupt_file_is_regenerated_rather_than_raising(tmp_path: pathlib.Path):
+    """A half-written binding must not be the thing that stops a run.
+
+    This file names a disposable `rbxt-` problem, never authored content. Nothing
+    is lost by rebinding -- the old remote problem is simply left behind.
+    """
+    rbx_id_path(tmp_path).write_text('{ this is not json')
+
+    slug = ensure_slug(tmp_path)
+
+    assert slug
+    assert json.loads(rbx_id_path(tmp_path).read_text())['slug'] == slug
+
+
+def test_a_file_holding_no_slug_is_regenerated(tmp_path: pathlib.Path):
+    rbx_id_path(tmp_path).write_text(json.dumps({'note': 'hello'}))
+
+    assert ensure_slug(tmp_path)
+
+
+def test_regenerating_keeps_the_fields_somebody_else_wrote(tmp_path: pathlib.Path):
+    rbx_id_path(tmp_path).write_text(json.dumps({'note': 'hello'}))
+
+    ensure_slug(tmp_path)
+
+    payload = json.loads(rbx_id_path(tmp_path).read_text())
+    assert payload['note'] == 'hello'
+
+
+# -- adoption --------------------------------------------------------------------
+
+
+def test_adopting_records_a_slug_when_there_is_none(tmp_path: pathlib.Path):
+    assert adopt_slug('deadbeef', tmp_path) == 'deadbeef'
+    assert ensure_slug(tmp_path) == 'deadbeef'
+
+
+def test_an_existing_slug_wins_over_an_adopted_one(tmp_path: pathlib.Path):
+    """Overwriting would move whichever backend had already bound to it, which is
+    the one outcome this file exists to prevent."""
+    existing = ensure_slug(tmp_path)
+
+    assert adopt_slug('deadbeef', tmp_path) == existing
+    assert read_slug(tmp_path) == existing
+
+
+# -- what the backends make of it ------------------------------------------------
+
+
+def test_moj_and_domjudge_name_the_same_package_from_the_same_slug(
+    tmp_path: pathlib.Path,
+):
+    """THE test. One package, one identity, however it is reached.
+
+    The two spellings differ because the servers do -- MOJ scopes ids by org, and
+    DOMjudge's are flat and per-phase -- but the half that identifies the
+    *package* is one value, decided in one place.
+    """
+    from rbx.box.runners.base import RunPurpose
+    from rbx.box.runners.domjudge.staging import probe_problem_id
+
+    moj_id = ensure_moj_id('alice', tmp_path)
+    slug = read_slug(tmp_path)
+
+    assert slug is not None
+    assert moj_id == f'alice#rbxt-{slug}'
+    assert probe_problem_id(slug, RunPurpose.ESTIMATION) == f'rbxt-{slug}-estimation'
+
+
+def test_a_package_bound_before_the_shared_file_keeps_its_problem(
+    tmp_path: pathlib.Path,
+):
+    """Migration, and it has to be this direction.
+
+    A `.moj-id` written months ago names a problem MOJ already holds. Minting a
+    fresh slug beside it would move the package to a new problem on the next run
+    and leave the old one orphaned, so the existing slug is adopted instead --
+    and DOMjudge then lands on the same identity.
+    """
+    (tmp_path / '.moj-id').write_text(json.dumps({'id': 'alice#rbxt-deadbeef'}))
+
+    assert ensure_moj_id('alice', tmp_path) == 'alice#rbxt-deadbeef'
+    assert read_slug(tmp_path) == 'deadbeef'
+
+
+def test_a_foreign_binding_is_not_adopted(tmp_path: pathlib.Path):
+    """A real, published problem's id is the other server's naming, not an
+    identity rbx may hand to another judge -- and rbx never created it, so it is
+    not rbx's to spread."""
+    (tmp_path / '.moj-id').write_text(json.dumps({'id': 'alice#somaditos'}))
+
+    assert ensure_moj_id('bob', tmp_path) == 'alice#somaditos'
+    assert read_slug(tmp_path) is None


### PR DESCRIPTION
`rbx time --runner domjudge` is a command a setter runs *again* — tweak a solution, re-estimate, look at the table once more. Every re-run re-staged the whole probe package and re-submitted every solution, including ones whose source had not changed by a byte. With `MAX_INFLIGHT_SUBMISSIONS = 1`, that serial judging is most of what a re-run costs.

This adds the two caches the MOJ runner already has, plus the fingerprint both need.

## A real package fingerprint

`_package_fingerprint` hashes the package name and testcase count only — deliberately, so the `rbxt-` problem id does not churn and strand dead problems on the server. That cannot answer "is the judge configured identically?", so `_build_probe` now also returns `_directory_fingerprint` of the built package tree: `domjudge-problem.ini` (which carries the pinned limit), `problem.yaml`, `data/`, `output_validators/`. Taken over the tree rather than the zip, because `shutil.make_archive` stamps entries with their mtime. The problem id is unchanged.

## The upload fast path

`.rbx/domjudge-runner.json` maps `<server>|<problem id>` to the fingerprint this machine last staged there. Two departures from MOJ's equivalent:

- **Keyed by server**, since `rbxt-` ids are derived from the package and collide across instances.
- **The record alone is not trusted**: the problem must still be listed in the probe contest. That catches a probe deleted in the jury interface, or a record carried onto an instance that was wiped. `stage_problem` fetches that list anyway on the path this skips, so it costs a request only when it is about to save an upload.

The record is cleared *before* an upload, so a crash mid-upload re-uploads next time.

## The judgement cache

`.rbx/domjudge-judgements/<key>.json`, written whole then `replace`d. The key covers the cache version, server, contest, problem id, package fingerprint, solution filename, DOMjudge language id, and the exact amalgamated bytes submitted. The pinned limit needs no term of its own — it is in the ini the fingerprint covers — so the validation phase misses on every solution by construction, which is right.

Stored is the API's own answer (judgement + run list), never the derived evaluations: a hit publishes into the same `_Judging` a fresh submission does, so pairing, the mismatch guard and the unknown-verdict refusal all still apply, and a hit is provably the same measurement. It is consulted **before** the concurrency slot, so free work never queues behind expensive work.

**Never written** when the judging has no runs at all (a compile error, a judgehost that fell over — the analogue of MOJ's `ran_nothing`), when the run list was refused as unpairable, or when any verdict falls outside `_OUTCOMES`. Each is a thing the setter is about to fix, and a cached failure would make the fix appear to change nothing. A WA, an RE or a TLE **is** cached — real, reproducible measurements, and the slowest solutions in the package.

## One difference from MOJ worth noting

A MOJ probe ships its solutions inside the package, so editing any of them invalidates every other solution's timing. A DOMjudge probe ships **no** submissions (they would be judged for real and race the measured runs), so the model solution is just another submission here, and editing it costs one re-measurement rather than all of them. Pinned by `test_editing_the_model_solution_invalidates_only_itself`.

## Testing

20 new tests in `tests/rbx/box/runners/domjudge/test_cache.py`, on a new `FakeApi` harness (`conftest.py`) that drives `prepare` / `run_solution` / `close` for real, package build included, with the API faked at its own boundary. Nothing touches the network.

`uv run pytest tests/rbx/box/runners tests/rbx/box/packaging/test_domjudge.py tests/rbx/box/packaging/test_domjudge_probe.py` — 326 passed. `ruff check` / `ruff format --check` clean.

Design: `docs/plans/2026-09-08-domjudge-runner-caching-design.md`.


---

## Second commit: one problem id across remote judges

Each backend answered "what is this package called on the server?" its own way — MOJ minted a slug into `.moj-id`, DOMjudge hashed `f'{pkg.name}:{len(entries)}'`. One package, two unrelated identities, and DOMjudge's **moved whenever a testcase was added**: the run staged a brand new problem and abandoned the previous one. Two packages agreeing on name and testcase count also collided on a shared instance.

`rbx/box/runners/problem_id.py` now holds the one identity: a random slug in `.rbx-id` at the package root, minted once and kept. Each backend renders its own id from it — `<login>#rbxt-<slug>` (MOJ ids are scoped by org) and `rbxt-<slug>-<purpose>` (DOMjudge ids are flat, and the two phases pin different limits). `RBXT_PREFIX` moved there too: the marker for "a problem rbx may overwrite" belongs to every backend.

Random rather than derived, in both directions: not from the package name (rbx names are not unique — two setters on the same tutorial package would write over each other on a shared server), and not from the testset (which changes constantly).

**Migration runs one way.** A `.moj-id` written before `.rbx-id` existed names a problem MOJ already holds, so `ensure_moj_id` *adopts* its slug rather than replacing it. An existing shared slug always wins, so a package with both keeps both and neither backend is moved off the problem it uses. A foreign binding — `.moj-id` is written by `moj upload` too — is neither adopted nor rewritten.

DOMjudge probe problems staged before this keep their old hash-derived ids and are left behind; they are private and throwaway.

`.rbx-id` is added to the default presets' `.gitignore`, alongside `.moj-id`. **Worth a look:** commit 674c3689 added `.moj-id` there, but `problem_id.py`'s docstrings and `_partials/moj-backend.md` both said it was *committed* — and the "two setters reach the same problem" guarantee depends on that. I followed the `.gitignore` (the later decision) and corrected the prose to match; if the docstrings were right and the ignore was the mistake, both files should come back out.

12 files, 432 insertions. `tests/rbx/box/runners/test_problem_id.py` adds 12 tests, including that MOJ and DOMjudge name the same package from the same slug, and that a package bound before the shared file keeps its problem.

`uv run pytest tests/rbx/box/runners tests/rbx/box/presets tests/rbx/box/packaging/test_domjudge*.py` — 715 passed. `mkdocs build` clean (only the repo's pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Bn6wfS7622fjxVQR3QF18
