### PR TITLE
feat(issues): migrate the too-much-stderr check to a detector

### DIFF
--- a/rbx/box/issues/detectors.py
+++ b/rbx/box/issues/detectors.py
@@ -24,6 +24,7 @@ from rbx.box.issues.schema import (
     HiddenVerdictIssue,
     Issue,
     IssueSeverity,
+    NoisyStderrIssue,
     TightTimeMarginIssue,
     UnexpectedScoreIssue,
     UnmetExpectationIssue,
@@ -36,6 +37,11 @@ from rbx.box.issues.schema import (
 # already effectively broken, and flagging at 0.5 would fire on every package
 # whose limits are deliberately snug.
 TIGHT_TIME_MARGIN_RATIO = 0.8
+
+# How much a solution may print to stderr on a single testcase before it is
+# worth a mention. 1MB is far past any plausible deliberate use: a solution that
+# writes this much is printing debug output it forgot to remove.
+STDERR_THRESHOLD_IN_BYTES = 1024 * 1024
 
 
 def detect_unmet_expectations(state: RunState) -> List[Issue]:
@@ -183,6 +189,32 @@ def detect_tight_time_margin(state: RunState) -> List[Issue]:
     return issues
 
 
+def detect_noisy_stderr(state: RunState) -> List[Issue]:
+    """Solutions that printed a lot to stderr.
+
+    One issue per solution rather than per testcase: the remedy is a single edit
+    to the solution, and a package whose debug output is on every testcase would
+    otherwise produce one issue per test. The artifact named is the noisiest
+    one, which is the one worth opening.
+
+    The sizes were taken by `run_state.size_stderr_artifacts`; this detector,
+    like every other, only reads the state it was handed.
+    """
+    issues: List[Issue] = []
+    for solution in state.report.solutions:
+        artifact = state.stderr.get(solution.index)
+        if artifact is None or artifact.size <= STDERR_THRESHOLD_IN_BYTES:
+            continue
+        issues.append(
+            NoisyStderrIssue(
+                solution=solution.path,
+                path=artifact.path,
+                size=artifact.size,
+            )
+        )
+    return issues
+
+
 def detect_untuned_limits(state: RunState) -> List[Issue]:
     """Timing failures on a package whose limits were never tuned here.
 
@@ -207,6 +239,7 @@ DETECTORS: List[Callable[[RunState], List[Issue]]] = [
     detect_borderline_tle,
     detect_hidden_verdicts,
     detect_tight_time_margin,
+    detect_noisy_stderr,
     detect_untuned_limits,
 ]
 

--- a/rbx/box/issues/rendering.py
+++ b/rbx/box/issues/rendering.py
@@ -23,7 +23,7 @@ from rich.table import Table
 from rich.text import Text
 
 from rbx import console
-from rbx.box.formatting import get_formatted_time, href
+from rbx.box.formatting import get_formatted_memory, get_formatted_time, href
 from rbx.box.issues.schema import (
     BorderlineTleIssue,
     CompilationFailedIssue,
@@ -37,6 +37,7 @@ from rbx.box.issues.schema import (
     IssueSeverity,
     MissingStatementLanguageIssue,
     NoAcceptedSolutionIssue,
+    NoisyStderrIssue,
     NoSamplesIssue,
     NoValidatorIssue,
     TightTimeMarginIssue,
@@ -143,6 +144,8 @@ def summarize(issue: Issue) -> str:
             f'used {get_formatted_time(int(issue.maxTime * 1000))} of a '
             f'{get_formatted_time(int(issue.timeLimit * 1000))} limit'
         )
+    if isinstance(issue, NoisyStderrIssue):
+        return f'wrote {get_formatted_memory(issue.size)} to stderr on one test'
     if isinstance(issue, UntunedLimitsIssue):
         return 'the time limit may not be tuned to this machine'
     if isinstance(issue, NoAcceptedSolutionIssue):
@@ -219,6 +222,13 @@ def explain(issue: Issue, runs_dir: Optional[str] = None) -> List[str]:
         return [
             f'{ratio:.0%} of the time limit on this machine. Fine here, tight '
             f'on a slower judge.'
+        ]
+    if isinstance(issue, NoisyStderrIssue):
+        return [
+            'Stderr this large is almost always debug output left behind. It '
+            'costs time on every testcase, and some judges reject a submission '
+            'that produces it.',
+            f'stderr: {href(_resolve(issue.path, runs_dir))}',
         ]
     if isinstance(issue, UntunedLimitsIssue):
         return [

--- a/rbx/box/issues/run_state.py
+++ b/rbx/box/issues/run_state.py
@@ -2,7 +2,10 @@
 
 `rbx issues` is meant to be instant -- it computes nothing, it reads what the
 last run already wrote. So this module reads `.rbx/runs` and nothing else: no
-package is loaded, no testcases are extracted, no sandbox is touched.
+package is loaded, no testcases are extracted, no sandbox is touched. The one
+step past the two YAML files is `size_stderr_artifacts`, which `stat()`s the
+`.err` files already sitting in that directory; it lives here rather than in the
+detector that needs it so the detectors stay pure over the state they are given.
 
 That is also why it does not import `rbx.box.solutions` to parse `skeleton.yml`.
 That module is thousands of lines and pulls in most of the box, and paying for
@@ -13,7 +16,7 @@ together so the narrow read cannot silently drift from the real model.
 """
 
 import pathlib
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import yaml
 from pydantic import BaseModel
@@ -22,6 +25,12 @@ from rbx.box import run_report
 from rbx.box.compilation_findings import SolutionCompilation
 
 SKELETON_FILENAME = 'skeleton.yml'
+
+# Stderr artifacts that belong to something other than the solution. A
+# communication run writes the interactor's stderr beside the solution's, and
+# every run may keep the checker's; both end in `.err` and neither says anything
+# about how noisy the *solution* is.
+_NON_SOLUTION_STDERR_SUFFIXES = ('.checker.err', '.int.err')
 
 
 class UnsupportedReportVersion(Exception):
@@ -53,12 +62,24 @@ class SkeletonView(BaseModel):
     compilation: List[SolutionCompilation] = []
 
 
+class StderrArtifact(BaseModel):
+    """The largest stderr one solution's run wrote, and how large it was."""
+
+    # Relative to the runs dir, e.g. `0/main/001.err`.
+    path: pathlib.Path
+    size: int  # bytes
+
+
 class RunState(BaseModel):
     """One package's last run, as the detectors see it."""
 
     report: run_report.RunReport
     skeleton: SkeletonView
     runs_dir: pathlib.Path
+    # The noisiest stderr artifact per solution index, when the solution wrote
+    # one at all. Sized here rather than in the detector so the detectors stay
+    # pure over the state they are handed -- see `size_stderr_artifacts`.
+    stderr: Dict[int, StderrArtifact] = {}
     # `report.yml`'s mtime, as a POSIX timestamp. When the run happened, near
     # enough: the report is rewritten as each solution lands, so it is stamped
     # at the end of the run rather than the start.
@@ -80,6 +101,50 @@ def _load_yaml(path: pathlib.Path) -> Optional[dict]:
     except yaml.YAMLError:
         return None
     return data if isinstance(data, dict) else None
+
+
+def _is_solution_stderr(path: pathlib.Path) -> bool:
+    name = path.name
+    if not name.endswith('.err'):
+        return False
+    return not any(name.endswith(suffix) for suffix in _NON_SOLUTION_STDERR_SUFFIXES)
+
+
+def size_stderr_artifacts(
+    runs_dir: pathlib.Path, indices: List[int]
+) -> Dict[int, StderrArtifact]:
+    """The noisiest stderr each of `indices` wrote, by `stat()`-ing the runs dir.
+
+    The one place `rbx issues` looks at the run beyond its two YAML files. It is
+    done here, eagerly, rather than inside the detector: a detector that stats
+    is a detector that needs a populated directory tree to test, which is
+    exactly the coupling the detectors were pulled out of the issue stack to
+    escape. The cost is a `stat()` per testcase artifact, which is the same
+    order as reading the report itself.
+
+    Only the indices the report names are walked, so a stale directory left by a
+    longer previous run is never sized.
+    """
+    sizes: Dict[int, StderrArtifact] = {}
+    for index in indices:
+        solution_dir = runs_dir / str(index)
+        if not solution_dir.is_dir():
+            continue
+        largest: Optional[StderrArtifact] = None
+        for path in solution_dir.rglob('*.err'):
+            if not _is_solution_stderr(path):
+                continue
+            try:
+                size = path.stat().st_size
+            except OSError:
+                # A run cleaned up underneath us reads as no artifact at all,
+                # for the same reason a half-written report reads as no run.
+                continue
+            if largest is None or size > largest.size:
+                largest = StderrArtifact(path=path.relative_to(runs_dir), size=size)
+        if largest is not None:
+            sizes[index] = largest
+    return sizes
 
 
 def load_run_state(runs_dir: pathlib.Path) -> Optional[RunState]:
@@ -109,5 +174,8 @@ def load_run_state(runs_dir: pathlib.Path) -> Optional[RunState]:
         report=report,
         skeleton=SkeletonView.model_validate(skeleton_data),
         runs_dir=runs_dir,
+        stderr=size_stderr_artifacts(
+            runs_dir, [solution.index for solution in report.solutions]
+        ),
         ran_at=run_report.report_path(runs_dir).stat().st_mtime,
     )

--- a/rbx/box/issues/schema.py
+++ b/rbx/box/issues/schema.py
@@ -229,6 +229,27 @@ class TightTimeMarginIssue(_RunIssue):
         return IssueSeverity.WARNING
 
 
+class NoisyStderrIssue(_RunIssue):
+    """A solution printed an unreasonable amount to stderr.
+
+    Almost always debug output left behind: it costs time on every testcase, it
+    can be enough to fill a judge's disk, and on some judges it is enough to
+    fail the submission outright. The run itself passes, which is why it needs
+    saying.
+    """
+
+    kind: Literal['noisy_stderr'] = 'noisy_stderr'
+    solution: str
+    # The noisiest artifact, relative to the runs dir, e.g. `0/main/001.err`.
+    path: pathlib.Path
+    size: int  # bytes
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.WARNING
+
+
 class UntunedLimitsIssue(_RunIssue):
     """Expectations failed on timing, and the limits were never tuned here.
 
@@ -366,6 +387,7 @@ Issue = Annotated[
         BorderlineTleIssue,
         HiddenVerdictIssue,
         TightTimeMarginIssue,
+        NoisyStderrIssue,
         UntunedLimitsIssue,
         NoAcceptedSolutionIssue,
         NoValidatorIssue,

--- a/rbx/box/tasks.py
+++ b/rbx/box/tasks.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Optional, Tuple, Type
+from typing import Optional, Type
 
 from rbx.box import checkers, environment, limits_info, package, state
 from rbx.box.code import (
@@ -10,7 +10,6 @@ from rbx.box.code import (
 )
 from rbx.box.environment import EnvironmentSandbox, ExecutionConfig, VerificationLevel
 from rbx.box.retries import Retrier, get_retrier_config
-from rbx.box.sanitizers.issue_stack import Issue, add_issue
 from rbx.box.schema import CodeItem, Interactor, Testcase
 from rbx.grading import profiling
 from rbx.grading.judge.sandbox import SandboxBase
@@ -26,23 +25,10 @@ from rbx.grading.steps import (
 )
 from rbx.utils import model_to_yaml
 
-STDERR_THRESHOLD_IN_BYTES = 1024 * 1024  # 1MB
-
 # Extra wall time (ms) granted to the interactor on top of the solution's wall
 # time in communication tasks, so the interactor never times out before the
 # solution does. Mirrors BOCA's `ittime = ttime + 1`.
 _INTERACTOR_WALL_MARGIN_MS = 1000
-
-
-class TooMuchStderrIssue(Issue):
-    def __init__(self, solution: CodeItem):
-        self.solution = solution
-
-    def get_detailed_section(self) -> Tuple[str, ...]:
-        return ('solutions',)
-
-    def get_detailed_message(self) -> str:
-        return f'{self.solution.href()} produces too much stderr.'
 
 
 def get_testcase_output_path(
@@ -109,15 +95,6 @@ def _resolve_checker_stderr_path(
     if checker_error_path is None or not checker_error_path.is_file():
         return None
     return checker_error_path.absolute()
-
-
-def _check_stderr(solution: CodeItem, stderr_path: pathlib.Path):
-    # The stderr file is absent when the program failed to even start (e.g. a
-    # missing interpreter/runtime), in which case there is no stderr to inspect.
-    if not stderr_path.is_file():
-        return
-    if stderr_path.stat().st_size > STDERR_THRESHOLD_IN_BYTES:
-        add_issue(TooMuchStderrIssue(solution))
 
 
 def get_limits_for_language(
@@ -243,8 +220,6 @@ async def run_solution_on_testcase(
                 )
         else:
             checker_result = checkers.check_with_no_output(run_log)
-
-        _check_stderr(solution, error_path)
 
         eval = Evaluation(
             result=checker_result,
@@ -438,8 +413,6 @@ async def _run_communication_solution_on_testcase(
             output_path,
             checker_stderr_path=checker_error_path,
         )
-
-        _check_stderr(solution, solution_error_path)
 
         eval = Evaluation(
             result=checker_result,

--- a/tests/rbx/box/issues_test.py
+++ b/tests/rbx/box/issues_test.py
@@ -29,11 +29,13 @@ from rbx.grading.steps import Outcome
 def make_state(
     solutions=None,
     compilation=None,
+    stderr=None,
 ) -> run_state.RunState:
     return run_state.RunState(
         report=RunReport(solutions=solutions or []),
         skeleton=run_state.SkeletonView(compilation=compilation or []),
         runs_dir=pathlib.Path('.rbx/runs'),
+        stderr=stderr or {},
         ran_at=time.time(),
     )
 
@@ -315,6 +317,56 @@ class TestTimingRisk:
         assert detectors.detect_untuned_limits(make_state([solution()])) == []
 
 
+class TestNoisyStderr:
+    def _artifact(self, size: int) -> run_state.StderrArtifact:
+        return run_state.StderrArtifact(path=pathlib.Path('0/main/001.err'), size=size)
+
+    def test_flags_a_solution_that_flooded_stderr(self):
+        state = make_state(
+            [solution(path='sol/main.cpp', index=0)],
+            stderr={0: self._artifact(detectors.STDERR_THRESHOLD_IN_BYTES + 1)},
+        )
+
+        issues = detectors.detect_noisy_stderr(state)
+
+        assert kinds(issues) == ['noisy_stderr']
+        assert issues[0].solution == 'sol/main.cpp'
+        assert issues[0].path == pathlib.Path('0/main/001.err')
+
+    def test_leaves_ordinary_stderr_alone(self):
+        state = make_state(
+            [solution(index=0)],
+            stderr={0: self._artifact(detectors.STDERR_THRESHOLD_IN_BYTES)},
+        )
+
+        assert detectors.detect_noisy_stderr(state) == []
+
+    def test_says_nothing_when_no_artifact_was_sized(self):
+        assert detectors.detect_noisy_stderr(make_state([solution()])) == []
+
+    def test_reports_one_issue_per_solution_not_per_testcase(self):
+        """The remedy is a single edit; one issue per test would bury the run."""
+        state = make_state(
+            [solution(path='sol/a.cpp', index=0), solution(path='sol/b.cpp', index=1)],
+            stderr={
+                0: self._artifact(detectors.STDERR_THRESHOLD_IN_BYTES * 3),
+                1: self._artifact(detectors.STDERR_THRESHOLD_IN_BYTES * 2),
+            },
+        )
+
+        issues = detectors.detect_noisy_stderr(state)
+
+        assert [issue.solution for issue in issues] == ['sol/a.cpp', 'sol/b.cpp']
+
+    def test_is_a_warning_rather_than_an_error(self):
+        """The package still works; the solution is just noisy."""
+        issue = schema.NoisyStderrIssue(
+            solution='s', path=pathlib.Path('0/main/001.err'), size=1
+        )
+
+        assert issue.severity == schema.IssueSeverity.WARNING
+
+
 class TestDetectAll:
     def test_puts_errors_before_warnings(self):
         state = make_state(
@@ -406,6 +458,59 @@ class TestLoadRunState:
         self._write(tmp_path, RunReport())
 
         assert build_report(tmp_path).runsDir == str(tmp_path)
+
+
+class TestStderrSizing:
+    """The one place `rbx issues` looks past `report.yml` and `skeleton.yml`."""
+
+    def _write_err(self, path: pathlib.Path, size: int) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b'x' * size)
+
+    def test_keeps_the_noisiest_artifact_per_solution(self, tmp_path: pathlib.Path):
+        self._write_err(tmp_path / '0' / 'main' / '001.err', 10)
+        self._write_err(tmp_path / '0' / 'main' / '002.err', 40)
+        self._write_err(tmp_path / '1' / 'main' / '001.err', 20)
+
+        sizes = run_state.size_stderr_artifacts(tmp_path, [0, 1])
+
+        assert sizes[0].size == 40
+        assert sizes[0].path == pathlib.Path('0/main/002.err')
+        assert sizes[1].size == 20
+
+    def test_ignores_stderr_that_is_not_the_solution(self, tmp_path: pathlib.Path):
+        """A chatty checker or interactor says nothing about the solution."""
+        self._write_err(tmp_path / '0' / 'main' / '001.err', 10)
+        self._write_err(tmp_path / '0' / 'main' / '001.checker.err', 500)
+        self._write_err(tmp_path / '0' / 'main' / '001.int.err', 500)
+
+        sizes = run_state.size_stderr_artifacts(tmp_path, [0])
+
+        assert sizes[0].path == pathlib.Path('0/main/001.err')
+        assert sizes[0].size == 10
+
+    def test_skips_a_solution_that_wrote_nothing(self, tmp_path: pathlib.Path):
+        assert run_state.size_stderr_artifacts(tmp_path, [0, 1]) == {}
+
+    def test_never_walks_a_directory_the_report_does_not_name(
+        self, tmp_path: pathlib.Path
+    ):
+        """A longer previous run leaves directories this run has no solution for."""
+        self._write_err(tmp_path / '7' / 'main' / '001.err', 100)
+
+        assert run_state.size_stderr_artifacts(tmp_path, [0]) == {}
+
+    def test_load_run_state_sizes_the_artifacts(self, tmp_path: pathlib.Path):
+        run_report.write_report(
+            run_report.report_path(tmp_path),
+            RunReport(solutions=[solution(path='sol/a.cpp', index=0)]),
+        )
+        self._write_err(tmp_path / '0' / 'main' / '001.err', 30)
+
+        state = run_state.load_run_state(tmp_path)
+
+        assert state is not None
+        assert state.stderr[0].size == 30
 
 
 class TestSkeletonViewDoesNotDrift:
@@ -523,6 +628,9 @@ class TestRendering:
             schema.BorderlineTleIssue(solution='s'),
             schema.HiddenVerdictIssue(solution='s'),
             schema.TightTimeMarginIssue(solution='s', maxTime=1.0, timeLimit=1.0),
+            schema.NoisyStderrIssue(
+                solution='s', path=pathlib.Path('0/main/1.err'), size=1
+            ),
             schema.UntunedLimitsIssue(),
             schema.NoAcceptedSolutionIssue(),
             schema.NoValidatorIssue(),


### PR DESCRIPTION
Closes #836. Follow-up to #792 / #834.

`TooMuchStderrIssue` was one of the last producers still on `issue_stack`: decided mid-run in `tasks._check_stderr`, rendered at process exit, then lost — so a later `rbx issues` could never mention it. It is derivable, and now is.

## What changed

- **`NoisyStderrIssue`** (`issues/schema.py`), a run-family issue carrying the solution, the noisiest `.err` artifact (relative to the runs dir) and its size. A **warning**, not an error — the package works, the solution is just noisy, a distinction the issue tree could not express. No format-version bump: adding a kind is not a change an existing reader misreads.
- **`detect_noisy_stderr`** (`issues/detectors.py`), which owns `STDERR_THRESHOLD_IN_BYTES` (1 MiB, moved from `tasks.py`). One issue per solution, not per testcase: the remedy is a single edit, and a package with debug output on every test would otherwise produce one issue per test.
- **`run_state.size_stderr_artifacts`**, the sizing pass. This is the decision the issue asked to make: the sizes are taken **eagerly in `load_run_state`**, so detectors stay pure over the `RunState` they are handed — a detector that stats is a detector that needs a populated directory tree to test, which is exactly the coupling the detectors were pulled out of the issue stack to escape. Only the solution indices the report names are walked (a longer previous run leaves stale dirs), and `.checker.err` / `.int.err` are skipped, since a chatty checker or interactor says nothing about the solution.
- **`tasks.py`** loses `TooMuchStderrIssue`, `_check_stderr`, both call sites and the threshold constant.

## Rendering

```
! sols/main.cpp wrote 2 MiB to stderr on one test
    Stderr this large is almost always debug output left behind. It costs
    time on every testcase, and some judges reject a submission that
    produces it.
    stderr: .rbx/runs/0/main/1-gen-001.err
```

## Verification

- `uv run pytest tests/rbx/box/issues_test.py` — 89 passed, including a new `TestNoisyStderr` (threshold boundary, one-per-solution, warning severity) and `TestStderrSizing` (largest wins, non-solution stderr ignored, stale dirs never walked, `load_run_state` wiring).
- `tests/rbx/box/sanitizers/issue_stack_test.py`, `run_report_test.py`, `checkers_communication_test.py` — 63 passed.
- `ruff check` / `ruff format --check` clean.
- End-to-end against a real package whose solution floods stderr: `rbx run`'s post-run section and `rbx issues -d` both report it and link the exact artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLdpi5paCkadVnNnsa9SHt