### PR TITLE
feat(issues): add a sanitizer-finding detector

### DIFF
--- a/rbx/box/issues/detectors.py
+++ b/rbx/box/issues/detectors.py
@@ -25,6 +25,7 @@ from rbx.box.issues.schema import (
     Issue,
     IssueSeverity,
     NoisyStderrIssue,
+    SanitizerFindingIssue,
     TightTimeMarginIssue,
     UnexpectedScoreIssue,
     UnmetExpectationIssue,
@@ -215,6 +216,36 @@ def detect_noisy_stderr(state: RunState) -> List[Issue]:
     return issues
 
 
+def detect_sanitizer_findings(state: RunState) -> List[Issue]:
+    """Solutions a sanitizer had something to say about.
+
+    Not filtered to the runs that passed, even though those are the case this
+    exists for: on a solution that failed, an ASAN or UBSAN finding is very
+    often *why* it failed, and dropping it there would hide the one line that
+    explains the verdict.
+
+    The flag is read off the report rather than pooled from the groups, for the
+    reason `run_report` gives for publishing it: rbx pools over the evaluations
+    it actually ran, and a subset run or a `--fail-fast` abort leaves that set
+    and the one a reader finds on disk disagreeing. The groups only *name* where
+    it fired.
+    """
+    issues: List[Issue] = []
+    for solution in state.report.solutions:
+        if not solution.sanitizerWarnings:
+            continue
+        issues.append(
+            SanitizerFindingIssue(
+                solution=solution.path,
+                groups=[
+                    group.name for group in solution.groups if group.sanitizerWarnings
+                ],
+                log=state.sanitizer_logs.get(solution.path),
+            )
+        )
+    return issues
+
+
 def detect_untuned_limits(state: RunState) -> List[Issue]:
     """Timing failures on a package whose limits were never tuned here.
 
@@ -236,6 +267,7 @@ DETECTORS: List[Callable[[RunState], List[Issue]]] = [
     detect_unmet_expectations,
     detect_unexpected_scores,
     detect_compilation,
+    detect_sanitizer_findings,
     detect_borderline_tle,
     detect_hidden_verdicts,
     detect_tight_time_margin,

--- a/rbx/box/issues/rendering.py
+++ b/rbx/box/issues/rendering.py
@@ -13,6 +13,7 @@ Two levels, and the *same* renderer serves both surfaces at each level:
 """
 
 import json
+import os
 import pathlib
 import time
 from enum import Enum
@@ -40,6 +41,7 @@ from rbx.box.issues.schema import (
     NoisyStderrIssue,
     NoSamplesIssue,
     NoValidatorIssue,
+    SanitizerFindingIssue,
     TightTimeMarginIssue,
     UnexpectedScoreIssue,
     UnmetExpectationIssue,
@@ -96,10 +98,14 @@ def _resolve(path: pathlib.Path, runs_dir: Optional[str]) -> pathlib.Path:
 
     Compilation logs are stored relative so a package read on another host still
     resolves them; a terminal hyperlink needs the other form.
+
+    Normalized because not every relative path points *into* the runs dir: a
+    sanitizer log is kept beside it, so joining gives `.rbx/runs/../warnings/x`,
+    which is right but reads as noise and wraps a terminal line for no reason.
     """
     if runs_dir is None:
         return path
-    return pathlib.Path(runs_dir) / path
+    return pathlib.Path(os.path.normpath(pathlib.Path(runs_dir) / path))
 
 
 def _solution_of(issue: Issue) -> Optional[str]:
@@ -146,6 +152,8 @@ def summarize(issue: Issue) -> str:
         )
     if isinstance(issue, NoisyStderrIssue):
         return f'wrote {get_formatted_memory(issue.size)} to stderr on one test'
+    if isinstance(issue, SanitizerFindingIssue):
+        return 'a sanitizer fired while running this solution'
     if isinstance(issue, UntunedLimitsIssue):
         return 'the time limit may not be tuned to this machine'
     if isinstance(issue, NoAcceptedSolutionIssue):
@@ -230,6 +238,17 @@ def explain(issue: Issue, runs_dir: Optional[str] = None) -> List[str]:
             'that produces it.',
             f'stderr: {href(_resolve(issue.path, runs_dir))}',
         ]
+    if isinstance(issue, SanitizerFindingIssue):
+        lines = [
+            'ASAN or UBSAN found something -- an out-of-bounds access, signed '
+            'overflow, an uninitialised read -- while this solution ran. The '
+            'verdict may well be fine here and undefined on the judge.'
+        ]
+        if issue.groups:
+            lines.append(f'groups:   {", ".join(issue.groups)}')
+        if issue.log is not None:
+            lines.append(f'log: {href(_resolve(issue.log, runs_dir))}')
+        return lines
     if isinstance(issue, UntunedLimitsIssue):
         return [
             'Solutions failed their expectations by being too fast or too slow, '

--- a/rbx/box/issues/run_state.py
+++ b/rbx/box/issues/run_state.py
@@ -1,11 +1,13 @@
 """The on-disk state the detectors run over.
 
 `rbx issues` is meant to be instant -- it computes nothing, it reads what the
-last run already wrote. So this module reads `.rbx/runs` and nothing else: no
-package is loaded, no testcases are extracted, no sandbox is touched. The one
-step past the two YAML files is `size_stderr_artifacts`, which `stat()`s the
-`.err` files already sitting in that directory; it lives here rather than in the
-detector that needs it so the detectors stay pure over the state they are given.
+last run already wrote. So this module reads the package cache and nothing else:
+no package is loaded, no testcases are extracted, no sandbox is touched. Two
+steps go past the two YAML files -- `size_stderr_artifacts`, which `stat()`s the
+`.err` files already sitting in the runs dir, and `locate_sanitizer_logs`, which
+looks for the sanitizer output beside it. Both live here rather than in the
+detectors that need them so the detectors stay pure over the state they are
+given.
 
 That is also why it does not import `rbx.box.solutions` to parse `skeleton.yml`.
 That module is thousands of lines and pulls in most of the box, and paying for
@@ -23,8 +25,14 @@ from pydantic import BaseModel
 
 from rbx.box import run_report
 from rbx.box.compilation_findings import SolutionCompilation
+from rbx.box.sanitizers import warning_stack
 
 SKELETON_FILENAME = 'skeleton.yml'
+
+# Where the sanitizer logs sit, relative to the runs dir. Beside it rather than
+# inside it because the run writes them through `warning_stack`, whose home is
+# the package cache dir -- of which the runs dir is another child.
+SANITIZER_LOGS_DIR = pathlib.Path('..') / warning_stack.WARNINGS_DIR_NAME
 
 # Stderr artifacts that belong to something other than the solution. A
 # communication run writes the interactor's stderr beside the solution's, and
@@ -80,6 +88,10 @@ class RunState(BaseModel):
     # one at all. Sized here rather than in the detector so the detectors stay
     # pure over the state they are handed -- see `size_stderr_artifacts`.
     stderr: Dict[int, StderrArtifact] = {}
+    # The kept sanitizer output per solution path, for the solutions that have
+    # one on disk. Located here rather than in the detector for the reason the
+    # stderr sizes are -- see `locate_sanitizer_logs`.
+    sanitizer_logs: Dict[str, pathlib.Path] = {}
     # `report.yml`'s mtime, as a POSIX timestamp. When the run happened, near
     # enough: the report is rewritten as each solution lands, so it is stamped
     # at the end of the run rather than the start.
@@ -147,6 +159,34 @@ def size_stderr_artifacts(
     return sizes
 
 
+def locate_sanitizer_logs(
+    runs_dir: pathlib.Path, paths: List[str]
+) -> Dict[str, pathlib.Path]:
+    """The kept sanitizer output for each of `paths` that still has one.
+
+    `report.yml` records only *that* a sanitizer fired, so the log has to be
+    found by name -- which `warning_stack.sanitizer_log_name` answers, so the
+    reader cannot drift from the writer that put it there.
+
+    Like `size_stderr_artifacts` this happens here, eagerly, rather than inside
+    the detector: a detector that stats is a detector that needs a populated
+    directory to test.
+
+    Only the paths the caller names are looked up, and a missing log is simply
+    absent -- `warning_stack` clears its directory at the start of every process
+    that writes one, so a `rbx compile` between the run and the read leaves the
+    report's flag standing with no file behind it.
+    """
+    logs: Dict[str, pathlib.Path] = {}
+    for path in paths:
+        relative = SANITIZER_LOGS_DIR / warning_stack.sanitizer_log_name(
+            pathlib.Path(path)
+        )
+        if (runs_dir / relative).is_file():
+            logs[path] = relative
+    return logs
+
+
 def load_run_state(runs_dir: pathlib.Path) -> Optional[RunState]:
     """The last run in `runs_dir`, or None when there was not one.
 
@@ -176,6 +216,14 @@ def load_run_state(runs_dir: pathlib.Path) -> Optional[RunState]:
         runs_dir=runs_dir,
         stderr=size_stderr_artifacts(
             runs_dir, [solution.index for solution in report.solutions]
+        ),
+        sanitizer_logs=locate_sanitizer_logs(
+            runs_dir,
+            [
+                solution.path
+                for solution in report.solutions
+                if solution.sanitizerWarnings
+            ],
         ),
         ran_at=run_report.report_path(runs_dir).stat().st_mtime,
     )

--- a/rbx/box/issues/schema.py
+++ b/rbx/box/issues/schema.py
@@ -250,6 +250,40 @@ class NoisyStderrIssue(_RunIssue):
         return IssueSeverity.WARNING
 
 
+class SanitizerFindingIssue(_RunIssue):
+    """A sanitizer fired on one of this solution's runs.
+
+    ASAN or UBSAN found something -- a buffer overrun, signed overflow, an
+    uninitialised read -- while the solution was doing whatever it was declared
+    to do. The run itself usually *passes*, which is exactly why this needs
+    saying: `status` is OK and `matchesExpectation` is true, so a client reading
+    only those draws a clean row for a solution rbx is printing a WARNING about.
+
+    Reported whether or not the expectation held. On a solution that failed, the
+    finding is very often the cause of the failure, and suppressing it there
+    would hide the one line that explains the verdict.
+    """
+
+    kind: Literal['sanitizer_finding'] = 'sanitizer_finding'
+    solution: str
+    # The groups that tripped it, empty when only the solution-wide flag is set.
+    groups: List[str] = []
+    # The kept sanitizer output, relative to the runs dir --
+    # `../warnings/sol/main.cpp.log`. Relative for the reason a compilation log
+    # is, and outside the runs dir because the run writes it through
+    # `warning_stack`, whose home is the package cache dir.
+    #
+    # Absent when the log is gone: `warning_stack` clears its directory at the
+    # start of every process that writes one, so a `rbx compile` between the run
+    # and the read leaves the finding standing with nothing to open.
+    log: Optional[pathlib.Path] = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def severity(self) -> IssueSeverity:
+        return IssueSeverity.WARNING
+
+
 class UntunedLimitsIssue(_RunIssue):
     """Expectations failed on timing, and the limits were never tuned here.
 
@@ -388,6 +422,7 @@ Issue = Annotated[
         HiddenVerdictIssue,
         TightTimeMarginIssue,
         NoisyStderrIssue,
+        SanitizerFindingIssue,
         UntunedLimitsIssue,
         NoAcceptedSolutionIssue,
         NoValidatorIssue,

--- a/rbx/box/sanitizers/warning_stack.py
+++ b/rbx/box/sanitizers/warning_stack.py
@@ -14,6 +14,21 @@ if TYPE_CHECKING:
     from rbx.box.linters.linter import LinterMessage
 
 
+WARNINGS_DIR_NAME = 'warnings'
+
+
+def sanitizer_log_name(path: pathlib.Path) -> pathlib.Path:
+    """The name a first-party file's sanitizer log is kept under.
+
+    Public, and pure, so the reader side resolves a log exactly the way the
+    writer side put it there: `rbx issues` links these logs off a `report.yml`
+    that records only that a sanitizer fired, so it has to rebuild the name from
+    the solution's path. A second copy of the rule would be a second thing to
+    keep in step.
+    """
+    return path.with_suffix(path.suffix + '.log')
+
+
 class WarningStack:
     def __init__(self, root: pathlib.Path):
         self.root = root
@@ -33,7 +48,7 @@ class WarningStack:
         if code.path in self.sanitizer_warnings:
             return
         dest_path = _get_warning_runs_dir(self.root).joinpath(
-            code.path.with_suffix(code.path.suffix + '.log')
+            sanitizer_log_name(code.path)
         )
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         f = await reference.get_file(cacher)
@@ -73,7 +88,7 @@ def _get_cache_dir(root: pathlib.Path) -> pathlib.Path:
 
 @functools.cache
 def _get_warning_runs_dir(root: pathlib.Path) -> pathlib.Path:
-    dir = _get_cache_dir(root) / 'warnings'
+    dir = _get_cache_dir(root) / WARNINGS_DIR_NAME
     shutil.rmtree(dir, ignore_errors=True)
     dir.mkdir(parents=True, exist_ok=True)
     return dir

--- a/tests/rbx/box/issues_test.py
+++ b/tests/rbx/box/issues_test.py
@@ -22,7 +22,8 @@ from rbx.box.issues import config_detectors, detectors, rendering, run_state, sc
 from rbx.box.issues import config_state as config_state_module
 from rbx.box.issues.contest import build_report
 from rbx.box.run_report import RunGroupReport, RunReport, RunSolutionReport
-from rbx.box.schema import ExpectedOutcome, Solution
+from rbx.box.sanitizers import warning_stack
+from rbx.box.schema import CodeItem, ExpectedOutcome, Solution
 from rbx.grading.steps import Outcome
 
 
@@ -30,12 +31,14 @@ def make_state(
     solutions=None,
     compilation=None,
     stderr=None,
+    sanitizer_logs=None,
 ) -> run_state.RunState:
     return run_state.RunState(
         report=RunReport(solutions=solutions or []),
         skeleton=run_state.SkeletonView(compilation=compilation or []),
         runs_dir=pathlib.Path('.rbx/runs'),
         stderr=stderr or {},
+        sanitizer_logs=sanitizer_logs or {},
         ran_at=time.time(),
     )
 
@@ -367,6 +370,89 @@ class TestNoisyStderr:
         assert issue.severity == schema.IssueSeverity.WARNING
 
 
+class TestSanitizerFindings:
+    def test_flags_a_solution_that_passed_but_tripped_a_sanitizer(self):
+        """The case the flag exists for: `status` is OK and nothing else says so."""
+        state = make_state(
+            [
+                solution(
+                    path='sol/main.cpp',
+                    sanitizerWarnings=True,
+                    groups=[
+                        RunGroupReport(name='samples'),
+                        RunGroupReport(name='big', sanitizerWarnings=True),
+                    ],
+                )
+            ]
+        )
+
+        issues = detectors.detect_sanitizer_findings(state)
+
+        assert kinds(issues) == ['sanitizer_finding']
+        assert issues[0].solution == 'sol/main.cpp'
+        assert issues[0].groups == ['big']
+        assert issues[0].severity == schema.IssueSeverity.WARNING
+
+    def test_stays_quiet_when_nothing_tripped(self):
+        assert detectors.detect_sanitizer_findings(make_state([solution()])) == []
+
+    def test_reports_a_solution_that_also_failed_its_expectation(self):
+        """A sanitizer finding on a failing solution is usually the cause of it.
+
+        Suppressing it there would hide the one line that explains the verdict.
+        """
+        state = make_state(
+            [
+                solution(
+                    path='sol/wa.cpp',
+                    status='UNEXPECTED_VERDICTS',
+                    matchesExpectation=False,
+                    pooledMatchesExpectation=False,
+                    outcome=Outcome.WRONG_ANSWER,
+                    sanitizerWarnings=True,
+                )
+            ]
+        )
+
+        assert kinds(detectors.detect_sanitizer_findings(state)) == [
+            'sanitizer_finding'
+        ]
+
+    def test_carries_the_log_that_was_kept_for_the_solution(self):
+        state = make_state(
+            [solution(path='sol/main.cpp', sanitizerWarnings=True)],
+            sanitizer_logs={
+                'sol/main.cpp': pathlib.Path('../warnings/sol/main.cpp.log')
+            },
+        )
+
+        (issue,) = detectors.detect_sanitizer_findings(state)
+
+        assert issue.log == pathlib.Path('../warnings/sol/main.cpp.log')
+
+    def test_reports_the_finding_even_when_the_log_is_gone(self):
+        """The report says a sanitizer fired; a missing log does not unsay it."""
+        state = make_state([solution(sanitizerWarnings=True)])
+
+        (issue,) = detectors.detect_sanitizer_findings(state)
+
+        assert issue.log is None
+
+    def test_names_no_groups_when_only_the_solution_level_flag_is_set(self):
+        state = make_state(
+            [
+                solution(
+                    sanitizerWarnings=True,
+                    groups=[RunGroupReport(name='samples')],
+                )
+            ]
+        )
+
+        (issue,) = detectors.detect_sanitizer_findings(state)
+
+        assert issue.groups == []
+
+
 class TestDetectAll:
     def test_puts_errors_before_warnings(self):
         state = make_state(
@@ -513,6 +599,60 @@ class TestStderrSizing:
         assert state.stderr[0].size == 30
 
 
+class TestSanitizerLogLocation:
+    """The sanitizer logs sit beside the runs dir, not inside it."""
+
+    def _write_log(self, runs_dir: pathlib.Path, name: str) -> pathlib.Path:
+        path = runs_dir.parent / 'warnings' / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('==1==ERROR: AddressSanitizer\n')
+        return path
+
+    def test_finds_the_log_a_run_kept_for_a_solution(self, tmp_path: pathlib.Path):
+        runs_dir = tmp_path / 'runs'
+        runs_dir.mkdir()
+        self._write_log(runs_dir, 'sol/main.cpp.log')
+
+        logs = run_state.locate_sanitizer_logs(runs_dir, ['sol/main.cpp'])
+
+        assert logs == {'sol/main.cpp': pathlib.Path('../warnings/sol/main.cpp.log')}
+
+    def test_says_nothing_about_a_solution_with_no_log(self, tmp_path: pathlib.Path):
+        runs_dir = tmp_path / 'runs'
+        runs_dir.mkdir()
+
+        assert run_state.locate_sanitizer_logs(runs_dir, ['sol/main.cpp']) == {}
+
+    def test_resolves_the_log_the_way_the_run_wrote_it(self, tmp_path: pathlib.Path):
+        """The reader and the writer must agree on where the log went."""
+        code = CodeItem(path=pathlib.Path('sol/main.cpp'))
+        written = warning_stack.sanitizer_log_name(code.path)
+
+        assert written == pathlib.Path('sol/main.cpp.log')
+
+    def test_load_run_state_locates_the_logs(self, tmp_path: pathlib.Path):
+        runs_dir = tmp_path / 'runs'
+        runs_dir.mkdir()
+        run_report.write_report(
+            run_report.report_path(runs_dir),
+            RunReport(
+                solutions=[
+                    solution(path='sol/a.cpp', index=0, sanitizerWarnings=True),
+                    solution(path='sol/b.cpp', index=1),
+                ]
+            ),
+        )
+        self._write_log(runs_dir, 'sol/a.cpp.log')
+        self._write_log(runs_dir, 'sol/b.cpp.log')
+
+        state = run_state.load_run_state(runs_dir)
+
+        assert state is not None
+        # Only the solutions the report says tripped a sanitizer are looked up:
+        # a log left behind by an earlier run says nothing about this one.
+        assert list(state.sanitizer_logs) == ['sol/a.cpp']
+
+
 class TestSkeletonViewDoesNotDrift:
     def test_parses_a_real_skeleton(self):
         """`SkeletonView` is a narrow read of a model it does not import.
@@ -614,6 +754,24 @@ class TestRendering:
 
         assert any('/pkg/.rbx/runs/compilation/0.log' in line for line in lines)
 
+    def test_a_sanitizer_log_link_leaves_the_runs_dir_cleanly(self):
+        """It is kept beside the runs dir, so the joined path has a `..` in it."""
+        issue = schema.SanitizerFindingIssue(
+            solution='sols/main.cpp',
+            log=pathlib.Path('../warnings/sols/main.cpp.log'),
+        )
+
+        lines = rendering.explain(issue, runs_dir='/pkg/.rbx/runs')
+
+        assert any('/pkg/.rbx/warnings/sols/main.cpp.log' in line for line in lines)
+
+    def test_a_sanitizer_finding_without_a_log_says_nothing_about_one(self):
+        issue = schema.SanitizerFindingIssue(solution='sols/main.cpp')
+
+        lines = rendering.explain(issue, runs_dir='/pkg/.rbx/runs')
+
+        assert not any('log:' in line for line in lines)
+
     def test_every_kind_has_a_summary_and_a_severity(self):
         """A new kind must not fall through to 'unknown issue'."""
         samples = [
@@ -631,6 +789,7 @@ class TestRendering:
             schema.NoisyStderrIssue(
                 solution='s', path=pathlib.Path('0/main/1.err'), size=1
             ),
+            schema.SanitizerFindingIssue(solution='s'),
             schema.UntunedLimitsIssue(),
             schema.NoAcceptedSolutionIssue(),
             schema.NoValidatorIssue(),


### PR DESCRIPTION
Closes #835.

`report.yml` already publishes `sanitizerWarnings`, per solution and per group, but nothing derived an issue from it. The case that matters is a run that otherwise **passed**: `status` is OK and `matchesExpectation` is true, so a client reading only those draws a clean row for a solution rbx is printing a WARNING about in the terminal.

`SanitizerFindingIssue` reports it now, naming the groups that tripped and linking the log `warning_stack` already keeps.

```
! sols/main.cpp a sanitizer fired while running this solution
    ASAN or UBSAN found something -- an out-of-bounds access, signed overflow,
    an uninitialised read -- while this solution ran. The verdict may well be
    fine here and undefined on the judge.
    groups:   big
    log: /pkg/.rbx/warnings/sols/main.cpp.log
```

### Notes on the design

- **The log is located in `load_run_state`, not in the detector.** Same reason #862 sized the `.err` artifacts there: a detector that stats is a detector that needs a populated directory to test, which is the coupling the detectors were pulled out of the issue stack to escape.
- **The log name is rebuilt through `warning_stack.sanitizer_log_name`**, newly extracted and public, rather than a second copy of the rule -- the reader and the writer cannot drift. It resolves to `../warnings/<solution>.log` relative to the runs dir, since `warning_stack`'s home is the package cache dir of which the runs dir is another child. `_resolve` now normalizes, so the link reads `/pkg/.rbx/warnings/...` rather than `/pkg/.rbx/runs/../warnings/...`.
- **A missing log does not unsay the finding.** `warning_stack` clears its directory at the start of every process that writes one, so a `rbx compile` between the run and the read leaves the report's flag standing with no file behind it; `log` is `Optional` and the detail lines simply omit it.
- **Reported whether or not the expectation held.** On a solution that failed, an ASAN or UBSAN finding is very often *why* it failed, and dropping it there would hide the one line that explains the verdict.
- **`print_warning_stack_report` keeps its own sanitizer section**, unlike the too-much-stderr producer #862 retired: it covers every first-party file, generators and validators included, while the report only knows about solutions. Compilation warnings are already double-covered the same way.
- `ISSUES_FORMAT_VERSION` stays at 2 -- per its own docstring, a new kind is readable by an older client through `kind`/`family`/`severity`.

### Testing

`tests/rbx/box/issues_test.py`: detector coverage (passing run, failing run, groups, log present/absent), `locate_sanitizer_logs` against a real directory, and the log-link rendering. `test_every_kind_has_a_summary_and_a_severity` pins the new kind into the union.

```
uv run pytest tests/rbx/box/issues_test.py tests/rbx/box/run_report_test.py tests/rbx/box/sanitizers tests/rbx/box/lazy_cli_test.py -q
# 208 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QowRrs5XQBzNTkeETkQdZg
